### PR TITLE
Importers: per-page catalogue records (#1469) + Tinderbox link importer (#744)

### DIFF
--- a/fichero-engine/src/fichero/__main__.py
+++ b/fichero-engine/src/fichero/__main__.py
@@ -762,6 +762,56 @@ def import_box_links_command(
     typer.echo(f"skipped_rows: {summary.skipped_rows}")
 
 
+@app.command(name="import-tinderbox-links")
+def import_tinderbox_links_command(
+    library_path: Path = typer.Option(
+        Path("~/Library/Application Support/Fichero/Tinderbox-Links.fichero"),
+        "--library-path",
+        help="Target .fichero package to create/update.",
+    ),
+    tbx_path: Path = typer.Option(
+        Path("~/Documents/Notes.tbx"),
+        "--tbx-path",
+        help="Path to the Tinderbox .tbx document.",
+    ),
+    reset: bool = typer.Option(
+        False,
+        "--reset",
+        help="Delete the target package before importing.",
+    ),
+) -> None:
+    """Import/link Tinderbox notes from a .tbx file into the library model."""
+
+    from fichero.tinderbox_link_import import import_tinderbox_links
+
+    try:
+        summary = import_tinderbox_links(
+            library_path=library_path,
+            tbx_path=tbx_path,
+            reset=reset,
+        )
+    except Exception as exc:
+        typer.secho(f"Tinderbox link import failed: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1) from exc
+
+    if summary.errors:
+        typer.secho(
+            f"Imported with {len(summary.errors)} errors.",
+            fg=typer.colors.YELLOW,
+            err=True,
+        )
+        for err in summary.errors[:10]:
+            typer.echo(f"  {err}", err=True)
+
+    typer.echo(f"library: {summary.library_path}")
+    typer.echo(f"tbx_path: {summary.tbx_path}")
+    typer.echo(f"root_document_id: {summary.root_document_id}")
+    typer.echo(f"imported_notes: {summary.imported_notes}")
+    typer.echo(f"updated_notes: {summary.updated_notes}")
+    typer.echo(f"deleted_notes: {summary.deleted_notes}")
+    typer.echo(f"skipped_notes: {summary.skipped_notes}")
+
+
 @artifacts_app.command("list")
 def artifacts_list(
     ctx: typer.Context,

--- a/fichero-engine/src/fichero/tinderbox_link_import.py
+++ b/fichero-engine/src/fichero/tinderbox_link_import.py
@@ -1,0 +1,208 @@
+"""Link-only Tinderbox (.tbx) importer into the Fichero library model."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+from fichero.db import db_manager
+from fichero.models import DocType, Document, FileType, Status
+
+
+@dataclass(frozen=True)
+class TinderboxLinkImportSummary:
+    library_path: Path
+    tbx_path: Path
+    root_document_id: str
+    imported_notes: int = 0
+    updated_notes: int = 0
+    deleted_notes: int = 0
+    skipped_notes: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+def import_tinderbox_links(
+    *,
+    library_path: Path,
+    tbx_path: Path,
+    reset: bool = False,
+) -> TinderboxLinkImportSummary:
+    library_path = library_path.expanduser().resolve()
+    tbx_path = tbx_path.expanduser().resolve()
+
+    _ensure_library_package(library_path)
+    db = db_manager.get_database(library_path)
+
+    root = _find_root_doc(db, tbx_path) or Document(
+        name=f"Tinderbox: {tbx_path.stem}",
+        path=str(tbx_path),
+        doc_type=DocType.folder,
+        status=Status.completed,
+        metadata={"source_type": "tinderbox_link_import", "tbx_path": str(tbx_path)},
+    )
+    db.save(root, auto_embed=False)
+
+    notes = parse_tinderbox_notes(tbx_path)
+    note_ids = {note["id"] for note in notes}
+
+    existing_docs = [
+        doc
+        for doc in db.query(Document, parent_id=root.id)
+        if doc.doc_type == DocType.file and (doc.metadata or {}).get("source_type") == "tinderbox_note"
+    ]
+    existing_by_note_id = {
+        str((doc.metadata or {}).get("tinderbox_id") or ""): doc
+        for doc in existing_docs
+        if (doc.metadata or {}).get("tinderbox_id")
+    }
+
+    imported = 0
+    updated = 0
+    skipped = 0
+    errors: list[str] = []
+
+    for note in notes:
+        note_id = note["id"]
+        content = note.get("text") or ""
+        url = note.get("url") or ""
+        if url and not content.strip():
+            skipped += 1
+            continue
+
+        metadata = {
+            "source_type": "tinderbox_note",
+            "tinderbox_id": note_id,
+            "tinderbox_path": note.get("tb_path") or "",
+            "tinderbox_tags": note.get("tags") or [],
+            "tinderbox_prototype": note.get("prototype") or "",
+            "tinderbox_attrs": note.get("attrs") or {},
+            "tinderbox_modified": note.get("modified") or "",
+            "link_only": True,
+            "remote_reference": True,
+        }
+
+        existing = existing_by_note_id.get(note_id)
+        try:
+            if existing is None:
+                doc = Document(
+                    name=note.get("name") or f"Tinderbox note {note_id}",
+                    path=f"tinderbox://{tbx_path.name}/{note_id}",
+                    doc_type=DocType.file,
+                    file_type=FileType.text,
+                    parent_id=root.id,
+                    status=Status.completed,
+                    page_content=content,
+                    metadata=metadata,
+                )
+                db.save(doc)
+                imported += 1
+            else:
+                existing.name = note.get("name") or existing.name
+                existing.path = f"tinderbox://{tbx_path.name}/{note_id}"
+                existing.page_content = content
+                existing.metadata = metadata
+                existing.status = Status.completed
+                db.save(existing)
+                updated += 1
+        except Exception as exc:  # pragma: no cover
+            errors.append(f"note:{note_id}:{exc}")
+
+    deleted = 0
+    for doc in existing_docs:
+        note_id = str((doc.metadata or {}).get("tinderbox_id") or "")
+        if note_id and note_id not in note_ids:
+            db.delete(doc)
+            deleted += 1
+
+    return TinderboxLinkImportSummary(
+        library_path=library_path,
+        tbx_path=tbx_path,
+        root_document_id=root.id,
+        imported_notes=imported,
+        updated_notes=updated,
+        deleted_notes=deleted,
+        skipped_notes=skipped,
+        errors=errors,
+    )
+
+
+def parse_tinderbox_notes(tbx_path: Path) -> list[dict[str, Any]]:
+    notes: list[dict[str, Any]] = []
+    for event, elem in ET.iterparse(tbx_path, events=("end",)):
+        tag = _local_name(elem.tag)
+        if tag not in {"note", "item"}:
+            continue
+        attrs = _collect_attrs(elem)
+        note_id = _pick(attrs, "id", "$ID", "ID")
+        if not note_id:
+            elem.clear()
+            continue
+        name = _pick(attrs, "$Name", "Name", "name") or f"Tinderbox note {note_id}"
+        text = _pick(attrs, "$Text", "Text", "text") or ""
+        tags_raw = _pick(attrs, "$Tags", "Tags", "$Keywords", "Keywords") or ""
+        tags = [token.strip() for token in tags_raw.replace(";", ",").split(",") if token.strip()]
+        notes.append(
+            {
+                "id": note_id,
+                "name": name,
+                "text": text,
+                "tb_path": _pick(attrs, "$Path", "Path") or "",
+                "prototype": _pick(attrs, "$Prototype", "Prototype") or "",
+                "modified": _pick(attrs, "$Modified", "Modified") or "",
+                "url": _pick(attrs, "$URL", "URL") or "",
+                "tags": tags,
+                "attrs": attrs,
+            }
+        )
+        elem.clear()
+    return notes
+
+
+def _collect_attrs(elem: ET.Element) -> dict[str, str]:
+    attrs: dict[str, str] = {str(k): str(v) for k, v in elem.attrib.items()}
+    for child in list(elem):
+        child_tag = _local_name(child.tag)
+        if child_tag != "attribute":
+            continue
+        key = child.attrib.get("name") or child.attrib.get("key") or child.attrib.get("Name")
+        if not key:
+            continue
+        value = "".join(part for part in child.itertext()).strip()
+        attrs[str(key)] = value
+    return attrs
+
+
+def _pick(attrs: dict[str, str], *keys: str) -> str:
+    for key in keys:
+        value = attrs.get(key)
+        if value is None:
+            continue
+        value = str(value).strip()
+        if value:
+            return value
+    return ""
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1].lower()
+
+
+def _find_root_doc(db: Any, tbx_path: Path) -> Document | None:
+    for doc in db.all(Document):
+        metadata = doc.metadata if isinstance(doc.metadata, dict) else {}
+        if (
+            doc.doc_type == DocType.folder
+            and metadata.get("source_type") == "tinderbox_link_import"
+            and metadata.get("tbx_path") == str(tbx_path)
+        ):
+            return doc
+    return None
+
+
+def _ensure_library_package(library_path: Path) -> None:
+    library_path.mkdir(parents=True, exist_ok=True)
+    (library_path / "files").mkdir(exist_ok=True)
+    (library_path / "lance").mkdir(exist_ok=True)
+    (library_path / "vectors").mkdir(exist_ok=True)

--- a/fichero-engine/src/fichero/workflows/runtime.py
+++ b/fichero-engine/src/fichero/workflows/runtime.py
@@ -45,8 +45,16 @@ def to_workflow_def(workflow: Any) -> WorkflowDef:
                 label=_as_mapping(n).get("label", ""),
                 inputs=_as_mapping(n).get("inputs", {}),
                 config=_as_mapping(n).get("config", {}),
-                provider_name=_as_mapping(n).get("provider_name", ""),
-                model_name=_as_mapping(n).get("model_name", ""),
+                provider_name=(
+                    _as_mapping(n).get("provider_name")
+                    or _as_mapping(n).get("providerName")
+                    or ""
+                ),
+                model_name=(
+                    _as_mapping(n).get("model_name")
+                    or _as_mapping(n).get("modelName")
+                    or ""
+                ),
             )
             for n in workflow.nodes
         ],

--- a/fichero-engine/src/fichero/workflows/tools/extract_all.py
+++ b/fichero-engine/src/fichero/workflows/tools/extract_all.py
@@ -866,6 +866,10 @@ def _recover_text_and_records(
             result = item.get("result")
             if not isinstance(result, dict):
                 continue
+            records = _normalize_records(result.get("records"))
+            if records:
+                parallel_records.extend(records)
+                continue
             page_records = _normalize_records(result.get("page_records"))
             if page_records:
                 parallel_records.extend(page_records)

--- a/fichero-engine/tests/unit/test_tinderbox_link_import.py
+++ b/fichero-engine/tests/unit/test_tinderbox_link_import.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fichero.db import db_manager
+from fichero.models import DocType, FileType, Document
+from fichero.tinderbox_link_import import import_tinderbox_links
+
+
+def _write_tbx(path: Path, body: str) -> None:
+    path.write_text(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<tbx>\n" + body + "\n</tbx>\n",
+        encoding="utf-8",
+    )
+
+
+def test_import_tinderbox_links_upserts_and_removes_deleted_notes(tmp_path):
+    library_path = tmp_path / "tbx.fichero"
+    tbx_path = tmp_path / "notes.tbx"
+
+    _write_tbx(
+        tbx_path,
+        """
+<note ID="n1" Name="First" Path="/One" Text="alpha text" Tags="a,b" Modified="2024-01-01" />
+<note ID="n2" Name="Second" Path="/Two" Text="beta text" />
+        """.strip(),
+    )
+
+    summary = import_tinderbox_links(
+        library_path=library_path,
+        tbx_path=tbx_path,
+        reset=False,
+    )
+
+    db = db_manager.get_database(library_path)
+    roots = [
+        d
+        for d in db.all(Document)
+        if d.doc_type == DocType.folder
+        and (d.metadata or {}).get("source_type") == "tinderbox_link_import"
+    ]
+    assert len(roots) == 1
+
+    docs = [
+        d
+        for d in db.all(Document)
+        if d.parent_id == roots[0].id and d.doc_type == DocType.file
+    ]
+    assert len(docs) == 2
+    by_id = {(d.metadata or {}).get("tinderbox_id"): d for d in docs}
+    assert by_id["n1"].file_type == FileType.text
+    assert by_id["n1"].page_content == "alpha text"
+    assert by_id["n2"].page_content == "beta text"
+    assert summary.imported_notes == 2
+
+    _write_tbx(
+        tbx_path,
+        """
+<note ID="n1" Name="First updated" Path="/One" Text="alpha updated" Tags="a,c" Modified="2024-01-02" />
+        """.strip(),
+    )
+
+    summary2 = import_tinderbox_links(
+        library_path=library_path,
+        tbx_path=tbx_path,
+        reset=False,
+    )
+
+    docs_after = [
+        d
+        for d in db.all(Document)
+        if d.parent_id == roots[0].id and d.doc_type == DocType.file
+    ]
+    assert len(docs_after) == 1
+    only = docs_after[0]
+    assert (only.metadata or {}).get("tinderbox_id") == "n1"
+    assert only.name == "First updated"
+    assert only.page_content == "alpha updated"
+    assert summary2.updated_notes == 1
+    assert summary2.deleted_notes == 1
+
+
+def test_import_tinderbox_links_skips_url_bookmarks_without_text(tmp_path):
+    library_path = tmp_path / "tbx-url.fichero"
+    tbx_path = tmp_path / "bookmarks.tbx"
+    _write_tbx(
+        tbx_path,
+        """
+<note ID="n-url" Name="Bookmark" URL="https://example.com" Text="" />
+<note ID="n-text" Name="Real" Text="content" />
+        """.strip(),
+    )
+
+    summary = import_tinderbox_links(library_path=library_path, tbx_path=tbx_path)
+    db = db_manager.get_database(library_path)
+    note_docs = [
+        d
+        for d in db.all(Document)
+        if d.doc_type == DocType.file
+        and (d.metadata or {}).get("source_type") == "tinderbox_note"
+    ]
+    assert len(note_docs) == 1
+    assert note_docs[0].name == "Real"
+    assert summary.skipped_notes >= 1

--- a/fichero-engine/tests/unit/test_tinderbox_link_import_cli.py
+++ b/fichero-engine/tests/unit/test_tinderbox_link_import_cli.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from fichero import __main__ as cli
+from fichero.tinderbox_link_import import TinderboxLinkImportSummary
+
+
+runner = CliRunner()
+
+
+def test_import_tinderbox_links_cli_invokes_importer(monkeypatch, tmp_path):
+    captured = {}
+
+    def fake_import_tinderbox_links(*, library_path: Path, tbx_path: Path, reset: bool = False):
+        captured["library_path"] = library_path
+        captured["tbx_path"] = tbx_path
+        captured["reset"] = reset
+        return TinderboxLinkImportSummary(
+            library_path=library_path,
+            tbx_path=tbx_path,
+            root_document_id="tbx-root",
+            imported_notes=2,
+            updated_notes=1,
+            deleted_notes=1,
+            skipped_notes=0,
+            errors=[],
+        )
+
+    monkeypatch.setattr(
+        "fichero.tinderbox_link_import.import_tinderbox_links",
+        fake_import_tinderbox_links,
+    )
+
+    result = runner.invoke(
+        cli.app,
+        [
+            "import-tinderbox-links",
+            "--library-path",
+            str(tmp_path / "tbx.fichero"),
+            "--tbx-path",
+            str(tmp_path / "notes.tbx"),
+            "--reset",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured["reset"] is True
+    assert "imported_notes: 2" in result.output
+    assert "updated_notes: 1" in result.output
+    assert "deleted_notes: 1" in result.output

--- a/fichero-engine/tests/unit/workflows/test_extract_all_input_recovery.py
+++ b/fichero-engine/tests/unit/workflows/test_extract_all_input_recovery.py
@@ -59,3 +59,32 @@ def test_recover_text_from_parallel_page_records_when_outputs_empty():
 
     assert text == "Parallel page"
     assert records == [{"index": 0, "doc_id": "page-1", "text": "Parallel page"}]
+
+
+def test_recover_text_from_parallel_records_when_outputs_empty():
+    """Prefer canonical records from parallel fan-out results (#1469)."""
+    text, records = _recover_text_and_records(
+        {"text": None, "records": []},
+        {
+            "parallel_results": {
+                "transcribe": [
+                    {
+                        "index": 0,
+                        "success": True,
+                        "result": {
+                            "records": [
+                                {"doc_id": "page-a", "text": "Parallel A"},
+                                {"doc_id": "page-b", "text": "Parallel B"},
+                            ],
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+    assert text == "Parallel A\n\nParallel B"
+    assert records == [
+        {"index": 0, "doc_id": "page-a", "text": "Parallel A"},
+        {"index": 1, "doc_id": "page-b", "text": "Parallel B"},
+    ]

--- a/fichero-engine/tests/unit/workflows/test_runtime_helpers.py
+++ b/fichero-engine/tests/unit/workflows/test_runtime_helpers.py
@@ -61,3 +61,23 @@ def test_to_workflow_def_accepts_camel_case_edge_aliases():
     assert wf_def.edges[0].target == "b"
     assert wf_def.edges[0].source_port == "text"
     assert wf_def.edges[0].target_port == "context"
+
+
+def test_to_workflow_def_accepts_camel_case_node_provider_fields():
+    workflow = SimpleNamespace(
+        id="wf-3",
+        name="Runtime Node Alias Test",
+        nodes=[
+            {
+                "id": "n1",
+                "tool": "transcribe",
+                "providerName": "openai",
+                "modelName": "gpt-5",
+            }
+        ],
+        edges=[],
+    )
+
+    wf_def = to_workflow_def(workflow)
+    assert wf_def.nodes[0].provider_name == "openai"
+    assert wf_def.nodes[0].model_name == "gpt-5"


### PR DESCRIPTION
Backend milestone work. #1469 preserves per-page records from parallel catalogue runs (the root-cause fix behind empty page-level KG/Map/Timeline). #744 adds a Tinderbox .tbx link importer + CLI.

Gates: RED→GREEN per issue, full pytest (3707 passed), ruff clean (worker f_ms_kg). Manager-reviewed diff: 8 files, +478/-2, additive & focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)