### PR TITLE
KG: Map+Timeline stop dropping in-scope claims (#1470/#1471) + restore entity-browser View-menu entry (#1485)

### DIFF
--- a/fichero/fichero/Views/KnowledgeGraph/KGMapView.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/KGMapView.swift
@@ -165,9 +165,6 @@ struct KGMapView: View {
         return map
     }
 
-    private var scopeEntityIds: Set<String> {
-        Set(entities.compactMap(\.id))
-    }
 
     /// Claims with valid coordinates that pass the scope filter.
     private var locatedClaims: [LocatedClaim] {
@@ -199,13 +196,16 @@ struct KGMapView: View {
     }
 
     private func isInScope(_ claim: Components.Schemas.KnowledgeClaim) -> Bool {
+        // `claims` are already document-scoped by listClaims(sourceDocumentId:,
+        // includeDescendants:), so every loaded claim is in scope by
+        // construction. The previous additional entity-overlap filter (claim's
+        // entities ∩ this document's entity list) dropped every geocoded place
+        // claim whose place entity wasn't in the doc-only entity list, so the
+        // map always read "No mapped claims" even with geocoded data (#1471).
+        // Only narrow by entity when the user explicitly focuses on a selection.
+        guard focusOnSelection, let selectedEntityId else { return true }
         let ids = Set([claim.subjectEntityId].compactMap { $0 }).union(claim.entityIds ?? [])
-        if focusOnSelection, let selectedEntityId {
-            guard ids.contains(selectedEntityId) else { return false }
-        }
-        if ids.isEmpty { return !focusOnSelection }
-        if scopeEntityIds.isEmpty { return !focusOnSelection }
-        return !ids.isDisjoint(with: scopeEntityIds)
+        return ids.contains(selectedEntityId)
     }
 
     @MainActor

--- a/fichero/fichero/Views/KnowledgeGraph/KGTimelineView.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/KGTimelineView.swift
@@ -207,11 +207,6 @@ struct KGTimelineView: View {
         return map
     }
 
-    /// Set of in-scope entity ids — drives the kind-filter cross-filter.
-    private var scopeEntityIds: Set<String> {
-        Set(entities.compactMap(\.id))
-    }
-
     /// Claims with a parseable start date, in scope, sorted by start.
     private var datedClaims: [DatedClaim] {
         claims.compactMap { claim -> DatedClaim? in
@@ -243,16 +238,16 @@ struct KGTimelineView: View {
     /// In scope when (a) the claim's subject resolves to a visible entity
     /// (kind filter), and (b) if focusing, it belongs to the selected entity.
     private func isInScope(_ claim: Components.Schemas.KnowledgeClaim) -> Bool {
+        // `claims` are already document-scoped by listClaims(sourceDocumentId:,
+        // includeDescendants:), so every loaded claim is in scope by
+        // construction. The previous entity-overlap filter (claim's entities ∩
+        // this document's entity list) dropped every dated claim whose entity
+        // wasn't in the doc-only entity list, so the timeline showed "No dated
+        // claims" even with parseable dates (#1470). Only narrow by entity when
+        // the user explicitly focuses on a selection.
+        guard focusOnSelection, let selectedEntityId else { return true }
         let ids = Set([claim.subjectEntityId].compactMap { $0 }).union(claim.entityIds ?? [])
-        if focusOnSelection, let selectedEntityId {
-            guard ids.contains(selectedEntityId) else { return false }
-        }
-        // Honour the kind filter: keep claims touching at least one visible
-        // entity. Claims with no resolved entity are kept (otherwise they'd
-        // silently vanish) only when no focus is active.
-        if ids.isEmpty { return !focusOnSelection }
-        if scopeEntityIds.isEmpty { return !focusOnSelection }
-        return !ids.isDisjoint(with: scopeEntityIds)
+        return ids.contains(selectedEntityId)
     }
 
     private static func lane(for kind: Components.Schemas.EntityTypeOutput?) -> String {

--- a/fichero/fichero/Views/Menu/ViewMenuCommands.swift
+++ b/fichero/fichero/Views/Menu/ViewMenuCommands.swift
@@ -153,6 +153,37 @@ struct SidebarModeSection: View {
                     sidebarMode?.wrappedValue = .mindPalace
                 }
             }
+
+            // Research (8) + Knowledge Graph (9) menu entries. These exist in the
+            // sidebar mode-icon bar but had dropped out of the View menu, so the
+            // menu items + ⌃⌘8 / ⌃⌘9 shortcuts that surface the entity browser
+            // (OntologyBrowser) went missing — the lost entry point in #1485.
+            if featureManager.isResearchEnabled {
+                SidebarModeButton(
+                    mode: .research,
+                    label: SidebarMode.research.label,
+                    icon: SidebarMode.research.icon,
+                    shortcut: SidebarMode.research.shortcutNumber,
+                    current: currentMode
+                ) {
+                    sidebarMode?.wrappedValue = .research
+                }
+            }
+
+            if featureManager.isKnowledgeGraphEnabled {
+                Divider()
+
+                // Knowledge Graph mode — entity list + per-entity KG (OntologyBrowser).
+                SidebarModeButton(
+                    mode: .knowledgeGraph,
+                    label: SidebarMode.knowledgeGraph.label,
+                    icon: SidebarMode.knowledgeGraph.icon,
+                    shortcut: SidebarMode.knowledgeGraph.shortcutNumber,
+                    current: currentMode
+                ) {
+                    sidebarMode?.wrappedValue = .knowledgeGraph
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The 2 pure-SwiftUI KG fixes (split out from ms/kg-hermeneutics-fe; the WebKit/JS lozenge/provenance commits are staged separately for visual verification).

- #1470/#1471: remove a redundant entity-overlap filter that dropped every geocoded place claim + dated claim already in document scope — the root cause of 'No mapped claims' / empty timeline.
- #1485: restore Research(⌃⌘8) + Knowledge Graph(⌃⌘9) View-menu entries (re-wires the lost OntologyBrowser entry point in place).

GATE: clean xcodebuild BUILD SUCCEEDED, swiftlint 41 style-only, manager self-review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)