### PR TITLE
Research: non-blocking async URL-safety DNS checks (#461)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/research_tools.py
+++ b/fichero-engine/src/fichero/api/routes/research_tools.py
@@ -29,6 +29,7 @@ Internal/private IP ranges and blocked URL schemes are rejected at the boundary.
 """
 
 import ipaddress
+import asyncio
 import re
 import socket
 import time
@@ -98,7 +99,7 @@ _CLOUD_METADATA_HOSTS = frozenset(
 )
 
 
-def _is_internal_ip(hostname: str | None) -> bool:
+async def _is_internal_ip(hostname: str | None) -> bool:
     """Check if a hostname or IP is internal/private."""
     if not hostname:
         return False
@@ -116,7 +117,7 @@ def _is_internal_ip(hostname: str | None) -> bool:
         pass
 
     try:
-        addrs = socket.getaddrinfo(hostname, None)
+        addrs = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
         for addr_info in addrs:
             ip_str = addr_info[4][0]
             try:
@@ -132,7 +133,7 @@ def _is_internal_ip(hostname: str | None) -> bool:
     return False
 
 
-def _is_safe_url(url: str, allow_userinfo: bool = False) -> tuple[bool, str]:
+async def _is_safe_url(url: str, allow_userinfo: bool = False) -> tuple[bool, str]:
     """Comprehensive URL safety check for sandboxed requests."""
     if not url:
         return False, "URL is empty"
@@ -159,11 +160,11 @@ def _is_safe_url(url: str, allow_userinfo: bool = False) -> tuple[bool, str]:
     if not hostname:
         return False, "URL must have a hostname"
 
-    if _is_internal_ip(hostname):
+    if await _is_internal_ip(hostname):
         return False, f"Internal addresses are not allowed: {hostname}"
 
     if re.match(r"^0[xX][0-9a-fA-F]+", hostname) or re.match(r"^\d+$", hostname):
-        if _is_internal_ip(hostname):
+        if await _is_internal_ip(hostname):
             return False, "Numeric IP addresses are not allowed"
 
     # Basic traversal hardening for path confusion vectors.
@@ -178,9 +179,9 @@ def _is_safe_url(url: str, allow_userinfo: bool = False) -> tuple[bool, str]:
     return True, ""
 
 
-def _is_sandbox_violation(url: str) -> bool:
+async def _is_sandbox_violation(url: str) -> bool:
     """Check if URL violates sandbox constraints."""
-    is_safe, _ = _is_safe_url(url)
+    is_safe, _ = await _is_safe_url(url)
     return not is_safe
 
 
@@ -195,7 +196,7 @@ async def _safe_http_get(
     """GET with explicit redirect validation to prevent SSRF redirect bypass."""
     current_url = url
     for _ in range(max_redirects + 1):
-        is_safe, error = _is_safe_url(current_url)
+        is_safe, error = await _is_safe_url(current_url)
         if not is_safe:
             raise HTTPException(status_code=400, detail=f"URL not allowed: {error}")
 
@@ -211,7 +212,7 @@ async def _safe_http_get(
             if not location:
                 raise HTTPException(status_code=400, detail="Redirect missing location")
             next_url = urljoin(str(current_url), location)
-            is_safe, error = _is_safe_url(next_url)
+            is_safe, error = await _is_safe_url(next_url)
             if not is_safe:
                 raise HTTPException(
                     status_code=400,
@@ -293,7 +294,7 @@ async def execute_web_search(
         snippet = re.sub(r"<[^>]+>", "", match.group(3)).strip()
         # Validate search results using comprehensive security check
         if url:
-            is_safe, _ = _is_safe_url(url)
+            is_safe, _ = await _is_safe_url(url)
             if is_safe:
                 results.append(
                     WebSearchResult(
@@ -321,14 +322,14 @@ async def execute_browser_navigate(
     request: BrowserNavigateRequest,
 ) -> BrowserNavigateResponse:
     """Navigate to a URL and extract content (sandboxed — no filesystem/CLI escape)."""
-    if _is_sandbox_violation(request.url):
+    if await _is_sandbox_violation(request.url):
         raise HTTPException(
             status_code=400,
             detail="URL scheme not allowed in sandboxed browser",
         )
 
     # Comprehensive URL validation (SSRF protection)
-    is_safe, error_msg = _is_safe_url(request.url)
+    is_safe, error_msg = await _is_safe_url(request.url)
     if not is_safe:
         raise HTTPException(status_code=400, detail=f"URL not allowed: {error_msg}")
 
@@ -379,7 +380,7 @@ async def execute_browser_navigate(
         href = match.group(1)
         # Validate extracted links using comprehensive security check
         if href.startswith("http"):
-            is_safe, _ = _is_safe_url(href)
+            is_safe, _ = await _is_safe_url(href)
             if is_safe:
                 links.append(href)
 
@@ -406,14 +407,14 @@ async def execute_document_fetch(
     db: Database = Depends(get_library_database),
 ) -> DocumentFetchResponse:
     """Fetch a document URL and optionally save as Layer 1 Source (sandboxed)."""
-    if _is_sandbox_violation(request.url):
+    if await _is_sandbox_violation(request.url):
         raise HTTPException(
             status_code=400,
             detail="URL scheme not allowed in sandboxed fetch",
         )
 
     # Comprehensive URL validation (SSRF protection)
-    is_safe, error_msg = _is_safe_url(request.url)
+    is_safe, error_msg = await _is_safe_url(request.url)
     if not is_safe:
         raise HTTPException(status_code=400, detail=f"URL not allowed: {error_msg}")
 
@@ -535,10 +536,10 @@ async def browser_save(
     from pathlib import Path as _Path
     from fichero.ingest import ingest_file, IngestMode
 
-    if _is_sandbox_violation(request.url):
+    if await _is_sandbox_violation(request.url):
         raise HTTPException(status_code=400, detail="URL scheme not allowed in sandboxed fetch")
 
-    is_safe, error_msg = _is_safe_url(request.url)
+    is_safe, error_msg = await _is_safe_url(request.url)
     if not is_safe:
         raise HTTPException(status_code=400, detail=f"URL not allowed: {error_msg}")
 

--- a/fichero-engine/src/fichero/workflows/tools/research.py
+++ b/fichero-engine/src/fichero/workflows/tools/research.py
@@ -15,6 +15,7 @@ workflows without HTTP overhead.
 from __future__ import annotations
 
 import ipaddress
+import asyncio
 import logging
 import re
 import socket
@@ -76,7 +77,7 @@ _CLOUD_METADATA_HOSTS = frozenset(
 _MAX_CONTENT_SIZE = 10 * 1024 * 1024
 
 
-def _is_internal_ip(hostname: str | None) -> bool:
+async def _is_internal_ip(hostname: str | None) -> bool:
     """Check if a hostname or IP is internal/private.
 
     Args:
@@ -106,7 +107,7 @@ def _is_internal_ip(hostname: str | None) -> bool:
     # Try to resolve the hostname
     try:
         # Get all addresses (IPv4 and IPv6)
-        addrs = socket.getaddrinfo(hostname, None)
+        addrs = await asyncio.to_thread(socket.getaddrinfo, hostname, None)
         for addr_info in addrs:
             ip_str = addr_info[4][0]
             try:
@@ -124,7 +125,7 @@ def _is_internal_ip(hostname: str | None) -> bool:
     return False
 
 
-def _is_safe_url(url: str, allow_userinfo: bool = False) -> tuple[bool, str]:
+async def _is_safe_url(url: str, allow_userinfo: bool = False) -> tuple[bool, str]:
     """Comprehensive URL safety check for sandboxed requests.
 
     Args:
@@ -164,14 +165,14 @@ def _is_safe_url(url: str, allow_userinfo: bool = False) -> tuple[bool, str]:
         return False, "URL must have a hostname"
 
     # Check for internal IPs
-    if _is_internal_ip(hostname):
+    if await _is_internal_ip(hostname):
         return False, f"Internal addresses are not allowed: {hostname}"
 
     # Check for bare IP address bypass attempts
     # (e.g., http://0x7f.0.0.1/ is 127.0.0.1 in hex)
     if re.match(r"^0[xX][0-9a-fA-F]+", hostname) or re.match(r"^\d+$", hostname):
         # Numeric hostname might be octal/hex IP
-        if _is_internal_ip(hostname):
+        if await _is_internal_ip(hostname):
             return False, "Numeric IP addresses are not allowed"
 
     return True, ""
@@ -198,12 +199,12 @@ def _check_content_size(content: bytes | str, max_size: int = _MAX_CONTENT_SIZE)
     return True, ""
 
 
-def _is_sandbox_violation(url: str) -> bool:
+async def _is_sandbox_violation(url: str) -> bool:
     """Check if URL violates sandbox constraints.
 
     DEPRECATED: Use _is_safe_url() instead for comprehensive validation.
     """
-    is_safe, _ = _is_safe_url(url)
+    is_safe, _ = await _is_safe_url(url)
     return not is_safe
 
 
@@ -372,7 +373,7 @@ async def research_web_search(
         snippet = re.sub(r"<[^>]+>", "", match.group(3)).strip()
         # Validate search results using comprehensive security check
         if url:
-            is_safe, _ = _is_safe_url(url)
+            is_safe, _ = await _is_safe_url(url)
             if is_safe:
                 results.append(
                     {
@@ -500,7 +501,7 @@ async def research_browser_navigate(
             "error": "No URL provided",
         }
 
-    if _is_sandbox_violation(url):
+    if await _is_sandbox_violation(url):
         return {
             "url": url,
             "title": None,
@@ -511,7 +512,7 @@ async def research_browser_navigate(
         }
 
     # Comprehensive URL validation (SSRF protection)
-    is_safe, error_msg = _is_safe_url(url)
+    is_safe, error_msg = await _is_safe_url(url)
     if not is_safe:
         return {
             "url": url,
@@ -588,7 +589,7 @@ async def research_browser_navigate(
         href = match.group(1)
         # Validate extracted links using comprehensive security check
         if href.startswith("http"):
-            is_safe, _ = _is_safe_url(href)
+            is_safe, _ = await _is_safe_url(href)
             if is_safe:
                 links.append(href)
 
@@ -738,7 +739,7 @@ async def research_document_fetch(
             "error": "No URL provided",
         }
 
-    if _is_sandbox_violation(url):
+    if await _is_sandbox_violation(url):
         return {
             "url": url,
             "title": None,
@@ -750,7 +751,7 @@ async def research_document_fetch(
         }
 
     # Comprehensive URL validation (SSRF protection)
-    is_safe, error_msg = _is_safe_url(url)
+    is_safe, error_msg = await _is_safe_url(url)
     if not is_safe:
         return {
             "url": url,

--- a/fichero-engine/tests/unit/test_research_url_validation_nonblocking.py
+++ b/fichero-engine/tests/unit/test_research_url_validation_nonblocking.py
@@ -1,0 +1,33 @@
+"""Regression tests for async/non-blocking SSRF URL validation (#461)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from fichero.api.routes import research_tools as api_research_tools
+from fichero.workflows.tools import research as workflow_research
+
+
+@pytest.mark.asyncio
+async def test_api_route_url_validation_offloads_dns_lookup_to_thread(monkeypatch):
+    to_thread = AsyncMock(return_value=[(None, None, None, None, ("93.184.216.34", 0))])
+    monkeypatch.setattr(api_research_tools.asyncio, "to_thread", to_thread)
+
+    safe, error = await api_research_tools._is_safe_url("https://example.com/path")
+    assert safe is True
+    assert error == ""
+    to_thread.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_workflow_tool_url_validation_offloads_dns_lookup_to_thread(monkeypatch):
+    to_thread = AsyncMock(return_value=[(None, None, None, None, ("93.184.216.34", 0))])
+    monkeypatch.setattr(workflow_research.asyncio, "to_thread", to_thread)
+
+    safe, error = await workflow_research._is_safe_url("https://example.com/path")
+    assert safe is True
+    assert error == ""
+    to_thread.assert_awaited_once()
+


### PR DESCRIPTION
Makes the research browser-save URL-safety DNS resolution non-blocking (async/executor) so it can't stall the event loop. Gated pytest+ruff (worker f_ms_kg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)