### PR TITLE
feat: add thinking mode selector to workflow node config

### DIFF
--- a/fichero-swiftui/fichero-swiftui.xcodeproj/project.pbxproj
+++ b/fichero-swiftui/fichero-swiftui.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		202674992F475B33008EAB5D /* SearchNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674982F475B33008EAB5D /* SearchNodeConfig.swift */; };
 		2026749B2F475B4A008EAB5D /* FilesNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026749A2F475B4A008EAB5D /* FilesNodeConfig.swift */; };
 		2026749D2F475B64008EAB5D /* TranscribeNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026749C2F475B64008EAB5D /* TranscribeNodeConfig.swift */; };
+		A48C3E366EB68F5DFBD38499 /* ThinkingModePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8C3EFBCE91C295309468AB /* ThinkingModePicker.swift */; };
 		2026749F2F475B7A008EAB5D /* DescribeNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026749E2F475B7A008EAB5D /* DescribeNodeConfig.swift */; };
 		202674A22F4762E6008EAB5D /* ImageZoomToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674A12F4762E6008EAB5D /* ImageZoomToolbar.swift */; };
 		202674A42F47642A008EAB5D /* SummarizeFileNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674A32F47642A008EAB5D /* SummarizeFileNodeConfig.swift */; };
@@ -435,6 +436,7 @@
 		202674982F475B33008EAB5D /* SearchNodeConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchNodeConfig.swift; sourceTree = "<group>"; };
 		2026749A2F475B4A008EAB5D /* FilesNodeConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesNodeConfig.swift; sourceTree = "<group>"; };
 		2026749C2F475B64008EAB5D /* TranscribeNodeConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscribeNodeConfig.swift; sourceTree = "<group>"; };
+		3E8C3EFBCE91C295309468AB /* ThinkingModePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinkingModePicker.swift; sourceTree = "<group>"; };
 		2026749E2F475B7A008EAB5D /* DescribeNodeConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DescribeNodeConfig.swift; sourceTree = "<group>"; };
 		202674A12F4762E6008EAB5D /* ImageZoomToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageZoomToolbar.swift; sourceTree = "<group>"; };
 		202674A32F47642A008EAB5D /* SummarizeFileNodeConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummarizeFileNodeConfig.swift; sourceTree = "<group>"; };
@@ -782,6 +784,7 @@
 				202674982F475B33008EAB5D /* SearchNodeConfig.swift */,
 				2026749A2F475B4A008EAB5D /* FilesNodeConfig.swift */,
 				2026749C2F475B64008EAB5D /* TranscribeNodeConfig.swift */,
+				3E8C3EFBCE91C295309468AB /* ThinkingModePicker.swift */,
 				2026749E2F475B7A008EAB5D /* DescribeNodeConfig.swift */,
 				202674A32F47642A008EAB5D /* SummarizeFileNodeConfig.swift */,
 				202674A52F476439008EAB5D /* SummarizeFolderNodeConfig.swift */,
@@ -1658,6 +1661,7 @@
 				20D8ED6D2F48E62F006950A3 /* DocumentStore+Helpers.swift in Sources */,
 				20D8EE3E2F4BE1AB006950A3 /* ActionLibraryService.swift in Sources */,
 				2026749D2F475B64008EAB5D /* TranscribeNodeConfig.swift in Sources */,
+				A48C3E366EB68F5DFBD38499 /* ThinkingModePicker.swift in Sources */,
 				20D8ED632F48E61C006950A3 /* SidebarItem+MoreFactories.swift in Sources */,
 				202674DC2F489677008EAB5D /* SearchView+Helpers.swift in Sources */,
 				A1BFB2D12F042C4100EAA55A /* ProvidersView.swift in Sources */,

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/DescribeNodeConfig.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/DescribeNodeConfig.swift
@@ -66,6 +66,9 @@ struct DescribeNodeConfig: View {
                     }
             }
 
+            // Thinking mode
+            ThinkingModePicker(node: $node)
+
             // Custom prompt
             VStack(alignment: .leading, spacing: 4) {
                 Text("Prompt")

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/ExtractEntitiesNodeConfig.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/ExtractEntitiesNodeConfig.swift
@@ -38,6 +38,9 @@ struct ExtractEntitiesNodeConfig: View {
                 }
             }
 
+            // Thinking mode
+            ThinkingModePicker(node: $node)
+
             // Include context
             Toggle("Include Context", isOn: $includeContext)
                 .font(.caption)

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/SummarizeCollectionNodeConfig.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/SummarizeCollectionNodeConfig.swift
@@ -48,6 +48,9 @@ struct SummarizeCollectionNodeConfig: View {
                 }
             }
 
+            // Thinking mode
+            ThinkingModePicker(node: $node)
+
             // Include statistics
             Toggle("Include Statistics", isOn: $includeStatistics)
                 .font(.caption)

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/SummarizeFileNodeConfig.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/SummarizeFileNodeConfig.swift
@@ -48,6 +48,9 @@ struct SummarizeFileNodeConfig: View {
                 }
             }
 
+            // Thinking mode
+            ThinkingModePicker(node: $node)
+
             // Custom prompt
             VStack(alignment: .leading, spacing: 4) {
                 Text("Custom Prompt (optional)")

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/SummarizeFolderNodeConfig.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/SummarizeFolderNodeConfig.swift
@@ -48,6 +48,9 @@ struct SummarizeFolderNodeConfig: View {
                 }
             }
 
+            // Thinking mode
+            ThinkingModePicker(node: $node)
+
             // Include themes
             Toggle("Include Themes", isOn: $includeThemes)
                 .font(.caption)

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/ThinkingModePicker.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodeConfigs/ThinkingModePicker.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+/// Reusable thinking mode picker for LLM-based workflow node configs.
+/// Maps to the backend's `thinking_mode` config key (off/short/medium/long).
+struct ThinkingModePicker: View {
+    @Binding var node: WorkflowNode
+
+    @State private var thinkingMode: String = "off"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Thinking Mode")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            Picker("", selection: $thinkingMode) {
+                Text("Off").tag("off")
+                Text("Short").tag("short")
+                Text("Medium").tag("medium")
+                Text("Long").tag("long")
+            }
+            .labelsHidden()
+            .pickerStyle(.segmented)
+            .onChange(of: thinkingMode) { _, newValue in
+                if newValue == "off" {
+                    node.config?.removeValue(forKey: "thinking_mode")
+                } else {
+                    if node.config == nil {
+                        node.config = [:]
+                    }
+                    node.config?["thinking_mode"] = .string(newValue)
+                }
+            }
+
+            Text("Extended thinking for complex reasoning tasks")
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+        .onAppear {
+            if let configValue = node.config?["thinking_mode"],
+               case .string(let mode) = configValue {
+                thinkingMode = mode
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Created reusable `ThinkingModePicker` component for LLM-based workflow nodes
- Added thinking mode picker (Off/Short/Medium/Long) to: SummarizeFile, SummarizeCollection, SummarizeFolder, ExtractEntities, Describe node configs
- Maps to backend's `thinking_mode` config key in `BASE_CONFIG_SCHEMA`

Closes #344

## Test plan
- [ ] Open workflow editor, add a Summarize File node → verify thinking mode picker appears
- [ ] Select "Medium" → verify config saves `thinking_mode: "medium"`
- [ ] Select "Off" → verify `thinking_mode` is removed from config
- [ ] Verify picker appears on all five LLM-based node types
- [ ] Verify existing node configs load saved thinking_mode values

🤖 Generated with [Claude Code](https://claude.com/claude-code)