### PR TITLE
fix: replace print() error logging with ErrorService in LibraryView

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,10 +1,10 @@
 # STATE.md — Fichero
 
-Last updated: 2026-03-23
+Last updated: 2026-03-24
 
 ## Current Branch
 
-`main` — 14 uncommitted files (UI fixes + feature enablement, not yet committed)
+`main` — clean. All previous changes committed and pushed.
 
 ## Source of Truth
 
@@ -35,10 +35,14 @@ Last updated: 2026-03-23
 - Sparkle key pair
 - **#322** — Image centering still not fully working (contentInsets approach, needs visual verification)
 
+## Recent PRs
+
+- **PR #329** — fix: show actual file size in table Size column (#314) — awaiting review
+
 ## Next Session — Start Here
 
-1. **Commit changes** — 14 dirty files on main. Review diff and commit in logical chunks.
-2. **#322** — Image centering: verify current contentInsets approach works. If not, try NSClipView centering or wrap image in a container view.
+1. **#322** — Image centering: verify current contentInsets approach works. If not, try NSClipView centering or wrap image in a container view.
+2. **#313** — Library View: Add connection/API error state UI.
 3. **#324** — Settings: default font, font size, margins with reset button.
 4. **#327** — Folder preview: show folder contents grid instead of file preview.
 5. **#326** — Keyboard shortcuts: verify all navigation shortcuts work end-to-end.

--- a/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+InlineEditing.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+InlineEditing.swift
@@ -28,7 +28,7 @@ extension LibraryView {
             do {
                 _ = try await library.documentStore.renameDocument(doc, to: newName)
             } catch {
-                print("Failed to rename document: \(error)")
+                ErrorService.shared.reportError(error)
             }
         }
     }

--- a/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+KeyboardShortcuts.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+KeyboardShortcuts.swift
@@ -90,7 +90,7 @@ extension LibraryView {
             do {
                 try await library.documentStore.deleteDocument(doc)
             } catch {
-                print("Failed to delete document \(doc.name): \(error)")
+                ErrorService.shared.reportError(error)
             }
         }
         // Clear selection for deleted items


### PR DESCRIPTION
## Summary
- Replace `print()` error logging with `ErrorService.shared.reportError()` in rename and delete handlers
- Failures now surface as user-facing alert dialogs instead of silent console logs

Closes #315

## Test plan
- [ ] Trigger a rename failure (e.g., rename to invalid name) — verify error alert appears
- [ ] Trigger a delete failure — verify error alert appears
- [ ] Verify no `print("Failed to...")` calls remain in Library view code

🤖 Generated with [Claude Code](https://claude.com/claude-code)