### PR TITLE
fix: icon view default scale and preview pane on launch

### DIFF
--- a/STATE.md
+++ b/STATE.md
@@ -1,10 +1,10 @@
 # STATE.md — Fichero
 
-Last updated: 2026-03-23
+Last updated: 2026-03-24
 
 ## Current Branch
 
-`main` — 14 uncommitted files (UI fixes + feature enablement, not yet committed)
+`main` — clean. All previous changes committed and pushed.
 
 ## Source of Truth
 
@@ -35,10 +35,14 @@ Last updated: 2026-03-23
 - Sparkle key pair
 - **#322** — Image centering still not fully working (contentInsets approach, needs visual verification)
 
+## Recent PRs
+
+- **PR #329** — fix: show actual file size in table Size column (#314) — awaiting review
+
 ## Next Session — Start Here
 
-1. **Commit changes** — 14 dirty files on main. Review diff and commit in logical chunks.
-2. **#322** — Image centering: verify current contentInsets approach works. If not, try NSClipView centering or wrap image in a container view.
+1. **#322** — Image centering: verify current contentInsets approach works. If not, try NSClipView centering or wrap image in a container view.
+2. **#313** — Library View: Add connection/API error state UI.
 3. **#324** — Settings: default font, font size, margins with reset button.
 4. **#327** — Folder preview: show folder contents grid instead of file preview.
 5. **#326** — Keyboard shortcuts: verify all navigation shortcuts work end-to-end.

--- a/fichero-swiftui/fichero-swiftui/Views/ContentView.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/ContentView.swift
@@ -231,6 +231,14 @@ struct ContentView: View {
                 itemId: storedViewModeItemId
             )
         }
+        .onChange(of: documentStore.currentDocuments) { oldDocs, newDocs in
+            // On initial load, populate preview with restored selection
+            guard oldDocs.isEmpty, !newDocs.isEmpty, detailDocument == nil else { return }
+            if let firstSelectedId = browserSelection.first,
+               let doc = newDocs.first(where: { $0.id == firstSelectedId }) {
+                detailDocument = doc
+            }
+        }
         .onChange(of: showInspectorSidebar) { _, newValue in
             if viewSettings.showInspector != newValue {
                 viewSettings.showInspector = newValue

--- a/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView.swift
@@ -69,7 +69,7 @@ struct LibraryView: View {
     @State var gridColumnCount: Int = 4
 
     // Zoom scale for icon and map views (persisted per-app)
-    @AppStorage("library.iconViewScale") var iconViewScale: Double = 3.0
+    @AppStorage("library.iconViewScale") var iconViewScale: Double = 1.0
     @State var mapCanvasScale: CGFloat = 1.0
 
     var body: some View {


### PR DESCRIPTION
## Summary
- Change default `iconViewScale` from 3.0 to 1.0 — cells are now ~120px wide instead of ~360px, showing multiple columns by default
- Auto-populate preview pane on launch: when documents load and a selection exists from the previous session, the preview pane shows that document immediately
- The layout jump on first run is mitigated by the smaller default scale (grid reflows less when selection highlights a cell in a multi-column layout)

Closes #330

## Test plan
- [ ] Fresh install (delete `library.iconViewScale` from UserDefaults) — icon view shows multi-column grid
- [ ] Select a file, quit, relaunch — preview pane shows the selected file on launch
- [ ] Icon scale is still persisted when user changes it via zoom controls
- [ ] First-run click doesn't cause visible layout jump

🤖 Generated with [Claude Code](https://claude.com/claude-code)