### PR TITLE
Search explain: real doc fields + source attribution (#424)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/search_explain.py
+++ b/fichero-engine/src/fichero/api/routes/search_explain.py
@@ -17,7 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
 from fichero.api.main import get_library_database
-from fichero.db import Database
+from fichero.db import Database, _fold_for_search
 from fichero.knowledge_models import KnowledgeClaim
 from fichero.models import Document
 
@@ -444,24 +444,24 @@ async def _semantic_search(
 ) -> list[dict[str, Any]]:
     """Perform semantic search."""
     try:
-        from fichero.embeddings import generate_query_embedding
-
-        query_vector = generate_query_embedding(query)
-
-        # Search documents
-        results = db.search_vectors("document_chunks", query_vector, limit=config.max_results)
-
+        results, _, _ = db.search(
+            query=query,
+            limit=config.max_results,
+            min_score=config.min_score_threshold,
+            search_type="semantic",
+            highlight_results=False,
+        )
         return [
             {
-                "id": r.get("id", ""),
-                "title": r.get("title", "Untitled"),
-                "text": r.get("text", ""),
-                "relevance_score": r.get("_score", 0.0),
+                "id": r.document_id,
+                "title": (r.metadata or {}).get("name", "Untitled"),
+                "text": r.content_preview or "",
+                "relevance_score": r.score,
                 "source_type": "document",
                 "match_type": "semantic",
             }
             for r in results
-            if r.get("_score", 0) >= config.min_score_threshold
+            if r.score >= config.min_score_threshold
         ]
     except Exception as e:
         logger.warning(f"Semantic search failed: {e}")
@@ -473,19 +473,21 @@ async def _fulltext_search(
 ) -> list[dict[str, Any]]:
     """Perform full-text search."""
     try:
-        # Simple keyword search across documents
+        # Simple keyword search across documents using folded text.
         documents = db.all(Document)
-        query_lower = query.lower()
+        query_folded = _fold_for_search(query)
 
         results = []
         for doc in documents:
             score = 0.0
-            text = getattr(doc, "content", "") or ""
-            title = getattr(doc, "title", "") or ""
+            text = getattr(doc, "page_content", "") or ""
+            title = getattr(doc, "name", "") or ""
+            title_folded = _fold_for_search(title)
+            text_folded = _fold_for_search(text)
 
-            if query_lower in title.lower():
+            if query_folded in title_folded:
                 score += 0.5
-            if query_lower in text.lower():
+            if query_folded in text_folded:
                 score += 0.3
 
             if score >= config.min_score_threshold * 0.5:  # Lower threshold for keyword

--- a/fichero-engine/tests/unit/test_routes_search_explain.py
+++ b/fichero-engine/tests/unit/test_routes_search_explain.py
@@ -4,6 +4,7 @@ Search explain provides transparency into RAG search operations — how results
 were ranked, source attribution, and available RAG modes. Routes live at
 /api/search/... (router prefix="/search" mounted at "/api").
 """
+from fichero.models import Document
 
 # ---------------------------------------------------------------------------
 # GET /api/search/modes
@@ -81,6 +82,27 @@ class TestExplainSearch:
         })
         assert r.status_code == 200
         assert r.json()["rag_mode"] == "speculative"
+
+    def test_explain_fulltext_includes_source_attribution(self, client, db):
+        doc = Document(
+            id="doc-camilo",
+            name="Camilo ledger note",
+            page_content="Camilo appears in this archival passage.",
+        )
+        db.save(doc)
+
+        r = client.post("/api/search/explain", json={
+            "query": "camilo",
+            "search_type": "fulltext",
+            "rag_mode": "balanced",
+        })
+        assert r.status_code == 200
+        body = r.json()
+        assert body["sources"], "Expected at least one attributed source"
+        first = body["sources"][0]
+        assert first["source_id"] == doc.id
+        assert first["title"] == doc.name
+        assert first["excerpt"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Tight fix (+43/-19) to search-explain. Gated pytest+ruff (worker f_ms_settings), rebased onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)