### PR TITLE
Window chrome b4: Sort+Filter into Library rail (#1477) + per-window pane-toggle polish (#1516)

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -168,6 +168,7 @@
 		4EBA402FBE51F9F56366C3A5 /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3CD4902A47A5787D61C6D72 /* FlowLayout.swift */; };
 		544F0C27E64420694C462156 /* ResearchBrowserPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2290E008AD4F8ACF613B8C /* ResearchBrowserPane.swift */; };
 		54A07EFB77CACCF2E0ADDD84 /* ImageEditingServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA2442EE35411B543D0868B /* ImageEditingServiceGenerated.swift */; };
+		560311302E8DCC126BD757E2 /* LibraryToolbarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99857D7C99E753A3405778FC /* LibraryToolbarState.swift */; };
 		56DCD53ACD6483561CF542B3 /* KGTemporalSpatial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43EAB861267206E7A929830F /* KGTemporalSpatial.swift */; };
 		5D064ECAAD353BDB778B8580 /* AnnotationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D7DC57117008EBCFE607A9 /* AnnotationService.swift */; };
 		5E8 /* SidebarItemBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9 /* SidebarItemBuilder.swift */; };
@@ -640,6 +641,7 @@
 		923BD592D3257176C51CAC1C /* ContentView+WorkflowActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+WorkflowActions.swift"; sourceTree = "<group>"; };
 		92773EAEE52587BBA8DEDC9F /* LibraryView+TableMapViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "LibraryView+TableMapViews.swift"; sourceTree = "<group>"; };
 		95706A3222B50B478F15D83D /* ImageEditChainPanel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageEditChainPanel.swift; sourceTree = "<group>"; };
+		99857D7C99E753A3405778FC /* LibraryToolbarState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LibraryToolbarState.swift; sourceTree = "<group>"; };
 		9DDD2864E374789E10D5B169 /* PDFPageView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFPageView.swift; sourceTree = "<group>"; };
 		9E04EE1958EB4E23A7E1E328 /* WindowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowState.swift; sourceTree = "<group>"; };
 		A0264B7B8616BA5159B2CEF1 /* TriggerEditorFormPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TriggerEditorFormPanel.swift; path = fichero/Views/Automation/TriggerEditorView/TriggerEditorFormPanel.swift; sourceTree = SOURCE_ROOT; };
@@ -1552,6 +1554,7 @@
 				A9CC1872944150E583173CB8 /* ImageEditor */,
 				A5C119BA4657FD54B0F01D6C /* DocumentKGSurface.swift */,
 				80E4C1042F69F06267FA6CCD /* DocumentCanvas.swift */,
+				99857D7C99E753A3405778FC /* LibraryToolbarState.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -2245,6 +2248,7 @@
 				286700373FC6B54B843E8DA5 /* NodePopover+Comparison.swift in Sources */,
 				0C6B1EE6EDE444C4F95ED9FD /* NoteService.swift in Sources */,
 				C5B7DEB948261159D439C454 /* DocumentNotesTab.swift in Sources */,
+				560311302E8DCC126BD757E2 /* LibraryToolbarState.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero/Views/ContentView+Actions.swift
+++ b/fichero/fichero/Views/ContentView+Actions.swift
@@ -42,7 +42,12 @@ extension ContentView {
     /// Cycle keyboard focus between sidebar, content, and inspector panes
     func cyclePaneFocus(reverse: Bool) {
         var panes: [PaneFocus] = [.sidebar, .content]
-        if showsPreviewPane {
+        // Only offer the preview pane to Tab-cycling when one actually renders.
+        // In widescreen both the canvas and reading panes can be hidden (#1448),
+        // in which case focusing .preview would be a no-op (#1516).
+        let previewPaneVisible = currentLayoutMode != .widescreen
+            || showDocumentCanvas || showReadingPane
+        if showsPreviewPane && previewPaneVisible {
             panes.append(.preview)
         }
         if showInspectorSidebar {

--- a/fichero/fichero/Views/ContentView+Navigation.swift
+++ b/fichero/fichero/Views/ContentView+Navigation.swift
@@ -58,6 +58,7 @@ extension ContentView {
                             await documentStore.refresh()
                         }
                     },
+                    libraryToolbar: libraryToolbarState,
                     selection: $browserSelection,
                     detailDocument: $detailDocument,
                     viewMode: $viewSettings.libraryLayout,

--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -237,9 +237,16 @@ extension ContentView {
                     // per-window (#1448). When the canvas is hidden the reading
                     // pane takes over the freed space so there's never a gap.
                     HStack(spacing: 0) {
+                        // When both reading panes are hidden the list takes the
+                        // whole width instead of staying a fixed column with a
+                        // blank grey area beside it (#1516). list-only is a valid
+                        // state — the library list is the always-present spine.
                         contentWithOptionalModeRail
                             .overlay { paneFocusIndicator(for: .content) }
-                            .frame(width: clampedWidescreenContentPaneWidth)
+                            .frame(
+                                width: (showDocumentCanvas || showReadingPane)
+                                    ? clampedWidescreenContentPaneWidth : .infinity
+                            )
 
                         if showDocumentCanvas || showReadingPane {
                             ResizableDivider(

--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -90,9 +90,65 @@ extension ContentView {
                     modeRailButton(mode)
                 }
                 Spacer(minLength: 0)
+                // Sort + Filter live here — at the Library view's top-right,
+                // next to the display-mode buttons — instead of the global
+                // window toolbar (#1477).
+                librarySortFilterControls
             }
             // XCUITest hook for the view-mode rail (#1230).
             .accessibilityIdentifier("viewModeRail")
+        }
+    }
+
+    /// Sort menu + inline-filter toggle for the Library mode rail. Library only
+    /// (search/workflows don't carry these). Drives the shared LibraryToolbarState
+    /// so the controls and the LibraryView stay in sync (#1477).
+    @ViewBuilder
+    private var librarySortFilterControls: some View {
+        if sidebarMode == .library {
+            Menu {
+                ForEach(LibrarySortField.allCases) { field in
+                    Button {
+                        libraryToolbarState.sortFieldRaw = field.rawValue
+                    } label: {
+                        Label(field.rawValue, systemImage: field.icon)
+                        if libraryToolbarState.sortField == field {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+                Divider()
+                Button {
+                    libraryToolbarState.sortAscending = true
+                } label: {
+                    Text("Ascending")
+                    if libraryToolbarState.sortAscending { Image(systemName: "checkmark") }
+                }
+                Button {
+                    libraryToolbarState.sortAscending = false
+                } label: {
+                    Text("Descending")
+                    if !libraryToolbarState.sortAscending { Image(systemName: "checkmark") }
+                }
+            } label: {
+                Image(systemName: "arrow.up.arrow.down")
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .help("Sort \(libraryToolbarState.sortField.rawValue), \(libraryToolbarState.sortAscending ? "ascending" : "descending")")
+            .accessibilityIdentifier("librarySortMenu")
+
+            if featureManager.isLibraryFilterToolbarEnabled {
+                Button {
+                    libraryToolbarState.showFilterBar.toggle()
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(libraryToolbarState.showFilterBar ? Color.accentColor : Color.secondary)
+                .help("Filter (⌘F)")
+                .accessibilityIdentifier("libraryFilterButton")
+            }
         }
     }
 

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -673,6 +673,10 @@ extension ContentView {
                     Image(systemName: "doc.richtext")
                 }
                 .help(showDocumentCanvas ? "Hide Document Canvas" : "Show Document Canvas")
+                // The canvas/reading split only exists in the widescreen reading
+                // layout — disable the toggles elsewhere so they're not dead
+                // controls (#1516).
+                .disabled(currentLayoutMode != .widescreen)
             }
 
             ToolbarItem(placement: .automatic) {
@@ -684,6 +688,7 @@ extension ContentView {
                     Image(systemName: "text.book.closed")
                 }
                 .help(showReadingPane ? "Hide Reading Pane" : "Show Reading Pane")
+                .disabled(currentLayoutMode != .widescreen)
             }
         }
 

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -116,6 +116,10 @@ struct ContentView: View {
     // selection-driven behaviour (e.g. folders collapse the preview) by
     // turning this on. App-wide preference, toggled from the View menu. (#1452)
     @AppStorage("layout.followsSelection") var layoutFollowsSelection: Bool = false
+    // Library sort field / direction / filter-bar visibility, lifted out of
+    // LibraryView's @State so the in-content mode rail can host the Sort + Filter
+    // controls at the Library view's top-right (#1477).
+    @StateObject var libraryToolbarState = LibraryToolbarState()
 
     // Map view persistence (latitude, longitude, zoom)
     @SceneStorage("mapLatitude") var mapLatitude: Double = 0.0

--- a/fichero/fichero/Views/Library/LibraryToolbarState.swift
+++ b/fichero/fichero/Views/Library/LibraryToolbarState.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+/// Shared, observable home for the Library view's toolbar-facing controls —
+/// sort field, sort direction, and inline-filter-bar visibility.
+///
+/// These three values used to be `@State` inside `LibraryView`, which made them
+/// unreachable from the in-content mode rail (a sibling view that owns the
+/// view-mode buttons). Lifting them into one `ObservableObject` — owned by
+/// `ContentView` and shared with both `LibraryView` and the mode rail — lets the
+/// Sort and Filter controls live at the Library view's top-right next to the
+/// display-mode buttons (#1477) while `LibraryView` keeps its per-folder sort
+/// persistence (the `*ByFolder` @SceneStorage stays in `LibraryView` and simply
+/// reads/writes these values).
+@MainActor
+final class LibraryToolbarState: ObservableObject {
+    /// Raw value of the active `LibrarySortField` (kept as `String` to match the
+    /// existing per-folder persistence + FocusedValue plumbing).
+    @Published var sortFieldRaw: String = LibrarySortField.name.rawValue
+    /// Sort direction — `true` ascending.
+    @Published var sortAscending: Bool = true
+    /// Whether the inline ⌘F filter bar is shown inside the library content.
+    @Published var showFilterBar: Bool = false
+
+    /// Convenience typed accessor for the active sort field.
+    var sortField: LibrarySortField {
+        LibrarySortField(rawValue: sortFieldRaw) ?? .name
+    }
+}

--- a/fichero/fichero/Views/Library/LibraryView+KeyboardShortcuts.swift
+++ b/fichero/fichero/Views/Library/LibraryView+KeyboardShortcuts.swift
@@ -45,8 +45,8 @@ extension LibraryView {
             .focusedSceneValue(\.libraryDeleteSelection, !selection.isEmpty ? {
                 promptDeleteSelected()
             } : nil)
-            .focusedSceneValue(\.librarySortField, $sortFieldRaw)
-            .focusedSceneValue(\.librarySortAscending, $sortAscending)
+            .focusedSceneValue(\.librarySortField, $libraryToolbar.sortFieldRaw)
+            .focusedSceneValue(\.librarySortAscending, $libraryToolbar.sortAscending)
             .confirmationDialog(
                 "Delete \(documentsToDelete.count) document\(documentsToDelete.count == 1 ? "" : "s")?",
                 isPresented: $showDeleteConfirmation,

--- a/fichero/fichero/Views/Library/LibraryView.swift
+++ b/fichero/fichero/Views/Library/LibraryView.swift
@@ -9,6 +9,9 @@ struct LibraryView: View {
     let isConnected: Bool
     let errorMessage: String?
     let onRetry: () -> Void
+    /// Sort field / direction / filter-bar visibility, lifted out of @State so
+    /// the in-content mode rail can drive them too (#1477). Owned by ContentView.
+    @ObservedObject var libraryToolbar: LibraryToolbarState
     @Binding var selection: Set<String>
     @Binding var detailDocument: Document?
     @Binding var viewMode: LibraryLayout
@@ -32,7 +35,6 @@ struct LibraryView: View {
     var onToolbarSearchSubmit: (String) -> Void = { _ in }
 
     @State var searchText: String = ""
-    @State var showFilterBar = false
     /// Text for the toolbar's `.searchable` field. Distinct from
     /// `searchText` (which drives the inline ⌘F filter bar inside the
     /// view) — `toolbarQuery` lives on the window toolbar so users can
@@ -40,14 +42,28 @@ struct LibraryView: View {
     /// inline filter stays as a quick local-narrow.
     @State var toolbarQuery: String = ""
     @FocusState var filterFieldFocused: Bool
-    @State var sortFieldRaw: String = LibrarySortField.name.rawValue
-    @State var sortAscending: Bool = true
     @State var sortOrder: [KeyPathComparator<Document>] = [.init(\.name, order: .forward)]
     @SceneStorage("library.sortFieldsByFolder") var sortFieldsByFolderJSON: String = "{}"
     @SceneStorage("library.sortAscendingByFolder") var sortAscendingByFolderJSON: String = "{}"
 
+    // Sort field / direction / filter-bar visibility now live on the shared
+    // store (#1477). These computed forwarders keep the existing call sites and
+    // `$`-bindings working unchanged.
+    var sortFieldRaw: String {
+        get { libraryToolbar.sortFieldRaw }
+        nonmutating set { libraryToolbar.sortFieldRaw = newValue }
+    }
+    var sortAscending: Bool {
+        get { libraryToolbar.sortAscending }
+        nonmutating set { libraryToolbar.sortAscending = newValue }
+    }
+    var showFilterBar: Bool {
+        get { libraryToolbar.showFilterBar }
+        nonmutating set { libraryToolbar.showFilterBar = newValue }
+    }
+
     var sortField: LibrarySortField {
-        LibrarySortField(rawValue: sortFieldRaw) ?? .name
+        libraryToolbar.sortField
     }
 
     // Workflow picker state
@@ -303,6 +319,7 @@ struct LibraryView: View {
         isConnected: true,
         errorMessage: nil,
         onRetry: {},
+        libraryToolbar: LibraryToolbarState(),
         selection: .constant(Set<String>()),
         detailDocument: .constant(nil),
         viewMode: .constant(.icons),
@@ -319,6 +336,7 @@ struct LibraryView: View {
         isConnected: false,
         errorMessage: nil,
         onRetry: {},
+        libraryToolbar: LibraryToolbarState(),
         selection: .constant(Set<String>()),
         detailDocument: .constant(nil),
         viewMode: .constant(.icons),


### PR DESCRIPTION
#1477 lifts sort/filter into a shared LibraryToolbarState store and relocates the controls into the Library mode rail (filter feature-flagged). #1516 polishes the per-window pane toggles. GATE: manager-reviewed diff (additive, new file registered), independent clean xcodebuild BUILD SUCCEEDED, swiftlint 40 style-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)