### PR TITLE
Window chrome b3: per-window pane show/hide (#1448) + stable-layout default (#1452) + preview constant (#1449)

### DIFF
--- a/fichero/fichero/Views/ContentView+Actions.swift
+++ b/fichero/fichero/Views/ContentView+Actions.swift
@@ -129,9 +129,11 @@ extension ContentView {
         guard currentLayoutMode != .none else { return false }
         switch viewMode {
         case .library:
-            // Hide preview pane when a folder is selected — grid takes
-            // full width, inspector shows folder metadata. (#712)
-            if let doc = inspectorDocument, doc.docType == .folder {
+            // Stable layout (default): a folder keeps the same panes as a file,
+            // so selecting different items never reflows the window (#1452). The
+            // legacy behaviour — folder collapses the preview so the grid takes
+            // full width (#712) — is now opt-in via layoutFollowsSelection.
+            if layoutFollowsSelection, let doc = inspectorDocument, doc.docType == .folder {
                 return false
             }
             return true

--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -176,68 +176,96 @@ extension ContentView {
                     .frame(maxWidth: .infinity)
 
                 case .widescreen:
+                    // Library list is always present; the document canvas and the
+                    // reading/WebKit pane are each independently toggleable
+                    // per-window (#1448). When the canvas is hidden the reading
+                    // pane takes over the freed space so there's never a gap.
                     HStack(spacing: 0) {
                         contentWithOptionalModeRail
                             .overlay { paneFocusIndicator(for: .content) }
                             .frame(width: clampedWidescreenContentPaneWidth)
 
-                        ResizableDivider(
-                            width: $widescreenContentPaneWidth,
-                            minWidth: ContentView.contentListMinWidth,
-                            maxWidth: 900,
-                            edge: .leading
-                        )
-
-                        if let pdfPath = detailPDFPath {
-                            PDFPageWithToolbar(
-                                path: pdfPath,
-                                pageIndex: selectedPageIndex,
-                                onPageIndexChange: { index in
-                                    guard documentScrollSync.beginDriving(.pdf) else { return }
-                                    syncGridSelectionToPDFPage(index: index)
-                                }
+                        if showDocumentCanvas || showReadingPane {
+                            ResizableDivider(
+                                width: $widescreenContentPaneWidth,
+                                minWidth: ContentView.contentListMinWidth,
+                                maxWidth: 900,
+                                edge: .leading
                             )
-                            .overlay { paneFocusIndicator(for: .preview) }
-                            .frame(minWidth: ContentView.pdfCanvasMinWidth, maxWidth: .infinity)
-                        } else {
-                            EditorView(
-                                document: detailDocument,
-                                showHeader: false,
-                                onPDFPageIndexChange: { index in
-                                    syncGridSelectionToPDFPage(index: index)
-                                },
-                                onNavigateToDocument: { docId in
-                                    selectDocument(withId: docId)
-                                },
-                                selectedDocumentIDs: browserSelection
-                            )
-                            .overlay { paneFocusIndicator(for: .preview) }
-                            .frame(maxWidth: .infinity)
                         }
 
-                        ResizableDivider(
-                            width: $pageContentPaneWidth,
-                            minWidth: 220,
-                            maxWidth: 540,
-                            edge: .trailing
-                        )
+                        if showDocumentCanvas {
+                            widescreenCanvasPane
 
-                        knowledgeSurface(
-                            for: detailDocument,
-                            activePageNumber: detailPDFPath == nil ? nil : selectedPageIndex + 1,
-                            pageCount: pdfDocPages.isEmpty ? nil : pdfDocPages.count,
-                            scrollSync: documentScrollSync,
-                            onPageSelected: { index in
-                                syncGridSelectionToPDFPage(index: index)
+                            if showReadingPane {
+                                ResizableDivider(
+                                    width: $pageContentPaneWidth,
+                                    minWidth: 220,
+                                    maxWidth: 540,
+                                    edge: .trailing
+                                )
+                                widescreenReadingPane
+                                    .frame(width: CGFloat(pageContentPaneWidth))
                             }
-                        )
-                        .frame(width: CGFloat(pageContentPaneWidth))
+                        } else if showReadingPane {
+                            widescreenReadingPane
+                                .frame(maxWidth: .infinity)
+                        }
                     }
                     .frame(maxWidth: .infinity)
                 }
             }
             .animation(.easeInOut(duration: 0.18), value: layout)
         }
+    }
+
+    /// The document-canvas pane of the widescreen reading layout — a PDF page
+    /// viewer when a PDF is active, otherwise the image/preview editor. Carries
+    /// its own flexible width so it fills whatever the list/reading panes leave.
+    /// Extracted so the canvas can be conditionally shown/hidden (#1448).
+    @ViewBuilder
+    var widescreenCanvasPane: some View {
+        if let pdfPath = detailPDFPath {
+            PDFPageWithToolbar(
+                path: pdfPath,
+                pageIndex: selectedPageIndex,
+                onPageIndexChange: { index in
+                    guard documentScrollSync.beginDriving(.pdf) else { return }
+                    syncGridSelectionToPDFPage(index: index)
+                }
+            )
+            .overlay { paneFocusIndicator(for: .preview) }
+            .frame(minWidth: ContentView.pdfCanvasMinWidth, maxWidth: .infinity)
+        } else {
+            EditorView(
+                document: detailDocument,
+                showHeader: false,
+                onPDFPageIndexChange: { index in
+                    syncGridSelectionToPDFPage(index: index)
+                },
+                onNavigateToDocument: { docId in
+                    selectDocument(withId: docId)
+                },
+                selectedDocumentIDs: browserSelection
+            )
+            .overlay { paneFocusIndicator(for: .preview) }
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    /// The reading / WebKit "Knowledge" pane of the widescreen layout.
+    /// Extracted so it can be conditionally shown/hidden per-window (#1448).
+    @ViewBuilder
+    var widescreenReadingPane: some View {
+        knowledgeSurface(
+            for: detailDocument,
+            activePageNumber: detailPDFPath == nil ? nil : selectedPageIndex + 1,
+            pageCount: pdfDocPages.isEmpty ? nil : pdfDocPages.count,
+            scrollSync: documentScrollSync,
+            onPageSelected: { index in
+                syncGridSelectionToPDFPage(index: index)
+            }
+        )
     }
 
     // MARK: - Preview View

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -104,6 +104,12 @@ struct ContentView: View {
     @SceneStorage("showSidebar") var showSidebar: Bool = true
     @SceneStorage("showInspectorSidebar") var showInspectorSidebar: Bool = true
     @SceneStorage("showDocumentGrid") var showDocumentGrid: Bool = true
+    // Per-window visibility of the two reading-surface panes (#1448). Each
+    // window keeps its own choice via @SceneStorage (same pattern as the
+    // sidebar/inspector toggles). The library list/grid is intentionally NOT
+    // toggleable — it is always present as the spine of the workspace.
+    @SceneStorage("showDocumentCanvas") var showDocumentCanvas: Bool = true
+    @SceneStorage("showReadingPane") var showReadingPane: Bool = true
 
     // Map view persistence (latitude, longitude, zoom)
     @SceneStorage("mapLatitude") var mapLatitude: Double = 0.0
@@ -641,6 +647,34 @@ extension ContentView {
             }
             .help(showDocumentGrid ? "Hide Document Grid (⌘⇧G)" : "Show Document Grid (⌘⇧G)")
             .keyboardShortcut("g", modifiers: [.command, .shift])
+        }
+
+        // Per-window show/hide for the document canvas and the reading/WebKit
+        // pane (#1448). Only meaningful in the reading-capable modes where those
+        // panes exist, so they're gated on showsPreviewPane to avoid dead
+        // controls elsewhere. The library list/grid stays always-present.
+        if showsPreviewPane {
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        showDocumentCanvas.toggle()
+                    }
+                } label: {
+                    Image(systemName: "doc.richtext")
+                }
+                .help(showDocumentCanvas ? "Hide Document Canvas" : "Show Document Canvas")
+            }
+
+            ToolbarItem(placement: .automatic) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        showReadingPane.toggle()
+                    }
+                } label: {
+                    Image(systemName: "text.book.closed")
+                }
+                .help(showReadingPane ? "Hide Reading Pane" : "Show Reading Pane")
+            }
         }
 
         // Inspector toggle at the trailing edge of the toolbar — the

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -110,6 +110,12 @@ struct ContentView: View {
     // toggleable — it is always present as the spine of the workspace.
     @SceneStorage("showDocumentCanvas") var showDocumentCanvas: Bool = true
     @SceneStorage("showReadingPane") var showReadingPane: Bool = true
+    // When false (default), selecting a different item NEVER changes which
+    // panes are visible — a folder shows the same panes as a PDF. The visible
+    // pane set is the user's choice (the toggles above). Opt in to the old
+    // selection-driven behaviour (e.g. folders collapse the preview) by
+    // turning this on. App-wide preference, toggled from the View menu. (#1452)
+    @AppStorage("layout.followsSelection") var layoutFollowsSelection: Bool = false
 
     // Map view persistence (latitude, longitude, zoom)
     @SceneStorage("mapLatitude") var mapLatitude: Double = 0.0

--- a/fichero/fichero/Views/Menu/ViewMenuCommands.swift
+++ b/fichero/fichero/Views/Menu/ViewMenuCommands.swift
@@ -31,6 +31,10 @@ struct ViewMenuCommands: View {
 
         Divider()
 
+        SelectionDrivenLayoutToggle()
+
+        Divider()
+
         NavigateToParentButton()
 
         Divider()
@@ -466,6 +470,23 @@ struct InspectorButton: View {
         }
         .keyboardShortcut("i", modifiers: [.command, .option])
         .disabled(showInspector == nil)
+    }
+}
+
+// MARK: - Selection-driven Layout
+
+/// Opt-in toggle for selection-driven layout changes. OFF by default so the
+/// visible pane set is stable — selecting a folder vs a PDF shows the same
+/// panes. ON restores the legacy behaviour where a folder collapses the
+/// preview pane. App-wide @AppStorage, so a Toggle reflects external changes
+/// (mirrors ShowRulerButton's rationale). (#1452)
+struct SelectionDrivenLayoutToggle: View {
+    @AppStorage("layout.followsSelection") private var layoutFollowsSelection: Bool = false
+
+    var body: some View {
+        Toggle(isOn: $layoutFollowsSelection) {
+            Label("Selection Changes Layout", systemImage: "rectangle.on.rectangle")
+        }
     }
 }
 

--- a/fichero/fichero/Views/Toolbars/MainToolbar.swift
+++ b/fichero/fichero/Views/Toolbars/MainToolbar.swift
@@ -130,7 +130,7 @@ enum ViewDisplayMode: String, CaseIterable, Identifiable {
         itemRegistry: registry,
         searchText: $searchText
     )
-    .frame(height: 44)
+    .frame(height: MiniToolbar<EmptyView>.standardHeight)
     .onAppear {
         registry.createFolder = { print("Create folder") }
         registry.createSearch = { print("Create search") }


### PR DESCRIPTION
GATE: clean xcodebuild BUILD SUCCEEDED, swiftlint 39 style-only; 2 reviewers — correctness APPROVE, iterate-not-replace NO BLOCKING. #1448 reuses #1451 @SceneStorage per-window pattern (no new store/files); #1452 gates the existing selection→layout branch behind an opt-in setting in place. Two non-blocking UX follow-ups filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)