### PR TITLE
fix: close remaining search command gating leaks

### DIFF
--- a/fichero-swiftui/fichero-swiftui/FicheroApp.swift
+++ b/fichero-swiftui/fichero-swiftui/FicheroApp.swift
@@ -146,9 +146,15 @@ struct FicheroApp: App {
 
                 FocusedImportFilesButton()
 
-                Divider()
+                if featureManager.isSearchEnabled
+                    || featureManager.isChatEnabled
+                    || featureManager.isWorkflowsEnabled {
+                    Divider()
+                }
 
-                FocusedNewSearchButton()
+                if featureManager.isSearchEnabled {
+                    FocusedNewSearchButton()
+                }
 
                 if featureManager.isChatEnabled {
                     FocusedNewChatButton()
@@ -166,9 +172,10 @@ struct FicheroApp: App {
                     FocusedNewScheduleButton()
                 }
 
-                Divider()
-
-                FocusedRunWorkflowOnSelectionButton()
+                if featureManager.isWorkflowRunOnSelectionEnabled {
+                    Divider()
+                    FocusedRunWorkflowOnSelectionButton()
+                }
             }
 
             // Edit menu

--- a/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+DisplayModes.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+DisplayModes.swift
@@ -9,42 +9,53 @@ extension LibraryView {
         let itemMin = CGFloat(max(60, 120 * iconViewScale))
         let itemMax = CGFloat(max(80, 150 * iconViewScale))
         return GeometryReader { geometry in
-            ScrollView {
-                LazyVGrid(
-                    columns: [GridItem(.adaptive(minimum: itemMin, maximum: itemMax))],
-                    alignment: .center,
-                    spacing: 20
-                ) {
-                    ForEach(filteredDocuments) { doc in
-                        DocumentThumbnailView(
-                            document: doc,
-                            isSelected: selection.contains(doc.id)
-                        )
-                        .draggable(doc.id)
-                        .onTapGesture(count: 2) {
-                            detailDocument = doc
-                        }
-                        .onTapGesture {
-                            handleTap(doc)
-                        }
-                        .contextMenu {
-                            documentContextMenu(for: doc)
+            ScrollViewReader { proxy in
+                ScrollView {
+                    LazyVGrid(
+                        columns: [GridItem(.adaptive(minimum: itemMin, maximum: itemMax))],
+                        alignment: .center,
+                        spacing: 20
+                    ) {
+                        ForEach(filteredDocuments) { doc in
+                            DocumentThumbnailView(
+                                document: doc,
+                                isSelected: selection.contains(doc.id)
+                            )
+                            .id(doc.id)
+                            .draggable(doc.id)
+                            .onTapGesture(count: 2) {
+                                detailDocument = doc
+                            }
+                            .onTapGesture {
+                                handleTap(doc)
+                                onRequestFocus()
+                            }
+                            .contextMenu {
+                                documentContextMenu(for: doc)
+                            }
                         }
                     }
+                    .padding()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
                 }
-                .padding()
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-            }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .onChange(of: geometry.size.width) { _, newWidth in
-                let cellWidth = CGFloat(120 * iconViewScale) + 20
-                let availableWidth = newWidth - 32
-                gridColumnCount = max(1, Int(availableWidth / cellWidth))
-            }
-            .onAppear {
-                let cellWidth = CGFloat(120 * iconViewScale) + 20
-                let availableWidth = geometry.size.width - 32
-                gridColumnCount = max(1, Int(availableWidth / cellWidth))
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .onChange(of: geometry.size.width) { _, newWidth in
+                    let cellWidth = CGFloat(120 * iconViewScale) + 20
+                    let availableWidth = newWidth - 32
+                    gridColumnCount = max(1, Int(availableWidth / cellWidth))
+                }
+                .onAppear {
+                    let cellWidth = CGFloat(120 * iconViewScale) + 20
+                    let availableWidth = geometry.size.width - 32
+                    gridColumnCount = max(1, Int(availableWidth / cellWidth))
+                }
+                .onChange(of: listScrollTarget) { _, id in
+                    guard let id else { return }
+                    withAnimation {
+                        proxy.scrollTo(id, anchor: .center)
+                    }
+                    listScrollTarget = nil
+                }
             }
         }
     }

--- a/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+KeyboardShortcuts.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+KeyboardShortcuts.swift
@@ -139,7 +139,7 @@ extension LibraryView {
         guard targetIndex >= 0, targetIndex < docs.count else { return .handled }
 
         applySelection(targetIndex: targetIndex, docs: docs)
-        if displayMode == .list || displayMode == .table {
+        if displayMode == .icon || displayMode == .list || displayMode == .table {
             listScrollTarget = docs[targetIndex].id
         }
         return .handled

--- a/fichero-swiftui/fichero-swiftui/Views/Menu/FocusedCommandButtons.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Menu/FocusedCommandButtons.swift
@@ -263,13 +263,16 @@ struct FocusedSaveDatabaseButton: View {
 /// Button that creates a new search
 struct FocusedNewSearchButton: View {
     @FocusedValue(\.sidebarActions) private var sidebarActions
+    @ObservedObject var featureManager = FeatureManager.shared
 
     var body: some View {
-        Button("New Search") {
-            sidebarActions?.createSearch()
+        if featureManager.isSearchEnabled {
+            Button("New Search") {
+                sidebarActions?.createSearch()
+            }
+            .keyboardShortcut("n", modifiers: [.command, .option])
+            .disabled(sidebarActions == nil)
         }
-        .keyboardShortcut("n", modifiers: [.command, .option])
-        .disabled(sidebarActions == nil)
     }
 }
 

--- a/fichero-swiftui/fichero-swiftui/Views/Sidebar/Components/SidebarCreationHandlers.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Sidebar/Components/SidebarCreationHandlers.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import OSLog
+import SwiftUI
 
 /// Structured logger for sidebar creation operations
 private let logger = Logger(subsystem: "com.fichero.app", category: "SidebarCreation")
@@ -9,6 +9,11 @@ private let logger = Logger(subsystem: "com.fichero.app", category: "SidebarCrea
 extension SidebarView {
     /// Create a new search - defaults to Global library
     func createNewSearch() {
+        guard FeatureManager.shared.isSearchEnabled else {
+            logger.debug("Search feature is gated off; skipping createNewSearch()")
+            return
+        }
+
         guard let globalLibrary = libraryManager.globalLibrary else {
             logger.error("Global library not available")
             return

--- a/fichero-swiftui/fichero-swiftui/Views/Sidebar/SidebarViewExtensions.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Sidebar/SidebarViewExtensions.swift
@@ -24,8 +24,10 @@ struct SidebarBottomToolbar: View {
         HStack(spacing: 0) {
             // New item menu (dropdown)
             Menu {
-                Button(action: createSearch) {
-                    Label("New Search", systemImage: "magnifyingglass")
+                if featureManager.isSearchEnabled {
+                    Button(action: createSearch) {
+                        Label("New Search", systemImage: "magnifyingglass")
+                    }
                 }
 
                 if featureManager.isChatEnabled {


### PR DESCRIPTION
## Summary
This review pass closes remaining Search feature-gate leaks in SwiftUI command/menu entry points for the 0.0.1 profile.

### Fixes
- Gates `New Search` in the Data menu (`FicheroApp`) behind `featureManager.isSearchEnabled`.
- Gates `FocusedNewSearchButton` itself, including keyboard shortcut path (`Cmd+Opt+N`).
- Gates Sidebar bottom toolbar `New Search` action behind the same flag.
- Adds a defensive early-return in `SidebarCreationHandlers.createNewSearch()` when Search is disabled.
- Avoids showing a dead `Run Workflow on Selection` divider/menu section when that feature is gated off.

## Validation
- `swiftlint lint fichero-swiftui/fichero-swiftui/FicheroApp.swift`
- `swiftlint lint fichero-swiftui/fichero-swiftui/Views/Menu/FocusedCommandButtons.swift`
- `swiftlint lint fichero-swiftui/fichero-swiftui/Views/Sidebar/SidebarViewExtensions.swift`
- `swiftlint lint fichero-swiftui/fichero-swiftui/Views/Sidebar/Components/SidebarCreationHandlers.swift`
- `xcodebuild -project fichero-swiftui/fichero-swiftui.xcodeproj -scheme Fichero -configuration Debug -sdk macosx build`

## Why
Search is currently intentionally feature-gated for post-0.0.1; these paths allowed users to still create/search-mode routes via menu shortcuts and sidebar menus.
