### PR TITLE
Backend: deterministic clean_text (#1462) + timeline/map claim fields (#1470/#1471)

### DIFF
--- a/fichero-engine/src/fichero/workflows/tools/extractors.py
+++ b/fichero-engine/src/fichero/workflows/tools/extractors.py
@@ -2373,6 +2373,7 @@ def _write_kg_rows(
         # KnowledgeClaim field stays NULL when the LLM doesn't date it.
         t_start = (item.get("time_start") or "").strip() or None
         t_end = (item.get("time_end") or "").strip() or None
+        t_precision = (item.get("time_precision") or "").strip() or None
         # Toulmin (#907) — populated by the LLM only for analytic
         # claim_types; fact claims emit empty strings which we drop.
         grounds_val = (item.get("grounds") or "").strip() or None
@@ -2394,6 +2395,23 @@ def _write_kg_rows(
                 or item.get("fecha_normalizada")
                 or ""
             )
+            normalized = str(normalized).strip()
+            if normalized and not t_start and not t_end:
+                if "/" in normalized:
+                    start_raw, end_raw = normalized.split("/", 1)
+                    t_start = start_raw.strip() or None
+                    t_end = end_raw.strip() or None
+                    t_precision = t_precision or "range"
+                else:
+                    t_start = normalized
+                    t_end = normalized
+                    if not t_precision:
+                        if len(normalized) == 4:
+                            t_precision = "year"
+                        elif len(normalized) == 7:
+                            t_precision = "month"
+                        elif len(normalized) >= 10:
+                            t_precision = "day"
             stem = normalized or date_text
             # Avoid double-period when predicate already ends in
             # terminal punctuation (#1113 polish).
@@ -2430,6 +2448,7 @@ def _write_kg_rows(
                 epistemic_status=epistemic,
                 time_start=t_start,
                 time_end=t_end,
+                time_precision=t_precision,
                 # SVO promotion (#984): also write to the typed
                 # top-level fields. Date-style claims have an implicit
                 # subject = the normalised date string.
@@ -2566,6 +2585,11 @@ def _write_kg_rows(
             claim_type=ctype or ClaimType.fact,
             metadata=meta,
             epistemic_status=epistemic,
+            claim_location=(
+                canonical
+                if entity_type == EntityType.location and canonical
+                else None
+            ),
             # SVO promotion (#984): typed top-level fields. The
             # subject IS the entity, so subject_entity_id resolves
             # the lookup at write time.

--- a/fichero-engine/src/fichero/workflows/tools/text_cleaning.py
+++ b/fichero-engine/src/fichero/workflows/tools/text_cleaning.py
@@ -31,6 +31,61 @@ class TextCleaner:
         return "\n".join(clean_lines)
 
     @staticmethod
+    def remove_ocr_garbage_lines(text: str) -> str:
+        """Drop obvious OCR garbage while preserving plausible content lines."""
+        lines = text.splitlines()
+        kept: list[str] = []
+
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line:
+                kept.append("")
+                continue
+
+            # Keep plausible year-only lines (timeline-relevant).
+            if re.fullmatch(r"(1[5-9]\d{2}|20\d{2})", line):
+                kept.append(line)
+                continue
+
+            letters = sum(1 for ch in line if ch.isalpha())
+            digits = sum(1 for ch in line if ch.isdigit())
+            alnum = sum(1 for ch in line if ch.isalnum())
+            non_space = sum(1 for ch in line if not ch.isspace())
+            words = [w for w in re.split(r"\s+", line) if w]
+            alpha_words = [w for w in words if sum(c.isalpha() for c in w) >= 2]
+
+            if non_space == 0:
+                kept.append("")
+                continue
+
+            letter_ratio = letters / non_space
+            digit_ratio = digits / non_space
+            alpha_word_ratio = (len(alpha_words) / len(words)) if words else 0.0
+
+            # Drop extreme repeated-char lines such as "000000000000000000".
+            collapsed = re.sub(r"\s+", "", line)
+            if len(collapsed) >= 10 and len(set(collapsed)) <= 2:
+                continue
+
+            # Drop very short pure number lines (page noise / OCR residue).
+            if re.fullmatch(r"\d{1,8}", line):
+                continue
+
+            # Drop symbol/digit soup lines with too little alphabetic signal.
+            if digit_ratio >= 0.4 and letter_ratio < 0.35 and alpha_word_ratio < 0.5:
+                continue
+
+            # Lines like "..." are non-content separators.
+            if re.fullmatch(r"[.\-_=:;,*]{3,}", line):
+                continue
+
+            # Keep line by default when it has meaningful alphabetic content.
+            if letters >= 3 or alnum >= 3:
+                kept.append(line)
+
+        return "\n".join(kept)
+
+    @staticmethod
     def remove_specific_phrases(text: str) -> str:
         """Remove common OCR/LLM wrapper phrases and formatting noise."""
         phrases_to_remove = [
@@ -215,6 +270,7 @@ class TextCleaner:
     def clean_text(text: str) -> str:
         """Run deterministic cleaning passes in fixed order."""
         text = TextCleaner.remove_pathological_patterns(text)
+        text = TextCleaner.remove_ocr_garbage_lines(text)
         text = TextCleaner.remove_specific_phrases(text)
         text = TextCleaner.combine_single_word_paragraphs(text)
         text = TextCleaner.remove_repeated_phrases(text)
@@ -222,4 +278,3 @@ class TextCleaner:
         text = TextCleaner.split_long_lines(text, max_length=72)
         text = TextCleaner.clean_line_spacing(text)
         return text.strip()
-

--- a/fichero-engine/tests/unit/test_clean_text.py
+++ b/fichero-engine/tests/unit/test_clean_text.py
@@ -25,6 +25,7 @@ from fichero.workflows.tools.clean_text import (
     clean_text,
     _build_prompt,
 )
+from fichero.workflows.tools.text_cleaning import TextCleaner
 from fichero.llm import LLMConfig
 
 
@@ -142,6 +143,38 @@ class TestRegistration:
 
 
 class TestRuntimeBehavior:
+    def test_programmatic_cleaner_drops_ocr_digit_soup_keeps_real_lines(self):
+        raw_text = """
+33005 00s000Gc00000(0000005a5a 0D6000000000000000002 ...
+República de Colombia
+INTENDE ICIA NAL. DEL CHOCO
+DISTRITO JUDICIAL DE CALI
+JUZGADO PRIMERO DEL CIBCEITO
+ISTMIN
+1930
+...
+000000000000000000
+23908
+TTP. HERALDO.
+290029090
+"""
+
+        cleaned = TextCleaner.clean_text(raw_text)
+
+        # Real content remains.
+        assert "República de Colombia" in cleaned
+        assert "DISTRITO JUDICIAL DE CALI" in cleaned
+        assert "JUZGADO PRIMERO DEL CIBCEITO" in cleaned
+        assert "ISTMIN" in cleaned
+        assert "1930" in cleaned
+        assert "TTP. HERALDO." in cleaned
+
+        # OCR digit/symbol soup and single-number garbage are removed.
+        assert "33005 00s000Gc00000" not in cleaned
+        assert "000000000000000000" not in cleaned
+        assert "23908" not in cleaned
+        assert "290029090" not in cleaned
+
     @pytest.mark.asyncio
     async def test_programmatic_is_default_and_does_not_call_llm(self):
         cfg = LLMConfig(provider="openai", model="gpt-5")

--- a/fichero-engine/tests/unit/workflows/test_default_workflow_e2e_harness.py
+++ b/fichero-engine/tests/unit/workflows/test_default_workflow_e2e_harness.py
@@ -413,6 +413,34 @@ def _assert_kg_rows_landed(
     assert "Regression Person signed the fixture deed." in claim_texts
     assert any(claim.entity_ids for claim in fixture_claims)
 
+    # #1470/#1471 backend probe contract:
+    # - timeline path needs parsed temporal fields on extracted date claims
+    # - map path needs structured place_values on extracted place claims
+    date_claims = [
+        claim
+        for claim in fixture_claims
+        if (
+            (claim.metadata or {}).get("date_normalized")
+            or "1842" in (claim.text or "")
+        )
+    ]
+    assert date_claims, "expected at least one extracted date claim in fixture output"
+    assert any(
+        claim.time_start or claim.time_end or claim.date_values
+        for claim in date_claims
+    ), "date claims missing parsed temporal fields (time_start/time_end/date_values)"
+
+    place_claims = [
+        claim
+        for claim in fixture_claims
+        if "Regression Place" in (claim.text or "")
+    ]
+    assert place_claims, "expected at least one extracted place claim in fixture output"
+    assert any(
+        claim.claim_location or claim.place_values
+        for claim in place_claims
+    ), "place claims missing spatial fields (claim_location/place_values)"
+
 
 # ---------------------------------------------------------------------------
 # Twostage-path harness (#1285 re-open)


### PR DESCRIPTION
#1462 makes Clean-Up-Text a deterministic rule-based OCR-garbage path (LLM optional fallback). #1470/#1471 persist date + place claim fields so the KG timeline/map have data to render (the SwiftUI display halves stay separate). Gated: 3714 pytest passed, ruff clean (worker f_ms_kg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)