### PR TITLE
Thinking-layer UI: SourceOutlineView inspector tab (#1492) + surface Research workspace at first run (#1499)

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		049 /* DocumentServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148 /* DocumentServiceGenerated.swift */; };
 		0A667D33534B55BD383F4D55 /* KGMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F131D425C0276D277D805678 /* KGMapView.swift */; };
 		0C6B1EE6EDE444C4F95ED9FD /* NoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF58B21F339179A8162AD6C5 /* NoteService.swift */; };
+		0DCB0C277BB0F99DF7326AF0 /* SourceOutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F348C1F78D105C8017210F17 /* SourceOutlineView.swift */; };
 		0EB90A1DBB324F96AE256464 /* PDFThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1786CA1F532B414196BAAABE /* PDFThumbnailView.swift */; };
 		0F105FC52C12302CF5A2AC42 /* ClaimSummaryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F1ACEB8F688C8749B36E04B /* ClaimSummaryCardView.swift */; };
 		0F10EA9CD30A9CC13ED3E074 /* EntityDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F14337BE87CA15E70323ED4 /* EntityDetailView.swift */; };
@@ -840,6 +841,7 @@
 		EE2ECCF57DC8B6308FCAE62F /* MindPalaceState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MindPalaceState.swift; sourceTree = "<group>"; };
 		EF014F0FAEFCA5233DCB114F /* ImageEditorModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageEditorModel.swift; sourceTree = "<group>"; };
 		F131D425C0276D277D805678 /* KGMapView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KGMapView.swift; sourceTree = "<group>"; };
+		F348C1F78D105C8017210F17 /* SourceOutlineView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SourceOutlineView.swift; sourceTree = "<group>"; };
 		F4189C51250E0B39E05CD87B /* AISettingsView+Tabs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AISettingsView+Tabs.swift"; sourceTree = "<group>"; };
 		F92B0E47A1378F8B2AE6EFB3 /* AddToRoomPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AddToRoomPicker.swift; sourceTree = "<group>"; };
 		FF58B21F339179A8162AD6C5 /* NoteService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NoteService.swift; sourceTree = "<group>"; };
@@ -1601,6 +1603,7 @@
 				36234E44A7E494963A441CDC /* DocumentInspectorContentTab.swift */,
 				AB786740043A3DAB4CDBFD6F /* DocumentInspectorAnnotationsTab.swift */,
 				B00A8552DEACF83751D617C6 /* DocumentNotesTab.swift */,
+				F348C1F78D105C8017210F17 /* SourceOutlineView.swift */,
 			);
 			path = DocumentInspector;
 			sourceTree = "<group>";
@@ -2249,6 +2252,7 @@
 				0C6B1EE6EDE444C4F95ED9FD /* NoteService.swift in Sources */,
 				C5B7DEB948261159D439C454 /* DocumentNotesTab.swift in Sources */,
 				560311302E8DCC126BD757E2 /* LibraryToolbarState.swift in Sources */,
+				0DCB0C277BB0F99DF7326AF0 /* SourceOutlineView.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero/Views/Library/DocumentInspector.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector.swift
@@ -21,6 +21,7 @@ extension Notification.Name {
 /// outputs" → "metadata about the document".
 enum InspectorTab: String, CaseIterable, Identifiable {
     case content = "Content"
+    case outline = "Outline"
     case annotations = "Annotations"
     case notes = "Notes"
     case knowledgeGraph = "Knowledge Graph"
@@ -33,6 +34,7 @@ enum InspectorTab: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .content: return "doc.text"
+        case .outline: return "list.bullet.indent"
         case .annotations: return "highlighter"
         case .notes: return "pencil.and.scribble"
         case .knowledgeGraph: return "point.3.connected.trianglepath.dotted"
@@ -47,6 +49,8 @@ enum InspectorTab: String, CaseIterable, Identifiable {
         switch self {
         case .content:
             return "Content — read the document's extracted text and page contents"
+        case .outline:
+            return "Outline — drill down the document's structure: chapters, sections, pages, and what's on each"
         case .annotations:
             return "Annotations — view and edit highlights and notes on this document"
         case .notes:
@@ -221,6 +225,8 @@ struct DocumentInspector: View {
         switch selectedTab {
         case .content:
             contentTab(for: doc)
+        case .outline:
+            SourceOutlineView(documentId: doc.id)
         case .annotations:
             DocumentInspectorAnnotationsTab(document: doc)
         case .notes:
@@ -238,7 +244,7 @@ struct DocumentInspector: View {
 
     private func availableTabs(for doc: Document?) -> [InspectorTab] {
         guard let doc else { return InspectorTab.allCases }
-        var tabs: [InspectorTab] = [.content, .annotations, .notes, .knowledgeGraph, .artifacts]
+        var tabs: [InspectorTab] = [.content, .outline, .annotations, .notes, .knowledgeGraph, .artifacts]
         if doc.fileType == .image || doc.fileType == .pdf || doc.docType == .page {
             tabs.append(.edits)
         }

--- a/fichero/fichero/Views/Library/DocumentInspector/SourceOutlineView.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/SourceOutlineView.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+
+/// One row of a document's hierarchical outline, as returned by
+/// GET /api/documents/{id}/outline (#1491). The endpoint returns a flat,
+/// depth-first preorder list; `depth` drives the tree nesting.
+struct DocumentOutlineRow: Codable, Identifiable, Hashable {
+    let id: String
+    let depth: Int
+    let kind: String
+    let label: String
+    let count: Int
+}
+
+/// Envelope for the outline endpoint.
+struct DocumentOutlineResponse: Codable {
+    let documentId: String
+    let rows: [DocumentOutlineRow]
+    let count: Int
+
+    enum CodingKeys: String, CodingKey {
+        case documentId = "document_id"
+        case rows
+        case count
+    }
+}
+
+/// Nested node built from the flat outline rows so SwiftUI's `List(_:children:)`
+/// can render a collapsible disclosure tree. Leaves carry `children == nil`.
+private struct OutlineNode: Identifiable, Hashable {
+    let row: DocumentOutlineRow
+    var children: [OutlineNode]?
+    var id: String { row.id }
+}
+
+/// Unified drill-down inspector tab (Thing 1 of the thinking-layer, #1492):
+/// a collapsible source outline — chapters/sections → pages →
+/// annotations/entities/claims — over the merged outline endpoint (#1491).
+/// Added as a tab ALONGSIDE the existing inspector tabs; it removes none.
+struct SourceOutlineView: View {
+    let documentId: String
+
+    @EnvironmentObject private var apiClient: APIClient
+    @State private var nodes: [OutlineNode] = []
+    @State private var isLoading = false
+    @State private var loadError: String?
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let loadError {
+                emptyState(
+                    title: "Couldn't load outline",
+                    message: loadError,
+                    icon: "exclamationmark.triangle"
+                )
+            } else if nodes.isEmpty {
+                emptyState(
+                    title: "No outline yet",
+                    message: "This document has no structured outline. Run extraction to build chapters, sections, and pages.",
+                    icon: "list.bullet.indent"
+                )
+            } else {
+                List(nodes, children: \.children) { node in
+                    outlineRow(node.row)
+                }
+                .listStyle(.sidebar)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .task(id: documentId) { await load() }
+    }
+
+    private func outlineRow(_ row: DocumentOutlineRow) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon(for: row.kind))
+                .foregroundStyle(.secondary)
+                .frame(width: 16)
+            Text(row.label)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer(minLength: 4)
+            if row.count > 0 {
+                Text("\(row.count)")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(Capsule().fill(Color.secondary.opacity(0.12)))
+            }
+        }
+        .help("\(row.kind.capitalized): \(row.label)")
+    }
+
+    private func icon(for kind: String) -> String {
+        switch kind.lowercased() {
+        case "chapter": return "book.closed"
+        case "section": return "list.bullet.indent"
+        case "page": return "doc"
+        case "annotation": return "highlighter"
+        case "entity", "person", "place", "organization": return "person.crop.circle"
+        case "claim": return "quote.bubble"
+        default: return "circle.fill"
+        }
+    }
+
+    @ViewBuilder
+    private func emptyState(title: String, message: String, icon: String) -> some View {
+        VStack(spacing: 10) {
+            Image(systemName: icon)
+                .font(.system(size: 32))
+                .foregroundStyle(.tertiary)
+            Text(title)
+                .font(.headline)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 260)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func load() async {
+        isLoading = true
+        loadError = nil
+        defer { isLoading = false }
+        do {
+            let response: DocumentOutlineResponse = try await apiClient.get(
+                "/documents/\(documentId)/outline"
+            )
+            nodes = Self.buildTree(response.rows)
+        } catch {
+            loadError = error.localizedDescription
+        }
+    }
+
+    /// Build a nested tree from the flat depth-first preorder rows: each run of
+    /// rows at `depth + 1` immediately following a row is that row's children.
+    private static func buildTree(_ rows: [DocumentOutlineRow]) -> [OutlineNode] {
+        var index = 0
+        func consume(atDepth depth: Int) -> [OutlineNode] {
+            var result: [OutlineNode] = []
+            while index < rows.count, rows[index].depth == depth {
+                let row = rows[index]
+                index += 1
+                let children = consume(atDepth: depth + 1)
+                result.append(OutlineNode(row: row, children: children.isEmpty ? nil : children))
+            }
+            return result
+        }
+        return consume(atDepth: rows.first?.depth ?? 0)
+    }
+}

--- a/fichero/fichero/Views/Onboarding/FirstRunWindow.swift
+++ b/fichero/fichero/Views/Onboarding/FirstRunWindow.swift
@@ -82,6 +82,10 @@ struct FirstRunWindow: View {
                         HStack(spacing: 8) {
                             detailPill("Local-first", icon: "desktopcomputer")
                             detailPill("Knowledge graph ready", icon: "point.3.connected.trianglepath.dotted")
+                            // Surface the Research workspace at first run so it's
+                            // discoverable — it lives behind the flask icon in the
+                            // sidebar mode bar (⌃⌘8). (#1499)
+                            detailPill("Research workspace (⌃⌘8)", icon: "flask")
                         }
                     }
                 )


### PR DESCRIPTION
First user-visible thinking-layer pieces (epic #1488). #1492 adds an .outline inspector tab (additive — all existing tabs kept) with SourceOutlineView decoding the merged GET /api/documents/{id}/outline (#1491). #1499 surfaces the Research workspace in onboarding (View-menu entries + ⌃⌘8 already restored by #1485). GATE: clean xcodebuild BUILD SUCCEEDED, swiftlint (1 pre-existing file-length warning), manager self-review clean, new file registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)