### PR TITLE
feat: unify vision engine into provider/model selector

### DIFF
--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/DynamicConfigView.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/DynamicConfigView.swift
@@ -61,7 +61,7 @@ struct DynamicConfigView: View {
 
     // MARK: - Grouped Keys
 
-    let dedicatedKeys: Set<String> = ["provider_name", "model_name"]
+    let dedicatedKeys: Set<String> = ["provider_name", "model_name", "vision_mode"]
 
     var visibleKeys: [String] {
         toolInfo.configSchema.keys.filter { key in

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/TranscribeNodeConfig.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/TranscribeNodeConfig.swift
@@ -1,13 +1,15 @@
 import SwiftUI
 
 /// Configuration view for transcribe node
+///
+/// The Vision Engine toggle has been removed — Apple Vision is now a provider
+/// option in the unified provider/model selector (see NodeProviderModelSelector).
 struct TranscribeNodeConfig: View {
     @Binding var node: WorkflowNode
 
     let toolInfo: ToolInfo?
     let backendPrompt: String?
 
-    @State private var visionMode: String = "apple"
     @State private var language: String = "en"
     @State private var maxImageDimension: Double = 11024
     @State private var promptText: String = ""
@@ -22,36 +24,19 @@ struct TranscribeNodeConfig: View {
         return toolInfo?.defaultPrompt
     }
 
+    /// Whether the node is currently configured for LLM mode (not Apple Vision)
+    private var isLLMMode: Bool {
+        if let configValue = node.config?["vision_mode"],
+           case .string(let mode) = configValue {
+            return mode == "llm"
+        }
+        // Default: Apple Vision (not LLM mode)
+        return false
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            // Vision Mode selector
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Vision Engine")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                Picker("Vision Engine", selection: $visionMode) {
-                    Label("Apple Vision (On-Device)", systemImage: "apple.logo")
-                        .tag("apple")
-                    Label("Vision LLM (Cloud)", systemImage: "cloud")
-                        .tag("llm")
-                }
-                .pickerStyle(.menu)
-                .onChange(of: visionMode) { _, newValue in
-                    if node.config == nil {
-                        node.config = [:]
-                    }
-                    node.config?["vision_mode"] = .string(newValue)
-                    node.usesLLM = (newValue == "llm")
-                    // Clear provider/model when switching to Apple Vision
-                    if newValue == "apple" {
-                        node.providerName = nil
-                        node.modelName = nil
-                    }
-                }
-            }
-
-            // Language
+            // Language (always shown — relevant for both Apple Vision and LLM)
             VStack(alignment: .leading, spacing: 4) {
                 Text("Language")
                     .font(.caption)
@@ -68,7 +53,7 @@ struct TranscribeNodeConfig: View {
             }
 
             // Image Size (only for LLM mode)
-            if visionMode == "llm" {
+            if isLLMMode {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Max Image Size")
                         .font(.caption)
@@ -98,7 +83,7 @@ struct TranscribeNodeConfig: View {
             }
 
             // Custom prompt (only for LLM mode)
-            if visionMode == "llm" {
+            if isLLMMode {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("Prompt")
                         .font(.caption)
@@ -146,11 +131,6 @@ struct TranscribeNodeConfig: View {
     }
 
     private func loadInitialState() {
-        if let configValue = node.config?["vision_mode"],
-           case .string(let mode) = configValue {
-            visionMode = mode
-        }
-
         if let configValue = node.config?["language"],
            case .string(let lang) = configValue {
             language = lang

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodePopover.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodePopover.swift
@@ -18,8 +18,7 @@ struct NodePopover: View {
     @State private var selectedProviderId: String = ""
     @State private var selectedModelId: String = ""
 
-    // Vision mode for transcribe/describe (used by shouldShowProviderSection)
-    @State private var visionMode: String = "apple"  // "apple" or "llm"
+    // Vision mode is now managed by the provider selector (Apple Vision = a provider)
 
     @EnvironmentObject var chatService: ChatServiceGenerated
     @EnvironmentObject var documentStore: DocumentStore
@@ -81,9 +80,9 @@ struct NodePopover: View {
                 await loadProviders()
             }
         }
-        .onChange(of: visionMode) { _, newValue in
-            // Load providers when switching to LLM mode
-            if newValue == "llm" && providers.isEmpty {
+        .onChange(of: selectedProviderId) { _, newValue in
+            // Load providers when switching away from Apple Vision to an LLM provider
+            if newValue != appleVisionProviderId && !newValue.isEmpty && providers.isEmpty {
                 Task { @MainActor in
                     await loadProviders()
                 }
@@ -139,17 +138,16 @@ struct NodePopover: View {
     // MARK: - Config Helpers
 
     private func initConfigFromNode() {
-        // Vision mode only applies to tools that support Apple Vision (transcribe)
-        // Default to "apple" for transcribe, "llm" for all other vision tools
-        if Self.appleVisionTools.contains(node.tool) {
+        // Restore provider selection from node config
+        // For Apple Vision tools, check if vision_mode is "apple" to pre-select Apple Vision provider
+        if toolSupportsAppleVision {
             if let configValue = node.config?["vision_mode"],
-               case .string(let mode) = configValue {
-                visionMode = mode
-            } else {
-                visionMode = "apple"
+               case .string(let mode) = configValue, mode == "apple" {
+                selectedProviderId = appleVisionProviderId
+            } else if node.providerName == nil && node.config?["vision_mode"] == nil {
+                // Default to Apple Vision for transcribe when no provider set
+                selectedProviderId = appleVisionProviderId
             }
-        } else {
-            visionMode = "llm"  // All other vision tools only support LLM
         }
     }
 
@@ -212,6 +210,7 @@ struct NodePopover: View {
             isLoadingProviders: $isLoadingProviders,
             providers: providers,
             toolRequiresVision: toolRequiresVision,
+            toolSupportsAppleVision: toolSupportsAppleVision,
             onLoadProviders: loadProviders
         )
     }
@@ -290,9 +289,9 @@ struct NodePopover: View {
 
     /// Whether to show the provider/model section
     private var shouldShowProviderSection: Bool {
-        // For tools that support Apple Vision switching, only show when using LLM mode
+        // Always show for Apple Vision tools (provider selector includes Apple Vision option)
         if toolSupportsAppleVision {
-            return visionMode == "llm"
+            return true
         }
         // For other vision tools (LLM-only), always show if it's a vision tool
         if toolRequiresVision {

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeProviderModelSelector.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeProviderModelSelector.swift
@@ -1,7 +1,10 @@
-import SwiftUI
 import OSLog
+import SwiftUI
 
 private let logger = Logger(subsystem: "com.tubb.Fichero", category: "NodeProviderModelSelector")
+
+/// Sentinel provider ID for Apple Vision (on-device OCR)
+let appleVisionProviderId = "apple_vision"
 
 /// Provider and model selection component for workflow nodes
 struct NodeProviderModelSelector: View {
@@ -12,7 +15,14 @@ struct NodeProviderModelSelector: View {
 
     let providers: [LLMProvider]
     let toolRequiresVision: Bool
+    /// Whether this tool supports Apple Vision as a provider option
+    let toolSupportsAppleVision: Bool
     let onLoadProviders: () async -> Void
+
+    /// Whether Apple Vision is currently selected
+    private var isAppleVisionSelected: Bool {
+        selectedProviderId == appleVisionProviderId
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -25,7 +35,7 @@ struct NodeProviderModelSelector: View {
                 if isLoadingProviders {
                     ProgressView()
                         .frame(maxWidth: .infinity, alignment: .leading)
-                } else if providers.isEmpty {
+                } else if providers.isEmpty && !toolSupportsAppleVision {
                     Text("No providers configured")
                         .font(.caption)
                         .foregroundColor(.orange)
@@ -34,13 +44,15 @@ struct NodeProviderModelSelector: View {
                 }
             }
 
-            // Model picker
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Model")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
+            // Model picker (hidden when Apple Vision is selected)
+            if !isAppleVisionSelected {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Model")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
 
-                modelPicker
+                    modelPicker
+                }
             }
         }
     }
@@ -55,7 +67,7 @@ struct NodeProviderModelSelector: View {
         }
 
         return Group {
-            if availableProviders.isEmpty {
+            if availableProviders.isEmpty && !toolSupportsAppleVision {
                 if toolRequiresVision {
                     Text("No vision-capable providers available")
                         .font(.caption)
@@ -68,6 +80,13 @@ struct NodeProviderModelSelector: View {
             } else {
                 Picker("Provider", selection: $selectedProviderId) {
                     Text("Select provider...").tag("")
+
+                    // Apple Vision as first option for tools that support it
+                    if toolSupportsAppleVision {
+                        Label("Apple Vision (On-Device)", systemImage: "apple.logo")
+                            .tag(appleVisionProviderId)
+                    }
+
                     ForEach(availableProviders) { provider in
                         Text(provider.name).tag(provider.id)
                     }
@@ -75,20 +94,29 @@ struct NodeProviderModelSelector: View {
                 .pickerStyle(.menu)
                 .onChange(of: selectedProviderId) { _, newValue in
                     guard !newValue.isEmpty else { return }
-                    // Use provider ID (e.g. "openrouter") not display name (e.g. "OpenRouter")
-                    // The backend expects the provider type ID
-                    node.providerName = newValue
-                    print("[DEBUG] Provider selected: id=\(newValue)")
-                    if let provider = providers.first(where: { $0.id == newValue }),
-                       let firstModel = provider.models.first {
-                        selectedModelId = firstModel
-                        node.modelName = firstModel
-                        print("[DEBUG] Model set to: \(firstModel)")
+
+                    if newValue == appleVisionProviderId {
+                        // Apple Vision selected — set vision_mode, clear LLM provider/model
+                        if node.config == nil { node.config = [:] }
+                        node.config?["vision_mode"] = .string("apple")
+                        node.providerName = nil
+                        node.modelName = nil
+                        node.usesLLM = false
+                        selectedModelId = ""
+                        logger.info("Apple Vision selected for node \(node.id)")
+                    } else {
+                        // LLM provider selected
+                        if node.config == nil { node.config = [:] }
+                        node.config?["vision_mode"] = .string("llm")
+                        node.providerName = newValue
+                        node.usesLLM = true
+                        logger.info("Provider selected: id=\(newValue)")
+                        if let provider = providers.first(where: { $0.id == newValue }),
+                           let firstModel = provider.models.first {
+                            selectedModelId = firstModel
+                            node.modelName = firstModel
+                        }
                     }
-                    print(
-                        "[DEBUG] Node after update: providerName=\(node.providerName ?? "nil"), " +
-                        "modelName=\(node.modelName ?? "nil")"
-                    )
                 }
             }
         }
@@ -114,7 +142,7 @@ struct NodeProviderModelSelector: View {
                 .onChange(of: selectedModelId) { _, newValue in
                     guard !newValue.isEmpty else { return }
                     node.modelName = newValue
-                    print("[DEBUG] Model manually selected: \(newValue), node.modelName=\(node.modelName ?? "nil")")
+                    logger.info("Model selected: \(newValue)")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Removes the "Vision Engine" toggle from workflow node config
- Adds "Apple Vision (On-Device)" as a provider option in the unified provider/model picker
- When Apple Vision is selected, hides the model picker (no model selection needed)
- When any LLM provider is selected, sets vision_mode=llm and shows model picker as usual
- Hides `vision_mode` from DynamicConfigView dedicated keys (now managed by provider selector)

Closes #345

## Test plan
- [ ] Open a workflow with a Transcribe node — verify no "Vision Engine" toggle
- [ ] Verify Apple Vision appears as first provider option for Transcribe
- [ ] Select Apple Vision — model picker should be hidden
- [ ] Select an LLM provider — model picker should appear
- [ ] Verify Describe and other vision tools still show LLM providers only (no Apple Vision option)
- [ ] Verify saved workflows with existing vision_mode config still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)