### PR TITLE
Thinking-layer backend foundations: Note→chapter field (#1489), workspace CRUD (#1490), outline endpoint (#1491)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/document_inspector.py
+++ b/fichero-engine/src/fichero/api/routes/document_inspector.py
@@ -20,6 +20,7 @@ from fichero.db import Database
 from fichero.hermeneutics_models import Interpretation
 from fichero.knowledge_models import (
     Annotation,
+    BookStructureNode,
     DocumentCitation,
     EntityType,
     KnowledgeClaim,
@@ -28,7 +29,7 @@ from fichero.knowledge_models import (
     Project,
     ProjectInclusion,
 )
-from fichero.models import Artifact, Document
+from fichero.models import Artifact, Document, DocType
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/documents")
@@ -48,6 +49,20 @@ class DocumentInspectorResponse(BaseModel):
     citations_inbound: list[DocumentCitation]  # what cites this doc
     interpretations: list[Interpretation]
     projects: list[Project]
+
+
+class DocumentOutlineRow(BaseModel):
+    id: str
+    depth: int
+    kind: str
+    label: str
+    count: int
+
+
+class DocumentOutlineResponse(BaseModel):
+    document_id: str
+    rows: list[DocumentOutlineRow]
+    count: int
 
 
 @router.get(
@@ -146,6 +161,140 @@ async def inspector(
         interpretations=interpretations,
         projects=projects,
     )
+
+
+@router.get(
+    "/{document_id}/outline",
+    response_model=DocumentOutlineResponse,
+    summary="Hierarchical source outline for document drill-down",
+)
+async def document_outline(
+    document_id: str,
+    db: Database = Depends(get_library_database),
+) -> DocumentOutlineResponse:
+    doc = db.get(Document, document_id)
+    if doc is None:
+        raise HTTPException(404, f"Document not found: {document_id}")
+
+    from fichero.api.routes.claims import _descendant_doc_ids
+
+    doc_ids = _descendant_doc_ids(db, document_id)
+    descendants = [d for d in db.query(Document) if d.id in doc_ids and d.id != document_id]
+    pages = sorted(
+        [d for d in descendants if d.doc_type == DocType.page],
+        key=lambda d: (d.sequence or 0, d.name),
+    )
+    chunks = [d for d in descendants if d.doc_type == DocType.chunk]
+
+    claims = [c for c in db.query(KnowledgeClaim) if c.source_document_id in doc_ids]
+    annotations = [a for a in db.query(Annotation) if a.document_id in doc_ids]
+    artifacts = [a for a in db.query(Artifact) if a.document_id in doc_ids]
+    citations = [
+        c for c in db.query(DocumentCitation)
+        if c.source_document_id in doc_ids or c.target_document_id in doc_ids
+    ]
+
+    page_id_by_sequence = {p.sequence: p.id for p in pages if p.sequence is not None}
+    claim_count_by_doc: dict[str, int] = {}
+    for claim in claims:
+        claim_count_by_doc[claim.source_document_id] = claim_count_by_doc.get(claim.source_document_id, 0) + 1
+    annotation_count_by_doc: dict[str, int] = {}
+    for ann in annotations:
+        annotation_count_by_doc[ann.document_id] = annotation_count_by_doc.get(ann.document_id, 0) + 1
+    artifact_count_by_doc: dict[str, int] = {}
+    for artifact in artifacts:
+        artifact_count_by_doc[artifact.document_id] = artifact_count_by_doc.get(artifact.document_id, 0) + 1
+    citation_count_by_doc: dict[str, int] = {}
+    for citation in citations:
+        if citation.source_document_id in doc_ids:
+            citation_count_by_doc[citation.source_document_id] = citation_count_by_doc.get(citation.source_document_id, 0) + 1
+        if citation.target_document_id in doc_ids:
+            citation_count_by_doc[citation.target_document_id] = citation_count_by_doc.get(citation.target_document_id, 0) + 1
+
+    rows: list[DocumentOutlineRow] = []
+    for page in pages:
+        rows.append(
+            DocumentOutlineRow(
+                id=page.id,
+                depth=1,
+                kind="page",
+                label=page.name,
+                count=(
+                    claim_count_by_doc.get(page.id, 0)
+                    + annotation_count_by_doc.get(page.id, 0)
+                    + artifact_count_by_doc.get(page.id, 0)
+                    + citation_count_by_doc.get(page.id, 0)
+                ),
+            )
+        )
+
+    for chunk in chunks:
+        rows.append(
+            DocumentOutlineRow(
+                id=chunk.id,
+                depth=2,
+                kind="chunk",
+                label=chunk.name,
+                count=(
+                    claim_count_by_doc.get(chunk.id, 0)
+                    + annotation_count_by_doc.get(chunk.id, 0)
+                    + artifact_count_by_doc.get(chunk.id, 0)
+                    + citation_count_by_doc.get(chunk.id, 0)
+                ),
+            )
+        )
+
+    structure_nodes = [
+        s for s in db.query(BookStructureNode)
+        if s.source_document_id == document_id
+    ]
+    structure_nodes.sort(key=lambda s: (s.level, s.start_sequence, s.title))
+    for node in structure_nodes:
+        in_range_doc_ids = {
+            page_id_by_sequence.get(seq)
+            for seq in range(node.start_sequence, (node.end_sequence or node.start_sequence) + 1)
+        }
+        in_range_doc_ids.discard(None)
+        rows.append(
+            DocumentOutlineRow(
+                id=node.id,
+                depth=node.level,
+                kind=node.kind,
+                label=node.title,
+                count=sum(claim_count_by_doc.get(pid, 0) for pid in in_range_doc_ids),
+            )
+        )
+
+    linked_entity_ids = {
+        entity_id
+        for claim in claims
+        for entity_id in (claim.entity_ids or [])
+        if entity_id
+    }
+    entities = [
+        entity for entity in (db.get(KnowledgeEntity, entity_id) for entity_id in linked_entity_ids)
+        if entity is not None
+    ]
+    rows.append(
+        DocumentOutlineRow(
+            id=f"{document_id}:annotations",
+            depth=1,
+            kind="annotation-group",
+            label="Annotations",
+            count=len(annotations),
+        )
+    )
+    rows.append(
+        DocumentOutlineRow(
+            id=f"{document_id}:entities",
+            depth=1,
+            kind="entity-group",
+            label="Entities",
+            count=len(entities),
+        )
+    )
+
+    return DocumentOutlineResponse(document_id=document_id, rows=rows, count=len(rows))
 
 
 # =============================================================================

--- a/fichero-engine/src/fichero/api/routes/documents.py
+++ b/fichero-engine/src/fichero/api/routes/documents.py
@@ -14,7 +14,15 @@ from pydantic import BaseModel, ConfigDict, ValidationError
 
 from fichero.api.main import get_library_database
 from fichero.db import Database
-from fichero.knowledge_models import ClassificationDimension, ClassificationValue
+from fichero.knowledge_models import (
+    Annotation,
+    ClassificationDimension,
+    ClassificationValue,
+    DocumentCitation,
+    KnowledgeClaim,
+    KnowledgeEntity,
+    Note,
+)
 from fichero.models import Artifact, DocType, Document, FileType, Status
 from fichero.models import DocumentListResponse, DocumentNote, RelatedDocumentListResponse
 
@@ -151,6 +159,83 @@ class DocumentNoteUpsert(BaseModel):
     """Request body for per-document note upsert."""
 
     content: str
+
+
+class WorkspaceCuratedItem(BaseModel):
+    id: str
+    target_type: str
+    target_id: str
+    role: str | None = None
+    added_at: str | None = None
+    x: float | None = None
+    y: float | None = None
+    notes: str | None = None
+
+
+class WorkspacePatchRequest(BaseModel):
+    add: list[WorkspaceCuratedItem] = []
+    remove_ids: list[str] = []
+    reorder_ids: list[str] | None = None
+
+
+class WorkspaceItemsResponse(BaseModel):
+    document_id: str
+    items: list[dict[str, Any]]
+    count: int
+
+
+def _workspace_doc_or_404(db: Database, doc_id: str) -> Document:
+    doc = db.get(Document, doc_id)
+    if not doc:
+        raise HTTPException(status_code=404, detail=f"Document not found: {doc_id}")
+    if doc.doc_type != DocType.folder:
+        raise HTTPException(status_code=400, detail="Document is not a folder")
+    return doc
+
+
+def _normalize_curated_items(items: list[Any] | None) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for item in items or []:
+        if not isinstance(item, dict):
+            continue
+        item_id = str(item.get("id") or "").strip()
+        target_type = str(item.get("target_type") or "").strip()
+        target_id = str(item.get("target_id") or "").strip()
+        if not item_id or not target_type or not target_id:
+            continue
+        normalized.append(
+            {
+                "id": item_id,
+                "target_type": target_type,
+                "target_id": target_id,
+                "role": item.get("role"),
+                "added_at": item.get("added_at"),
+                "x": item.get("x"),
+                "y": item.get("y"),
+                "notes": item.get("notes"),
+            }
+        )
+    return normalized
+
+
+def _resolve_workspace_item_target(db: Database, item: dict[str, Any]) -> Any:
+    target_type = str(item.get("target_type") or "").strip().lower()
+    target_id = str(item.get("target_id") or "").strip()
+    if not target_id:
+        return None
+    model_by_type = {
+        "document": Document,
+        "entity": KnowledgeEntity,
+        "claim": KnowledgeClaim,
+        "note": Note,
+        "annotation": Annotation,
+        "citation": DocumentCitation,
+    }
+    model = model_by_type.get(target_type)
+    if model is None:
+        return None
+    target = db.get(model, target_id)
+    return target.model_dump() if target is not None else None
 
 
 # Routes
@@ -303,6 +388,80 @@ async def delete_document_note(
     if not notes:
         raise HTTPException(status_code=404, detail=f"Document note not found: {doc_id}")
     db.delete(notes[0])
+
+
+@router.patch("/{doc_id}/workspace", response_model=WorkspaceItemsResponse)
+async def patch_workspace_items(
+    doc_id: str,
+    request: WorkspacePatchRequest,
+    db: Database = Depends(get_library_database),
+) -> WorkspaceItemsResponse:
+    """Atomically add/remove/reorder workspace curated items."""
+    doc = _workspace_doc_or_404(db, doc_id)
+    current_items = _normalize_curated_items(doc.curated_items)
+    by_id = {item["id"]: item for item in current_items}
+
+    for remove_id in request.remove_ids:
+        by_id.pop(remove_id, None)
+
+    now_iso = datetime.now().isoformat()
+    for incoming in request.add:
+        payload = incoming.model_dump()
+        payload["added_at"] = payload.get("added_at") or now_iso
+        by_id[payload["id"]] = payload
+
+    ordered_ids: list[str]
+    if request.reorder_ids is not None:
+        seen = set()
+        ordered_ids = []
+        for item_id in request.reorder_ids:
+            if item_id in by_id and item_id not in seen:
+                ordered_ids.append(item_id)
+                seen.add(item_id)
+        for item in current_items:
+            item_id = item["id"]
+            if item_id in by_id and item_id not in seen:
+                ordered_ids.append(item_id)
+                seen.add(item_id)
+        for item_id in by_id:
+            if item_id not in seen:
+                ordered_ids.append(item_id)
+                seen.add(item_id)
+    else:
+        ordered_ids = [item["id"] for item in current_items if item["id"] in by_id]
+        for item_id in by_id:
+            if item_id not in ordered_ids:
+                ordered_ids.append(item_id)
+
+    doc.is_workspace = True
+    doc.curated_items = [by_id[item_id] for item_id in ordered_ids]
+    doc.updated_at = datetime.now()
+    db.save(doc)
+
+    return WorkspaceItemsResponse(
+        document_id=doc.id,
+        items=doc.curated_items,
+        count=len(doc.curated_items),
+    )
+
+
+@router.get("/{doc_id}/workspace/items", response_model=WorkspaceItemsResponse)
+async def get_workspace_items(
+    doc_id: str,
+    db: Database = Depends(get_library_database),
+) -> WorkspaceItemsResponse:
+    """List curated workspace items with alias resolution to full targets."""
+    doc = _workspace_doc_or_404(db, doc_id)
+    items = _normalize_curated_items(doc.curated_items)
+    resolved = []
+    for item in items:
+        resolved.append(
+            {
+                **item,
+                "target": _resolve_workspace_item_target(db, item),
+            }
+        )
+    return WorkspaceItemsResponse(document_id=doc.id, items=resolved, count=len(resolved))
 
 
 @router.get("/{doc_id}/children")

--- a/fichero-engine/src/fichero/api/routes/notes.py
+++ b/fichero-engine/src/fichero/api/routes/notes.py
@@ -37,6 +37,7 @@ class NoteCreateRequest(BaseModel):
     linked_entity_ids: list[str] = []
     linked_claim_ids: list[str] = []
     linked_document_ids: list[str] = []
+    linked_structure_node_id: str | None = None
     address: str | None = None
     parent_address: str | None = None
 
@@ -58,6 +59,7 @@ async def list_notes(
     linked_entity_id: str | None = Query(default=None),
     linked_claim_id: str | None = Query(default=None),
     linked_document_id: str | None = Query(default=None),
+    linked_structure_node_id: str | None = Query(default=None),
     q: str | None = Query(default=None, description="full-text body search"),
     db: Database = Depends(get_library_database),
 ) -> NoteListResponse:
@@ -72,6 +74,8 @@ async def list_notes(
         rows = [r for r in rows if linked_claim_id in (r.linked_claim_ids or [])]
     if linked_document_id is not None:
         rows = [r for r in rows if linked_document_id in (r.linked_document_ids or [])]
+    if linked_structure_node_id is not None:
+        rows = [r for r in rows if r.linked_structure_node_id == linked_structure_node_id]
     if q:
         needle = q.lower()
         rows = [
@@ -103,6 +107,7 @@ class NotePatchRequest(BaseModel):
     linked_entity_ids: list[str] | None = None
     linked_claim_ids: list[str] | None = None
     linked_document_ids: list[str] | None = None
+    linked_structure_node_id: str | None = None
     address: str | None = None
     parent_address: str | None = None
 

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -2222,6 +2222,18 @@ def register_generated_openapi_commands(
             return client.request("GET", path, params=params)
         invoke(ctx, op_call)
 
+    @target_app.command("hierarchical-source-outline-for-drill-down")
+    def documents_hierarchical_source_outline_for_drill_down_get(
+        ctx: typer.Context,
+        document_id: str = typer.Argument(..., help="Path parameter: document_id."),
+    ) -> None:
+        """Hierarchical source outline for document drill-down (GET /api/documents/{document_id}/outline)."""
+        def op_call(client: FicheroClient) -> Any:
+            path = f"/api/documents/{document_id}/outline"
+            params = None
+            return client.request("GET", path, params=params)
+        invoke(ctx, op_call)
+
     target_app = existing_apps.get('entities')
     if target_app is None:
         target_app = typer.Typer(help='Generated OpenAPI commands for entities endpoints.', no_args_is_help=True)

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -5655,6 +5655,7 @@ def register_generated_openapi_commands(
         linked_claim_id: Optional[str] = typer.Option(None, "--linked-claim-id", help="Query parameter: linked_claim_id."),
         linked_document_id: Optional[str] = typer.Option(None, "--linked-document-id", help="Query parameter: linked_document_id."),
         linked_entity_id: Optional[str] = typer.Option(None, "--linked-entity-id", help="Query parameter: linked_entity_id."),
+        linked_structure_node_id: Optional[str] = typer.Option(None, "--linked-structure-node-id", help="Query parameter: linked_structure_node_id."),
         q: Optional[str] = typer.Option(None, "--q", help="Query parameter: q."),
         tag: Optional[str] = typer.Option(None, "--tag", help="Query parameter: tag."),
     ) -> None:
@@ -5666,6 +5667,7 @@ def register_generated_openapi_commands(
                 "linked_claim_id": linked_claim_id,
                 "linked_document_id": linked_document_id,
                 "linked_entity_id": linked_entity_id,
+                "linked_structure_node_id": linked_structure_node_id,
                 "q": q,
                 "tag": tag,
             }

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -2156,6 +2156,33 @@ def register_generated_openapi_commands(
             return client.request("GET", path, params=params)
         invoke(ctx, op_call)
 
+    @target_app.command("patch-workspace-items")
+    def documents_patch_workspace_items_patch(
+        ctx: typer.Context,
+        doc_id: str = typer.Argument(..., help="Path parameter: doc_id."),
+        body: Optional[str] = typer.Option(None, "--body", help="Inline JSON request body."),
+        body_file: Optional[Path] = typer.Option(None, "--body-file", exists=True, dir_okay=False, readable=True, help="Path to a JSON request body file."),
+    ) -> None:
+        """Patch Workspace Items (PATCH /api/documents/{doc_id}/workspace)."""
+        def op_call(client: FicheroClient) -> Any:
+            path = f"/api/documents/{doc_id}/workspace"
+            params = None
+            payload = _load_json_payload(body, body_file, required=True)
+            return client.request("PATCH", path, params=params, json=payload)
+        invoke(ctx, op_call)
+
+    @target_app.command("get-workspace-items")
+    def documents_get_workspace_items_get(
+        ctx: typer.Context,
+        doc_id: str = typer.Argument(..., help="Path parameter: doc_id."),
+    ) -> None:
+        """Get Workspace Items (GET /api/documents/{doc_id}/workspace/items)."""
+        def op_call(client: FicheroClient) -> Any:
+            path = f"/api/documents/{doc_id}/workspace/items"
+            params = None
+            return client.request("GET", path, params=params)
+        invoke(ctx, op_call)
+
     @target_app.command("get-citations")
     def documents_get_citations_get(
         ctx: typer.Context,

--- a/fichero-engine/src/fichero/knowledge_models.py
+++ b/fichero-engine/src/fichero/knowledge_models.py
@@ -1184,6 +1184,7 @@ class Note(BaseModel):
     linked_entity_ids: list[str] = Field(default_factory=list)
     linked_claim_ids: list[str] = Field(default_factory=list)
     linked_document_ids: list[str] = Field(default_factory=list)
+    linked_structure_node_id: str | None = None
 
     # Luhmann-style numeric address (optional). "1.4a.2" denotes
     # zettel #2 under branch 1.4a. Free-form so users can adopt other

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -2296,6 +2296,18 @@
         ],
         "request_model": null,
         "response_model": "DocumentKnowledgeGraphResponse"
+      },
+      {
+        "method": "GET",
+        "path": "/documents/{document_id}/outline",
+        "operation_id": "document_outline_api_documents__document_id__outline_get",
+        "summary": "Hierarchical source outline for document drill-down",
+        "path_params": [
+          "document_id"
+        ],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "DocumentOutlineResponse"
       }
     ],
     "entities": [

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -5786,6 +5786,11 @@
             "type": "string"
           },
           {
+            "name": "linked_structure_node_id",
+            "required": false,
+            "type": "string"
+          },
+          {
             "name": "q",
             "required": false,
             "type": "string"

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -2232,6 +2232,30 @@
         "response_model": "WorkflowRunProvenanceListResponse"
       },
       {
+        "method": "PATCH",
+        "path": "/documents/{doc_id}/workspace",
+        "operation_id": "patch_workspace_items_api_documents__doc_id__workspace_patch",
+        "summary": "Patch Workspace Items",
+        "path_params": [
+          "doc_id"
+        ],
+        "query_params": [],
+        "request_model": "WorkspacePatchRequest",
+        "response_model": "WorkspaceItemsResponse"
+      },
+      {
+        "method": "GET",
+        "path": "/documents/{doc_id}/workspace/items",
+        "operation_id": "get_workspace_items_api_documents__doc_id__workspace_items_get",
+        "summary": "Get Workspace Items",
+        "path_params": [
+          "doc_id"
+        ],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "WorkspaceItemsResponse"
+      },
+      {
         "method": "GET",
         "path": "/documents/{document_id}/citations",
         "operation_id": "get_document_citations_api_documents__document_id__citations_get",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -1495,6 +1495,16 @@
             }
           },
           {
+            "name": "linked_structure_node_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Linked Structure Node Id"
+            }
+          },
+          {
             "name": "q",
             "in": "query",
             "required": false,
@@ -45397,6 +45407,11 @@
             "type": "array",
             "title": "Linked Document Ids"
           },
+          "linked_structure_node_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Linked Structure Node Id"
+          },
           "address": {
             "type": "string",
             "nullable": true,
@@ -45583,6 +45598,11 @@
             "type": "array",
             "nullable": true,
             "title": "Linked Document Ids"
+          },
+          "linked_structure_node_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Linked Structure Node Id"
           },
           "address": {
             "type": "string",
@@ -54924,6 +54944,11 @@
             "type": "array",
             "title": "Linked Document Ids",
             "default": []
+          },
+          "linked_structure_node_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Linked Structure Node Id"
           },
           "address": {
             "type": "string",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -7419,6 +7419,57 @@
         }
       }
     },
+    "/api/documents/{document_id}/outline": {
+      "get": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Hierarchical source outline for document drill-down",
+        "operationId": "document_outline_api_documents__document_id__outline_get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Library-Path",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Fichero-Library-Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentOutlineResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/documents/{document_id}/knowledge-graph": {
       "get": {
         "tags": [
@@ -38649,6 +38700,65 @@
         ],
         "title": "DocumentNoteUpsert",
         "description": "Request body for per-document note upsert."
+      },
+      "DocumentOutlineResponse": {
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "title": "Document Id"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentOutlineRow"
+            },
+            "type": "array",
+            "title": "Rows"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id",
+          "rows",
+          "count"
+        ],
+        "title": "DocumentOutlineResponse"
+      },
+      "DocumentOutlineRow": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "depth": {
+            "type": "integer",
+            "title": "Depth"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "depth",
+          "kind",
+          "label",
+          "count"
+        ],
+        "title": "DocumentOutlineRow"
       },
       "DocumentSource": {
         "properties": {

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -6159,6 +6159,120 @@
         }
       }
     },
+    "/api/documents/{doc_id}/workspace": {
+      "patch": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Patch Workspace Items",
+        "description": "Atomically add/remove/reorder workspace curated items.",
+        "operationId": "patch_workspace_items_api_documents__doc_id__workspace_patch",
+        "parameters": [
+          {
+            "name": "doc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Doc Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Library-Path",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Fichero-Library-Path"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspacePatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceItemsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/documents/{doc_id}/workspace/items": {
+      "get": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Get Workspace Items",
+        "description": "List curated workspace items with alias resolution to full targets.",
+        "operationId": "get_workspace_items_api_documents__doc_id__workspace_items_get",
+        "parameters": [
+          {
+            "name": "doc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Doc Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Library-Path",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Fichero-Library-Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceItemsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/documents/{doc_id}/children": {
       "get": {
         "tags": [
@@ -54395,6 +54509,111 @@
         ],
         "title": "WorkflowVisualizationResponse",
         "description": "Response with workflow visualization data."
+      },
+      "WorkspaceCuratedItem": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "target_type": {
+            "type": "string",
+            "title": "Target Type"
+          },
+          "target_id": {
+            "type": "string",
+            "title": "Target Id"
+          },
+          "role": {
+            "type": "string",
+            "nullable": true,
+            "title": "Role"
+          },
+          "added_at": {
+            "type": "string",
+            "nullable": true,
+            "title": "Added At"
+          },
+          "x": {
+            "type": "number",
+            "nullable": true,
+            "title": "X"
+          },
+          "y": {
+            "type": "number",
+            "nullable": true,
+            "title": "Y"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true,
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "target_type",
+          "target_id"
+        ],
+        "title": "WorkspaceCuratedItem"
+      },
+      "WorkspaceItemsResponse": {
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "title": "Document Id"
+          },
+          "items": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id",
+          "items",
+          "count"
+        ],
+        "title": "WorkspaceItemsResponse"
+      },
+      "WorkspacePatchRequest": {
+        "properties": {
+          "add": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceCuratedItem"
+            },
+            "type": "array",
+            "title": "Add",
+            "default": []
+          },
+          "remove_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Remove Ids",
+            "default": []
+          },
+          "reorder_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "nullable": true,
+            "title": "Reorder Ids"
+          }
+        },
+        "type": "object",
+        "title": "WorkspacePatchRequest"
       },
       "XlsxIngestRequest": {
         "properties": {

--- a/fichero-engine/tests/unit/kg/test_inspector_aggregates.py
+++ b/fichero-engine/tests/unit/kg/test_inspector_aggregates.py
@@ -14,6 +14,7 @@ from fichero.hermeneutics_models import FrameworkType, Interpretation, Interpret
 from fichero.knowledge_models import (
     Annotation,
     AnnotationKind,
+    BookStructureNode,
     DocumentCitation,
     EntityType,
     KnowledgeClaim,
@@ -296,6 +297,57 @@ class TestDocumentKnowledgeGraph:
         assert people.items[0].canonical_name == "J. Davidson"
         assert people.items[0].entity_id == canonical.id
         assert len(people.items[0].claim_ids) == 2
+
+
+class TestDocumentOutline:
+    def test_outline_aggregates_pages_structure_and_groups(self, db):
+        from fichero.api.routes import document_inspector
+
+        doc = Document(id="outline-doc", name="Book", doc_type=DocType.file)
+        page1 = Document(id="outline-page-1", name="Page 1", doc_type=DocType.page, parent_id=doc.id, sequence=1)
+        page2 = Document(id="outline-page-2", name="Page 2", doc_type=DocType.page, parent_id=doc.id, sequence=2)
+        chunk = Document(id="outline-chunk", name="Chunk A", doc_type=DocType.chunk, parent_id=page1.id)
+        db.save(doc)
+        db.save(page1)
+        db.save(page2)
+        db.save(chunk)
+
+        chapter = BookStructureNode(
+            source_document_id=doc.id,
+            title="Chapter 1",
+            level=1,
+            kind="chapter",
+            start_sequence=1,
+            end_sequence=2,
+        )
+        section = BookStructureNode(
+            source_document_id=doc.id,
+            title="Section 1.1",
+            level=2,
+            kind="section",
+            start_sequence=1,
+            end_sequence=1,
+            parent_structure_id=chapter.id,
+        )
+        db.save(chapter)
+        db.save(section)
+
+        entity = KnowledgeEntity(canonical_name="Davidson", entity_type=EntityType.person)
+        db.save(entity)
+        db.save(KnowledgeClaim(text="Davidson signed.", source_document_id=page1.id, entity_ids=[entity.id]))
+        db.save(Annotation(document_id=page1.id, kind=AnnotationKind.note, text="check this"))
+        db.save(Artifact(document_id=page1.id, artifact_type="transcription", content="text"))
+        db.save(DocumentCitation(source_document_id=page1.id, target_citation_text="cite"))
+
+        result = asyncio.run(document_inspector.document_outline(doc.id, db=db))
+        assert result.document_id == doc.id
+        kinds = {row.kind for row in result.rows}
+        assert {"page", "chapter", "section", "chunk", "annotation-group", "entity-group"} <= kinds
+        chapter_row = next(row for row in result.rows if row.kind == "chapter")
+        assert chapter_row.label == "Chapter 1"
+        assert chapter_row.depth == 1
+        page_row = next(row for row in result.rows if row.kind == "page" and row.label == "Page 1")
+        assert page_row.count >= 1
 
     def test_parent_pdf_rolls_up_page_claims_by_default(self, db):
         """Page-level KG rows surface when the parent PDF is selected."""

--- a/fichero-engine/tests/unit/test_routes_documents_workspace.py
+++ b/fichero-engine/tests/unit/test_routes_documents_workspace.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from fichero.models import DocType, Document
+
+
+def test_workspace_patch_add_remove_reorder_items(client, db):
+    workspace = Document(id="ws-1", name="Workspace", doc_type=DocType.folder, is_workspace=True)
+    db.save(workspace)
+
+    add_first = client.patch(
+        f"/api/documents/{workspace.id}/workspace",
+        json={
+            "add": [
+                {"id": "item-a", "target_type": "document", "target_id": "doc-a", "role": "source"},
+                {"id": "item-b", "target_type": "document", "target_id": "doc-b", "role": "source"},
+            ]
+        },
+    )
+    assert add_first.status_code == 200
+    assert [item["id"] for item in add_first.json()["items"]] == ["item-a", "item-b"]
+
+    mutate = client.patch(
+        f"/api/documents/{workspace.id}/workspace",
+        json={
+            "remove_ids": ["item-a"],
+            "add": [{"id": "item-c", "target_type": "document", "target_id": "doc-c"}],
+            "reorder_ids": ["item-c", "item-b"],
+        },
+    )
+    assert mutate.status_code == 200
+    payload = mutate.json()
+    assert payload["count"] == 2
+    assert [item["id"] for item in payload["items"]] == ["item-c", "item-b"]
+
+
+def test_workspace_items_resolve_document_alias_targets(client, db):
+    workspace = Document(
+        id="ws-2",
+        name="Workspace 2",
+        doc_type=DocType.folder,
+        is_workspace=True,
+        curated_items=[
+            {"id": "item-doc", "target_type": "document", "target_id": "doc-1", "role": "source"}
+        ],
+    )
+    target_doc = Document(id="doc-1", name="Source Doc", doc_type=DocType.file)
+    db.save(workspace)
+    db.save(target_doc)
+
+    response = client.get(f"/api/documents/{workspace.id}/workspace/items")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["count"] == 1
+    item = payload["items"][0]
+    assert item["id"] == "item-doc"
+    assert item["target"]["id"] == "doc-1"
+    assert item["target"]["name"] == "Source Doc"

--- a/fichero-engine/tests/unit/test_routes_notes.py
+++ b/fichero-engine/tests/unit/test_routes_notes.py
@@ -52,6 +52,33 @@ class TestNotesCRUD:
         assert by_query.json()["count"] == 1
         assert by_query.json()["items"][0]["title"] == "Hub"
 
+    def test_linked_structure_node_id_create_patch_and_filter(self, client, db):
+        created = client.post(
+            "/api/notes",
+            json={
+                "title": "Section note",
+                "body": "Attached to outline section",
+                "linked_structure_node_id": "node-1",
+            },
+        )
+        assert created.status_code == 200
+        note_id = created.json()["id"]
+        assert created.json()["linked_structure_node_id"] == "node-1"
+
+        db.save(Note(title="Other", body="Detached", linked_structure_node_id="node-2"))
+
+        filtered = client.get("/api/notes?linked_structure_node_id=node-1")
+        assert filtered.status_code == 200
+        assert filtered.json()["count"] == 1
+        assert filtered.json()["items"][0]["id"] == note_id
+
+        patched = client.patch(
+            f"/api/notes/{note_id}",
+            json={"linked_structure_node_id": "node-3"},
+        )
+        assert patched.status_code == 200
+        assert patched.json()["linked_structure_node_id"] == "node-3"
+
 
 class TestNoteLinks:
     def test_create_and_delete_link(self, client, db):

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -1495,6 +1495,16 @@
             }
           },
           {
+            "name": "linked_structure_node_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Linked Structure Node Id"
+            }
+          },
+          {
             "name": "q",
             "in": "query",
             "required": false,
@@ -45397,6 +45407,11 @@
             "type": "array",
             "title": "Linked Document Ids"
           },
+          "linked_structure_node_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Linked Structure Node Id"
+          },
           "address": {
             "type": "string",
             "nullable": true,
@@ -45583,6 +45598,11 @@
             "type": "array",
             "nullable": true,
             "title": "Linked Document Ids"
+          },
+          "linked_structure_node_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Linked Structure Node Id"
           },
           "address": {
             "type": "string",
@@ -54924,6 +54944,11 @@
             "type": "array",
             "title": "Linked Document Ids",
             "default": []
+          },
+          "linked_structure_node_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Linked Structure Node Id"
           },
           "address": {
             "type": "string",

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -7419,6 +7419,57 @@
         }
       }
     },
+    "/api/documents/{document_id}/outline": {
+      "get": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Hierarchical source outline for document drill-down",
+        "operationId": "document_outline_api_documents__document_id__outline_get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Library-Path",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Fichero-Library-Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentOutlineResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/documents/{document_id}/knowledge-graph": {
       "get": {
         "tags": [
@@ -38649,6 +38700,65 @@
         ],
         "title": "DocumentNoteUpsert",
         "description": "Request body for per-document note upsert."
+      },
+      "DocumentOutlineResponse": {
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "title": "Document Id"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/DocumentOutlineRow"
+            },
+            "type": "array",
+            "title": "Rows"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id",
+          "rows",
+          "count"
+        ],
+        "title": "DocumentOutlineResponse"
+      },
+      "DocumentOutlineRow": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "depth": {
+            "type": "integer",
+            "title": "Depth"
+          },
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "label": {
+            "type": "string",
+            "title": "Label"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "depth",
+          "kind",
+          "label",
+          "count"
+        ],
+        "title": "DocumentOutlineRow"
       },
       "DocumentSource": {
         "properties": {

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -6159,6 +6159,120 @@
         }
       }
     },
+    "/api/documents/{doc_id}/workspace": {
+      "patch": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Patch Workspace Items",
+        "description": "Atomically add/remove/reorder workspace curated items.",
+        "operationId": "patch_workspace_items_api_documents__doc_id__workspace_patch",
+        "parameters": [
+          {
+            "name": "doc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Doc Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Library-Path",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Fichero-Library-Path"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspacePatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceItemsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/documents/{doc_id}/workspace/items": {
+      "get": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Get Workspace Items",
+        "description": "List curated workspace items with alias resolution to full targets.",
+        "operationId": "get_workspace_items_api_documents__doc_id__workspace_items_get",
+        "parameters": [
+          {
+            "name": "doc_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Doc Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Library-Path",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Fichero-Library-Path"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceItemsResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/documents/{doc_id}/children": {
       "get": {
         "tags": [
@@ -54395,6 +54509,111 @@
         ],
         "title": "WorkflowVisualizationResponse",
         "description": "Response with workflow visualization data."
+      },
+      "WorkspaceCuratedItem": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "target_type": {
+            "type": "string",
+            "title": "Target Type"
+          },
+          "target_id": {
+            "type": "string",
+            "title": "Target Id"
+          },
+          "role": {
+            "type": "string",
+            "nullable": true,
+            "title": "Role"
+          },
+          "added_at": {
+            "type": "string",
+            "nullable": true,
+            "title": "Added At"
+          },
+          "x": {
+            "type": "number",
+            "nullable": true,
+            "title": "X"
+          },
+          "y": {
+            "type": "number",
+            "nullable": true,
+            "title": "Y"
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true,
+            "title": "Notes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "target_type",
+          "target_id"
+        ],
+        "title": "WorkspaceCuratedItem"
+      },
+      "WorkspaceItemsResponse": {
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "title": "Document Id"
+          },
+          "items": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id",
+          "items",
+          "count"
+        ],
+        "title": "WorkspaceItemsResponse"
+      },
+      "WorkspacePatchRequest": {
+        "properties": {
+          "add": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceCuratedItem"
+            },
+            "type": "array",
+            "title": "Add",
+            "default": []
+          },
+          "remove_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Remove Ids",
+            "default": []
+          },
+          "reorder_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "nullable": true,
+            "title": "Reorder Ids"
+          }
+        },
+        "type": "object",
+        "title": "WorkspacePatchRequest"
       },
       "XlsxIngestRequest": {
         "properties": {


### PR DESCRIPTION
Backend foundations for the thinking-layer epic #1488. All additive, reuse existing Document.is_workspace/curated_items (no new tables), gated pytest+ruff (worker f_ms_kg). +1242/-2, tests + regenerated openapi included. See docs/architecture/thinking-layer.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)