### PR TITLE
Add built-in default workflow templates with install/reset

### DIFF
--- a/fichero-swiftui/fichero-swiftui/Models/WorkflowStore.swift
+++ b/fichero-swiftui/fichero-swiftui/Models/WorkflowStore.swift
@@ -17,6 +17,10 @@ class WorkflowStore: ObservableObject {
     private let logger = Logger(subsystem: "ca.tubb.Fichero", category: "WorkflowStore")
     private let workflowService: WorkflowServiceGenerated
     private let ficheroClient: FicheroClient
+    private let defaultWorkflowTemplates: [DefaultWorkflowTemplate] = [
+        .filesToTranscribe,
+        .collectionToTranscribe
+    ]
 
     init(ficheroClient: FicheroClient) {
         self.ficheroClient = ficheroClient
@@ -288,6 +292,68 @@ class WorkflowStore: ObservableObject {
         return item
     }
 
+    // MARK: - Default Templates
+
+    /// Install built-in default workflows if they are missing.
+    @discardableResult
+    func installDefaultWorkflowTemplates() async throws -> [WorkflowSidebarItem] {
+        try await syncDefaultWorkflowTemplates(resetExisting: false)
+    }
+
+    /// Remove and recreate built-in default workflows.
+    @discardableResult
+    func resetDefaultWorkflowTemplates() async throws -> [WorkflowSidebarItem] {
+        try await syncDefaultWorkflowTemplates(resetExisting: true)
+    }
+
+    @discardableResult
+    private func syncDefaultWorkflowTemplates(resetExisting: Bool) async throws -> [WorkflowSidebarItem] {
+        let toolsByName = try await loadToolRegistry()
+        let workflowResponses = try await workflowService.listWorkflows()
+        let existingByName = Dictionary(
+            uniqueKeysWithValues: workflowResponses.map { ($0.name, $0) }
+        )
+
+        if resetExisting {
+            for template in defaultWorkflowTemplates {
+                if let existing = existingByName[template.name] {
+                    try await workflowService.deleteWorkflow(existing.id)
+                }
+            }
+        }
+
+        var created: [WorkflowSidebarItem] = []
+        for template in defaultWorkflowTemplates {
+            if !resetExisting, existingByName[template.name] != nil {
+                continue
+            }
+
+            let definition = try template.makeDefinition(toolsByName: toolsByName)
+            let response = try await workflowService.createWorkflow(definition)
+            created.append(
+                WorkflowSidebarItem(
+                    id: response.id,
+                    name: response.name,
+                    description: response.description,
+                    nodeCount: response.nodes.count,
+                    isEnabled: true,
+                    folderPath: response.folderPath,
+                    sortOrder: response.sortOrder,
+                    createdAt: Date(),
+                    updatedAt: Date()
+                )
+            )
+        }
+
+        await loadWorkflows()
+        return created
+    }
+
+    private func loadToolRegistry() async throws -> [String: ToolInfo] {
+        let tools = try await workflowService.listTools()
+        return Dictionary(uniqueKeysWithValues: tools.map { ($0.name.lowercased(), $0) })
+    }
+
     // MARK: - Workflow Execution
 
     private lazy var executionService: WorkflowExecutionService = {
@@ -368,6 +434,7 @@ enum WorkflowStoreError: Error, LocalizedError {
     case notFound(String)
     case saveFailed(String)
     case executionFailed(String)
+    case templateInstallFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -377,6 +444,75 @@ enum WorkflowStoreError: Error, LocalizedError {
             return "Save failed: \(message)"
         case .executionFailed(let message):
             return "Execution failed: \(message)"
+        case .templateInstallFailed(let message):
+            return "Template install failed: \(message)"
         }
+    }
+}
+
+// MARK: - Default Workflow Templates
+
+private enum DefaultWorkflowTemplate {
+    case filesToTranscribe
+    case collectionToTranscribe
+
+    var name: String {
+        switch self {
+        case .filesToTranscribe:
+            return "Default · Transcribe Files"
+        case .collectionToTranscribe:
+            return "Default · Transcribe Collection"
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .filesToTranscribe:
+            return "Run transcription over selected files."
+        case .collectionToTranscribe:
+            return "Run transcription over a collection source."
+        }
+    }
+
+    func makeDefinition(toolsByName: [String: ToolInfo]) throws -> WorkflowDefinition {
+        let sourceToolName = switch self {
+        case .filesToTranscribe: "files"
+        case .collectionToTranscribe: "collection"
+        }
+
+        guard let sourceTool = toolsByName[sourceToolName] else {
+            throw WorkflowStoreError.templateInstallFailed("Missing source tool '\(sourceToolName)'")
+        }
+        guard let transcribeTool = toolsByName["transcribe"] else {
+            throw WorkflowStoreError.templateInstallFailed("Missing tool 'transcribe'")
+        }
+
+        let sourceNode = WorkflowNode(
+            from: sourceTool,
+            positionX: 220,
+            positionY: 220
+        )
+        let transcribeNode = WorkflowNode(
+            from: transcribeTool,
+            positionX: 540,
+            positionY: 220
+        )
+
+        let sourcePort = sourceNode.outputPorts.first?.id ?? "output"
+        let targetPort = transcribeNode.inputPorts.first?.id ?? "input"
+
+        return WorkflowDefinition(
+            name: name,
+            description: description,
+            nodes: [sourceNode, transcribeNode],
+            edges: [
+                WorkflowEdge(
+                    sourceNodeId: sourceNode.id,
+                    targetNodeId: transcribeNode.id,
+                    sourcePortId: sourcePort,
+                    targetPortId: targetPort
+                )
+            ]
+        )
     }
 }

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/WorkflowLibraryView.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/WorkflowLibraryView.swift
@@ -60,6 +60,9 @@ struct WorkflowListView: View {
     @State private var isLoading = false
     @State private var tableSortOrder = [KeyPathComparator(\WorkflowSidebarItem.name)]
     @State private var isImporting = false
+    @State private var isManagingDefaults = false
+    @State private var showResetDefaultsConfirmation = false
+    @State private var templateOperationMessage: String?
     @ObservedObject var featureManager = FeatureManager.shared
 
     /// View display mode from toolbar
@@ -93,6 +96,29 @@ struct WorkflowListView: View {
             if let workflow = workflowToDelete {
                 Text("Are you sure you want to delete \"\(workflow.name)\"? This action cannot be undone.")
             }
+        }
+        .alert("Reset Default Workflows?", isPresented: $showResetDefaultsConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Reset", role: .destructive) {
+                Task { await resetDefaultWorkflows() }
+            }
+        } message: {
+            Text("This removes and recreates built-in default workflows.")
+        }
+        .alert(
+            "Workflow Templates",
+            isPresented: Binding(
+                get: { templateOperationMessage != nil },
+                set: { show in
+                    if !show {
+                        templateOperationMessage = nil
+                    }
+                }
+            )
+        ) {
+            Button("OK") { templateOperationMessage = nil }
+        } message: {
+            Text(templateOperationMessage ?? "")
         }
     }
 
@@ -129,6 +155,21 @@ struct WorkflowListView: View {
                     Image(systemName: "plus")
                 }
                 .help("Create new workflow")
+
+                Menu {
+                    Button("Install Defaults") {
+                        Task { await installDefaultWorkflows() }
+                    }
+                    .disabled(isManagingDefaults)
+
+                    Button("Reset Defaults", role: .destructive) {
+                        showResetDefaultsConfirmation = true
+                    }
+                    .disabled(isManagingDefaults)
+                } label: {
+                    Image(systemName: "sparkles")
+                }
+                .help("Manage built-in default workflows")
 
                 if featureManager.isWorkflowImportExportEnabled {
                     Button {
@@ -385,6 +426,36 @@ struct WorkflowListView: View {
                 name: workflow.name,
                 using: workflowServiceGenerated
             )
+        }
+    }
+
+    private func installDefaultWorkflows() async {
+        guard !isManagingDefaults else { return }
+        isManagingDefaults = true
+        defer { isManagingDefaults = false }
+
+        do {
+            let created = try await workflowStore.installDefaultWorkflowTemplates()
+            if created.isEmpty {
+                templateOperationMessage = "Default workflows are already installed."
+            } else {
+                templateOperationMessage = "Installed \(created.count) default workflow(s)."
+            }
+        } catch {
+            templateOperationMessage = "Failed to install defaults: \(error.localizedDescription)"
+        }
+    }
+
+    private func resetDefaultWorkflows() async {
+        guard !isManagingDefaults else { return }
+        isManagingDefaults = true
+        defer { isManagingDefaults = false }
+
+        do {
+            let created = try await workflowStore.resetDefaultWorkflowTemplates()
+            templateOperationMessage = "Reset defaults complete (\(created.count) recreated)."
+        } catch {
+            templateOperationMessage = "Failed to reset defaults: \(error.localizedDescription)"
         }
     }
 }


### PR DESCRIPTION
## Summary
- add built-in default workflow templates in WorkflowStore:
  - Default · Transcribe Files
  - Default · Transcribe Collection
- add install/reset APIs in workflow store to seed defaults or recreate them
- add workflow library toolbar controls (sparkles menu) for:
  - Install Defaults
  - Reset Defaults (with confirmation)
- surface install/reset results via user-facing alerts

## Validation
- swiftlint lint on touched files (warnings only)
- xcodebuild -project fichero-swiftui/fichero-swiftui.xcodeproj -scheme Fichero -configuration Debug -sdk macosx build

Refs: #291
