### PR TITLE
docs: define workflow QA validation gates for 0.0.1 (#250)

### DIFF
--- a/docs/qa/VIEW_QA_MATRIX.md
+++ b/docs/qa/VIEW_QA_MATRIX.md
@@ -3,6 +3,7 @@
 Purpose: provide a single checklist for Daniel's manual QA runs and Codex follow-up triage.
 
 For release-gate execution on milestone `0.0.1`, use [0.0.1-manual-qa-checklist.md](./0.0.1-manual-qa-checklist.md).
+Workflow release gate details are tracked in [workflow-qa-validation-gates.md](./workflow-qa-validation-gates.md).
 
 ## Reporting Format
 - Prefix every result with `[DANIEL]` or `[CODEX]` in issue comments.

--- a/docs/qa/workflow-qa-validation-gates.md
+++ b/docs/qa/workflow-qa-validation-gates.md
@@ -1,0 +1,40 @@
+# Workflow QA Validation Gates (0.0.1)
+
+Purpose: define the workflow-specific release gate for issue `#250`.
+
+## Gate A: Surface and Gating
+- [ ] Workflow sidebar/menu surfaces appear only when workflow feature tier is enabled.
+- [ ] Off-tier workflow execution surfaces remain hidden in release mode.
+- [ ] Search/library workflows integration entry points do not expose unsupported controls.
+
+## Gate B: Core Authoring Path
+- [ ] Create a workflow from the workflow library.
+- [ ] Rename and duplicate the workflow.
+- [ ] Delete a workflow and verify it is removed after relaunch.
+- [ ] Reorder workflows and confirm order persistence.
+
+## Gate C: Execution Path
+- [ ] Execute a workflow against at least 3 library documents.
+- [ ] Output log updates during run (not only after completion).
+- [ ] Run status transitions are visible and final state is correct.
+- [ ] Failure path surfaces actionable error text for invalid node config.
+
+## Gate D: Data Integrity
+- [ ] Executions generate expected artifacts and attach them to source documents.
+- [ ] Cancelling/deleting documents does not leave stale workflow run references.
+- [ ] No orphan workflows remain after reset/delete operations.
+
+## Gate E: API Contract
+- [ ] OpenAPI contract contains expected workflow endpoints for current tier.
+- [ ] Swift generated client compiles against current backend contract.
+- [ ] Contract test suite passes for workflow endpoints.
+
+## Required Evidence
+- [ ] `swiftlint` output for workflow-touched files.
+- [ ] `xcodebuild test` summary for workflow-related suites.
+- [ ] `pytest` summary for backend workflow tests.
+- [ ] One pass report from Daniel and one independent pass from Codex.
+- [ ] Link all discovered failures to dedicated GitHub issues.
+
+## Exit Criteria
+Issue `#250` can be closed only when Gates A-E have explicit pass/fail entries and all failures are either fixed or tracked as accepted follow-up issues with milestone assignment.


### PR DESCRIPTION
## Summary
- add `docs/qa/workflow-qa-validation-gates.md` as the explicit release-gate runbook for `#250`
- define Gates A-E (surface, authoring, execution, integrity, API contract)
- define required evidence and closure criteria
- link the runbook from `docs/qa/VIEW_QA_MATRIX.md`

## Validation
- documentation-only change
