### PR TITLE
0.0.1 Library UI: Connection Errors, Size Column, and ErrorService (#313 #314 #315)

### DIFF
--- a/fichero-swiftui/fichero-swiftui/Views/ContentView+Navigation.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/ContentView+Navigation.swift
@@ -6,23 +6,52 @@ import SwiftUI
 
 extension ContentView {
 
+    private var libraryLoadErrorMessage: String? {
+        guard !documentStore.isLoading else { return nil }
+        guard selectedDocuments.isEmpty else { return nil }
+
+        if let error = documentStore.error {
+            return error.localizedDescription
+        }
+
+        if !documentStore.isConnected {
+            return "Cannot connect to the local API server."
+        }
+
+        return nil
+    }
+
     // MARK: - Content View Router (Middle Column)
 
     @ViewBuilder
     var contentView: some View {
         switch viewMode {
         case .library:
-            LibraryView(
-                documents: selectedDocuments,
-                selection: $browserSelection,
-                detailDocument: $detailDocument,
-                viewMode: $viewSettings.libraryLayout,
-                displayMode: viewDisplayMode,
-                folderId: selectedSidebarItemId,
-                onRequestFocus: { focusedPane = .content },
-                onRequestPreviousPaneFocus: { cyclePaneFocus(reverse: true) },
-                onRequestNextPaneFocus: { cyclePaneFocus(reverse: false) }
-            )
+            if let errorMessage = libraryLoadErrorMessage {
+                ContentUnavailableView {
+                    Label("Library Unavailable", systemImage: "wifi.exclamationmark")
+                } description: {
+                    Text(errorMessage)
+                } actions: {
+                    Button("Retry") {
+                        Task { @MainActor in
+                            await documentStore.refresh()
+                        }
+                    }
+                }
+            } else {
+                LibraryView(
+                    documents: selectedDocuments,
+                    selection: $browserSelection,
+                    detailDocument: $detailDocument,
+                    viewMode: $viewSettings.libraryLayout,
+                    displayMode: viewDisplayMode,
+                    folderId: selectedSidebarItemId,
+                    onRequestFocus: { focusedPane = .content },
+                    onRequestPreviousPaneFocus: { cyclePaneFocus(reverse: true) },
+                    onRequestNextPaneFocus: { cyclePaneFocus(reverse: false) }
+                )
+            }
 
         case .search(let savedSearch):
             SearchView(

--- a/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+ColumnConfig.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+ColumnConfig.swift
@@ -107,9 +107,42 @@ extension LibraryView {
             Text(doc.updatedAt, style: .date)
                 .font(.caption).foregroundColor(.secondary)
         case "size":
-            Text("-").font(.caption).foregroundColor(.secondary)
+            if let fileSize = fileSizeInBytes(for: doc) {
+                Text(ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                Text("-").font(.caption).foregroundColor(.secondary)
+            }
         default:
             Text("-").foregroundColor(.secondary)
         }
+    }
+
+    private func fileSizeInBytes(for doc: Document) -> Int64? {
+        let metadataKeys = ["File_Size", "file_size", "size"]
+
+        for key in metadataKeys {
+            guard let value = doc.metadata[key]?.value else { continue }
+
+            switch value {
+            case let intValue as Int:
+                return Int64(intValue)
+            case let intValue as Int64:
+                return intValue
+            case let doubleValue as Double:
+                return Int64(doubleValue)
+            case let numberValue as NSNumber:
+                return numberValue.int64Value
+            case let stringValue as String:
+                if let parsed = Int64(stringValue) {
+                    return parsed
+                }
+            default:
+                continue
+            }
+        }
+
+        return nil
     }
 }

--- a/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+InlineEditing.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+InlineEditing.swift
@@ -28,7 +28,15 @@ extension LibraryView {
             do {
                 _ = try await library.documentStore.renameDocument(doc, to: newName)
             } catch {
-                print("Failed to rename document: \(error)")
+                ErrorService.shared.reportError(
+                    ErrorModel.fileSystemError(
+                        message: "Failed to rename \"\(doc.name)\" to \"\(newName)\".",
+                        context: [
+                            "operation": "rename_document",
+                            "document_id": doc.id
+                        ]
+                    )
+                )
             }
         }
     }

--- a/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+KeyboardShortcuts.swift
+++ b/fichero-swiftui/fichero-swiftui/Views/Library/LibraryView+KeyboardShortcuts.swift
@@ -90,7 +90,16 @@ extension LibraryView {
             do {
                 try await library.documentStore.deleteDocument(doc)
             } catch {
-                print("Failed to delete document \(doc.name): \(error)")
+                ErrorService.shared.reportError(
+                    ErrorModel.fileSystemError(
+                        message: "Failed to delete \"\(doc.name)\".",
+                        context: [
+                            "operation": "delete_document",
+                            "document_id": doc.id,
+                            "underlying_error": error.localizedDescription
+                        ]
+                    )
+                )
             }
         }
         // Clear selection for deleted items


### PR DESCRIPTION
Restores local implementations for:
- #313: Connection/API error state UI in Library View
- #314: Populated Size column from metadata in Table View
- #315: Replace print() error logging with ErrorService in Library actions

Validated with:
- swiftlint (4/4 files passed)
- ruff (backend passed)
- git push verified