### PR TITLE
fix: resolve ruff lint violations across backend source (#237)

### DIFF
--- a/fichero-api/src/fichero/api/main.py
+++ b/fichero-api/src/fichero/api/main.py
@@ -110,8 +110,8 @@ app.add_middleware(
 
 
 # FastAPI dependency: Get database for current library
-from fastapi import Header, HTTPException, Depends
-from fichero.db import Database, db_manager
+from fastapi import Header, HTTPException, Depends  # noqa: E402
+from fichero.db import Database, db_manager  # noqa: E402
 
 
 async def get_library_database(
@@ -200,7 +200,7 @@ async def get_stats(db: Database = Depends(get_library_database)):
 
 
 # Include route modules
-from fichero.api.routes import (
+from fichero.api.routes import (  # noqa: E402
     documents,
     search,
     ingest,

--- a/fichero-api/src/fichero/api/routes/activity.py
+++ b/fichero-api/src/fichero/api/routes/activity.py
@@ -26,7 +26,6 @@ from fichero.workflows.activity import (
     ActivityFilter,
     ActivityLevel,
     ActivityStats,
-    ActivityTracker,
     ActivityType,
     get_activity_tracker,
 )
@@ -137,7 +136,7 @@ async def list_activities(
     level_list = None
     if levels:
         try:
-            level_list = [ActivityLevel(l.strip()) for l in levels.split(",")]
+            level_list = [ActivityLevel(lvl.strip()) for lvl in levels.split(",")]
         except ValueError as e:
             raise HTTPException(status_code=400, detail=f"Invalid activity level: {e}")
 
@@ -236,7 +235,7 @@ async def stream_activities(
     level_list = None
     if levels:
         try:
-            level_list = [ActivityLevel(l.strip()) for l in levels.split(",")]
+            level_list = [ActivityLevel(lvl.strip()) for lvl in levels.split(",")]
         except ValueError:
             pass
 

--- a/fichero-api/src/fichero/api/routes/artifacts.py
+++ b/fichero-api/src/fichero/api/routes/artifacts.py
@@ -17,7 +17,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # Import the get_library_database dependency
-from fichero.api.main import get_library_database
+from fichero.api.main import get_library_database  # noqa: E402
 
 
 # Response models

--- a/fichero-api/src/fichero/api/routes/batch.py
+++ b/fichero-api/src/fichero/api/routes/batch.py
@@ -11,7 +11,7 @@ import json
 import logging
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, HTTPException
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
@@ -20,7 +20,6 @@ from fichero.workflows.batch import (
     BatchEvent,
     BatchExecution,
     BatchItem,
-    BatchItemStatus,
     BatchManager,
     BatchProgress,
     BatchStatus,

--- a/fichero-api/src/fichero/api/routes/chains.py
+++ b/fichero-api/src/fichero/api/routes/chains.py
@@ -6,12 +6,11 @@ Provides endpoints for managing and executing workflow chains.
 
 from __future__ import annotations
 
-import asyncio
 import logging
 import uuid
 from typing import Any, Callable
 
-from fastapi import APIRouter, HTTPException, BackgroundTasks, Depends, Header
+from fastapi import APIRouter, HTTPException, BackgroundTasks, Header
 from pydantic import BaseModel, Field
 
 from fichero.workflows.chaining import (
@@ -27,7 +26,7 @@ from fichero.workflows.chaining import (
 )
 from fichero.workflows.types import WorkflowDef
 from fichero.workflows.workflow_store import WorkflowStore
-from fichero.db import Database, db_manager
+from fichero.db import db_manager
 
 logger = logging.getLogger(__name__)
 
@@ -365,7 +364,7 @@ async def execute_chain(
         execution_id=execution_id,
         chain_id=chain_id,
         status="running",
-        message=f"Chain execution started",
+        message="Chain execution started",
     )
 
 

--- a/fichero-api/src/fichero/api/routes/chat.py
+++ b/fichero-api/src/fichero/api/routes/chat.py
@@ -5,7 +5,6 @@ RAG-style chat using LangChain for semantic search and LLM generation.
 """
 
 import logging
-import os
 from typing import Optional, List
 from datetime import datetime
 
@@ -17,7 +16,7 @@ from fichero.api.main import get_library_database
 from fichero.app_db import get_app_db, AppDatabase
 from fichero.models import Document, Provider as ProviderModel, Model as ModelModel, Conversation
 from fichero.keychain import has_api_key
-from fichero.providers import PROVIDERS as PROVIDER_CATALOG, get_provider_info
+from fichero.providers import get_provider_info
 
 logger = logging.getLogger(__name__)
 
@@ -122,7 +121,7 @@ def _get_langchain_llm(db: Database, provider: str = None, model: str = None):
 
     Uses the unified llm.py interface which supports all providers via LiteLLM.
     """
-    from fichero.llm import LLMConfig, get_api_key
+    from fichero.llm import get_api_key
 
     # Get first configured provider/model if not specified
     if not provider or not model:

--- a/fichero-api/src/fichero/api/routes/documents.py
+++ b/fichero-api/src/fichero/api/routes/documents.py
@@ -18,7 +18,7 @@ router = APIRouter()
 
 
 # Import the get_library_database dependency
-from fichero.api.main import get_library_database
+from fichero.api.main import get_library_database  # noqa: E402
 
 
 # Request/Response models

--- a/fichero-api/src/fichero/api/routes/integrations.py
+++ b/fichero-api/src/fichero/api/routes/integrations.py
@@ -14,7 +14,7 @@ from typing import Optional
 from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel
 
-from fichero.integrations.base import get_integration_registry, IntegrationStatus
+from fichero.integrations.base import get_integration_registry
 
 router = APIRouter(prefix="/integrations", tags=["integrations"])
 

--- a/fichero-api/src/fichero/api/routes/mcp_servers.py
+++ b/fichero-api/src/fichero/api/routes/mcp_servers.py
@@ -5,7 +5,6 @@ API endpoints for managing MCP (Model Context Protocol) servers.
 """
 
 import logging
-from typing import Any
 
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel

--- a/fichero-api/src/fichero/api/routes/model_comparison.py
+++ b/fichero-api/src/fichero/api/routes/model_comparison.py
@@ -8,7 +8,6 @@ from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 from fichero.workflows.model_comparison import (
-    ModelComparisonEngine,
     ComparisonRequest,
     ModelSpec,
     get_comparison_engine,

--- a/fichero-api/src/fichero/api/routes/providers.py
+++ b/fichero-api/src/fichero/api/routes/providers.py
@@ -17,7 +17,7 @@ from fichero.db import Database
 from fichero.app_db import get_app_db, AppDatabase
 from fichero.api.main import get_library_database
 from fichero.models import Provider, Model, ProviderType
-from fichero.providers import PROVIDERS, get_provider_info, list_providers as list_catalog_providers
+from fichero.providers import get_provider_info, list_providers as list_catalog_providers
 from fichero.keychain import get_api_key, set_api_key, delete_api_key, has_api_key, is_available as keychain_available
 
 logger = logging.getLogger(__name__)
@@ -941,7 +941,6 @@ async def test_provider_connection(provider_type: str) -> ConnectionTestResponse
     - API key validity (for cloud providers)
     - Server availability (for local providers)
     """
-    import time
     import httpx
 
     info = get_provider_info(provider_type)

--- a/fichero-api/src/fichero/api/routes/search.py
+++ b/fichero-api/src/fichero/api/routes/search.py
@@ -8,7 +8,7 @@ import logging
 from typing import Optional
 from datetime import datetime
 
-from fastapi import APIRouter, HTTPException, Query, BackgroundTasks, Depends
+from fastapi import APIRouter, HTTPException, BackgroundTasks, Depends
 from pydantic import BaseModel
 
 from fichero.db import Database, SearchResult
@@ -23,7 +23,7 @@ def _safe_isoformat(value) -> str:
 
 
 # Import the get_library_database dependency
-from fichero.api.main import get_library_database
+from fichero.api.main import get_library_database  # noqa: E402
 
 
 # Request/Response models
@@ -167,10 +167,9 @@ async def embed_document(doc_id: str, db: Database = Depends(get_library_databas
 # Saved Searches
 # =============================================================================
 
-from datetime import datetime
-from typing import List
+from typing import List  # noqa: E402
 
-from fichero.models import SavedSearch
+from fichero.models import SavedSearch  # noqa: E402
 
 
 class SavedSearchCreate(BaseModel):

--- a/fichero-api/src/fichero/api/routes/storage.py
+++ b/fichero-api/src/fichero/api/routes/storage.py
@@ -99,7 +99,6 @@ async def get_source_file(
 
     Returns 404 if source is not accessible (e.g., external file moved).
     """
-    Path(x_fichero_library_path)
     doc = db.get(Document, doc_id)
     if not doc:
         raise HTTPException(status_code=404, detail=f"Document not found: {doc_id}")

--- a/fichero-api/src/fichero/api/routes/storage.py
+++ b/fichero-api/src/fichero/api/routes/storage.py
@@ -99,7 +99,7 @@ async def get_source_file(
 
     Returns 404 if source is not accessible (e.g., external file moved).
     """
-    package_path = Path(x_fichero_library_path)
+    Path(x_fichero_library_path)
     doc = db.get(Document, doc_id)
     if not doc:
         raise HTTPException(status_code=404, detail=f"Document not found: {doc_id}")

--- a/fichero-api/src/fichero/api/routes/workflow_execution.py
+++ b/fichero-api/src/fichero/api/routes/workflow_execution.py
@@ -14,7 +14,7 @@ from typing import Any, AsyncGenerator
 from uuid import uuid4
 
 from fastapi import APIRouter, HTTPException, Depends, BackgroundTasks, Request, Response
-from fastapi.responses import StreamingResponse, JSONResponse
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from fichero.db import Database
@@ -276,11 +276,11 @@ async def _run_workflow_in_background(
                 logger.warning(f"Could not load default provider: {e}")
 
         # Generate and save Python code
-        await log_execution(f"Generating Python code for workflow")
+        await log_execution("Generating Python code for workflow")
         python_code = _generate_workflow_python_code(workflow)
 
         # Create workflow snapshot for historical visualization (even if workflow is deleted)
-        await log_execution(f"Creating workflow snapshot")
+        await log_execution("Creating workflow snapshot")
         workflow_snapshot = {
             "nodes": [
                 {"id": n["id"], "tool": n["tool"], "label": n.get("label", "")}
@@ -294,7 +294,7 @@ async def _run_workflow_in_background(
         }
 
         # Build node name mapping (UUID → readable name)
-        await log_execution(f"Building node name mapping")
+        await log_execution("Building node name mapping")
         node_name_map = {}
         name_counts = {}
         for node in workflow.nodes:
@@ -312,7 +312,7 @@ async def _run_workflow_in_background(
             node_name_map[node_id] = unique_name
 
         # Generate Mermaid diagram for historical viewing
-        await log_execution(f"Generating workflow diagram")
+        await log_execution("Generating workflow diagram")
         try:
             app_preview = build_graph(workflow_def, enable_parallel=True, checkpointer=None)
             diagram_mermaid = app_preview.get_graph().draw_mermaid()
@@ -331,7 +331,7 @@ async def _run_workflow_in_background(
             diagram_mermaid=diagram_mermaid,
             started_at=start_time,
         )
-        await log_execution(f"Saved workflow run record with snapshot")
+        await log_execution("Saved workflow run record with snapshot")
 
         # Create event callback for parallel processing events
         async def emit_parallel_event(event_type: str, data: dict) -> None:
@@ -1433,7 +1433,6 @@ def _build_workflow_with_checkpointer(
         Compiled LangGraph application with checkpointing
     """
     from fichero.workflows.types import WorkflowDef, NodeDef, EdgeDef
-    from fichero.workflows.builder import build_graph, PARALLEL_TOOLS, SOURCE_TOOLS
 
     # Convert Workflow model to WorkflowDef
     workflow_def = WorkflowDef(
@@ -1483,7 +1482,7 @@ def _build_workflow_with_checkpointer(
     logger.debug(f"Building workflow '{workflow_def.name}': {len(workflow_def.nodes)} nodes, {len(workflow_def.edges)} edges")
 
     # Log edges and detect parallel edges
-    print(f"[BUILD] Edges:")
+    print("[BUILD] Edges:")
     for edge in workflow_def.edges:
         target_node = workflow_def.get_node(edge.target)
         source_node = workflow_def.get_node(edge.source)
@@ -1876,7 +1875,7 @@ def _generate_workflow_python_code(workflow: Workflow) -> str:
     using LangGraph primitives.
     """
     # Collect tool imports
-    tools_used = set(n.get("tool", "") for n in workflow.nodes if n.get("tool"))
+    set(n.get("tool", "") for n in workflow.nodes if n.get("tool"))
 
     # Build code
     lines = [
@@ -1925,18 +1924,18 @@ def _generate_workflow_python_code(workflow: Workflow) -> str:
 
         lines.extend([
             f'def {func_name}(state: State) -> dict[str, Any]:',
-            f'    """',
+            '    """',
             f'    Node: {label}',
             f'    Tool: {tool_name}',
-            f'    """',
+            '    """',
             f'    tool_fn = get_tool("{tool_name}")',
-            f'    if tool_fn is None:',
+            '    if tool_fn is None:',
             f'        return {{"errors": state.get("errors", []) + ["Tool not found: {tool_name}"]}}',
-            f'    ',
-            f'    # Get inputs from state',
-            f'    inputs = {{',
-            f'        "files": state.get("files", []),',
-            f'        "results": state.get("results", []),',
+            '    ',
+            '    # Get inputs from state',
+            '    inputs = {',
+            '        "files": state.get("files", []),',
+            '        "results": state.get("results", []),',
         ])
 
         # Add config values
@@ -1947,16 +1946,16 @@ def _generate_workflow_python_code(workflow: Workflow) -> str:
                 lines.append(f'        "{key}": {value!r},')
 
         lines.extend([
-            f'    }}',
-            f'    ',
-            f'    # Execute tool',
-            f'    try:',
-            f'        result = tool_fn(inputs)',
-            f'        return result',
-            f'    except Exception as e:',
-            f'        return {{"errors": state.get("errors", []) + [str(e)]}}',
-            f'',
-            f'',
+            '    }',
+            '    ',
+            '    # Execute tool',
+            '    try:',
+            '        result = tool_fn(inputs)',
+            '        return result',
+            '    except Exception as e:',
+            '        return {"errors": state.get("errors", []) + [str(e)]}',
+            '',
+            '',
         ])
 
     # Build graph

--- a/fichero-api/src/fichero/api/routes/workflow_execution.py
+++ b/fichero-api/src/fichero/api/routes/workflow_execution.py
@@ -1874,9 +1874,6 @@ def _generate_workflow_python_code(workflow: Workflow) -> str:
     Creates runnable Python code that builds and executes the workflow
     using LangGraph primitives.
     """
-    # Collect tool imports
-    set(n.get("tool", "") for n in workflow.nodes if n.get("tool"))
-
     # Build code
     lines = [
         '"""',

--- a/fichero-api/src/fichero/api/routes/workflows.py
+++ b/fichero-api/src/fichero/api/routes/workflows.py
@@ -123,7 +123,7 @@ def _dict_to_node_def(node_dict: dict, enrich_ports: bool = True) -> NodeDef:
     Returns:
         NodeDef with ports populated from registry (if enrich_ports=True)
     """
-    from fichero.workflows.types import PortDef, InputMapping, OutputSchema
+    from fichero.workflows.types import InputMapping, OutputSchema
 
     # Convert input_mappings to InputMapping objects
     input_mappings = [InputMapping(**m) for m in node_dict.get("input_mappings", [])]
@@ -370,7 +370,6 @@ async def import_workflow(
     """Import a workflow from JSON data."""
     try:
         from fichero.models import Workflow
-        from fichero.workflows.types import WorkflowDef, NodeDef, EdgeDef, PortDef
 
         # Validate that workflow_data contains required structure
         if "nodes" not in workflow_data or "edges" not in workflow_data:

--- a/fichero-api/src/fichero/bookmarks.py
+++ b/fichero-api/src/fichero/bookmarks.py
@@ -26,7 +26,6 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 logger = logging.getLogger(__name__)
 

--- a/fichero-api/src/fichero/db.py
+++ b/fichero-api/src/fichero/db.py
@@ -44,11 +44,8 @@ import re
 import duckdb
 from pydantic import BaseModel
 from fichero.errors import (
-    DatabaseError, 
-    FileSystemError, 
     ErrorCategory,
     handle_error,
-    log_and_recover,
     retry_on_failure
 )
 
@@ -493,7 +490,6 @@ class Database:
             Tuple of (results, total_count, search_stats)
         """
         import time
-        from typing import Any
         
         if not query or not query.strip():
             return [], 0, {"search_type": "none"}
@@ -633,7 +629,7 @@ class Database:
                                     to_date = datetime.fromisoformat(filters["date_to"])
                                     if created_date > to_date:
                                         match = False
-                            except:
+                            except (ValueError, TypeError):
                                 pass
                     
                     if match:

--- a/fichero-api/src/fichero/ingest.py
+++ b/fichero-api/src/fichero/ingest.py
@@ -40,10 +40,13 @@ import mimetypes
 import shutil
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Iterator
+from typing import TYPE_CHECKING, Callable, Iterator
 from uuid import uuid4
 
 from fichero.models import Document, DocType, FileType, Status
+
+if TYPE_CHECKING:
+    from fichero.db import Database
 
 logger = logging.getLogger(__name__)
 

--- a/fichero-api/src/fichero/integrations/bookends.py
+++ b/fichero-api/src/fichero/integrations/bookends.py
@@ -11,7 +11,6 @@ Uses AppleScript for communication with Bookends.
 """
 
 import logging
-from datetime import datetime
 from pathlib import Path
 from typing import Optional
 

--- a/fichero-api/src/fichero/llm.py
+++ b/fichero-api/src/fichero/llm.py
@@ -150,7 +150,7 @@ async def chat(
     Returns:
         Response string, or async generator if streaming
     """
-    from langchain_core.messages import HumanMessage, SystemMessage, AIMessage
+    from langchain_core.messages import HumanMessage, SystemMessage
 
     # Get LangChain model
     model = get_langchain_model(config)
@@ -385,14 +385,6 @@ async def vision_inference_api(
 
     # Hugging Face Inference API format for vision models
     # Uses multimodal inputs with text and image
-    payload = {
-        "inputs": prompt,
-        "parameters": {
-            "temperature": temperature,
-            "max_new_tokens": max_tokens,
-            "return_full_text": False,
-        },
-    }
 
     logger.info(f"HF Inference API call: {model} ({len(image_bytes)} bytes)")
 
@@ -686,7 +678,6 @@ def list_models_for_provider(provider: str) -> list[dict[str, Any]]:
     litellm = _get_litellm()
 
     models = []
-    prefix = f"{provider}/"
 
     def safe_int(val) -> int | None:
         """Safely convert value to int, return None if not possible."""

--- a/fichero-api/src/fichero/loaders/base.py
+++ b/fichero-api/src/fichero/loaders/base.py
@@ -16,7 +16,7 @@ from typing import Any, TYPE_CHECKING
 from pydantic import BaseModel, Field, ConfigDict
 
 if TYPE_CHECKING:
-    from PIL import Image
+    pass
 
 
 class MediaContent(BaseModel):
@@ -105,7 +105,6 @@ class MediaLoader(ABC):
 
         For use in non-async contexts.
         """
-        import asyncio
 
         try:
             loop = asyncio.get_running_loop()

--- a/fichero-api/src/fichero/loaders/docling_loader.py
+++ b/fichero-api/src/fichero/loaders/docling_loader.py
@@ -123,7 +123,7 @@ class DoclingLoader(MediaLoader):
     def is_available() -> bool:
         """Check if Docling is installed and available."""
         try:
-            from docling.document_converter import DocumentConverter
+            from docling.document_converter import DocumentConverter  # noqa: F401
             return True
         except ImportError:
             return False

--- a/fichero-api/src/fichero/loaders/iiif_loader.py
+++ b/fichero-api/src/fichero/loaders/iiif_loader.py
@@ -8,12 +8,15 @@ Downloads images from IIIF Image API endpoints.
 import logging
 from io import BytesIO
 from pathlib import Path
-from typing import Any
-from urllib.parse import urlparse
 
 from PIL import Image
 
+from typing import TYPE_CHECKING
+
 from fichero.loaders.base import MediaContent, MediaLoader
+
+if TYPE_CHECKING:
+    import aiohttp
 
 logger = logging.getLogger(__name__)
 

--- a/fichero-api/src/fichero/mcp_manager.py
+++ b/fichero-api/src/fichero/mcp_manager.py
@@ -8,7 +8,7 @@ Supports stdio, HTTP, SSE, and WebSocket transports.
 from __future__ import annotations
 
 import logging
-from typing import Any, AsyncIterator
+from typing import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 

--- a/fichero-api/src/fichero/models.py
+++ b/fichero-api/src/fichero/models.py
@@ -31,7 +31,6 @@ Usage:
 from pydantic import BaseModel, Field, ConfigDict, computed_field
 from datetime import datetime
 from enum import Enum
-from pathlib import Path
 from typing import Any
 from uuid import uuid4
 import base64

--- a/fichero-api/src/fichero/storage.py
+++ b/fichero-api/src/fichero/storage.py
@@ -456,7 +456,6 @@ def clear_all() -> int:
     Returns:
         Number of files removed
     """
-    import shutil
 
     thumb_dir = settings.thumb_dir
     if not thumb_dir.exists():
@@ -543,7 +542,7 @@ async def save_uploaded_file(file) -> Path:
         # Clean up on error
         try:
             temp_path.unlink()
-        except:
+        except OSError:
             pass
         raise e
 

--- a/fichero-api/src/fichero/workflows/activity.py
+++ b/fichero-api/src/fichero/workflows/activity.py
@@ -16,7 +16,7 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, AsyncIterator, Callable, Optional
+from typing import Any, AsyncIterator, Optional
 
 import duckdb
 
@@ -315,7 +315,7 @@ class ActivityStore:
                 if filter.levels:
                     placeholders = ", ".join("?" * len(filter.levels))
                     conditions.append(f"level IN ({placeholders})")
-                    params.extend([l.value for l in filter.levels])
+                    params.extend([lvl.value for lvl in filter.levels])
 
                 if filter.workflow_id:
                     conditions.append("workflow_id = ?")
@@ -440,9 +440,9 @@ class ActivityStore:
                 return ActivityStats(
                     total_activities=total,
                     activities_by_type={t[0]: t[1] for t in type_counts},
-                    activities_by_level={l[0]: l[1] for l in level_counts},
-                    error_count=sum(l[1] for l in level_counts if l[0] == 'error'),
-                    warning_count=sum(l[1] for l in level_counts if l[0] == 'warning'),
+                    activities_by_level={lc[0]: lc[1] for lc in level_counts},
+                    error_count=sum(lc[1] for lc in level_counts if lc[0] == 'error'),
+                    warning_count=sum(lc[1] for lc in level_counts if lc[0] == 'warning'),
                     avg_workflow_duration_ms=avg_duration,
                     success_rate=success_rate,
                     period_start=since,

--- a/fichero-api/src/fichero/workflows/builder.py
+++ b/fichero-api/src/fichero/workflows/builder.py
@@ -13,17 +13,15 @@ The builder:
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import operator
 import uuid
-from typing import Any, Annotated
+from typing import Any
 
 from langgraph.graph import StateGraph, START, END
 from langgraph.types import Send
 
 from fichero.workflows.types import State, WorkflowDef, NodeDef
-from fichero.workflows.registry import TOOLS, get_tool, get_tool_def
+from fichero.workflows.registry import get_tool, get_tool_def
 from fichero.workflows.resolver import resolve_inputs, evaluate_condition
 from fichero.workflows.cache import get_node_cache, compute_cache_key, CACHEABLE_TOOLS
 from fichero.llm import LLMConfig
@@ -533,7 +531,6 @@ def _make_parallel_node_function(
     async def parallel_node_function(state: State) -> dict:
         """Process a single file in parallel."""
         node_id = node_def.id
-        node_label = node_def.label or node_def.tool
 
         # Get single file info from state (set by Send)
         file_path = state.get("parallel_file", "")

--- a/fichero-api/src/fichero/workflows/chaining.py
+++ b/fichero-api/src/fichero/workflows/chaining.py
@@ -24,7 +24,7 @@ from typing import Any, Callable
 from pydantic import BaseModel, Field
 
 from fichero.workflows.types import WorkflowDef
-from fichero.workflows.executor import WorkflowExecutor, ProgressEvent, ProgressEventType
+from fichero.workflows.executor import WorkflowExecutor
 
 logger = logging.getLogger(__name__)
 

--- a/fichero-api/src/fichero/workflows/executor.py
+++ b/fichero-api/src/fichero/workflows/executor.py
@@ -24,17 +24,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 from collections import defaultdict
 
-from langgraph.graph import StateGraph, START, END
 from langgraph.graph.state import CompiledStateGraph
 
 from fichero.workflows.types import (
     State as BaseState,
     WorkflowDef,
-    NodeDef,
-    EdgeDef,
 )
-from fichero.workflows.registry import TOOLS, get_tool, get_tool_def
-from fichero.workflows.resolver import resolve_inputs, evaluate_condition
 from fichero.workflows.builder import build_graph
 from fichero.llm import LLMConfig
 
@@ -182,7 +177,7 @@ class WorkflowExecutor:
     async def _process_event_queue(self) -> None:
         """Process events from the queue."""
         while not self._event_queue.empty():
-            event = await self._event_queue.get()
+            await self._event_queue.get()
             # Events are already processed by listeners in _emit_event
             self._event_queue.task_done()
     
@@ -251,7 +246,7 @@ class WorkflowExecutor:
                     event_type=ProgressEventType.WORKFLOW_COMPLETED,
                     task_id=task_id,
                     workflow_id=self.workflow.id,
-                    message=f"Workflow completed successfully",
+                    message="Workflow completed successfully",
                     progress=1.0,
                 ))
             
@@ -708,8 +703,7 @@ async def validate_workflow_executor() -> bool:
     """Validate that the workflow executor is properly configured."""
     try:
         # Test basic functionality
-        from fichero.workflows.types import WorkflowDef, NodeDef
-        from fichero.workflows.registry import TOOL_DEFS
+        from fichero.workflows.types import WorkflowDef
         
         # Create a simple test workflow
         test_workflow = WorkflowDef(

--- a/fichero-api/src/fichero/workflows/file_watcher.py
+++ b/fichero-api/src/fichero/workflows/file_watcher.py
@@ -28,10 +28,6 @@ from watchdog.events import (
     FileModifiedEvent,
     FileDeletedEvent,
     FileMovedEvent,
-    DirCreatedEvent,
-    DirDeletedEvent,
-    DirModifiedEvent,
-    DirMovedEvent,
 )
 
 from fichero.workflows.batch import BatchManager
@@ -866,7 +862,6 @@ class FileWatcherManager:
     ) -> list[TriggerExecution]:
         """Get execution history for a trigger."""
         def _get_executions():
-            import json
             conn = duckdb.connect(self.db_path)
             try:
                 results = conn.execute("""

--- a/fichero-api/src/fichero/workflows/model_comparison.py
+++ b/fichero-api/src/fichero/workflows/model_comparison.py
@@ -18,7 +18,7 @@ from pydantic import BaseModel, Field
 
 from enum import Enum
 
-from fichero.llm import get_langchain_model, LLMConfig, get_model_info, vision
+from fichero.llm import get_langchain_model, LLMConfig, vision
 
 logger = logging.getLogger(__name__)
 
@@ -724,8 +724,8 @@ def get_comparison_engine() -> ModelComparisonEngine:
 # Workflow Tool Registration
 # =============================================================================
 
-from fichero.workflows.types import State, PortDef, DataType
-from fichero.workflows.registry import register_tool
+from fichero.workflows.types import State, PortDef, DataType  # noqa: E402
+from fichero.workflows.registry import register_tool  # noqa: E402
 
 
 @register_tool(

--- a/fichero-api/src/fichero/workflows/registry.py
+++ b/fichero-api/src/fichero/workflows/registry.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import logging
 import uuid
 from typing import Callable, Any
-from functools import wraps
 
 from fichero.workflows.types import (
     ToolDef,

--- a/fichero-api/src/fichero/workflows/state.py
+++ b/fichero-api/src/fichero/workflows/state.py
@@ -16,8 +16,7 @@ from __future__ import annotations
 
 import time
 import uuid
-from typing import Any, TypedDict, NotRequired
-from dataclasses import dataclass, field
+from typing import Any, TypedDict
 from enum import Enum
 
 from fichero.workflows.types import State as BaseState
@@ -454,10 +453,10 @@ async def test_state_management() -> bool:
         
         # Test serialization
         serialized = serialize_state(state)
-        deserialized = deserialize_state(serialized)
+        deserialize_state(serialized)
         
         # Test summary
-        summary = state.get_summary()
+        state.get_summary()
         
         return True
         

--- a/fichero-api/src/fichero/workflows/tools/audio_base.py
+++ b/fichero-api/src/fichero/workflows/tools/audio_base.py
@@ -30,14 +30,11 @@ from fichero.workflows.types import PortDef, DataType
 # Import from llm_base - the parent layer
 from fichero.workflows.tools.llm_base import (
     BASE_INPUT_PORTS,
-    BASE_OUTPUT_PORTS,
     BASE_CONFIG_SCHEMA,
     merge_config_schema,
     merge_ports,
     LLMToolConfig,
-    build_output_constraint,
     parse_output,
-    build_context_section,
     save_artifact as llm_save_artifact,
     save_to_file as llm_save_to_file,
 )

--- a/fichero-api/src/fichero/workflows/tools/compare.py
+++ b/fichero-api/src/fichero/workflows/tools/compare.py
@@ -11,7 +11,7 @@ import dataclasses
 import logging
 from typing import Any
 
-from fichero.workflows.types import State, PortDef, DataType
+from fichero.workflows.types import State
 from fichero.workflows.registry import register_tool
 from fichero.workflows.tools.llm_base import (
     BASE_OUTPUT_PORTS,

--- a/fichero-api/src/fichero/workflows/tools/entities.py
+++ b/fichero-api/src/fichero/workflows/tools/entities.py
@@ -7,7 +7,6 @@ Inherits from llm_base.py for shared config and processing.
 
 from __future__ import annotations
 
-import json
 import logging
 from typing import Any
 

--- a/fichero-api/src/fichero/workflows/tools/llm_base.py
+++ b/fichero-api/src/fichero/workflows/tools/llm_base.py
@@ -868,7 +868,7 @@ async def process_text(
     Returns:
         Dict with text, value, results, artifacts, error, output_files
     """
-    from fichero.llm import chat, LLMConfig
+    from fichero.llm import chat
 
     if not text:
         return {

--- a/fichero-api/src/fichero/workflows/tools/multi_agent.py
+++ b/fichero-api/src/fichero/workflows/tools/multi_agent.py
@@ -10,14 +10,13 @@ Implements advanced agent patterns for coordinating multiple agents:
 from __future__ import annotations
 
 import logging
-from typing import Any, Literal
+from typing import Any
 
 from langgraph.prebuilt import create_react_agent
-from langgraph.graph import StateGraph, START, END
 from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
 
 from fichero.workflows.types import State, PortDef, DataType
-from fichero.workflows.registry import register_tool, get_tool, TOOL_DEFS
+from fichero.workflows.registry import register_tool, get_tool
 from fichero.llm import get_langchain_model, LLMConfig
 from fichero.workflows.tools.agent import _wrap_workflow_tool
 
@@ -827,7 +826,7 @@ async def agent_coordinator(
             # Simple length-based similarity as proxy
             lengths = [len(r["result"]) for r in successful_results]
             avg_length = sum(lengths) / len(lengths)
-            variance = sum((l - avg_length) ** 2 for l in lengths) / len(lengths)
+            variance = sum((ln - avg_length) ** 2 for ln in lengths) / len(lengths)
             agreement_score = max(0, 1 - (variance / (avg_length ** 2 + 1)))
 
         # Combine results based on method

--- a/fichero-api/src/fichero/workflows/tools/objects.py
+++ b/fichero-api/src/fichero/workflows/tools/objects.py
@@ -62,20 +62,20 @@ def _build_prompt(detail_level: str, include_positions: bool) -> str:
         position_text = ', "position": "<top-left/top-center/top-right/center-left/center/center-right/bottom-left/bottom-center/bottom-right>"'
 
     detail_instructions = {
-        "count": f"""Count all distinct objects in this image.
+        "count": """Count all distinct objects in this image.
 
 Return as JSON:
-{{
+{
     "total_objects": <number>,
     "categories": [
-        {{"type": "<object type>", "count": <number>}}
+        {"type": "<object type>", "count": <number>}
     ]
-}}""",
+}""",
         "basic": f"""Identify all objects in this image.
 
 For each object, provide:
 - type (what it is)
-- count (how many){f'''
+- count (how many){'''
 - position (where in the image)''' if include_positions else ''}
 
 Return as JSON:
@@ -91,7 +91,7 @@ For each object, provide:
 - type (what it is)
 - description (appearance, condition, notable features)
 - size (relative: small/medium/large)
-- count (how many){f'''
+- count (how many){'''
 - position (where in the image)''' if include_positions else ''}
 
 Return as JSON:

--- a/fichero-api/src/fichero/workflows/tools/similarity.py
+++ b/fichero-api/src/fichero/workflows/tools/similarity.py
@@ -18,7 +18,6 @@ from fichero.workflows.tools.llm_base import (
     BASE_OUTPUT_PORTS,
     merge_config_schema,
     build_context_section,
-    build_output_constraint,
     parse_output,
 )
 from fichero.workflows.tools.vision_base import (

--- a/fichero-api/src/fichero/workflows/tools/sources.py
+++ b/fichero-api/src/fichero/workflows/tools/sources.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 
 import logging
 from typing import Any
-from pathlib import Path
 
 from fichero.workflows.types import State, PortDef, DataType
 from fichero.workflows.registry import register_tool

--- a/fichero-api/src/fichero/workflows/tools/video_base.py
+++ b/fichero-api/src/fichero/workflows/tools/video_base.py
@@ -36,12 +36,10 @@ from fichero.workflows.types import PortDef, DataType
 # Import from llm_base - the parent layer
 from fichero.workflows.tools.llm_base import (
     BASE_INPUT_PORTS,
-    BASE_OUTPUT_PORTS,
     BASE_CONFIG_SCHEMA,
     merge_config_schema,
     merge_ports,
     LLMToolConfig,
-    build_output_constraint,
     parse_output,
     build_context_section,
     build_reference_section,

--- a/fichero-api/src/fichero/workflows/tools/vision_base.py
+++ b/fichero-api/src/fichero/workflows/tools/vision_base.py
@@ -32,7 +32,6 @@ from fichero.workflows.types import PortDef, DataType
 from fichero.workflows.tools.llm_base import (
     # Port and config definitions
     BASE_INPUT_PORTS,
-    BASE_OUTPUT_PORTS,
     BASE_CONFIG_SCHEMA,
     merge_config_schema,
     merge_ports,

--- a/fichero-api/src/fichero/workflows/validation.py
+++ b/fichero-api/src/fichero/workflows/validation.py
@@ -7,12 +7,10 @@ Functions for validating tool connections, node configurations, and workflow str
 from __future__ import annotations
 
 import logging
-from typing import Any
 
 from fichero.workflows.types import (
     PortDef,
     NodeDef,
-    EdgeDef,
     WorkflowDef,
     DataType,
     ToolDef,


### PR DESCRIPTION
## Summary

- Ran `ruff check` against `fichero-api/src/` — 154 violations found
- 116 auto-fixed via `ruff check --fix`
- 32 fixed manually: ambiguous variable renames (`l` → `lvl`/`lc`/`ln`), `TYPE_CHECKING` import guards, bare `except` narrowed to specific types, `noqa` suppressions for intentional late imports
- 2 dead-code expressions removed after guardian review: discarded `Path()` call in `storage.py`, discarded `set()` call in `workflow_execution.py`
- `ruff check fichero-api/src/` now exits 0

## What was tested

- `PYTHONPATH=fichero-api/src .venv/bin/ruff check fichero-api/src/` — exits 0
- `PYTHONPATH=fichero-api/src python -m pytest fichero-api/tests/unit/ --ignore=fichero-api/tests/unit/_archived` — all pass
- Guardian check: ALIGNED (second pass after dead-code fix)

## Checklist
- [x] Build passes
- [x] Tests pass
- [x] Lint passes
- [x] No generated files edited manually
- [x] Commit messages follow conventions

Closes #237