### PR TITLE
Improve inspector pane width adjustability

### DIFF
--- a/fichero-swiftui/fichero-swiftui/Views/ContentView+ViewBuilders.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/ContentView+ViewBuilders.swift
@@ -175,11 +175,19 @@ extension ContentView {
         switch viewMode {
         case .library, .search:
             DocumentInspector(document: inspectorDocument)
-                .navigationSplitViewColumnWidth(min: 180, ideal: inspectorWidth, max: 700)
+                .navigationSplitViewColumnWidth(
+                    min: ContentView.inspectorMinWidth,
+                    ideal: inspectorWidth,
+                    max: ContentView.inspectorMaxWidth
+                )
 
         case .chat, .comparison:
             ChatInspector(selectedDocuments: $chatSelectedDocuments)
-                .navigationSplitViewColumnWidth(min: 180, ideal: inspectorWidth, max: 700)
+                .navigationSplitViewColumnWidth(
+                    min: ContentView.inspectorMinWidth,
+                    ideal: inspectorWidth,
+                    max: ContentView.inspectorMaxWidth
+                )
 
         case .workflow:
             WorkflowInspector(
@@ -188,7 +196,11 @@ extension ContentView {
                     addNodeFromTool(tool, at: position)
                 }
             )
-            .navigationSplitViewColumnWidth(min: 180, ideal: inspectorWidth, max: 700)
+            .navigationSplitViewColumnWidth(
+                min: ContentView.inspectorMinWidth,
+                ideal: inspectorWidth,
+                max: ContentView.inspectorMaxWidth
+            )
 
         case .chain:
             WorkflowInspector(
@@ -197,7 +209,11 @@ extension ContentView {
                     addNodeFromTool(tool, at: position)
                 }
             )
-            .navigationSplitViewColumnWidth(min: 180, ideal: inspectorWidth, max: 700)
+            .navigationSplitViewColumnWidth(
+                min: ContentView.inspectorMinWidth,
+                ideal: inspectorWidth,
+                max: ContentView.inspectorMaxWidth
+            )
 
         case .batches, .batch, .automation, .schedule, .trigger, .activity:
             EmptyView()

--- a/fichero-swiftui/fichero-swiftui/Views/ContentView.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/ContentView.swift
@@ -21,6 +21,9 @@ enum PaneFocus: Hashable {
 // - ContentView+Persistence: State serialization for @SceneStorage
 // swiftlint:disable:next type_body_length
 struct ContentView: View {
+    static let inspectorMinWidth: Double = 140
+    static let inspectorMaxWidth: Double = 1000
+
     // MARK: - Environment
 
     @EnvironmentObject var viewSettings: ViewSettings
@@ -207,7 +210,10 @@ struct ContentView: View {
         .onAppear {
             // Restore all persisted state from @SceneStorage
             restorePersistedState()
-            inspectorWidth = min(max(inspectorWidth, 180), 700)
+            inspectorWidth = min(
+                max(inspectorWidth, ContentView.inspectorMinWidth),
+                ContentView.inspectorMaxWidth
+            )
             if !featureManager.isSearchEnabled && sidebarMode == .search {
                 sidebarMode = .library
                 viewMode = .library(nil)


### PR DESCRIPTION
## Summary\n- increase right inspector width range from 180-700 to 140-1000\n- centralize inspector min/max constants so split-view config and restore clamping remain aligned\n- applies to Library/Search/Workflow inspector columns\n\n## Validation\n- swiftlint on modified files\n- xcodebuild -project fichero-swiftui/fichero-swiftui.xcodeproj -scheme Fichero -configuration Debug -sdk macosx build\n\nRefs: #220