### PR TITLE
0.0.1 hardening: inspector editor, workflow gating, layout/toolbar fixes

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -4,7 +4,7 @@ Last updated: 2026-03-09
 
 ## Current Branch
 
-`main` (clean, synced with `origin/main`)
+`main` (in-progress working tree; not yet committed)
 
 ## Source of Truth
 
@@ -37,6 +37,9 @@ Milestone `0.0.1` due date:
 - Verified build/lint after rich-text inspector changes:
   - `xcodebuild` (`Fichero`, Debug, macOS SDK) succeeds
   - `DocumentInspectorContentTab.swift` has 0 SwiftLint violations
+- Removed in-window toolbar title rendering to match tab-first macOS title behavior:
+  - `ContentView` now uses `.navigationTitle("")` for the main window view
+  - `xcodebuild` (`Fichero`, Debug, macOS SDK) still succeeds after this change
 - Verified backend workflow unit tests after `files` tool fix:
   - `134 passed`
 - Posted milestone progress update to `#279`:
@@ -74,3 +77,10 @@ Release/QA gate issues still open:
 4. Resolve `#263` build-phase reliability.
 5. Finalize `#278` Sparkle 0.0.1 release configuration.
 6. Drive `#238`, `#250`, and `#279` checklists to explicit pass/fail evidence.
+
+## In Progress Now
+
+- Continue 0.0.1 hardening pass on SwiftUI:
+  - verify DocumentInspector `NSTextView` edit/save/reload behavior under real UI flow
+  - confirm library/search layout defaults + inspector resizing behavior are stable
+  - keep feature-gating polish aligned with milestone `0.0.1`

--- a/fichero-swiftui/fichero-swiftui.xcodeproj/project.pbxproj
+++ b/fichero-swiftui/fichero-swiftui.xcodeproj/project.pbxproj
@@ -854,32 +854,20 @@
 			path = Actions;
 			sourceTree = "<group>";
 		};
-		400 = {
-			isa = PBXGroup;
-			children = (
-				A1624FF72F2EE5880019C019 /* FicheroBackend.app */,
-				A18B76672EFDCD6E001C9EC2 /* fichero-tests.xctestplan */,
-				A151C6DE2EFDCD4300E46CE0 /* fichero-tests.xctestplan */,
-				A16FDD632EFDCD17003296BF /* fichero-tests.xctestplan */,
-				410 /* fichero-swiftui */,
-				A10521AA2EFDC92400B28C3E /* fichero-swiftui-tests */,
-				A10521C22EFDC94100B28C3E /* fichero-swiftui-ui-tests */,
-				420 /* Products */,
-				DD03402A88F98251F388870F /* DocumentInspectorInfoTab.swift */,
-				E7B146AE8AC4CEEC3775CB94 /* DocumentInspectorMetadataTab.swift */,
-				312845068CA928DA393E0468 /* DocumentInspectorArtifactsTab.swift */,
-				36234E44A7E494963A441CDC /* DocumentInspectorContentTab.swift */,
-				A0264B7B8616BA5159B2CEF1 /* TriggerEditorFormPanel.swift */,
-				5BAA47F1959AD79AA6C2E3EF /* TriggerEditorPreviewPanel.swift */,
-				A3CD4902A47A5787D61C6D72 /* FlowLayout.swift */,
-				1C4E4291B8C33D501F176BF5 /* AIDefaults.swift */,
-				C07B489C8F89204C43BD6E46 /* AISettingsView.swift */,
-				C0104EC0811F842CAC3CC887 /* GeneralSettingsView.swift */,
-				371A4629B0A6A51DE6D6D872 /* BackendSettingsView.swift */,
-				1F4F4939BDACA726554E086D /* LocalModelsSettingsView.swift */,
-			);
-			sourceTree = "<group>";
-		};
+			400 = {
+				isa = PBXGroup;
+				children = (
+					A1624FF72F2EE5880019C019 /* FicheroBackend.app */,
+					A18B76672EFDCD6E001C9EC2 /* fichero-tests.xctestplan */,
+					A151C6DE2EFDCD4300E46CE0 /* fichero-tests.xctestplan */,
+					A16FDD632EFDCD17003296BF /* fichero-tests.xctestplan */,
+					410 /* fichero-swiftui */,
+					A10521AA2EFDC92400B28C3E /* fichero-swiftui-tests */,
+					A10521C22EFDC94100B28C3E /* fichero-swiftui-ui-tests */,
+					420 /* Products */,
+				);
+				sourceTree = "<group>";
+			};
 		410 /* fichero-swiftui */ = {
 			isa = PBXGroup;
 			children = (
@@ -1264,23 +1252,33 @@
 			path = Activity;
 			sourceTree = "<group>";
 		};
-		A1A3AA2A2F113E850021909D /* Automation */ = {
-			isa = PBXGroup;
-			children = (
-				16BEAA9442D4996FBD92BC7F /* ScheduleDetailView.swift */,
-				7B5ACEA3F5BC4462B7B18AA7 /* ScheduleEditorView.swift */,
-				B5A0010800000000BATCH5S1 /* ScheduleEditorView+Category.swift */,
-				152 /* ScheduleCreationSheet.swift */,
-				75371C597B1E4689B6E1803F /* TriggerEditorView.swift */,
-				C69898938F25CFEA64385A16 /* TriggerDetailView.swift */,
-				153 /* TriggerCreationSheet.swift */,
-				20D8ED5A2F48E4CA006950A3 /* TriggerDetailView+Configuration.swift */,
-				20D8ED5C2F48E4D4006950A3 /* TriggerDetailView+ExecutionHistory.swift */,
-				20D8ED5E2F48E4DA006950A3 /* TriggerDetailView+Helpers.swift */,
-			);
-			path = Automation;
-			sourceTree = "<group>";
-		};
+			A1A3AA2A2F113E850021909D /* Automation */ = {
+				isa = PBXGroup;
+				children = (
+					16BEAA9442D4996FBD92BC7F /* ScheduleDetailView.swift */,
+					7B5ACEA3F5BC4462B7B18AA7 /* ScheduleEditorView.swift */,
+					B5A0010800000000BATCH5S1 /* ScheduleEditorView+Category.swift */,
+					152 /* ScheduleCreationSheet.swift */,
+					75371C597B1E4689B6E1803F /* TriggerEditorView.swift */,
+					D11000012F99900100ABC002 /* TriggerEditorView */,
+					C69898938F25CFEA64385A16 /* TriggerDetailView.swift */,
+					153 /* TriggerCreationSheet.swift */,
+					20D8ED5A2F48E4CA006950A3 /* TriggerDetailView+Configuration.swift */,
+					20D8ED5C2F48E4D4006950A3 /* TriggerDetailView+ExecutionHistory.swift */,
+					20D8ED5E2F48E4DA006950A3 /* TriggerDetailView+Helpers.swift */,
+				);
+				path = Automation;
+				sourceTree = "<group>";
+			};
+			D11000012F99900100ABC002 /* TriggerEditorView */ = {
+				isa = PBXGroup;
+				children = (
+					A0264B7B8616BA5159B2CEF1 /* TriggerEditorFormPanel.swift */,
+					5BAA47F1959AD79AA6C2E3EF /* TriggerEditorPreviewPanel.swift */,
+				);
+				path = TriggerEditorView;
+				sourceTree = "<group>";
+			};
 		A1A3AA352F11665B0021909D /* Integrations */ = {
 			isa = PBXGroup;
 			children = (
@@ -1302,16 +1300,17 @@
 			path = App;
 			sourceTree = "<group>";
 		};
-		A1BFB2D62F042C6D00EAA55A /* Components */ = {
-			isa = PBXGroup;
-			children = (
-				A1BFB2EF2F043FA100EAA55A /* BackendConnectionView.swift */,
-				A13E7C512F280C1C00EC9EE1 /* BatchRow.swift */,
-				A1BFB2F22F045C8A00EAA55A /* LibraryImageView.swift */,
-				A1BFB2D42F042C6D00EAA55A /* ProviderLogoView.swift */,
-				A13E7C322F27F32E00EC9EE1 /* ScheduleRow.swift */,
-				A1BFB2D52F042C6D00EAA55A /* StatusBadge.swift */,
-				A13E7C332F27F32E00EC9EE1 /* TriggerRow.swift */,
+			A1BFB2D62F042C6D00EAA55A /* Components */ = {
+				isa = PBXGroup;
+				children = (
+					A1BFB2EF2F043FA100EAA55A /* BackendConnectionView.swift */,
+					A13E7C512F280C1C00EC9EE1 /* BatchRow.swift */,
+					A3CD4902A47A5787D61C6D72 /* FlowLayout.swift */,
+					A1BFB2F22F045C8A00EAA55A /* LibraryImageView.swift */,
+					A1BFB2D42F042C6D00EAA55A /* ProviderLogoView.swift */,
+					A13E7C322F27F32E00EC9EE1 /* ScheduleRow.swift */,
+					A1BFB2D52F042C6D00EAA55A /* StatusBadge.swift */,
+					A13E7C332F27F32E00EC9EE1 /* TriggerRow.swift */,
 				A13E7C372F27F33C00EC9EE1 /* WorkflowExecutionRow.swift */,
 				20D8ED502F48E2C4006950A3 /* WorkflowPreviewSheet.swift */,
 				20D8ED542F48E2CC006950A3 /* WorkflowExecutionRow+Helpers.swift */,
@@ -1330,14 +1329,19 @@
 			path = Menu;
 			sourceTree = "<group>";
 		};
-		A1BFB2DB2F042E5100EAA55A /* Settings */ = {
-			isa = PBXGroup;
-			children = (
-				A1BFB2DA2F042E5100EAA55A /* SettingsView.swift */,
-			);
-			path = Settings;
-			sourceTree = "<group>";
-		};
+			A1BFB2DB2F042E5100EAA55A /* Settings */ = {
+				isa = PBXGroup;
+				children = (
+					1C4E4291B8C33D501F176BF5 /* AIDefaults.swift */,
+					C07B489C8F89204C43BD6E46 /* AISettingsView.swift */,
+					371A4629B0A6A51DE6D6D872 /* BackendSettingsView.swift */,
+					C0104EC0811F842CAC3CC887 /* GeneralSettingsView.swift */,
+					1F4F4939BDACA726554E086D /* LocalModelsSettingsView.swift */,
+					A1BFB2DA2F042E5100EAA55A /* SettingsView.swift */,
+				);
+				path = Settings;
+				sourceTree = "<group>";
+			};
 		A1BFB4102F057C4000EAA55A /* Toolbars */ = {
 			isa = PBXGroup;
 			children = (
@@ -1386,14 +1390,15 @@
 			path = AIProviders;
 			sourceTree = "<group>";
 		};
-		A1FB1D802F0420A90023093C /* Library */ = {
-			isa = PBXGroup;
-			children = (
-				A1FB1D7E2F0420A90023093C /* DocumentInspector.swift */,
-				108 /* EditorView.swift */,
-				A1FB1D7F2F0420A90023093C /* LibraryView.swift */,
-				A1BFB3FA2F057B9300EAA55A /* CheckerboardPattern.swift */,
-				A1BFB3FB2F057B9300EAA55A /* FolderAccessManager.swift */,
+			A1FB1D802F0420A90023093C /* Library */ = {
+				isa = PBXGroup;
+				children = (
+					A1FB1D7E2F0420A90023093C /* DocumentInspector.swift */,
+					D11000012F99900100ABC001 /* DocumentInspector */,
+					108 /* EditorView.swift */,
+					A1FB1D7F2F0420A90023093C /* LibraryView.swift */,
+					A1BFB3FA2F057B9300EAA55A /* CheckerboardPattern.swift */,
+					A1BFB3FB2F057B9300EAA55A /* FolderAccessManager.swift */,
 				A1BFB3FC2F057B9300EAA55A /* ImageViewerComponents.swift */,
 				A1BFB3FD2F057B9300EAA55A /* MagnifierPanel.swift */,
 				A1BFB3FE2F057B9300EAA55A /* NavigatorMiniMap.swift */,
@@ -1408,9 +1413,20 @@
 				AA112233001122DD /* LibraryView+ColumnConfig.swift */,
 				AA112233001122FF /* LibraryView+FilterAndBatch.swift */,
 			);
-			path = Library;
-			sourceTree = "<group>";
-		};
+				path = Library;
+				sourceTree = "<group>";
+			};
+			D11000012F99900100ABC001 /* DocumentInspector */ = {
+				isa = PBXGroup;
+				children = (
+					DD03402A88F98251F388870F /* DocumentInspectorInfoTab.swift */,
+					E7B146AE8AC4CEEC3775CB94 /* DocumentInspectorMetadataTab.swift */,
+					312845068CA928DA393E0468 /* DocumentInspectorArtifactsTab.swift */,
+					36234E44A7E494963A441CDC /* DocumentInspectorContentTab.swift */,
+				);
+				path = DocumentInspector;
+				sourceTree = "<group>";
+			};
 		B2A003000000000000BATCH2 /* WorkflowChainListView */ = {
 			isa = PBXGroup;
 			children = (

--- a/fichero-swiftui/fichero-swiftui/FicheroApp.swift
+++ b/fichero-swiftui/fichero-swiftui/FicheroApp.swift
@@ -114,7 +114,7 @@ struct FicheroApp: App {
         }
         .defaultSize(width: 1400, height: 900)
         .windowStyle(.titleBar)
-        .windowToolbarStyle(.unified(showsTitle: true))
+        .windowToolbarStyle(.unified(showsTitle: false))
         .commands {
             CommandGroup(after: .appInfo) {
                 Button("Check for Updates...") {

--- a/fichero-swiftui/fichero-swiftui/Models/FeatureManager.swift
+++ b/fichero-swiftui/fichero-swiftui/Models/FeatureManager.swift
@@ -6,8 +6,8 @@ import SwiftUI
 @MainActor
 class FeatureManager: ObservableObject {
     static let shared = FeatureManager()
-    private static let releaseProfileVersion = 16
-    private static let workflowV001EnabledTools = "files,collection,search,transcribe"
+    private static let releaseProfileVersion = 17
+    private static let workflowV001EnabledTools = "files,collection,transcribe"
 
     /// Global toggle to override all flags for internal development.
     /// In a production release, this would be hardcoded to false.

--- a/fichero-swiftui/fichero-swiftui/Views/ContentView+Actions.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/ContentView+Actions.swift
@@ -14,6 +14,9 @@ extension ContentView {
     /// Cycle keyboard focus between sidebar, content, and inspector panes
     func cyclePaneFocus(reverse: Bool) {
         var panes: [PaneFocus] = [.sidebar, .content]
+        if showsPreviewPane {
+            panes.append(.preview)
+        }
         if showInspectorSidebar {
             panes.append(.inspector)
         }
@@ -28,6 +31,16 @@ extension ContentView {
             focusedPane = panes[(idx - 1 + panes.count) % panes.count]
         } else {
             focusedPane = panes[(idx + 1) % panes.count]
+        }
+    }
+
+    private var showsPreviewPane: Bool {
+        guard currentLayoutMode != .none else { return false }
+        switch viewMode {
+        case .library, .search:
+            return true
+        default:
+            return false
         }
     }
 
@@ -69,8 +82,11 @@ extension ContentView {
     }
 
     func updateColumnVisibility() {
+        let inspectorAvailableForMode = showInspectorToggle
+        let shouldShowDetailColumn = showInspectorSidebar && inspectorAvailableForMode
+
         withAnimation {
-            if showInspectorSidebar {
+            if shouldShowDetailColumn {
                 columnVisibility = .all
             } else {
                 columnVisibility = .doubleColumn

--- a/fichero-swiftui/fichero-swiftui/Views/ContentView+ViewBuilders.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/ContentView+ViewBuilders.swift
@@ -113,13 +113,17 @@ extension ContentView {
                 contentWithOptionalModeRail
                     .overlay { paneFocusIndicator(for: .content) }
                     .frame(minHeight: 150, idealHeight: 180)
+                    .focusable()
+                    .focused($focusedPane, equals: .content)
+                    .focusEffectDisabled()
 
                 previewView
+                    .overlay { paneFocusIndicator(for: .preview) }
                     .frame(minHeight: 400, idealHeight: 720)
+                    .focusable()
+                    .focused($focusedPane, equals: .preview)
+                    .focusEffectDisabled()
             }
-            .focusable()
-            .focused($focusedPane, equals: .content)
-            .focusEffectDisabled()
             .navigationSplitViewColumnWidth(min: 350, ideal: 700, max: .infinity)
 
         case .widescreen:
@@ -128,13 +132,17 @@ extension ContentView {
                 contentWithOptionalModeRail
                     .overlay { paneFocusIndicator(for: .content) }
                     .frame(minWidth: 200, idealWidth: 200)
+                    .focusable()
+                    .focused($focusedPane, equals: .content)
+                    .focusEffectDisabled()
 
                 previewView
+                    .overlay { paneFocusIndicator(for: .preview) }
                     .frame(minWidth: 400, idealWidth: 800)
+                    .focusable()
+                    .focused($focusedPane, equals: .preview)
+                    .focusEffectDisabled()
             }
-            .focusable()
-            .focused($focusedPane, equals: .content)
-            .focusEffectDisabled()
             .navigationSplitViewColumnWidth(min: 600, ideal: 1000, max: .infinity)
         }
     }

--- a/fichero-swiftui/fichero-swiftui/Views/ContentView.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/ContentView.swift
@@ -7,7 +7,7 @@ private let logger = Logger(subsystem: "ca.tubb.Fichero", category: "ContentView
 
 /// Identifies which main pane has keyboard focus for Tab cycling
 enum PaneFocus: Hashable {
-    case sidebar, content, inspector
+    case sidebar, content, preview, inspector
 }
 
 // Main content view with three-column navigation
@@ -194,7 +194,7 @@ struct ContentView: View {
         } content: {
             centerContent
         } detail: {
-            if showInspectorSidebar {
+            if showInspectorSidebar && showInspectorToggle {
                 detailView
             } else {
                 EmptyView()
@@ -202,8 +202,7 @@ struct ContentView: View {
             }
         }
         .navigationSplitViewStyle(.prominentDetail)
-        .navigationTitle(toolbarTitle)
-        .navigationSubtitle("")
+        .navigationTitle("")
         .toolbar(removing: .sidebarToggle)
         .onAppear {
             // Restore all persisted state from @SceneStorage
@@ -217,6 +216,7 @@ struct ContentView: View {
             if viewSettings.showInspector != showInspectorSidebar {
                 viewSettings.showInspector = showInspectorSidebar
             }
+            updateColumnVisibility()
             viewDisplayMode = normalizedViewDisplayMode(viewDisplayMode)
             viewSettings.previewMode = normalizedPreviewMode(viewSettings.previewMode)
             let initialLayoutMode: LayoutMode = switch viewSettings.previewMode {
@@ -241,10 +241,13 @@ struct ContentView: View {
             if viewSettings.showInspector != newValue {
                 viewSettings.showInspector = newValue
             }
+            updateColumnVisibility()
         }
         .onChange(of: viewSettings.showInspector) { _, newValue in
             if showInspectorSidebar != newValue {
                 showInspectorSidebar = newValue
+            } else {
+                updateColumnVisibility()
             }
         }
         .toolbar {
@@ -333,6 +336,7 @@ struct ContentView: View {
                     Button {
                         withAnimation {
                             showInspectorSidebar.toggle()
+                            updateColumnVisibility()
                         }
                     } label: {
                         Image(systemName: "sidebar.right")
@@ -415,6 +419,7 @@ struct ContentView: View {
             let (type, id) = serializeViewMode(newMode)
             storedViewModeType = type
             storedViewModeItemId = id
+            updateColumnVisibility()
         }
         .onChange(of: selectedSidebarItemId) { _, newFolderId in
             // Restore per-folder view mode when switching folders

--- a/fichero-swiftui/fichero-swiftui/Views/ContentViewModifiers.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/ContentViewModifiers.swift
@@ -261,8 +261,6 @@ struct MainContentModifiers: ViewModifier {
             logger.info("Library mode with no document selected - showing all documents")
         }
 
-        // Always show all 3 columns
-        columnVisibility = .all
     }
 
     private func handleSidebarModeChange(_ newMode: SidebarMode) {

--- a/fichero-swiftui/fichero-swiftui/Views/Library/DocumentInspector/DocumentInspectorContentTab.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/DocumentInspector/DocumentInspectorContentTab.swift
@@ -10,6 +10,10 @@ struct DocumentInspectorContentTab: View {
     @State private var draftAttributedText = NSAttributedString(string: "")
     @State private var originalPlainContent: String = ""
     @State private var originalRTFBase64: String = ""
+    @State private var lastLoadedSignature: String = ""
+    @State private var pendingExternalSignature: String?
+    @State private var isEditingText = false
+    @State private var editorRevision = 0
     @State private var isSaving = false
     @State private var saveError: String?
 
@@ -25,6 +29,15 @@ struct DocumentInspectorContentTab: View {
 
     private var hasChanges: Bool {
         draftContent != originalPlainContent || currentRTFBase64 != originalRTFBase64
+    }
+
+    private var documentSignature: String {
+        signature(
+            id: document.id,
+            updatedAt: document.updatedAt,
+            pageContent: document.pageContent,
+            richTextBase64: document.metadata[Self.richTextMetadataKey]?.value as? String
+        )
     }
 
     var body: some View {
@@ -64,11 +77,21 @@ struct DocumentInspectorContentTab: View {
             }
 
             ZStack(alignment: .topLeading) {
-                AttributedTextEditor(text: $draftAttributedText)
+                AttributedTextEditor(
+                    text: $draftAttributedText,
+                    isEditable: !isSaving,
+                    contentRevision: editorRevision,
+                    onEditingChanged: { isEditing in
+                        isEditingText = isEditing
+                        if !isEditing, pendingExternalSignature != nil, !hasChanges {
+                            loadDraft(from: document)
+                            saveError = nil
+                        }
+                    }
+                )
                     .frame(minHeight: 220)
                     .background(Color(.textBackgroundColor))
                     .cornerRadius(6)
-                    .disabled(isSaving)
 
                 if draftContent.isEmpty {
                     Text("Add notes or edit extracted text...")
@@ -83,6 +106,10 @@ struct DocumentInspectorContentTab: View {
                 Text(saveError)
                     .font(.caption)
                     .foregroundStyle(.red)
+            } else if pendingExternalSignature != nil {
+                Text("Document changed in the background. Save or Revert to refresh.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             } else if isSaving {
                 HStack(spacing: 6) {
                     ProgressView()
@@ -96,7 +123,12 @@ struct DocumentInspectorContentTab: View {
         .onAppear {
             loadDraft(from: document)
         }
-        .onChange(of: document.id) { _, _ in
+        .onChange(of: documentSignature) { _, newSignature in
+            guard newSignature != lastLoadedSignature else { return }
+            if isEditingText && hasChanges {
+                pendingExternalSignature = newSignature
+                return
+            }
             loadDraft(from: document)
             saveError = nil
         }
@@ -129,6 +161,7 @@ struct DocumentInspectorContentTab: View {
                 documentStore.updateLocal(updated)
                 documentStore.publish(.documentsUpdated(documentStore.currentDocuments))
                 loadDraft(from: updated)
+                pendingExternalSignature = nil
             } catch {
                 saveError = "Failed to save text: \(error.localizedDescription)"
             }
@@ -139,11 +172,16 @@ struct DocumentInspectorContentTab: View {
     private func loadDraft(from doc: Document) {
         let plainText = doc.pageContent ?? ""
         let metadataValue = doc.metadata[Self.richTextMetadataKey]?.value as? String
-        let richText = decodeRTF(base64: metadataValue) ?? NSAttributedString(string: plainText)
+        let richText = normalizeForEditor(
+            decodeRTF(base64: metadataValue) ?? NSAttributedString(string: plainText)
+        )
 
         draftAttributedText = richText
         originalPlainContent = plainText
         originalRTFBase64 = metadataValue ?? ""
+        lastLoadedSignature = signature(for: doc)
+        pendingExternalSignature = nil
+        editorRevision += 1
     }
 
     private func decodeRTF(base64: String?) -> NSAttributedString? {
@@ -185,57 +223,131 @@ struct DocumentInspectorContentTab: View {
             return String(describing: value)
         }
     }
+
+    private func signature(for doc: Document) -> String {
+        signature(
+            id: doc.id,
+            updatedAt: doc.updatedAt,
+            pageContent: doc.pageContent,
+            richTextBase64: doc.metadata[Self.richTextMetadataKey]?.value as? String
+        )
+    }
+
+    private func signature(
+        id: String,
+        updatedAt: Date,
+        pageContent: String?,
+        richTextBase64: String?
+    ) -> String {
+        "\(id)|\(updatedAt.timeIntervalSince1970)|\(pageContent ?? "")|\(richTextBase64 ?? "")"
+    }
+
+    private func normalizeForEditor(_ attributed: NSAttributedString) -> NSAttributedString {
+        let mutable = NSMutableAttributedString(attributedString: attributed)
+        guard mutable.length > 0 else {
+            // Keep empty content truly empty; typing attributes are provided by NSTextView config.
+            return mutable
+        }
+        let fullRange = NSRange(location: 0, length: mutable.length)
+
+        // Ensure text remains visible in all appearances.
+        mutable.addAttribute(.foregroundColor, value: NSColor.labelColor, range: fullRange)
+        if mutable.attribute(.font, at: 0, effectiveRange: nil) == nil {
+            mutable.addAttribute(.font, value: NSFont.systemFont(ofSize: NSFont.systemFontSize), range: fullRange)
+        }
+        return mutable
+    }
 }
 
 private struct AttributedTextEditor: NSViewRepresentable {
     @Binding var text: NSAttributedString
+    let isEditable: Bool
+    let contentRevision: Int
+    let onEditingChanged: (Bool) -> Void
 
     func makeNSView(context: Context) -> NSScrollView {
         let scrollView = NSScrollView()
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
         scrollView.borderType = .noBorder
-        scrollView.drawsBackground = false
+        scrollView.drawsBackground = true
+        scrollView.backgroundColor = .textBackgroundColor
 
         let textView = NSTextView()
-        textView.isEditable = true
+        textView.isEditable = isEditable
+        textView.isSelectable = true
         textView.isRichText = true
         textView.importsGraphics = false
         textView.allowsUndo = true
-        textView.usesAdaptiveColorMappingForDarkAppearance = true
-        textView.drawsBackground = false
+        textView.isAutomaticTextCompletionEnabled = true
+        textView.isContinuousSpellCheckingEnabled = true
+        textView.isGrammarCheckingEnabled = true
+        textView.isAutomaticSpellingCorrectionEnabled = true
+        textView.drawsBackground = true
+        textView.backgroundColor = .textBackgroundColor
+        textView.textColor = .labelColor
         textView.font = .systemFont(ofSize: NSFont.systemFontSize)
         textView.textContainerInset = NSSize(width: 8, height: 8)
+        textView.textContainer?.widthTracksTextView = true
+        textView.isHorizontallyResizable = false
+        textView.autoresizingMask = [.width]
         textView.delegate = context.coordinator
         textView.textStorage?.setAttributedString(text)
 
         scrollView.documentView = textView
         context.coordinator.textView = textView
+        context.coordinator.lastAppliedRevision = contentRevision
         return scrollView
     }
 
     func updateNSView(_ scrollView: NSScrollView, context: Context) {
         guard let textView = context.coordinator.textView else { return }
-        if textView.attributedString() != text {
-            textView.textStorage?.setAttributedString(text)
-        }
-    }
+        textView.isEditable = isEditable
 
-    func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
+        // Only push model text into AppKit view on explicit revision changes.
+        // This avoids clobbering active edits and selection.
+        if context.coordinator.lastAppliedRevision != contentRevision {
+            let selectedRanges = textView.selectedRanges
+            context.coordinator.isApplyingModelUpdate = true
+            textView.textStorage?.setAttributedString(text)
+            textView.setSelectedRanges(
+                selectedRanges,
+                affinity: textView.selectionAffinity,
+                stillSelecting: false
+            )
+            context.coordinator.lastAppliedRevision = contentRevision
+            context.coordinator.isApplyingModelUpdate = false
+        }
     }
 
     final class Coordinator: NSObject, NSTextViewDelegate {
         @Binding var text: NSAttributedString
         weak var textView: NSTextView?
+        var isApplyingModelUpdate = false
+        var lastAppliedRevision = 0
+        let onEditingChanged: (Bool) -> Void
 
-        init(text: Binding<NSAttributedString>) {
+        init(text: Binding<NSAttributedString>, onEditingChanged: @escaping (Bool) -> Void) {
             _text = text
+            self.onEditingChanged = onEditingChanged
         }
 
         func textDidChange(_ notification: Notification) {
             guard let textView else { return }
+            guard !isApplyingModelUpdate else { return }
             text = textView.attributedString()
         }
+
+        func textDidBeginEditing(_ notification: Notification) {
+            onEditingChanged(true)
+        }
+
+        func textDidEndEditing(_ notification: Notification) {
+            onEditingChanged(false)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text, onEditingChanged: onEditingChanged)
     }
 }

--- a/fichero-swiftui/fichero-swiftui/Views/Library/ImageViewer/ImageWithCursorTracking.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/ImageViewer/ImageWithCursorTracking.swift
@@ -409,5 +409,23 @@ struct ImageWithCursorTracking: NSViewRepresentable {
             scrollView.contentView.scroll(to: CGPoint(x: centerX, y: centerY))
             scrollView.reflectScrolledClipView(scrollView.contentView)
         }
+
+        /// Pan the visible area by a relative number of points in document coordinates.
+        @MainActor
+        func panBy(x deltaX: CGFloat, y deltaY: CGFloat) {
+            guard let scrollView = scrollView,
+                  let imageView = imageView as? NSImageView,
+                  let image = imageView.image else { return }
+
+            let visibleRect = scrollView.contentView.documentVisibleRect
+            let maxX = max(0, image.size.width - visibleRect.width)
+            let maxY = max(0, image.size.height - visibleRect.height)
+
+            let targetX = min(max(0, visibleRect.origin.x + deltaX), maxX)
+            let targetY = min(max(0, visibleRect.origin.y + deltaY), maxY)
+
+            scrollView.contentView.scroll(to: CGPoint(x: targetX, y: targetY))
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+        }
     }
 }

--- a/fichero-swiftui/fichero-swiftui/Views/Library/ImageViewerComponents.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/ImageViewerComponents.swift
@@ -1,6 +1,6 @@
-import SwiftUI
 import AppKit
 import OSLog
+import SwiftUI
 
 // MARK: - Zoomable Image Preview (with controls and magnifier)
 
@@ -262,6 +262,22 @@ struct ZoomableImagePreview: View {
             fitToWindow()
             return .handled
         }
+        .onKeyPress(.leftArrow, phases: .down) { _ in
+            panLeft()
+            return .handled
+        }
+        .onKeyPress(.rightArrow, phases: .down) { _ in
+            panRight()
+            return .handled
+        }
+        .onKeyPress(.upArrow, phases: .down) { _ in
+            panUp()
+            return .handled
+        }
+        .onKeyPress(.downArrow, phases: .down) { _ in
+            panDown()
+            return .handled
+        }
         .focusedSceneValue(\.imageZoomActions, ImageZoomActions(
             zoomIn: zoomIn,
             zoomOut: zoomOut,
@@ -305,5 +321,28 @@ struct ZoomableImagePreview: View {
         withAnimation(.easeInOut(duration: 0.2)) {
             scale = 1.0
         }
+    }
+
+    private func panLeft() {
+        panBy(deltaX: -80, deltaY: 0)
+    }
+
+    private func panRight() {
+        panBy(deltaX: 80, deltaY: 0)
+    }
+
+    private func panUp() {
+        panBy(deltaX: 0, deltaY: 80)
+    }
+
+    private func panDown() {
+        panBy(deltaX: 0, deltaY: -80)
+    }
+
+    private func panBy(deltaX: CGFloat, deltaY: CGFloat) {
+        imageCoordinator?.panBy(
+            x: deltaX / max(scale, 0.01),
+            y: deltaY / max(scale, 0.01)
+        )
     }
 }

--- a/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+KeyboardShortcuts.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+KeyboardShortcuts.swift
@@ -34,6 +34,9 @@ extension LibraryView {
             .onKeyPress(.rightArrow) {
                 handleArrowKey(direction: .right)
             }
+            .onMoveCommand { direction in
+                handleMoveCommand(direction)
+            }
             .focusedSceneValue(\.librarySelectAll, !filteredDocuments.isEmpty ? {
                 selectAll()
             } : nil)
@@ -119,6 +122,21 @@ extension LibraryView {
 
     enum ArrowDirection {
         case upDir, down, left, right
+    }
+
+    func handleMoveCommand(_ direction: MoveCommandDirection) {
+        switch direction {
+        case .up:
+            _ = handleArrowKey(direction: .upDir)
+        case .down:
+            _ = handleArrowKey(direction: .down)
+        case .left:
+            _ = handleArrowKey(direction: .left)
+        case .right:
+            _ = handleArrowKey(direction: .right)
+        default:
+            break
+        }
     }
 
     /// Handle arrow key press for navigating documents.

--- a/fichero-swiftui/fichero-swiftui/Views/Menu/AddItemMenu.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Menu/AddItemMenu.swift
@@ -36,51 +36,117 @@ struct AddItemMenu: View {
 
     @ViewBuilder
     private var menuContent: some View {
-        if let sidebarActions {
+        if let createFolderAction {
             Button("New Folder") {
-                sidebarActions.createFolder()
+                createFolderAction()
             }
 
             Menu("Import") {
                 Button("Link Files...") {
-                    sidebarActions.importFiles(.link)
+                    importLinkAction?()
                 }
+                .disabled(importLinkAction == nil)
 
                 Button("Copy Files...") {
-                    sidebarActions.importFiles(.copy)
+                    importCopyAction?()
                 }
+                .disabled(importCopyAction == nil)
 
                 Button("Add Files...") {
-                    sidebarActions.importFiles(.move)
+                    importMoveAction?()
                 }
+                .disabled(importMoveAction == nil)
             }
+            .disabled(importLinkAction == nil && importCopyAction == nil && importMoveAction == nil)
 
             Divider()
 
             if featureManager.isSearchEnabled {
                 Button("New Search") {
-                    sidebarActions.createSearch()
+                    createSearchAction?()
                 }
+                .disabled(createSearchAction == nil)
             }
 
             if featureManager.isChatEnabled {
                 Button("New Chat") {
-                    sidebarActions.createChat()
+                    createChatAction?()
                 }
+                .disabled(createChatAction == nil)
             }
 
             if featureManager.isWorkflowsEnabled {
                 Button("New Workflow") {
-                    sidebarActions.createWorkflow()
+                    createWorkflowAction?()
                 }
+                .disabled(createWorkflowAction == nil)
             }
 
             if featureManager.isAutomationEnabled {
                 Button("New Schedule") {
-                    sidebarActions.createSchedule()
+                    createScheduleAction?()
                 }
+                .disabled(createScheduleAction == nil)
             }
+        } else {
+            Text("No create actions available")
         }
+    }
+
+    private var createFolderAction: (() -> Void)? {
+        if let sidebarActions {
+            return sidebarActions.createFolder
+        }
+        return registry.createFolder
+    }
+
+    private var importLinkAction: (() -> Void)? {
+        if let sidebarActions {
+            return { sidebarActions.importFiles(.link) }
+        }
+        return registry.importFiles
+    }
+
+    private var importCopyAction: (() -> Void)? {
+        if let sidebarActions {
+            return { sidebarActions.importFiles(.copy) }
+        }
+        return registry.importFiles
+    }
+
+    private var importMoveAction: (() -> Void)? {
+        if let sidebarActions {
+            return { sidebarActions.importFiles(.move) }
+        }
+        return registry.importFiles
+    }
+
+    private var createSearchAction: (() -> Void)? {
+        if let sidebarActions {
+            return sidebarActions.createSearch
+        }
+        return registry.createSearch
+    }
+
+    private var createChatAction: (() -> Void)? {
+        if let sidebarActions {
+            return sidebarActions.createChat
+        }
+        return registry.createChat
+    }
+
+    private var createWorkflowAction: (() -> Void)? {
+        if let sidebarActions {
+            return sidebarActions.createWorkflow
+        }
+        return registry.createWorkflow
+    }
+
+    private var createScheduleAction: (() -> Void)? {
+        if let sidebarActions {
+            return sidebarActions.createSchedule
+        }
+        return registry.createSchedule
     }
 }
 

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/DynamicConfigView+FieldRendering.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/DynamicConfigView+FieldRendering.swift
@@ -1,47 +1,63 @@
 import SwiftUI
 
+private struct DynamicFolderPickerOption: Identifiable {
+    let folder: Document
+    let depth: Int
+
+    var id: String { folder.id }
+
+    var indentedName: String {
+        String(repeating: "  ", count: depth) + folder.name
+    }
+}
+
 extension DynamicConfigView {
 
     // MARK: - Field Rendering
 
     @ViewBuilder
+    // swiftlint:disable:next cyclomatic_complexity
     func configField(key: String, schema: [String: AnyCodableValue]) -> some View {
         if let type = getType(from: schema) {
             let description = getDescription(from: schema)
             let label = key.replacingOccurrences(of: "_", with: " ").capitalized
 
             VStack(alignment: .leading, spacing: 4) {
-            Text(label)
-                .font(.caption)
-                .foregroundColor(.secondary)
-
-            switch type {
-            case "string":
-                if let enumValues = getEnum(from: schema) {
-                    enumPicker(key: key, label: label, options: enumValues, description: description)
-                } else if key == "prompt" {
-                    promptEditor(key: key, description: description)
-                } else {
-                    stringField(key: key, description: description)
+                if type != "boolean" {
+                    Text(label)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 }
 
-            case "integer":
-                integerField(key: key, schema: schema, description: description)
+                switch type {
+                case "string":
+                    if isFolderTool, key == "folder_id" {
+                        folderPickerField()
+                    } else if let enumValues = getEnum(from: schema) {
+                        enumPicker(key: key, label: label, options: enumValues, description: description)
+                    } else if key == "prompt" {
+                        promptEditor(key: key, description: description)
+                    } else {
+                        stringField(key: key, description: description)
+                    }
 
-            case "number":
-                numberSlider(key: key, schema: schema, description: description)
+                case "integer":
+                    integerField(key: key, schema: schema, description: description)
 
-            case "array":
-                arrayField(key: key, schema: schema, description: description)
+                case "number":
+                    numberSlider(key: key, schema: schema, description: description)
 
-            case "boolean":
-                booleanToggle(key: key, description: description)
+                case "array":
+                    arrayField(key: key, schema: schema, description: description)
 
-            default:
-                Text("Unsupported type: \(type)")
-                    .font(.caption2)
-                    .foregroundColor(.red)
-            }
+                case "boolean":
+                    booleanToggle(key: key, description: description, label: label)
+
+                default:
+                    Text("Unsupported type: \(type)")
+                        .font(.caption2)
+                        .foregroundColor(.red)
+                }
 
                 if type != "boolean", let desc = description {
                     Text(desc)
@@ -131,7 +147,7 @@ extension DynamicConfigView {
         Group {
             if key == "max_image_dimension" {
                 Picker("Max Image Size", selection: Binding(
-                    get: { intValues[key] ?? 2048 },
+                    get: { intValues[key] ?? 11024 },
                     set: { newValue in
                         intValues[key] = newValue
                         updateConfig(key: key, value: .int(newValue))
@@ -141,7 +157,8 @@ extension DynamicConfigView {
                     Text("768px (Fast)").tag(768)
                     Text("1024px (Balanced)").tag(1024)
                     Text("1536px (Detailed)").tag(1536)
-                    Text("2048px (Default)").tag(2048)
+                    Text("2048px").tag(2048)
+                    Text("11024px (Default)").tag(11024)
                     Text("Original Size (Maximum)").tag(0)
                 }
                 .pickerStyle(.menu)
@@ -158,8 +175,8 @@ extension DynamicConfigView {
         }
     }
 
-    func booleanToggle(key: String, description: String?) -> some View {
-        Toggle(description ?? "", isOn: Binding(
+    func booleanToggle(key: String, description: String?, label: String) -> some View {
+        Toggle(description ?? label, isOn: Binding(
             get: { boolValues[key] ?? false },
             set: { newValue in
                 boolValues[key] = newValue
@@ -228,5 +245,84 @@ extension DynamicConfigView {
             }
         }
         return []
+    }
+
+    @ViewBuilder
+    private func folderPickerField() -> some View {
+        let folderOptions = buildFolderOptions(from: documentStore.collections)
+
+        Picker("Folder", selection: Binding(
+            get: { stringValues["folder_id"] ?? "" },
+            set: { newValue in
+                stringValues["folder_id"] = newValue
+                updateConfig(key: "folder_id", value: .string(newValue))
+
+                if let folder = folderOptions.first(where: { $0.folder.id == newValue })?.folder {
+                    let resolvedPath = folder.path ?? "/"
+                    stringValues["folder_path"] = resolvedPath
+                    updateConfig(key: "folder_path", value: .string(resolvedPath))
+                }
+            }
+        )) {
+            Text("Select folder...").tag("")
+            ForEach(folderOptions) { option in
+                Text(option.indentedName).tag(option.folder.id)
+            }
+        }
+        .pickerStyle(.menu)
+
+        if folderOptions.isEmpty {
+            Text("No folders found. Create one in Library first.")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .italic()
+        }
+    }
+
+    private func buildFolderOptions(from documents: [Document]) -> [DynamicFolderPickerOption] {
+        let allFolders = documents
+            .filter { $0.docType == .folder }
+            .sorted { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+
+        let validFolderIds = Set(allFolders.map(\.id))
+
+        var childrenMap: [String: [Document]] = [:]
+        for folder in allFolders {
+            guard let parentId = folder.parentId, validFolderIds.contains(parentId) else { continue }
+            childrenMap[parentId, default: []].append(folder)
+        }
+
+        for key in childrenMap.keys {
+            childrenMap[key]?.sort { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+        }
+
+        let inboxRoots = allFolders.filter { $0.parentId == nil && $0.name == "Inbox" }
+        let otherRoots = allFolders
+            .filter { folder in
+                folder.parentId == nil && folder.name != "Inbox"
+            }
+            .sorted { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+        let orderedRoots = inboxRoots + otherRoots
+
+        var options: [DynamicFolderPickerOption] = []
+
+        func traverse(_ folder: Document, depth: Int) {
+            options.append(DynamicFolderPickerOption(folder: folder, depth: depth))
+            for child in childrenMap[folder.id] ?? [] {
+                traverse(child, depth: depth + 1)
+            }
+        }
+
+        for root in orderedRoots {
+            traverse(root, depth: 0)
+        }
+
+        return options
     }
 }

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/DynamicConfigView.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/DynamicConfigView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct DynamicConfigView: View {
     let toolInfo: ToolInfo
     @Binding var config: [String: AnyCodableValue]?
+    @EnvironmentObject var documentStore: DocumentStore
 
     @State var stringValues: [String: String] = [:]
     @State var intValues: [String: Int] = [:]
@@ -51,6 +52,11 @@ struct DynamicConfigView: View {
         .onAppear {
             initializeValues()
         }
+        .task {
+            if isFolderTool, documentStore.collections.isEmpty {
+                await documentStore.loadCollections()
+            }
+        }
     }
 
     // MARK: - Grouped Keys
@@ -61,11 +67,21 @@ struct DynamicConfigView: View {
         toolInfo.configSchema.keys.filter { key in
             guard !dedicatedKeys.contains(key) else { return false }
             guard let schema = getFieldSchema(for: key) else { return false }
+            if isFolderTool, key == "folder_path" {
+                return false
+            }
             return !isHidden(schema: schema)
         }
     }
 
     var primaryKeys: [String] {
+        if isFolderTool {
+            let preferredOrder = ["folder_id", "file_types", "include_subfolders", "limit"]
+            let ordered = preferredOrder.filter { visibleKeys.contains($0) }
+            let rest = visibleKeys.filter { !preferredOrder.contains($0) }.sorted()
+            return ordered + rest
+        }
+
         let keys = visibleKeys.filter { key in
             guard let schema = getFieldSchema(for: key) else { return false }
             let group = getGroup(from: schema)
@@ -91,5 +107,9 @@ struct DynamicConfigView: View {
             guard let schema = getFieldSchema(for: key) else { return false }
             return getGroup(from: schema) == "advanced"
         }.sorted()
+    }
+
+    var isFolderTool: Bool {
+        toolInfo.name == "folder"
     }
 }

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/CollectionNodeConfig.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/CollectionNodeConfig.swift
@@ -1,5 +1,16 @@
 import SwiftUI
 
+private struct FolderPickerOption: Identifiable {
+    let folder: Document
+    let depth: Int
+
+    var id: String { folder.id }
+
+    var indentedName: String {
+        String(repeating: "  ", count: depth) + folder.name
+    }
+}
+
 /// Configuration view for collection node
 struct CollectionNodeConfig: View {
     @Binding var node: WorkflowNode
@@ -8,10 +19,12 @@ struct CollectionNodeConfig: View {
 
     @State private var collectionId: String = ""
 
-    private var folders: [Document] {
-        documentStore.collections
-            .filter { $0.docType == .folder }
-            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+    private var folderOptions: [FolderPickerOption] {
+        buildFolderOptions(from: documentStore.collections)
+    }
+
+    private var foldersById: [String: Document] {
+        Dictionary(uniqueKeysWithValues: folderOptions.map { ($0.folder.id, $0.folder) })
     }
 
     var body: some View {
@@ -22,8 +35,8 @@ struct CollectionNodeConfig: View {
 
             Picker("Select collection", selection: $collectionId) {
                 Text("Select...").tag("")
-                ForEach(folders, id: \.id) { folder in
-                    Text(folder.name).tag(folder.id)
+                ForEach(folderOptions) { option in
+                    Text(option.indentedName).tag(option.folder.id)
                 }
             }
             .pickerStyle(.menu)
@@ -33,7 +46,7 @@ struct CollectionNodeConfig: View {
                 }
                 node.config?["collection_id"] = .string(newValue)
             }
-            if folders.isEmpty {
+            if folderOptions.isEmpty {
                 Text("No folders found. Create a folder in Library first.")
                     .font(.caption2)
                     .foregroundColor(.secondary)
@@ -48,6 +61,16 @@ struct CollectionNodeConfig: View {
         .onAppear {
             loadInitialState()
         }
+        .onChange(of: documentStore.collections) { _, _ in
+            guard !collectionId.isEmpty else { return }
+            if foldersById[collectionId] == nil {
+                collectionId = ""
+                if node.config == nil {
+                    node.config = [:]
+                }
+                node.config?["collection_id"] = .string("")
+            }
+        }
     }
 
     private func loadInitialState() {
@@ -55,5 +78,52 @@ struct CollectionNodeConfig: View {
            case .string(let id) = configValue {
             collectionId = id
         }
+    }
+
+    private func buildFolderOptions(from documents: [Document]) -> [FolderPickerOption] {
+        let allFolders = documents
+            .filter { $0.docType == .folder }
+            .sorted { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+
+        let validFolderIds = Set(allFolders.map(\.id))
+
+        var childrenMap: [String: [Document]] = [:]
+        for folder in allFolders {
+            guard let parentId = folder.parentId, validFolderIds.contains(parentId) else { continue }
+            childrenMap[parentId, default: []].append(folder)
+        }
+
+        for key in childrenMap.keys {
+            childrenMap[key]?.sort { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+        }
+
+        let inboxRoots = allFolders.filter { $0.parentId == nil && $0.name == "Inbox" }
+        let otherRoots = allFolders
+            .filter { folder in
+                folder.parentId == nil && folder.name != "Inbox"
+            }
+            .sorted { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+        let orderedRoots = inboxRoots + otherRoots
+
+        var options: [FolderPickerOption] = []
+
+        func traverse(_ folder: Document, depth: Int) {
+            options.append(FolderPickerOption(folder: folder, depth: depth))
+            for child in childrenMap[folder.id] ?? [] {
+                traverse(child, depth: depth + 1)
+            }
+        }
+
+        for root in orderedRoots {
+            traverse(root, depth: 0)
+        }
+
+        return options
     }
 }

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/FilesNodeConfig.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/FilesNodeConfig.swift
@@ -13,6 +13,7 @@ struct FilesNodeConfig: View {
     @State private var showFilePicker = false
     @State private var stagedPickerSelection: Set<String> = []
     @State private var fileSearchText = ""
+    @State private var expandedFolderIds: Set<String> = []
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -70,14 +71,32 @@ struct FilesNodeConfig: View {
             }
     }
 
+    private var allFolders: [Document] {
+        documentStore.collections
+            .filter { $0.docType == .folder }
+            .sorted { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+    }
+
+    private var validFolderIds: Set<String> {
+        Set(allFolders.map(\.id))
+    }
+
     private var availableDocuments: [Document] {
         let candidates = documentStore.collections
-            .filter { $0.docType != .folder }
-            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            .filter { $0.docType == .file }
+            .filter { doc in
+                guard !doc.id.isEmpty else { return false }
+                guard let parentId = doc.parentId else { return true }
+                return validFolderIds.contains(parentId)
+            }
+            .sorted { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
 
         var seen = Set<String>()
         return candidates.filter { doc in
-            guard !doc.id.isEmpty else { return false }
             if seen.contains(doc.id) {
                 return false
             }
@@ -86,10 +105,41 @@ struct FilesNodeConfig: View {
         }
     }
 
+    private var folderChildrenMap: [String: [Document]] {
+        var map: [String: [Document]] = [:]
+        for folder in allFolders {
+            guard let parentId = folder.parentId, validFolderIds.contains(parentId) else { continue }
+            map[parentId, default: []].append(folder)
+        }
+        for key in map.keys {
+            map[key]?.sort { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+        }
+        return map
+    }
+
+    private var filesByParentMap: [String?: [Document]] {
+        let files = filteredDocuments
+        return Dictionary(grouping: files, by: { $0.parentId })
+    }
+
+    private var rootFolders: [Document] {
+        let inbox = allFolders.filter { $0.parentId == nil && $0.name == "Inbox" }
+        let otherRoots = allFolders
+            .filter { folder in
+                folder.parentId == nil && folder.name != "Inbox"
+            }
+            .sorted { lhs, rhs in
+                lhs.name.localizedCaseInsensitiveCompare(rhs.name) == .orderedAscending
+            }
+        return inbox + otherRoots
+    }
+
     private var filteredDocuments: [Document] {
         guard !fileSearchText.isEmpty else { return availableDocuments }
-        return availableDocuments.filter {
-            $0.name.localizedCaseInsensitiveContains(fileSearchText)
+        return availableDocuments.filter { doc in
+            doc.name.localizedCaseInsensitiveContains(fileSearchText)
         }
     }
 
@@ -143,6 +193,7 @@ struct FilesNodeConfig: View {
     private func showFilePickerSheet() {
         fileSearchText = ""
         stagedPickerSelection = Set(selectedFileIds)
+        expandedFolderIds = Set(rootFolders.map(\.id))
         showFilePicker = true
     }
 
@@ -164,37 +215,20 @@ struct FilesNodeConfig: View {
             } else {
                 ScrollView {
                     LazyVStack(spacing: 2) {
-                        ForEach(filteredDocuments, id: \.id) { doc in
-                            Button {
-                                togglePickerSelection(doc.id)
-                            } label: {
-                                HStack {
-                                    Image(
-                                        systemName: stagedPickerSelection.contains(doc.id)
-                                            ? "checkmark.circle.fill"
-                                            : "circle"
-                                    )
-                                    .foregroundStyle(
-                                        stagedPickerSelection.contains(doc.id)
-                                            ? Color.accentColor
-                                            : Color.secondary
-                                    )
-                                    Text(doc.name)
-                                        .foregroundStyle(.primary)
-                                        .lineLimit(1)
-                                    Spacer()
-                                }
-                                .padding(.vertical, 4)
+                        ForEach(rootFolders, id: \.id) { folder in
+                            folderSection(folder, depth: 0)
+                        }
+
+                        if let rootFiles = filesByParentMap[nil], !rootFiles.isEmpty {
+                            Text("Root")
+                                .font(.caption2)
+                                .foregroundColor(.secondary)
+                                .padding(.top, 6)
                                 .padding(.horizontal, 6)
-                                .contentShape(Rectangle())
+
+                            ForEach(rootFiles, id: \.id) { doc in
+                                filePickerRow(doc: doc, depth: 1)
                             }
-                            .buttonStyle(.plain)
-                            .background(
-                                RoundedRectangle(cornerRadius: 4)
-                                    .fill(stagedPickerSelection.contains(doc.id)
-                                        ? Color.accentColor.opacity(0.12)
-                                        : Color.clear)
-                            )
                         }
                     }
                     .padding(2)
@@ -231,6 +265,85 @@ struct FilesNodeConfig: View {
         } else {
             stagedPickerSelection.insert(id)
         }
+    }
+
+    private func folderSection(_ folder: Document, depth: Int) -> AnyView {
+        AnyView(
+            DisclosureGroup(
+            isExpanded: Binding(
+                get: { expandedFolderIds.contains(folder.id) },
+                set: { isExpanded in
+                    if isExpanded {
+                        expandedFolderIds.insert(folder.id)
+                    } else {
+                        expandedFolderIds.remove(folder.id)
+                    }
+                }
+            )
+        ) {
+            if let directFiles = filesByParentMap[folder.id], !directFiles.isEmpty {
+                ForEach(directFiles, id: \.id) { doc in
+                    filePickerRow(doc: doc, depth: depth + 1)
+                }
+            }
+
+            if let children = folderChildrenMap[folder.id] {
+                ForEach(children, id: \.id) { child in
+                    folderSection(child, depth: depth + 1)
+                }
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: folder.name == "Inbox" ? "tray.fill" : "folder")
+                    .foregroundStyle(.secondary)
+                Text(folder.name)
+                    .lineLimit(1)
+                    .foregroundStyle(.primary)
+                Spacer()
+            }
+            .padding(.vertical, 4)
+            .padding(.leading, CGFloat(depth) * 14 + 4)
+            .padding(.trailing, 6)
+            }
+            .disclosureGroupStyle(.automatic)
+        )
+    }
+
+    @ViewBuilder
+    private func filePickerRow(doc: Document, depth: Int) -> some View {
+        Button {
+            togglePickerSelection(doc.id)
+        } label: {
+            HStack(spacing: 6) {
+                Image(
+                    systemName: stagedPickerSelection.contains(doc.id)
+                        ? "checkmark.circle.fill"
+                        : "circle"
+                )
+                .foregroundStyle(
+                    stagedPickerSelection.contains(doc.id)
+                        ? Color.accentColor
+                        : Color.secondary
+                )
+                Image(systemName: doc.fileType?.icon ?? "doc")
+                    .foregroundStyle(.secondary)
+                Text(doc.name)
+                    .foregroundStyle(.primary)
+                    .lineLimit(1)
+                Spacer()
+            }
+            .padding(.vertical, 4)
+            .padding(.leading, CGFloat(depth) * 14 + 6)
+            .padding(.trailing, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(stagedPickerSelection.contains(doc.id)
+                    ? Color.accentColor.opacity(0.12)
+                    : Color.clear)
+        )
     }
 
     private func syncConfig() {

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/TranscribeNodeConfig.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/TranscribeNodeConfig.swift
@@ -9,7 +9,7 @@ struct TranscribeNodeConfig: View {
 
     @State private var visionMode: String = "apple"
     @State private var language: String = "en"
-    @State private var maxImageDimension: Double = 2048
+    @State private var maxImageDimension: Double = 11024
     @State private var promptText: String = ""
 
     /// Get the current default prompt - from backend if available, otherwise nil
@@ -79,7 +79,8 @@ struct TranscribeNodeConfig: View {
                         Text("768px (Fast)").tag(768.0)
                         Text("1024px (Balanced)").tag(1024.0)
                         Text("1536px (Detailed)").tag(1536.0)
-                        Text("2048px (Default)").tag(2048.0)
+                        Text("2048px").tag(2048.0)
+                        Text("11024px (Default)").tag(11024.0)
                         Text("Original Size (Maximum)").tag(0.0)
                     }
                     .pickerStyle(.menu)

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodePopover.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodePopover.swift
@@ -25,6 +25,7 @@ struct NodePopover: View {
     @EnvironmentObject var documentStore: DocumentStore
     @EnvironmentObject var savedSearchServiceGenerated: SavedSearchServiceGenerated
     @EnvironmentObject var workflowService: WorkflowServiceGenerated
+    @ObservedObject var featureManager = FeatureManager.shared
 
     // Dynamic prompt from backend (fetched based on current config)
     @State private var backendPrompt: String?
@@ -230,7 +231,7 @@ struct NodePopover: View {
                 }
 
                 // Input mappings section
-                if !node.inputPorts.isEmpty {
+                if featureManager.isWorkflowEditorAdvancedViewsEnabled, !node.inputPorts.isEmpty {
                     inputMappingsSection
                 }
             }

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/WorkflowCanvasView+EdgeConnection.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/WorkflowCanvasView+EdgeConnection.swift
@@ -207,26 +207,41 @@ extension WorkflowCanvasView {
 extension WorkflowCanvasView {
     func calculatePortPositions() -> [String: CGPoint] {
         var positions: [String: CGPoint] = [:]
+        let showAdvancedPorts = FeatureManager.shared.isWorkflowEditorAdvancedViewsEnabled
 
         for node in workflow.nodes {
             let nodePosition = CGPoint(x: node.positionX, y: node.positionY)
 
             // Input ports on left side
-            let inputCount = max(node.inputPorts.count, 1)
-            let inputSpacing = nodeHeight / CGFloat(inputCount + 1)
-            for (index, port) in node.inputPorts.enumerated() {
-                let portY = nodePosition.y - nodeHeight / 2 + inputSpacing * CGFloat(index + 1)
-                let portX = nodePosition.x - nodeWidth / 2
-                positions["\(node.id):\(port.id)"] = CGPoint(x: portX, y: portY)
+            if showAdvancedPorts {
+                let inputCount = max(node.inputPorts.count, 1)
+                let inputSpacing = nodeHeight / CGFloat(inputCount + 1)
+                for (index, port) in node.inputPorts.enumerated() {
+                    let portY = nodePosition.y - nodeHeight / 2 + inputSpacing * CGFloat(index + 1)
+                    let portX = nodePosition.x - nodeWidth / 2
+                    positions["\(node.id):\(port.id)"] = CGPoint(x: portX, y: portY)
+                }
+            } else {
+                let unifiedInputPoint = CGPoint(x: nodePosition.x - nodeWidth / 2, y: nodePosition.y)
+                for port in node.inputPorts {
+                    positions["\(node.id):\(port.id)"] = unifiedInputPoint
+                }
             }
 
             // Output ports on right side
-            let outputCount = max(node.outputPorts.count, 1)
-            let outputSpacing = nodeHeight / CGFloat(outputCount + 1)
-            for (index, port) in node.outputPorts.enumerated() {
-                let portY = nodePosition.y - nodeHeight / 2 + outputSpacing * CGFloat(index + 1)
-                let portX = nodePosition.x + nodeWidth / 2
-                positions["\(node.id):\(port.id)"] = CGPoint(x: portX, y: portY)
+            if showAdvancedPorts {
+                let outputCount = max(node.outputPorts.count, 1)
+                let outputSpacing = nodeHeight / CGFloat(outputCount + 1)
+                for (index, port) in node.outputPorts.enumerated() {
+                    let portY = nodePosition.y - nodeHeight / 2 + outputSpacing * CGFloat(index + 1)
+                    let portX = nodePosition.x + nodeWidth / 2
+                    positions["\(node.id):\(port.id)"] = CGPoint(x: portX, y: portY)
+                }
+            } else {
+                let unifiedOutputPoint = CGPoint(x: nodePosition.x + nodeWidth / 2, y: nodePosition.y)
+                for port in node.outputPorts {
+                    positions["\(node.id):\(port.id)"] = unifiedOutputPoint
+                }
             }
         }
 

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/WorkflowInspector.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/WorkflowInspector.swift
@@ -9,7 +9,6 @@ struct WorkflowInspector: View {
     let onAddNode: (ToolInfo, CGPoint) -> Void
 
     @State var selectedTab: InspectorTab = .builtin
-    @State var blocksExpanded: Bool = true
 
     // Built-in tools loaded from workflow registry (grouped by category)
     @State var toolCategories: [CategoryTools] = []
@@ -123,65 +122,47 @@ struct WorkflowInspector: View {
     // MARK: - Built-in Tools Section
 
     private var builtinToolsSection: some View {
-        DisclosureGroup(isExpanded: $blocksExpanded) {
-            VStack(spacing: 12) {
-                if isLoadingTools {
-                    ProgressView()
-                        .frame(maxWidth: .infinity, minHeight: 60)
-                } else if toolCategories.isEmpty {
-                    // API unavailable - show error message
-                    VStack(spacing: 8) {
-                        Image(systemName: "exclamationmark.triangle")
-                            .font(.title2)
-                            .foregroundColor(.orange)
-                        Text("Could not load tools")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Button("Retry") {
-                            Task { await loadBuiltinTools() }
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                    }
-                    .frame(maxWidth: .infinity, minHeight: 100)
-                } else if visibleBuiltinCategories.isEmpty {
-                    VStack(spacing: 8) {
-                        Image(systemName: "lock.shield")
-                            .font(.title2)
-                            .foregroundColor(.secondary)
-                        Text("No tools enabled")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        Text("Enable reviewed tools via feature flags.")
-                            .font(.caption2)
-                            .foregroundColor(.secondary)
-                    }
-                    .frame(maxWidth: .infinity, minHeight: 100)
-                } else {
-                    // Show tools from API grouped by category
-                    ForEach(visibleBuiltinCategories) { category in
-                        toolCategoryView(category)
-                    }
-                }
-            }
-            .padding(.top, 8)
-        } label: {
-            HStack {
-                Label("Registry Tools", systemImage: "square.grid.2x2")
-                    .font(.headline)
-                Spacer()
-                if !visibleBuiltinCategories.isEmpty {
-                    let totalTools = visibleBuiltinCategories.reduce(0) { $0 + $1.tools.count }
-                    Text("\(totalTools)")
+        VStack(spacing: 12) {
+            if isLoadingTools {
+                ProgressView()
+                    .frame(maxWidth: .infinity, minHeight: 60)
+            } else if toolCategories.isEmpty {
+                // API unavailable - show error message
+                VStack(spacing: 8) {
+                    Image(systemName: "exclamationmark.triangle")
+                        .font(.title2)
+                        .foregroundColor(.orange)
+                    Text("Could not load tools")
                         .font(.caption)
                         .foregroundColor(.secondary)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(Color(.controlBackgroundColor))
-                        .cornerRadius(4)
+                    Button("Retry") {
+                        Task { await loadBuiltinTools() }
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
+                .frame(maxWidth: .infinity, minHeight: 100)
+            } else if visibleBuiltinCategories.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "lock.shield")
+                        .font(.title2)
+                        .foregroundColor(.secondary)
+                    Text("No tools enabled")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text("Enable reviewed tools via feature flags.")
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, minHeight: 100)
+            } else {
+                // Show tools from API grouped by category
+                ForEach(visibleBuiltinCategories) { category in
+                    toolCategoryView(category)
                 }
             }
         }
+        .padding(.top, 8)
     }
 
     // MARK: - Tool Category View (Built-in)

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/WorkflowPortView.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/WorkflowPortView.swift
@@ -210,18 +210,7 @@ struct InputPortsView: View {
     private var visiblePorts: [PortInfo] {
         guard !showPortDetails else { return ports }
         guard !ports.isEmpty else { return [] }
-
-        let connectedIds = connectedPortIds
-        let connectedPorts = ports.filter { connectedIds.contains($0.id) }
-        let firstUnconnected = ports.first { !connectedIds.contains($0.id) }
-
-        if connectedPorts.isEmpty {
-            return [ports[0]]
-        }
-        if let firstUnconnected {
-            return connectedPorts + [firstUnconnected]
-        }
-        return connectedPorts
+        return [ports[0]]
     }
 
     var body: some View {
@@ -265,18 +254,7 @@ struct OutputPortsView: View {
     private var visiblePorts: [PortInfo] {
         guard !showPortDetails else { return ports }
         guard !ports.isEmpty else { return [] }
-
-        let connectedIds = connectedPortIds
-        let connectedPorts = ports.filter { connectedIds.contains($0.id) }
-        if connectedPorts.isEmpty {
-            return [ports[0]]
-        }
-
-        let primary = ports[0]
-        if connectedIds.contains(primary.id) {
-            return connectedPorts
-        }
-        return connectedPorts + [primary]
+        return [ports[0]]
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary\n- continue 0.0.1 feature-gating and UI hardening across library/search/workflow surfaces\n- improve Document Inspector content editing with AppKit rich text bridge behavior and save/reload guardrails\n- simplify workflow inspector presentation and tighten enabled tool defaults\n- fix inspector toggle/layout behaviors and remove in-window toolbar title rendering\n- update state tracking notes for current overnight pass\n\n## Validation\n- swiftlint (targeted files)\n- xcodebuild -project fichero-swiftui/fichero-swiftui.xcodeproj -scheme Fichero -configuration Debug -sdk macosx build\n\nRefs: #279