### PR TITLE
Window chrome: per-window inspector (#1451) + PDF page title (#1482) + sidebar pin (#1456) + edit-mode toggle (#1453) + PDF pane minWidth (#1454)

### DIFF
--- a/fichero/fichero/App/ViewSettings.swift
+++ b/fichero/fichero/App/ViewSettings.swift
@@ -6,7 +6,10 @@ import SwiftUI
 class ViewSettings: ObservableObject {
     @Published var libraryLayout: LibraryLayout = .icons
     @Published var previewMode: PreviewMode = .widescreen
-    @Published var showInspector: Bool = true
+    // NOTE: inspector visibility is intentionally NOT here. It is per-window
+    // state (`ContentView.showInspectorSidebar`, @SceneStorage) exposed to the
+    // View menu via `FocusedValues.showInspector` below, so toggling the
+    // inspector in one window no longer flips it in every other window (#1451).
 }
 
 // MARK: - View Mode Enums
@@ -125,4 +128,9 @@ enum PreviewMode: String, CaseIterable {
 /// Focused value for sidebar mode - allows menu commands to change per-window sidebar mode
 extension FocusedValues {
     @Entry var sidebarMode: Binding<SidebarMode>?
+
+    /// Per-window inspector visibility, published by the focused ContentView so
+    /// the View-menu "Show/Hide Inspector" command toggles only the focused
+    /// window — not every open window (#1451).
+    @Entry var showInspector: Binding<Bool>?
 }

--- a/fichero/fichero/Views/ContentView+ReadingLayout.swift
+++ b/fichero/fichero/Views/ContentView+ReadingLayout.swift
@@ -121,7 +121,7 @@ extension ContentView {
                 }
             )
             .overlay { paneFocusIndicator(for: .preview) }
-            .frame(maxWidth: .infinity)
+            .frame(minWidth: ContentView.pdfCanvasMinWidth, maxWidth: .infinity)
 
             ResizableDivider(
                 width: $pageContentPaneWidth,

--- a/fichero/fichero/Views/ContentView+State.swift
+++ b/fichero/fichero/Views/ContentView+State.swift
@@ -14,7 +14,19 @@ extension ContentView {
         let viewName: String
         switch viewMode {
         case .library(let document):
-            viewName = document?.name ?? "Library"
+            let baseName = document?.name ?? "Library"
+            // For a PDF, append the page the user is currently reading so the
+            // window/tab title tracks scroll + page-flip. Reuses the page-focus
+            // signal from #1463 (pageFocusDocument) rather than a parallel
+            // tracker, and the page-child count for the "of M" total. (#1482)
+            if let page = pageFocusDocument, page.docType == .page, let seq = page.sequence {
+                let total = pdfDocPages.count
+                viewName = total > 0
+                    ? "\(baseName) — Page \(seq) of \(total)"
+                    : "\(baseName) — Page \(seq)"
+            } else {
+                viewName = baseName
+            }
         case .search(let savedSearch):
             viewName = savedSearch?.name ?? "Search"
         case .chat(let conversation):
@@ -227,10 +239,8 @@ extension ContentView {
             sidebarMode = .library
             viewMode = .library(nil)
         }
-        // Sync View menu inspector command to per-window inspector state.
-        if viewSettings.showInspector != showInspectorSidebar {
-            viewSettings.showInspector = showInspectorSidebar
-        }
+        // Inspector visibility is per-window (@SceneStorage) and reaches the
+        // View menu via FocusedValues.showInspector — no app-wide seeding needed (#1451).
         updateColumnVisibility()
         viewDisplayMode = normalizedViewDisplayMode(viewDisplayMode)
         viewSettings.previewMode = normalizedPreviewMode(viewSettings.previewMode)

--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -56,6 +56,7 @@ extension ContentView {
         // Was 250 — felt bloated on small screens.
         .navigationSplitViewColumnWidth(min: 180, ideal: sidebarWidth, max: 360)
         .focusedSceneValue(\.sidebarMode, $sidebarMode)
+        .focusedSceneValue(\.showInspector, $showInspectorSidebar)
         .focusedSceneValue(\.navigateToParentAction, navigateToParent)
     }
 

--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -195,7 +195,7 @@ extension ContentView {
                                 }
                             )
                             .overlay { paneFocusIndicator(for: .preview) }
-                            .frame(maxWidth: .infinity)
+                            .frame(minWidth: ContentView.pdfCanvasMinWidth, maxWidth: .infinity)
                         } else {
                             EditorView(
                                 document: detailDocument,

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -302,18 +302,12 @@ struct ContentView: View {
         .onChange(of: documentStore.currentDocuments) { _, newDocs in
             handleCurrentDocumentsChange(newDocs)
         }
-        .onChange(of: showInspectorSidebar) { _, newValue in
-            if viewSettings.showInspector != newValue {
-                viewSettings.showInspector = newValue
-            }
+        // Inspector visibility is per-window (@SceneStorage). It is NOT mirrored
+        // into the app-wide ViewSettings any more — doing so flipped the
+        // inspector in every open window at once (#1451). The View menu reaches
+        // this window's state through FocusedValues.showInspector instead.
+        .onChange(of: showInspectorSidebar) { _, _ in
             updateColumnVisibility()
-        }
-        .onChange(of: viewSettings.showInspector) { _, newValue in
-            if showInspectorSidebar != newValue {
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    showInspectorSidebar = newValue
-                }
-            }
         }
         .toolbar { mainToolbarContent }
         .onChange(of: viewSettings.previewMode) { _, newPreviewMode in

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -31,6 +31,13 @@ struct ContentView: View {
     /// 4 mode icons × 40pt + MiniToolbar horizontal padding (12×2) + inter-item
     /// spacing (12) ≈ 240.
     static let contentListMinWidth: Double = 240
+    /// Minimum width of the flexible PDF canvas pane so its mini-toolbar
+    /// (zoom −/%/+, fit, actual-size, magnifier, loupe + two dividers) never
+    /// clips when the reading-surface dividers are dragged inward. The
+    /// resizable neighbours are already clamped by their ResizableDividers;
+    /// this guards the one `.frame(maxWidth: .infinity)` pane that otherwise
+    /// has no floor. (#1454)
+    static let pdfCanvasMinWidth: Double = 360
 
     // MARK: - Environment
 

--- a/fichero/fichero/Views/Library/EditorView.swift
+++ b/fichero/fichero/Views/Library/EditorView.swift
@@ -18,6 +18,12 @@ struct EditorView: View {
 
     @EnvironmentObject private var documentStore: DocumentStore
 
+    /// Whether the canvas is showing the editing surface (tools) rather than
+    /// the plain zoom/loupe preview. Off by default so chrome stays minimal
+    /// until the user opts into editing (#1453). Reset whenever the document
+    /// changes so a new selection always opens in view mode.
+    @State private var isEditing = false
+
     var body: some View {
         Group {
             if let doc = document {
@@ -27,6 +33,9 @@ struct EditorView: View {
             }
         }
         .frame(minWidth: 300)
+        .onChange(of: document?.id) { _, _ in
+            isEditing = false
+        }
     }
 
     // MARK: - Document Preview
@@ -131,11 +140,25 @@ struct EditorView: View {
                 onPageIndexChange: onPDFPageIndexChange
             )
         } else if doc.fileType == .image, let path = doc.path, !path.isEmpty {
-            // Local image file with a path → plain preview via DocumentCanvas (#1402).
-            // Uses the full ZoomableImagePreview stack (zoom/loupe/magnifier).
-            DocumentCanvas(
-                content: .imageFile(url: URL(fileURLWithPath: path), documentId: doc.id)
-            )
+            // Local image file with a path. View mode → plain preview via
+            // DocumentCanvas (#1402, full ZoomableImagePreview zoom/loupe/
+            // magnifier). Edit mode → the same ImageEditorView used by
+            // page-children, exposing crop/rotate/enhance/remove-bg tools, so
+            // single image files finally have a way to reach editing (#1453).
+            ZStack(alignment: .topTrailing) {
+                if isEditing {
+                    ImageEditorView(
+                        document: doc,
+                        onNavigate: onNavigateToDocument,
+                        selectedDocumentIDs: selectedDocumentIDs
+                    )
+                } else {
+                    DocumentCanvas(
+                        content: .imageFile(url: URL(fileURLWithPath: path), documentId: doc.id)
+                    )
+                }
+                editModeToggle
+            }
         } else if doc.fileType == .image {
             // Remote/no-path image → editor provides preview via backend render.
             ImageEditorView(
@@ -146,6 +169,28 @@ struct EditorView: View {
         } else {
             QuickLookDownloadView(document: doc)
         }
+    }
+
+    // MARK: - Edit-mode Toggle
+
+    /// Far-corner toggle that flips the image canvas between view and edit
+    /// mode. Floats at the top-trailing edge so it is visible whether or not
+    /// the document header is shown (the reading surface hides the header). (#1453)
+    private var editModeToggle: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                isEditing.toggle()
+            }
+        } label: {
+            Image(systemName: isEditing ? "checkmark.circle.fill" : "pencil.tip.crop.circle")
+                .font(.title3)
+                .padding(6)
+                .background(.thinMaterial, in: Circle())
+        }
+        .buttonStyle(.plain)
+        .help(isEditing ? "Done — return to viewing" : "Edit image (crop, rotate, enhance, remove background)")
+        .accessibilityIdentifier("canvasEditModeToggle")
+        .padding(10)
     }
 
     // MARK: - Text Preview

--- a/fichero/fichero/Views/Menu/ViewMenuCommands.swift
+++ b/fichero/fichero/Views/Menu/ViewMenuCommands.swift
@@ -27,7 +27,7 @@ struct ViewMenuCommands: View {
 
         Divider()
 
-        InspectorButton(viewSettings: viewSettings)
+        InspectorButton()
 
         Divider()
 
@@ -444,20 +444,28 @@ struct PreviewModeButton: View {
 
 // MARK: - Inspector Button
 
-/// Inspector show/hide command
+/// Inspector show/hide command.
+/// Reads/writes the focused window's inspector visibility via FocusedValues so
+/// the toggle is per-window, not app-wide (#1451). Defaults to "Show" when no
+/// window is focused (e.g. the command is evaluated with no key window).
 struct InspectorButton: View {
-    @ObservedObject var viewSettings: ViewSettings
+    @FocusedValue(\.showInspector) var showInspector
+
+    private var isVisible: Bool {
+        showInspector?.wrappedValue ?? false
+    }
 
     var body: some View {
         Button {
-            viewSettings.showInspector.toggle()
+            showInspector?.wrappedValue.toggle()
         } label: {
             Label(
-                viewSettings.showInspector ? "Hide Inspector" : "Show Inspector",
+                isVisible ? "Hide Inspector" : "Show Inspector",
                 systemImage: "sidebar.right"
             )
         }
         .keyboardShortcut("i", modifiers: [.command, .option])
+        .disabled(showInspector == nil)
     }
 }
 

--- a/fichero/fichero/Views/Sidebar/SidebarView+ViewComponents.swift
+++ b/fichero/fichero/Views/Sidebar/SidebarView+ViewComponents.swift
@@ -74,6 +74,9 @@ extension SidebarView {
             ForEach(cachedLibraryHeaders) { libraryHeader in
                 unifiedLibrarySection(libraryHeader)
             }
+            // App-level destinations pinned once at the bottom, not repeated
+            // under every library (#1456).
+            pinnedGlobalNavigationRows()
         }
         .listStyle(.sidebar)
         .scrollContentBackground(.hidden)
@@ -245,13 +248,12 @@ extension SidebarView {
             .listRowSeparator(.hidden)
             .listRowBackground(Color.clear)
 
-        if FeatureManager.shared.isWorkflowsEnabled {
-            workflowsNavigationRow()
-        }
-
-        if FeatureManager.shared.isBatchesEnabled {
-            batchesNavigationRow()
-        }
+        // Workflows / Batches / Activity used to render here, once per
+        // library. They are app-level destinations (fixed selection tags, no
+        // library scope), so repeating them under every library both
+        // duplicated the rows and made all copies highlight together. They are
+        // now pinned ONCE at the bottom of the sidebar — see
+        // `pinnedGlobalNavigationRows()` in `unifiedContent`. (#1456)
 
         if FeatureManager.shared.isAutomationEnabled {
             unifiedDisclosureSection(
@@ -261,10 +263,6 @@ extension SidebarView {
                 libraryId: libraryId,
                 items: buckets.scheduleItems + buckets.triggerItems
             )
-        }
-
-        if FeatureManager.shared.isActivityEnabled {
-            activityNavigationRow()
         }
 
         // Saved Searches at the bottom — Daniel: 'saved searches should
@@ -495,6 +493,34 @@ extension SidebarView {
             .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 8))
             .listRowSeparator(.hidden)
             .listRowBackground(Color.clear)
+    }
+
+    /// Workflows / Batches / Activity pinned once at the bottom of the sidebar.
+    /// These are app-level destinations with fixed selection tags, so they must
+    /// appear exactly once — not repeated under every library, which both
+    /// duplicated them and made all copies share one selection highlight (#1456).
+    @ViewBuilder
+    private func pinnedGlobalNavigationRows() -> some View {
+        if FeatureManager.shared.isWorkflowsEnabled
+            || FeatureManager.shared.isBatchesEnabled
+            || FeatureManager.shared.isActivityEnabled {
+            Divider()
+                .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+        }
+
+        if FeatureManager.shared.isWorkflowsEnabled {
+            workflowsNavigationRow()
+        }
+
+        if FeatureManager.shared.isBatchesEnabled {
+            batchesNavigationRow()
+        }
+
+        if FeatureManager.shared.isActivityEnabled {
+            activityNavigationRow()
+        }
     }
 
     // MARK: - Compact Activity Grid (no longer used for section — struct kept for reuse)


### PR DESCRIPTION
5 toolbar/window-chrome issues. GATE (verify→review→commit): clean xcodebuild BUILD SUCCEEDED, swiftlint 39 style-only; 2 review-only subagents — correctness APPROVE, iterate-not-replace NO BLOCKING. #1451 converts global inspector state → per-window @SceneStorage in place (not a parallel path). One non-blocking follow-up filed (⌘⌥I disabled when sidebar hidden).

🤖 Generated with [Claude Code](https://claude.com/claude-code)