### PR TITLE
fix: resolve lint regressions in workflow and library views (#294)

### DIFF
--- a/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+FilterAndBatch.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+FilterAndBatch.swift
@@ -167,7 +167,10 @@ extension LibraryView {
                 maxConcurrent: 5
             )
             logger.info(
-                "Created batch \(batch.batchId) for workflow \(workflowId) with \(self.selectedDocumentIdsForBatch.count) items"
+                """
+                Created batch \(batch.batchId) for workflow \(workflowId) \
+                with \(self.selectedDocumentIdsForBatch.count) items
+                """
             )
         } catch {
             logger.error("Run workflow failed: \(error.localizedDescription)")

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/FilesNodeConfig.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/FilesNodeConfig.swift
@@ -154,7 +154,11 @@ struct FilesNodeConfig: View {
                         togglePickerSelection(doc.id)
                     } label: {
                         HStack {
-                            Image(systemName: stagedPickerSelection.contains(doc.id) ? "checkmark.circle.fill" : "circle")
+                            Image(
+                                systemName: stagedPickerSelection.contains(doc.id)
+                                    ? "checkmark.circle.fill"
+                                    : "circle"
+                            )
                                 .foregroundStyle(
                                     stagedPickerSelection.contains(doc.id) ? Color.accentColor : Color.secondary
                                 )


### PR DESCRIPTION
## Summary
- fix line-length in LibraryView+FilterAndBatch
- fix line-length in FilesNodeConfig

## Validation
- targeted swiftlint passes for touched files

Closes #294