### PR TITLE
feat: add font, line spacing, and margin settings with reset

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,10 +1,10 @@
 # STATE.md — Fichero
 
-Last updated: 2026-03-23
+Last updated: 2026-03-24
 
 ## Current Branch
 
-`main` — 14 uncommitted files (UI fixes + feature enablement, not yet committed)
+`main` — clean. All previous changes committed and pushed.
 
 ## Source of Truth
 
@@ -35,10 +35,14 @@ Last updated: 2026-03-23
 - Sparkle key pair
 - **#322** — Image centering still not fully working (contentInsets approach, needs visual verification)
 
+## Recent PRs
+
+- **PR #329** — fix: show actual file size in table Size column (#314) — awaiting review
+
 ## Next Session — Start Here
 
-1. **Commit changes** — 14 dirty files on main. Review diff and commit in logical chunks.
-2. **#322** — Image centering: verify current contentInsets approach works. If not, try NSClipView centering or wrap image in a container view.
+1. **#322** — Image centering: verify current contentInsets approach works. If not, try NSClipView centering or wrap image in a container view.
+2. **#313** — Library View: Add connection/API error state UI.
 3. **#324** — Settings: default font, font size, margins with reset button.
 4. **#327** — Folder preview: show folder contents grid instead of file preview.
 5. **#326** — Keyboard shortcuts: verify all navigation shortcuts work end-to-end.

--- a/fichero-swiftui/fichero-swiftui/Views/Settings/GeneralSettingsView.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Settings/GeneralSettingsView.swift
@@ -8,6 +8,20 @@ struct GeneralSettingsView: View {
     @AppStorage("autoExtractText") private var autoExtractText: Bool = true
     @AppStorage("autoCreateEmbeddings") private var autoCreateEmbeddings: Bool = true
 
+    // Typography settings
+    @AppStorage("editor.fontName") private var fontName: String = "System"
+    @AppStorage("editor.fontSize") private var fontSize: Double = 14
+    @AppStorage("editor.lineSpacing") private var lineSpacing: Double = 4
+    @AppStorage("editor.marginHorizontal") private var marginH: Double = 16
+    @AppStorage("editor.marginVertical") private var marginV: Double = 12
+
+    private static let defaultFontName = "System"
+    private static let defaultFontSize: Double = 14
+    private static let defaultLineSpacing: Double = 4
+    private static let defaultMarginH: Double = 16
+    private static let defaultMarginV: Double = 12
+    private static let defaultThumbnailSize: Double = 120
+
     var body: some View {
         Form {
             Section("Display") {
@@ -16,11 +30,67 @@ struct GeneralSettingsView: View {
                 }
             }
 
+            Section("Typography") {
+                fontPicker
+
+                HStack {
+                    Text("Font Size")
+                    Spacer()
+                    TextField("", value: $fontSize, format: .number)
+                        .frame(width: 50)
+                        .textFieldStyle(.roundedBorder)
+                    Stepper("", value: $fontSize, in: 9...36, step: 1)
+                        .labelsHidden()
+                }
+
+                Slider(value: $lineSpacing, in: 0...20, step: 1) {
+                    Text("Line Spacing")
+                }
+            }
+
+            Section("Margins") {
+                Slider(value: $marginH, in: 0...80, step: 4) {
+                    Text("Horizontal")
+                }
+                Slider(value: $marginV, in: 0...80, step: 4) {
+                    Text("Vertical")
+                }
+            }
+
             Section("Ingestion") {
                 Toggle("Auto-extract text from documents", isOn: $autoExtractText)
                 Toggle("Auto-create search embeddings", isOn: $autoCreateEmbeddings)
             }
+
+            Section {
+                Button("Reset to Defaults") {
+                    fontName = Self.defaultFontName
+                    fontSize = Self.defaultFontSize
+                    lineSpacing = Self.defaultLineSpacing
+                    marginH = Self.defaultMarginH
+                    marginV = Self.defaultMarginV
+                    thumbnailSize = Self.defaultThumbnailSize
+                    autoExtractText = true
+                    autoCreateEmbeddings = true
+                }
+            }
         }
         .padding()
+    }
+
+    @ViewBuilder
+    private var fontPicker: some View {
+        Picker("Font", selection: $fontName) {
+            Text("System Default").tag("System")
+            Divider()
+            ForEach(availableFonts, id: \.self) { name in
+                Text(name).tag(name)
+            }
+        }
+    }
+
+    private var availableFonts: [String] {
+        let families = NSFontManager.shared.availableFontFamilies
+        return families.sorted()
     }
 }


### PR DESCRIPTION
## Summary
- Add Typography section: font picker (all system fonts), font size with stepper, line spacing slider
- Add Margins section: horizontal and vertical margin sliders
- Add Reset to Defaults button that restores all settings
- All values AppStorage-backed for persistence

Closes #324

## Test plan
- [ ] Open Settings > General — verify Typography and Margins sections appear
- [ ] Change font — verify picker shows all system fonts
- [ ] Adjust font size via stepper and text field
- [ ] Adjust line spacing and margin sliders
- [ ] Click Reset to Defaults — all values return to defaults
- [ ] Quit and relaunch — settings persist

Note: Editor views will need to read these `@AppStorage` keys to apply the settings. This PR adds the settings UI; a follow-up will wire them to the editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)