### PR TITLE
fix: show actual file size in table Size column

### DIFF
--- a/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+ColumnConfig.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+ColumnConfig.swift
@@ -107,7 +107,12 @@ extension LibraryView {
             Text(doc.updatedAt, style: .date)
                 .font(.caption).foregroundColor(.secondary)
         case "size":
-            Text("-").font(.caption).foregroundColor(.secondary)
+            if let fileSize = doc.metadata["File_Size"]?.value as? Int {
+                Text(ByteCountFormatter.string(fromByteCount: Int64(fileSize), countStyle: .file))
+                    .font(.caption).foregroundColor(.secondary)
+            } else {
+                Text("-").font(.caption).foregroundColor(.secondary)
+            }
         default:
             Text("-").foregroundColor(.secondary)
         }


### PR DESCRIPTION
## Summary
- Read `File_Size` from document metadata and format with `ByteCountFormatter` instead of showing a hardcoded dash in the table Size column
- Falls back to "-" when file size metadata is unavailable

Closes #314

## Test plan
- [ ] Enable Size column in table view (right-click column header)
- [ ] Verify files with ingested metadata show human-readable sizes (e.g., "4.2 MB")
- [ ] Verify documents without File_Size metadata show "-"

🤖 Generated with [Claude Code](https://claude.com/claude-code)