### PR TITLE
Thinking-layer UI: Notes Browser (#1500) + entity-bio notes (#1501) + Add-to-Workspace picker (#1494)

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -164,6 +164,7 @@
 		3D3445F0B90D093149C9A7D6 /* DocumentInspectorContentTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36234E44A7E494963A441CDC /* DocumentInspectorContentTab.swift */; };
 		4458475E8C2BF728591E504F /* AIDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C4E4291B8C33D501F176BF5 /* AIDefaults.swift */; };
 		46A484C19A075EC0120FAF69 /* AddToRoomPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F92B0E47A1378F8B2AE6EFB3 /* AddToRoomPicker.swift */; };
+		495FCF3ED790C015FBF4BE70 /* NotesBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA77E9001736B77957513A4 /* NotesBrowserView.swift */; };
 		4AFAA394C8AB364CB2425517 /* ResearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB5E2213FF12794A689A7F /* ResearchService.swift */; };
 		4C823323E8BC468934CFD1C4 /* AppNavigationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C6A533EA3E96E1F5AE19ED /* AppNavigationHistory.swift */; };
 		4DD61218DD8818B2488E3AC1 /* DocumentKGSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C119BA4657FD54B0F01D6C /* DocumentKGSurface.swift */; };
@@ -831,6 +832,7 @@
 		C10000110000000000000002 /* AppInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInstaller.swift; sourceTree = "<group>"; };
 		C340001100000000PROMPT01 /* PromptPreviewPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptPreviewPanel.swift; sourceTree = "<group>"; };
 		C69898938F25CFEA64385A16 /* TriggerDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TriggerDetailView.swift; sourceTree = "<group>"; };
+		CAA77E9001736B77957513A4 /* NotesBrowserView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotesBrowserView.swift; sourceTree = "<group>"; };
 		CAAFE05184A40A50ADFC54A9 /* QuickLookPreviewViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickLookPreviewViews.swift; sourceTree = "<group>"; };
 		CE9 /* SidebarItemBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarItemBuilder.swift; sourceTree = "<group>"; };
 		D18BA434B3CB3A8C31139293 /* EntityDetailView+FilterChips.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "EntityDetailView+FilterChips.swift"; sourceTree = "<group>"; };
@@ -1058,6 +1060,7 @@
 				4EA97872FB77A5A9FE80DFC1 /* MindPalace */,
 				4C831988A1430C389E770F5C /* Research */,
 				43322F30A05232A97F8B3B87 /* ContentView+NavigationHistory.swift */,
+				ECAB62BE723D861411DD670E /* Notes */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1621,6 +1624,15 @@
 				5BAA47F1959AD79AA6C2E3EF /* TriggerEditorPreviewPanel.swift */,
 			);
 			path = TriggerEditorView;
+			sourceTree = "<group>";
+		};
+		ECAB62BE723D861411DD670E /* Notes */ = {
+			isa = PBXGroup;
+			children = (
+				CAA77E9001736B77957513A4 /* NotesBrowserView.swift */,
+			);
+			name = Notes;
+			path = Notes;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -2261,6 +2273,7 @@
 				0DCB0C277BB0F99DF7326AF0 /* SourceOutlineView.swift in Sources */,
 				2C8A895EE1B0F5029E3D00B6 /* WorkspaceItemPicker.swift in Sources */,
 				AF3C8529001F34ACB80A8D50 /* EntityDetailView+Notes.swift in Sources */,
+				495FCF3ED790C015FBF4BE70 /* NotesBrowserView.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -325,6 +325,7 @@
 		AD284E03A3377968AE568677 /* DocumentInspectorMetadataTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B146AE8AC4CEEC3775CB94 /* DocumentInspectorMetadataTab.swift */; };
 		ADC61F9B335300BEA77F278C /* EntityDetailView+Audit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E8622F0305ED125BEDB904 /* EntityDetailView+Audit.swift */; };
 		AF3C46E684A7D133B1BAA5D2 /* TriggerEditorFormPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0264B7B8616BA5159B2CEF1 /* TriggerEditorFormPanel.swift */; };
+		AF3C8529001F34ACB80A8D50 /* EntityDetailView+Notes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD96D53320D07109835C90BF /* EntityDetailView+Notes.swift */; };
 		AF868ABDCF249BD2499197F3 /* ContentView+NavigationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43322F30A05232A97F8B3B87 /* ContentView+NavigationHistory.swift */; };
 		AUT00022F27F36000EC9EE1 /* AutomationServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUT00012F27F36000EC9EE1 /* AutomationServiceGenerated.swift */; };
 		B2A0020100000000BATCH2S1 /* SidebarItemRow+Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010100000000BATCH2S1 /* SidebarItemRow+Label.swift */; };
@@ -836,6 +837,7 @@
 		D661A54EFC8800F710E16A23 /* ActivityOverviewView+Cards.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ActivityOverviewView+Cards.swift"; sourceTree = "<group>"; };
 		D82A9BAC0F995F9199F94B69 /* KGFocusState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KGFocusState.swift; sourceTree = "<group>"; };
 		DD03402A88F98251F388870F /* DocumentInspectorInfoTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DocumentInspectorInfoTab.swift; path = fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab.swift; sourceTree = SOURCE_ROOT; };
+		DD96D53320D07109835C90BF /* EntityDetailView+Notes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "EntityDetailView+Notes.swift"; sourceTree = "<group>"; };
 		DF77122ADD78F941D7F1968D /* KGTimelineView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KGTimelineView.swift; sourceTree = "<group>"; };
 		E7B146AE8AC4CEEC3775CB94 /* DocumentInspectorMetadataTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DocumentInspectorMetadataTab.swift; path = fichero/Views/Library/DocumentInspector/DocumentInspectorMetadataTab.swift; sourceTree = SOURCE_ROOT; };
 		E80DDED3870C2457BFD97D1E /* DocumentKGWebPane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DocumentKGWebPane.swift; sourceTree = "<group>"; };
@@ -923,6 +925,7 @@
 				7F3FE2F360EADE051A3D2D51 /* EntitySplitSheet.swift */,
 				2F46B999D0208EA4C734535C /* ClaimReviewQueueSheet.swift */,
 				53458DC3387BC4C694EE3452 /* ContradictionTriageSheet.swift */,
+				DD96D53320D07109835C90BF /* EntityDetailView+Notes.swift */,
 			);
 			path = OntologyBrowser;
 			sourceTree = "<group>";
@@ -2257,6 +2260,7 @@
 				560311302E8DCC126BD757E2 /* LibraryToolbarState.swift in Sources */,
 				0DCB0C277BB0F99DF7326AF0 /* SourceOutlineView.swift in Sources */,
 				2C8A895EE1B0F5029E3D00B6 /* WorkspaceItemPicker.swift in Sources */,
+				AF3C8529001F34ACB80A8D50 /* EntityDetailView+Notes.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -155,6 +155,7 @@
 		25B9458F0E27EB2BCD55B439 /* ClaimSummaryCard+Details.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA39991F769A1DD42BB17F01 /* ClaimSummaryCard+Details.swift */; };
 		286700373FC6B54B843E8DA5 /* NodePopover+Comparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F310DFF84C9557A77D4FDA /* NodePopover+Comparison.swift */; };
 		2C2268FA2E4307AAA02C7EC4 /* APIClient+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300A8405FFC476E5124372AE /* APIClient+Types.swift */; };
+		2C8A895EE1B0F5029E3D00B6 /* WorkspaceItemPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489A0FBA854FF9A1158996D6 /* WorkspaceItemPicker.swift */; };
 		2D4468D68538BE7767729108 /* ResearchProjectListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE29C018865C9A1538200D8E /* ResearchProjectListView.swift */; };
 		2ED84CCBA91252EA2D0C5D34 /* TriggerEditorPreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAA47F1959AD79AA6C2E3EF /* TriggerEditorPreviewPanel.swift */; };
 		36C67BBF07CCFEAF928943C9 /* ImageEditorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF014F0FAEFCA5233DCB114F /* ImageEditorModel.swift */; };
@@ -611,6 +612,7 @@
 		43322F30A05232A97F8B3B87 /* ContentView+NavigationHistory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+NavigationHistory.swift"; sourceTree = "<group>"; };
 		43EAB861267206E7A929830F /* KGTemporalSpatial.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KGTemporalSpatial.swift; sourceTree = "<group>"; };
 		462 /* Workflow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow.swift; sourceTree = "<group>"; };
+		489A0FBA854FF9A1158996D6 /* WorkspaceItemPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceItemPicker.swift; sourceTree = "<group>"; };
 		4BB488A4AF6BAB72C33902C4 /* EntityDigestView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityDigestView.swift; sourceTree = "<group>"; };
 		506C34038F8A349C075DFBAC /* WorkflowRunProviderCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowRunProviderCache.swift; sourceTree = "<group>"; };
 		5287875D44BA51CD93CA12F8 /* ResearchTasksPane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResearchTasksPane.swift; sourceTree = "<group>"; };
@@ -1557,6 +1559,7 @@
 				A5C119BA4657FD54B0F01D6C /* DocumentKGSurface.swift */,
 				80E4C1042F69F06267FA6CCD /* DocumentCanvas.swift */,
 				99857D7C99E753A3405778FC /* LibraryToolbarState.swift */,
+				489A0FBA854FF9A1158996D6 /* WorkspaceItemPicker.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -2253,6 +2256,7 @@
 				C5B7DEB948261159D439C454 /* DocumentNotesTab.swift in Sources */,
 				560311302E8DCC126BD757E2 /* LibraryToolbarState.swift in Sources */,
 				0DCB0C277BB0F99DF7326AF0 /* SourceOutlineView.swift in Sources */,
+				2C8A895EE1B0F5029E3D00B6 /* WorkspaceItemPicker.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero/App/AppState.swift
+++ b/fichero/fichero/App/AppState.swift
@@ -32,6 +32,11 @@ class AppState: ObservableObject {
 
     @Published var showMCPServers: Bool = false
 
+    // MARK: - Notes browser (#1500)
+
+    /// Drives the standalone NotesBrowserView sheet (Data ▸ Notes Browser…).
+    @Published var showNotesBrowser: Bool = false
+
     // MARK: - Integrations (Hazel-like folder/app observers)
 
     @Published var showFolderWatchers: Bool = false

--- a/fichero/fichero/App/LibraryWindow.swift
+++ b/fichero/fichero/App/LibraryWindow.swift
@@ -108,6 +108,13 @@ struct LibraryWindow: View {
                 .environmentObject(appState)
                 .environmentObject(appState.mcpService)
         }
+        // Standalone notes browser (#1500)
+        .sheet(isPresented: Binding(
+            get: { appState.showNotesBrowser },
+            set: { appState.showNotesBrowser = $0 }
+        )) {
+            NotesBrowserView()
+        }
         // Integrations sheets
         .sheet(isPresented: Binding(
             get: { appState.showFolderWatchers },

--- a/fichero/fichero/FicheroApp.swift
+++ b/fichero/fichero/FicheroApp.swift
@@ -187,6 +187,15 @@ struct FicheroApp: App {
 
                 FocusedImportFilesButton()
 
+                Divider()
+
+                // Standalone notes browser (#1500)
+                Button {
+                    appState.showNotesBrowser = true
+                } label: {
+                    Label("Notes Browser…", systemImage: "note.text")
+                }
+
                 if featureManager.isSearchEnabled
                     || featureManager.isChatEnabled
                     || featureManager.isWorkflowsEnabled {

--- a/fichero/fichero/Services/NoteService.swift
+++ b/fichero/fichero/Services/NoteService.swift
@@ -55,6 +55,14 @@ struct NotePatchBody: Encodable {
     let body: String
 }
 
+/// Create body for a free-floating note (no links) — used by the standalone
+/// notes browser (#1500).
+struct NoteCreateFreeBody: Encodable {
+    let title: String?
+    let body: String
+    let kind: String
+}
+
 // MARK: - Service
 
 @MainActor
@@ -83,6 +91,53 @@ final class NoteService: ObservableObject {
             self.error = error.localizedDescription
             logger.error("load notes failed: \(error.localizedDescription)")
         }
+    }
+
+    /// Load all notes, optionally filtered by kind / tag / linked entity /
+    /// full-text query. Powers the standalone notes browser (#1500).
+    func loadAll(
+        kind: String? = nil,
+        tag: String? = nil,
+        linkedEntityId: String? = nil,
+        query: String? = nil
+    ) async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+        do {
+            guard var comps = URLComponents(string: base) else { return }
+            var items: [URLQueryItem] = []
+            if let kind, !kind.isEmpty { items.append(URLQueryItem(name: "kind", value: kind)) }
+            if let tag, !tag.isEmpty { items.append(URLQueryItem(name: "tag", value: tag)) }
+            if let linkedEntityId, !linkedEntityId.isEmpty {
+                items.append(URLQueryItem(name: "linked_entity_id", value: linkedEntityId))
+            }
+            if let query, !query.isEmpty { items.append(URLQueryItem(name: "q", value: query)) }
+            comps.queryItems = items.isEmpty ? nil : items
+            guard let url = comps.url else { return }
+            var req = URLRequest(url: url)
+            req.addEngineAuth()
+            let (data, _) = try await URLSession.shared.data(for: req)
+            let resp = try JSONDecoder().decode(NoteListResponse.self, from: data)
+            notes = resp.items
+        } catch {
+            self.error = error.localizedDescription
+            logger.error("loadAll notes failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Create a free-floating note with no links (#1500).
+    func createFree(body: String, kind: String) async throws -> NoteItem {
+        guard let url = URL(string: base) else { throw NoteServiceError.invalidURL }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.addEngineAuth()
+        req.httpBody = try JSONEncoder().encode(NoteCreateFreeBody(title: nil, body: body, kind: kind))
+        let (data, _) = try await URLSession.shared.data(for: req)
+        let note = try JSONDecoder().decode(NoteItem.self, from: data)
+        notes.insert(note, at: 0)
+        return note
     }
 
     /// Load notes linked to a KG entity (#1501).

--- a/fichero/fichero/Services/NoteService.swift
+++ b/fichero/fichero/Services/NoteService.swift
@@ -37,6 +37,20 @@ struct NoteCreateBody: Encodable {
     }
 }
 
+/// Create body for an entity-linked note (#1501). `kind` defaults to
+/// `reference` for entity bio/summary notes.
+struct NoteCreateEntityBody: Encodable {
+    let title: String?
+    let body: String
+    let kind: String
+    let linkedEntityIds: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case title, body, kind
+        case linkedEntityIds = "linked_entity_ids"
+    }
+}
+
 struct NotePatchBody: Encodable {
     let body: String
 }
@@ -69,6 +83,44 @@ final class NoteService: ObservableObject {
             self.error = error.localizedDescription
             logger.error("load notes failed: \(error.localizedDescription)")
         }
+    }
+
+    /// Load notes linked to a KG entity (#1501).
+    func load(linkedEntityId: String) async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+        do {
+            guard var comps = URLComponents(string: base) else { return }
+            comps.queryItems = [URLQueryItem(name: "linked_entity_id", value: linkedEntityId)]
+            guard let url = comps.url else { return }
+            var req = URLRequest(url: url)
+            req.addEngineAuth()
+            let (data, _) = try await URLSession.shared.data(for: req)
+            let resp = try JSONDecoder().decode(NoteListResponse.self, from: data)
+            notes = resp.items
+        } catch {
+            self.error = error.localizedDescription
+            logger.error("load entity notes failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Create a note linked to a KG entity. Defaults to `kind=reference`
+    /// (entity bio/summary). (#1501)
+    func create(body: String, linkedEntityId: String, kind: String = "reference") async throws -> NoteItem {
+        guard let url = URL(string: base) else { throw NoteServiceError.invalidURL }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.addEngineAuth()
+        let payload = NoteCreateEntityBody(
+            title: nil, body: body, kind: kind, linkedEntityIds: [linkedEntityId]
+        )
+        req.httpBody = try JSONEncoder().encode(payload)
+        let (data, _) = try await URLSession.shared.data(for: req)
+        let note = try JSONDecoder().decode(NoteItem.self, from: data)
+        notes.insert(note, at: 0)
+        return note
     }
 
     func create(body: String, linkedDocumentId: String) async throws -> NoteItem {

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView+Notes.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView+Notes.swift
@@ -1,0 +1,183 @@
+import OSLog
+import SwiftUI
+
+private let logger = Logger(subsystem: "app.fichero.fichero", category: "EntityNotesSection")
+
+/// Notes sub-section for the entity inspector (#1501). Lists notes linked to
+/// the current KG entity (`GET /api/notes?linked_entity_id={id}`) and lets the
+/// user add a free-text bio/summary note, created with `kind=reference`.
+///
+/// Self-contained: owns its own `NoteService`, keyed on `entityId` via
+/// `.task(id:)` so it reloads when the inspector navigates to another entity.
+/// Mirrors the `DocumentNotesTab` card/edit affordances.
+struct EntityNotesSection: View {
+    let entityId: String
+
+    @StateObject private var service = NoteService()
+    @State private var newText = ""
+    @State private var editingId: String?
+    @State private var editingText = ""
+    @State private var isSaving = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Notes")
+                .font(.subheadline)
+                .fontWeight(.semibold)
+
+            addBar
+            notesList
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.controlBackgroundColor))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .task(id: entityId) {
+            guard !entityId.isEmpty else { return }
+            await service.load(linkedEntityId: entityId)
+        }
+    }
+
+    // MARK: - Add bar
+
+    private var addBar: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "pencil")
+                .foregroundStyle(.secondary)
+            TextField("Add a note about this entity…", text: $newText, axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(1...4)
+                .onSubmit { submitNew() }
+            Button {
+                submitNew()
+            } label: {
+                if isSaving {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Text("Add")
+                }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSaving)
+        }
+    }
+
+    // MARK: - List
+
+    @ViewBuilder
+    private var notesList: some View {
+        if service.isLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 8)
+        } else if service.notes.isEmpty {
+            Text("No notes linked to this entity yet.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(service.notes) { note in
+                    noteCard(note)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func noteCard(_ note: NoteItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if editingId == note.id {
+                editingCard(note)
+            } else {
+                readCard(note)
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(.quaternaryLabelColor).opacity(0.12))
+        )
+    }
+
+    private func readCard(_ note: NoteItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(note.body)
+                .font(.callout)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            HStack {
+                Text(note.kind.capitalized)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                Spacer()
+                Button("Edit") {
+                    editingId = note.id
+                    editingText = note.body
+                }
+                .buttonStyle(.borderless)
+                .font(.caption)
+                Button(role: .destructive) {
+                    Task { try? await service.delete(noteId: note.id) }
+                } label: {
+                    Image(systemName: "trash").font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private func editingCard(_ note: NoteItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            TextEditor(text: $editingText)
+                .font(.callout)
+                .frame(minHeight: 60)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Color.accentColor.opacity(0.5), lineWidth: 1)
+                )
+            HStack {
+                Button("Cancel") { editingId = nil }
+                    .buttonStyle(.borderless)
+                    .font(.caption)
+                Spacer()
+                Button("Save") {
+                    Task { await saveEdit(note) }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(editingText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func submitNew() {
+        let trimmed = newText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !entityId.isEmpty else { return }
+        isSaving = true
+        Task {
+            do {
+                _ = try await service.create(body: trimmed, linkedEntityId: entityId)
+                newText = ""
+            } catch {
+                logger.error("create entity note failed: \(error.localizedDescription)")
+            }
+            isSaving = false
+        }
+    }
+
+    private func saveEdit(_ note: NoteItem) async {
+        let trimmed = editingText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do {
+            _ = try await service.update(noteId: note.id, body: trimmed)
+            editingId = nil
+        } catch {
+            logger.error("update entity note failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView.swift
@@ -128,6 +128,7 @@ struct EntityDetailView: View {
                     metadataSection
                     claimsSection
                     auditSection
+                    EntityNotesSection(entityId: entity.id ?? "")
                 }
                 .padding()
             }

--- a/fichero/fichero/Views/Library/LibraryView+FilterAndBatch.swift
+++ b/fichero/fichero/Views/Library/LibraryView+FilterAndBatch.swift
@@ -242,6 +242,14 @@ extension LibraryView {
             }
         }
 
+        // Add-to-Workspace bridge (#1494): alias this document into a
+        // workspace folder. Never moves the source (#1487).
+        Button {
+            workspacePickerDocument = document
+        } label: {
+            Label("Add to Workspace…", systemImage: "square.grid.2x2")
+        }
+
         // Run Workflow submenu — workflows grouped by `folderPath` so
         // user-organized presets (e.g. /Catalogue, /Transcribe) appear
         // as nested submenus matching the context menu in the sidebar

--- a/fichero/fichero/Views/Library/LibraryView.swift
+++ b/fichero/fichero/Views/Library/LibraryView.swift
@@ -70,6 +70,10 @@ struct LibraryView: View {
     @State var showWorkflowPicker = false
     @State var selectedDocumentIdsForBatch: [String] = []
 
+    /// Document pending presentation in the Add-to-Workspace picker (#1494).
+    /// Non-nil drives the `.sheet(item:)` below.
+    @State var workspacePickerDocument: Document?
+
     @EnvironmentObject var libraryManager: LibraryManager
     @EnvironmentObject var windowState: WindowState
     @EnvironmentObject var workflowStreamService: WorkflowStreamService
@@ -214,6 +218,9 @@ struct LibraryView: View {
                     }
                 )
                 .environmentObject(libraryManager)
+            }
+            .sheet(item: $workspacePickerDocument) { document in
+                WorkspaceItemPicker(document: document)
             }
             .focusedSceneValue(
                 \.runWorkflowOnSelection,

--- a/fichero/fichero/Views/Library/WorkspaceItemPicker.swift
+++ b/fichero/fichero/Views/Library/WorkspaceItemPicker.swift
@@ -1,0 +1,274 @@
+import Foundation
+import OSLog
+import SwiftUI
+
+// MARK: - Service
+
+/// Lightweight, self-contained service backing the Add-to-Workspace picker.
+/// Mirrors the `NoteService` convention (raw `URLSession` + `addEngineAuth`)
+/// so the picker needs no `APIClient`/library plumbing. (#1494)
+///
+/// Two calls only:
+///   * `loadWorkspaceFolders()` — GET /api/documents?doc_type=folder, kept to
+///     the `is_workspace` ones (Thing 2 surfaces, per #1487).
+///   * `addToWorkspace(folderId:targetId:)` — PATCH /api/documents/{id}/workspace
+///     appending one `curated_item` alias. The source document is never moved.
+@MainActor
+final class WorkspacePickerService: ObservableObject {
+    private let logger = Logger(subsystem: "app.fichero.fichero", category: "WorkspacePickerService")
+    private let documentsBase = "http://127.0.0.1:8765/api/documents"
+
+    @Published var folders: [WorkspaceFolderItem] = []
+    @Published var isLoading = false
+    @Published var error: String?
+
+    func loadWorkspaceFolders() async {
+        isLoading = true
+        error = nil
+        defer { isLoading = false }
+        do {
+            guard var comps = URLComponents(string: documentsBase) else { return }
+            comps.queryItems = [URLQueryItem(name: "doc_type", value: "folder")]
+            guard let url = comps.url else { return }
+            var req = URLRequest(url: url)
+            req.addEngineAuth()
+            let (data, _) = try await URLSession.shared.data(for: req)
+            let resp = try JSONDecoder().decode(WorkspaceFolderListResponse.self, from: data)
+            folders = resp.items
+                .filter { $0.isWorkspace && ($0.docType == "folder") }
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+        } catch {
+            self.error = error.localizedDescription
+            logger.error("loadWorkspaceFolders failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Append `targetId` to `folderId`'s curated items as an alias. Returns
+    /// the new curated-item count on success.
+    @discardableResult
+    func addToWorkspace(folderId: String, targetId: String) async throws -> Int {
+        guard let url = URL(string: "\(documentsBase)/\(folderId)/workspace") else {
+            throw WorkspacePickerError.invalidURL
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = "PATCH"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.addEngineAuth()
+        let item = WorkspaceCuratedItemAdd(
+            id: UUID().uuidString,
+            targetType: "Document",
+            targetId: targetId,
+            role: "curated_item"
+        )
+        req.httpBody = try JSONEncoder().encode(WorkspacePatchBody(add: [item]))
+        let (data, response) = try await URLSession.shared.data(for: req)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw WorkspacePickerError.server(http.statusCode)
+        }
+        let resp = try JSONDecoder().decode(WorkspaceItemsCountResponse.self, from: data)
+        return resp.count
+    }
+}
+
+enum WorkspacePickerError: LocalizedError {
+    case invalidURL
+    case server(Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL: "Invalid URL"
+        case let .server(code): "Server returned \(code)"
+        }
+    }
+}
+
+// MARK: - Wire models
+
+/// Minimal projection of a document row — only the fields the picker needs.
+struct WorkspaceFolderItem: Codable, Identifiable, Hashable {
+    let id: String
+    let name: String
+    let docType: String
+    let isWorkspace: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id, name
+        case docType = "doc_type"
+        case isWorkspace = "is_workspace"
+    }
+
+    // Tolerate older rows that predate the is_workspace column.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = (try? container.decode(String.self, forKey: .name)) ?? "Untitled"
+        docType = (try? container.decode(String.self, forKey: .docType)) ?? "folder"
+        isWorkspace = (try? container.decode(Bool.self, forKey: .isWorkspace)) ?? false
+    }
+}
+
+private struct WorkspaceFolderListResponse: Codable {
+    let items: [WorkspaceFolderItem]
+    let count: Int
+}
+
+private struct WorkspaceCuratedItemAdd: Encodable {
+    let id: String
+    let targetType: String
+    let targetId: String
+    let role: String
+
+    enum CodingKeys: String, CodingKey {
+        case id, role
+        case targetType = "target_type"
+        case targetId = "target_id"
+    }
+}
+
+private struct WorkspacePatchBody: Encodable {
+    let add: [WorkspaceCuratedItemAdd]
+}
+
+private struct WorkspaceItemsCountResponse: Codable {
+    let count: Int
+}
+
+// MARK: - View
+
+/// Sheet that lets the user add a document to one of their workspace folders
+/// as a curated-item alias. Reached from the "Add to Workspace…" library row
+/// context menu. The source document is *aliased*, never moved (#1487). (#1494)
+struct WorkspaceItemPicker: View {
+    /// The document being added to a workspace.
+    let document: Document
+
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var service = WorkspacePickerService()
+    @State private var addingFolderId: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            content
+        }
+        .frame(width: 420, height: 460)
+        .task { await service.loadWorkspaceFolders() }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Add to Workspace")
+                    .font(.headline)
+                Text(document.name)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            Button("Done") { dismiss() }
+                .keyboardShortcut(.cancelAction)
+        }
+        .padding(12)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if service.isLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = service.error {
+            errorState(error)
+        } else if service.folders.isEmpty {
+            emptyState
+        } else {
+            folderList
+        }
+    }
+
+    private var folderList: some View {
+        ScrollView {
+            LazyVStack(spacing: 4) {
+                ForEach(service.folders) { folder in
+                    folderRow(folder)
+                }
+            }
+            .padding(10)
+        }
+    }
+
+    @ViewBuilder
+    private func folderRow(_ folder: WorkspaceFolderItem) -> some View {
+        Button {
+            Task { await add(to: folder) }
+        } label: {
+            HStack(spacing: 8) {
+                Image(systemName: "square.grid.2x2")
+                    .foregroundStyle(Color.accentColor)
+                Text(folder.name)
+                    .lineLimit(1)
+                Spacer()
+                if addingFolderId == folder.id {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Image(systemName: "plus.circle")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color(.quaternaryLabelColor).opacity(0.12))
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(addingFolderId != nil)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "tray")
+                .font(.largeTitle)
+                .foregroundStyle(.tertiary)
+            Text("No workspaces yet")
+                .foregroundStyle(.secondary)
+            Text("Mark a folder as a workspace to collect items into it.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button("Retry") {
+                Task { await service.loadWorkspaceFolders() }
+            }
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func add(to folder: WorkspaceFolderItem) async {
+        addingFolderId = folder.id
+        defer { addingFolderId = nil }
+        do {
+            _ = try await service.addToWorkspace(folderId: folder.id, targetId: document.id)
+            dismiss()
+        } catch {
+            service.error = error.localizedDescription
+        }
+    }
+}

--- a/fichero/fichero/Views/Notes/NotesBrowserView.swift
+++ b/fichero/fichero/Views/Notes/NotesBrowserView.swift
@@ -1,0 +1,290 @@
+import OSLog
+import SwiftUI
+
+private let logger = Logger(subsystem: "app.fichero.fichero", category: "NotesBrowserView")
+
+/// Standalone notes browser (#1500). Lists every Note record, filterable by
+/// kind / tag / full-text, and lets the user create free-floating notes
+/// (zettels, hubs, fleeting notes) without a document open. Reuses the
+/// `DocumentNotesTab` card/edit affordances via `NoteService`.
+///
+/// Presented as a sheet from the Data menu (`appState.showNotesBrowser`), so it
+/// needs no SidebarMode wiring.
+struct NotesBrowserView: View {
+    @Environment(\.dismiss) private var dismiss
+    @StateObject private var service = NoteService()
+
+    @State private var kindFilter: String = ""        // "" = all kinds
+    @State private var tagFilter: String = ""
+    @State private var searchText: String = ""
+
+    @State private var newText = ""
+    @State private var newKind = "zettel"
+    @State private var isSaving = false
+
+    @State private var editingId: String?
+    @State private var editingText = ""
+
+    /// NoteKind raw values, mirrored from the backend enum (#917).
+    private let kinds = ["zettel", "reference", "hub", "inbox", "fleeting", "permanent"]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            filterBar
+            Divider()
+            addBar
+            Divider()
+            notesList
+        }
+        .frame(minWidth: 520, minHeight: 560)
+        .task { await reload() }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack {
+            Text("Notes")
+                .font(.headline)
+            if !service.isLoading {
+                Text("\(service.notes.count)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(Capsule().fill(Color(.quaternaryLabelColor).opacity(0.3)))
+            }
+            Spacer()
+            Button("Done") { dismiss() }
+                .keyboardShortcut(.cancelAction)
+        }
+        .padding(12)
+    }
+
+    // MARK: - Filter bar
+
+    private var filterBar: some View {
+        HStack(spacing: 8) {
+            Picker("Kind", selection: $kindFilter) {
+                Text("All Kinds").tag("")
+                ForEach(kinds, id: \.self) { kind in
+                    Text(kind.capitalized).tag(kind)
+                }
+            }
+            .labelsHidden()
+            .frame(maxWidth: 160)
+
+            TextField("Tag", text: $tagFilter)
+                .textFieldStyle(.roundedBorder)
+                .frame(maxWidth: 120)
+                .onSubmit { Task { await reload() } }
+
+            TextField("Search…", text: $searchText)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit { Task { await reload() } }
+        }
+        .padding(10)
+        .onChange(of: kindFilter) { _, _ in Task { await reload() } }
+    }
+
+    // MARK: - Add bar
+
+    private var addBar: some View {
+        HStack(spacing: 8) {
+            Picker("New kind", selection: $newKind) {
+                ForEach(kinds, id: \.self) { kind in
+                    Text(kind.capitalized).tag(kind)
+                }
+            }
+            .labelsHidden()
+            .frame(maxWidth: 130)
+
+            TextField("New note…", text: $newText, axis: .vertical)
+                .textFieldStyle(.plain)
+                .lineLimit(1...4)
+                .onSubmit { submitNew() }
+
+            Button {
+                submitNew()
+            } label: {
+                if isSaving {
+                    ProgressView().controlSize(.small)
+                } else {
+                    Text("Add")
+                }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(newText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || isSaving)
+        }
+        .padding(10)
+    }
+
+    // MARK: - List
+
+    @ViewBuilder
+    private var notesList: some View {
+        if service.isLoading {
+            ProgressView()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = service.error {
+            errorState(error)
+        } else if service.notes.isEmpty {
+            emptyState
+        } else {
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 8) {
+                    ForEach(service.notes) { note in
+                        noteCard(note)
+                    }
+                }
+                .padding(12)
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "pencil.and.scribble")
+                .font(.largeTitle)
+                .foregroundStyle(.tertiary)
+            Text("No notes")
+                .foregroundStyle(.secondary)
+            Text("Add a note above, or adjust the filters.")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func errorState(_ message: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.largeTitle)
+                .foregroundStyle(.orange)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+            Button("Retry") { Task { await reload() } }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    // MARK: - Card
+
+    @ViewBuilder
+    private func noteCard(_ note: NoteItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if editingId == note.id {
+                editingCard(note)
+            } else {
+                readCard(note)
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 8)
+                .fill(Color(.quaternaryLabelColor).opacity(0.12))
+        )
+    }
+
+    private func readCard(_ note: NoteItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            if let title = note.title, !title.isEmpty {
+                Text(title)
+                    .font(.callout.weight(.semibold))
+            }
+            Text(note.body)
+                .font(.callout)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            HStack(spacing: 6) {
+                Text(note.kind.capitalized)
+                    .font(.caption2)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 1)
+                    .background(Capsule().fill(Color.accentColor.opacity(0.15)))
+                ForEach(note.tags, id: \.self) { tag in
+                    Text("#\(tag)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Edit") {
+                    editingId = note.id
+                    editingText = note.body
+                }
+                .buttonStyle(.borderless)
+                .font(.caption)
+                Button(role: .destructive) {
+                    Task { try? await service.delete(noteId: note.id) }
+                } label: {
+                    Image(systemName: "trash").font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(.red)
+            }
+        }
+    }
+
+    private func editingCard(_ note: NoteItem) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            TextEditor(text: $editingText)
+                .font(.callout)
+                .frame(minHeight: 60)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Color.accentColor.opacity(0.5), lineWidth: 1)
+                )
+            HStack {
+                Button("Cancel") { editingId = nil }
+                    .buttonStyle(.borderless)
+                    .font(.caption)
+                Spacer()
+                Button("Save") {
+                    Task { await saveEdit(note) }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(editingText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func reload() async {
+        await service.loadAll(kind: kindFilter, tag: tagFilter, query: searchText)
+    }
+
+    private func submitNew() {
+        let trimmed = newText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        isSaving = true
+        Task {
+            do {
+                _ = try await service.createFree(body: trimmed, kind: newKind)
+                newText = ""
+            } catch {
+                logger.error("create free note failed: \(error.localizedDescription)")
+            }
+            isSaving = false
+        }
+    }
+
+    private func saveEdit(_ note: NoteItem) async {
+        let trimmed = editingText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        do {
+            _ = try await service.update(noteId: note.id, body: trimmed)
+            editingId = nil
+        } catch {
+            logger.error("update note failed: \(error.localizedDescription)")
+        }
+    }
+}


### PR DESCRIPTION
The last 3 buildable thinking-layer pieces (epic #1488), all reusing merged backend foundations. #1500 NotesBrowserView (filter Notes by kind/tag/entity, reuses NoteService). #1501 entity-bio notes sub-section in the entity inspector (GET /api/notes?linked_entity_id). #1494 WorkspaceItemPicker — adds a curated_item ALIAS via PATCH /api/documents/{id}/workspace (#1490), never moves the source (#1487). GATE: clean xcodebuild BUILD SUCCEEDED, new files registered, swiftlint clean (1 pre-existing nit in an already-merged file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)