### PR TITLE
Window chrome b2: de-dup view-mode picker (#1446), rename knowledge pane (#1450), shared toolbar height (#1449/#1460), inspector-when-collapsed (#1513)

### DIFF
--- a/fichero/fichero/Views/ContentView+KnowledgeSurface.swift
+++ b/fichero/fichero/Views/ContentView+KnowledgeSurface.swift
@@ -29,7 +29,11 @@ extension ContentView {
         } else {
             VStack(spacing: 8) {
                 Spacer()
-                Text("Knowledge Surface")
+                // User-facing name for this pane. The internal type is
+                // DocumentKGWebPane / DocumentKGSurface, but the user only ever
+                // sees "Knowledge" (and the Transcript/Digest/Graph tab strip
+                // when a document is loaded) — the internal name never leaks. (#1450)
+                Text("Knowledge")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Text("Select a document with extracted knowledge to view transcript, digest, and graph.")

--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -56,7 +56,10 @@ extension ContentView {
         // Was 250 — felt bloated on small screens.
         .navigationSplitViewColumnWidth(min: 180, ideal: sidebarWidth, max: 360)
         .focusedSceneValue(\.sidebarMode, $sidebarMode)
-        .focusedSceneValue(\.showInspector, $showInspectorSidebar)
+        // NOTE: \.showInspector is published from the detail column in
+        // ContentView.navigationSplitColumn (always present), NOT here — the
+        // sidebar leaves the hierarchy when collapsed, which disabled ⌘⌥I
+        // and the View-menu toggle while the sidebar was hidden (#1513).
         .focusedSceneValue(\.navigateToParentAction, navigateToParent)
     }
 

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -471,7 +471,13 @@ extension ContentView {
                 // current mode supports multiple presentations and more than one
                 // option is available. Syncs with viewSettings.libraryLayout so
                 // the View menu checkmark stays in sync (#1215).
-                if showViewModePicker && availableViewDisplayModes.count > 1 {
+                //
+                // De-duplicated (#1446): in Library/Search the same control is
+                // already rendered as the in-content mode rail (horizontalModeStrip),
+                // so suppress the toolbar copy there. The toolbar picker remains the
+                // sole view-mode control for modes that have no mode rail (e.g.
+                // Workflows), where `showModeRail` is false.
+                if showViewModePicker && availableViewDisplayModes.count > 1 && !showModeRail {
                     Picker("View", selection: $viewDisplayMode) {
                         ForEach(availableViewDisplayModes) { mode in
                             Label(mode.rawValue, systemImage: mode.icon)

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -298,6 +298,10 @@ struct ContentView: View {
         } detail: {
             centerContent
                 .frame(minWidth: CGFloat(ContentView.contentMinWidth), maxWidth: .infinity)
+                // Publish the per-window inspector binding from the detail
+                // column (always present) rather than the sidebar, which leaves
+                // the hierarchy when collapsed and made ⌘⌥I no-op (#1513/#1451).
+                .focusedSceneValue(\.showInspector, $showInspectorSidebar)
         }
         // Avoid duplicate generic per-column title pills in macOS split view.
         .navigationTitle(toolbarTitle)

--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditChainPanel.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditChainPanel.swift
@@ -62,7 +62,8 @@ struct ImageEditChainPanel: View {
             }
         }
         .padding(.horizontal, 12)
-        .frame(height: 44)
+        // Match the shared pane top-toolbar height (#1449/#1460).
+        .frame(height: MiniToolbar<EmptyView>.standardHeight)
     }
 
     // MARK: - Chain

--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
@@ -204,7 +204,9 @@ private extension ImageEditorView {
             }
         }
         .padding(.horizontal, 12)
-        .frame(height: 44)
+        // Single source of truth for top-toolbar height so the image-edit
+        // toolbar lines up with every other pane mini-toolbar (#1449/#1460).
+        .frame(height: MiniToolbar<EmptyView>.standardHeight)
         .background(Color(.windowBackgroundColor))
     }
 


### PR DESCRIPTION
4 toolbar fixes. GATE: clean xcodebuild BUILD SUCCEEDED, swiftlint 39 style-only; 2 reviewers — correctness APPROVE, iterate-not-replace NO BLOCKING (all 4 respect the rule; #1446 de-dups onto the canonical rail, #1449/#1460 collapse hardcoded 44 to one constant, #1513 moves focusedSceneValue to the always-present detail column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)