### PR TITLE
feat: add prompt preview panel to workflow node editor

### DIFF
--- a/fichero-swiftui/fichero-swiftui.xcodeproj/project.pbxproj
+++ b/fichero-swiftui/fichero-swiftui.xcodeproj/project.pbxproj
@@ -84,6 +84,7 @@
 		202674E42F489742008EAB5D /* ChatMapGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674E32F489742008EAB5D /* ChatMapGrid.swift */; };
 		202674E62F489757008EAB5D /* ChatMessagesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674E52F489757008EAB5D /* ChatMessagesList.swift */; };
 		2133BF0B15424FFDBA37619B /* FolderContentsGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 747AC1DB57A54EA79D0817E8 /* FolderContentsGrid.swift */; };
+		C340001000000000PROMPT01 /* PromptPreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C340001100000000PROMPT01 /* PromptPreviewPanel.swift */; };
 		202674E82F48976C008EAB5D /* ChatView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674E72F48976C008EAB5D /* ChatView+Extensions.swift */; };
 		20D8ED492F48E2B1006950A3 /* WorkflowInspector+AgentsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED482F48E2B1006950A3 /* WorkflowInspector+AgentsSection.swift */; };
 		20D8ED4B2F48E2B3006950A3 /* ActivityProgressModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED4A2F48E2B3006950A3 /* ActivityProgressModels.swift */; };
@@ -469,6 +470,7 @@
 		202674E32F489742008EAB5D /* ChatMapGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMapGrid.swift; sourceTree = "<group>"; };
 		202674E52F489757008EAB5D /* ChatMessagesList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatMessagesList.swift; sourceTree = "<group>"; };
 		747AC1DB57A54EA79D0817E8 /* FolderContentsGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderContentsGrid.swift; sourceTree = "<group>"; };
+		C340001100000000PROMPT01 /* PromptPreviewPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPreviewPanel.swift; sourceTree = "<group>"; };
 		202674E72F48976C008EAB5D /* ChatView+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ChatView+Extensions.swift"; sourceTree = "<group>"; };
 		20D8ED482F48E2B1006950A3 /* WorkflowInspector+AgentsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WorkflowInspector+AgentsSection.swift"; sourceTree = "<group>"; };
 		20D8ED4A2F48E2B3006950A3 /* ActivityProgressModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityProgressModels.swift; sourceTree = "<group>"; };
@@ -975,6 +977,7 @@
 				B4A0010C0000000000BATCH4 /* DynamicConfigView+SchemaHelpers.swift */,
 				B4A0010D0000000000BATCH4 /* DynamicConfigView+StateManagement.swift */,
 				202674932F475B06008EAB5D /* NodeConfigs */,
+				C340001100000000PROMPT01 /* PromptPreviewPanel.swift */,
 				202674AB2F4779AA008EAB5D /* NodeProviderModelSelector.swift */,
 				202674AD2F477AFE008EAB5D /* NodeInputMappings.swift */,
 				202674B32F4783A9008EAB5D /* WorkflowNodeCard.swift */,
@@ -1673,6 +1676,7 @@
 				A1A3AA122F110D520021909D /* WorkflowCanvasView+Gestures.swift in Sources */,
 				20D8ED572F48E2D7006950A3 /* ActivityProgressView+HistoricalProgress.swift in Sources */,
 				A1A3AA132F110D520021909D /* NodePopover.swift in Sources */,
+				C340001000000000PROMPT01 /* PromptPreviewPanel.swift in Sources */,
 				20D8ED5F2F48E4DA006950A3 /* TriggerDetailView+Helpers.swift in Sources */,
 				20D8EE3A2F4BD9F6006950A3 /* LibraryView+InlineEditing.swift in Sources */,
 				2026749F2F475B7A008EAB5D /* DescribeNodeConfig.swift in Sources */,

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/NodePopover.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/NodePopover.swift
@@ -58,6 +58,9 @@ struct NodePopover: View {
                     // Tool-specific configuration
                     toolConfigSection
 
+                    // Prompt preview (LLM tools only)
+                    PromptPreviewPanel(node: node)
+
                     if shouldShowProviderSection {
                         providerModelSection
                     }

--- a/fichero-swiftui/fichero-swiftui/Views/Workflow/PromptPreviewPanel.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Workflow/PromptPreviewPanel.swift
@@ -1,0 +1,170 @@
+import OSLog
+import SwiftUI
+
+private let logger = Logger(subsystem: "com.tubb.Fichero", category: "PromptPreviewPanel")
+
+/// Collapsible panel showing the fully assembled prompt for a workflow node.
+/// Fetches from the backend `/tools/{tool}/prompt` endpoint and updates
+/// live when the node config changes.
+struct PromptPreviewPanel: View {
+    let node: WorkflowNode
+    @EnvironmentObject var workflowService: WorkflowServiceGenerated
+
+    @State private var assembledPrompt: String?
+    @State private var isLoading: Bool = false
+    @State private var isExpanded: Bool = false
+    @State private var loadError: String?
+
+    /// Debounce timer to avoid hammering the API on every keystroke
+    @State private var debounceTask: Task<Void, Never>?
+
+    var body: some View {
+        if node.usesLLM {
+            DisclosureGroup("Prompt Preview", isExpanded: $isExpanded) {
+                VStack(alignment: .leading, spacing: 8) {
+                    if isLoading {
+                        HStack(spacing: 6) {
+                            ProgressView()
+                                .controlSize(.small)
+                            Text("Loading prompt...")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                    } else if let error = loadError {
+                        Label(error, systemImage: "exclamation.triangle")
+                            .font(.caption)
+                            .foregroundColor(.orange)
+                    } else if let prompt = assembledPrompt {
+                        promptTextView(prompt)
+                    } else {
+                        Text("Expand to load prompt preview")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+                .padding(.top, 6)
+            }
+            .onChange(of: isExpanded) { _, expanded in
+                if expanded {
+                    fetchPrompt()
+                }
+            }
+            .onChange(of: node.config) { _, _ in
+                if isExpanded {
+                    debouncedFetchPrompt()
+                }
+            }
+        }
+    }
+
+    // MARK: - Prompt Display
+
+    @ViewBuilder
+    private func promptTextView(_ prompt: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            // Header with copy button
+            HStack {
+                Text("Assembled Prompt")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                    .textCase(.uppercase)
+                Spacer()
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(prompt, forType: .string)
+                } label: {
+                    Image(systemName: "doc.on.doc")
+                        .font(.caption2)
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.secondary)
+                .help("Copy prompt to clipboard")
+            }
+
+            // Prompt text in a styled container
+            ScrollView {
+                Text(prompt)
+                    .font(.system(.caption, design: .monospaced))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(8)
+            }
+            .frame(minHeight: 60, maxHeight: 160)
+            .background(Color(.textBackgroundColor))
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(Color(.separatorColor), lineWidth: 1)
+            )
+
+            // Config indicator
+            if let config = node.config, !config.isEmpty {
+                let configKeys = config.keys.filter { $0 != "prompt" }.sorted()
+                if !configKeys.isEmpty {
+                    HStack(spacing: 4) {
+                        Image(systemName: "slider.horizontal.3")
+                            .font(.caption2)
+                        Text(configKeys.joined(separator: ", "))
+                            .font(.caption2)
+                    }
+                    .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+
+    // MARK: - Fetch Logic
+
+    private func fetchPrompt() {
+        isLoading = true
+        loadError = nil
+
+        Task { @MainActor in
+            do {
+                let config = buildConfigDict()
+                let prompt = try await workflowService.getToolPrompt(
+                    toolName: node.tool,
+                    config: config
+                )
+                assembledPrompt = prompt ?? workflowService.getToolInfo(named: node.tool)?.defaultPrompt
+                loadError = nil
+            } catch {
+                logger.error("Failed to fetch prompt preview: \(String(describing: error))")
+                // Fall back to default prompt from tool info
+                assembledPrompt = workflowService.getToolInfo(named: node.tool)?.defaultPrompt
+                if assembledPrompt == nil {
+                    loadError = "Could not load prompt"
+                }
+            }
+            isLoading = false
+        }
+    }
+
+    private func debouncedFetchPrompt() {
+        debounceTask?.cancel()
+        debounceTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            fetchPrompt()
+        }
+    }
+
+    /// Convert node config to [String: any Sendable] for the API call
+    private func buildConfigDict() -> [String: any Sendable] {
+        guard let config = node.config else { return [:] }
+        var result: [String: any Sendable] = [:]
+        for (key, value) in config {
+            switch value {
+            case .string(let str):
+                result[key] = str
+            case .int(let num):
+                result[key] = num
+            case .double(let num):
+                result[key] = num
+            case .bool(let flag):
+                result[key] = flag
+            default:
+                break
+            }
+        }
+        return result
+    }
+}


### PR DESCRIPTION
## Summary
- Add collapsible `PromptPreviewPanel` to the workflow node popover for LLM-enabled nodes
- Panel calls the existing `/workflows/tools/{tool}/prompt` backend endpoint to show the fully assembled prompt
- Live updates when config changes (300ms debounce to avoid API spam)
- Copy-to-clipboard button and config key indicator
- Falls back to tool's `defaultPrompt` if backend is unreachable

Closes #340

## Test plan
- [ ] Open workflow editor, double-click an LLM node (e.g., describe, summarize)
- [ ] Expand "Prompt Preview" disclosure group — verify prompt loads from backend
- [ ] Change config options (detail level, focus) — verify prompt updates live
- [ ] Click copy button — verify prompt copies to clipboard
- [ ] Non-LLM nodes (files, collection) should not show the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)