### PR TITLE
[STAGED — needs Daniel's visual gate] KG WebKit: clickable lozenges (#1466) + inline claim provenance (#1467)

### DIFF
--- a/fichero-engine/src/fichero/api/templates/document_view.html
+++ b/fichero-engine/src/fichero/api/templates/document_view.html
@@ -133,6 +133,23 @@
             font: 700 14px/1.3 var(--font-system);
         }
 
+        /* Entity names render as clickable macOS-accent lozenges, not bold
+           text — clicking opens that entity across the library via the bridge
+           (#1466 / #1363). */
+        .entity-lozenge {
+            font: 600 13px/1.2 var(--font-system);
+            color: var(--accent);
+            background: var(--accent-soft);
+            border: none;
+            border-radius: 999px;
+            padding: 3px 11px;
+            cursor: pointer;
+        }
+
+        .entity-lozenge:hover {
+            text-decoration: underline;
+        }
+
         .claim-row {
             border: 1px solid var(--line);
             border-radius: 10px;
@@ -372,7 +389,9 @@ function renderDigest() {
     }
     panel.innerHTML = groups.map((group) => `
         <section class="digest-group">
-            <h3>${escapeHtml(group.entity.canonical_name)}</h3>
+            <h3>${group.entity.id && group.entity.id !== "__ungrouped__"
+                ? `<button type="button" class="entity-lozenge" data-entity-id="${escapeHtml(group.entity.id)}">${escapeHtml(group.entity.canonical_name)}</button>`
+                : escapeHtml(group.entity.canonical_name)}</h3>
             ${group.claims.map((claim) => `
                 <div class="claim-row ${state.activeClaimId === claim.id ? "active" : ""}" data-claim-id="${claim.id}">
                     <div>${escapeHtml(claimSummary(claim))}</div>
@@ -400,6 +419,25 @@ function renderDigest() {
                 sourceDocumentId: claim.source_document_id,
                 passage: claim.source_excerpt,
                 pageNumber: claim.page_number,
+            });
+        });
+    });
+
+    // Clicking an entity-name lozenge opens that entity (#1466). The native
+    // bridge handles `entitySelected` → KGFocusState → retargets the Document
+    // Inspector to the entity (#1484). stopPropagation so it doesn't also fire
+    // the surrounding section's handlers.
+    panel.querySelectorAll(".entity-lozenge").forEach((el) => {
+        el.addEventListener("click", (event) => {
+            event.stopPropagation();
+            const entityId = el.dataset.entityId;
+            if (!entityId) return;
+            const entityClaims = claims.filter((item) => (item.entity_ids || []).includes(entityId));
+            state.activeEntityId = entityId;
+            updateGraphActiveNode();
+            notify("entitySelected", {
+                entityId: entityId,
+                sourceDocumentId: entityClaims[0]?.source_document_id || null,
             });
         });
     });

--- a/fichero-engine/src/fichero/api/templates/document_view.html
+++ b/fichero-engine/src/fichero/api/templates/document_view.html
@@ -171,6 +171,32 @@
             font: 500 11px/1.4 var(--font-mono);
         }
 
+        /* Provenance + click-to-expand source passage, inline under the claim
+           (#1467). The hint is always visible; the source box reveals on click
+           (the .source-open class is toggled on the .claim-row). */
+        .claim-source-hint {
+            margin-top: 6px;
+            color: var(--accent);
+            font: 600 11px/1.4 var(--font-system);
+        }
+
+        .claim-source-hint::before { content: "\25B8  "; }
+        .claim-row.source-open .claim-source-hint::before { content: "\25BE  "; }
+
+        .claim-source {
+            display: none;
+            margin-top: 8px;
+            padding: 8px 10px;
+            border-left: 3px solid var(--accent);
+            background: var(--accent-soft);
+            border-radius: 4px;
+            color: var(--text);
+            font: 400 12px/1.55 var(--font-system);
+            white-space: pre-wrap;
+        }
+
+        .claim-row.source-open .claim-source { display: block; }
+
         /* Let the graph fill the whole pane instead of a tiny fixed box (#1465).
            #graph-panel is a child of `.content` which has a definite height
            (`.shell` is 100vh), so height:100% resolves; the flex column lets the
@@ -395,8 +421,9 @@ function renderDigest() {
             ${group.claims.map((claim) => `
                 <div class="claim-row ${state.activeClaimId === claim.id ? "active" : ""}" data-claim-id="${claim.id}">
                     <div>${escapeHtml(claimSummary(claim))}</div>
-                    ${claim.source_excerpt ? `<div class="claim-meta">${escapeHtml(claim.source_excerpt)}</div>` : ""}
                     <div class="claim-meta">${escapeHtml(claimMeta(claim))}</div>
+                    ${claim.source_excerpt ? `<div class="claim-source-hint">Source</div>
+                    <div class="claim-source">${escapeHtml(claim.source_excerpt)}</div>` : ""}
                 </div>
             `).join("")}
         </section>
@@ -406,6 +433,9 @@ function renderDigest() {
         row.addEventListener("click", () => {
             const claim = claims.find((item) => item.id === row.dataset.claimId);
             if (!claim) return;
+            // Expand/collapse the claim's source passage inline, right under the
+            // statement — an in-place disclosure, not a jump-away (#1467).
+            row.classList.toggle("source-open");
             state.activeClaimId = claim.id;
             state.activeEntityId = claim.entity_ids?.[0] || null;
             // Update active class in-place so scroll position is preserved.


### PR DESCRIPTION
⚠️ **DO NOT auto-merge — staged for Daniel's visual verification.** These two commits edit the WebKit `document_view.html` template; a build pass cannot confirm the pane renders (a JS error blanks it). Swift app builds clean (VERIFY green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)