### PR TITLE
fix(image-edit): fuzzy-clean 500 on RGBA (Remove-Background output) (#1534)

### DIFF
--- a/fichero-engine/src/fichero/workflows/tools/fuzzy_clean_images.py
+++ b/fichero-engine/src/fichero/workflows/tools/fuzzy_clean_images.py
@@ -90,7 +90,18 @@ def apply_fuzzy_clean(image: Any, *, despeckle_radius: int = 3, background_clean
 
     cleaned = image.filter(ImageFilter.MedianFilter(size=_normalise_radius(despeckle_radius)))
     if background_clean:
-        cleaned = ImageOps.autocontrast(cleaned)
+        # ImageOps.autocontrast() raises "not supported for mode RGBA". The
+        # Remove-Background step produces RGBA output, so split the alpha off,
+        # autocontrast the colour channels, then re-attach the alpha (#1534).
+        if cleaned.mode in {"RGBA", "LA"}:
+            alpha = cleaned.getchannel("A")
+            rgb = ImageOps.autocontrast(cleaned.convert("RGB"))
+            cleaned = rgb.convert("RGBA")
+            cleaned.putalpha(alpha)
+        elif cleaned.mode == "P":
+            cleaned = ImageOps.autocontrast(cleaned.convert("RGB"))
+        else:
+            cleaned = ImageOps.autocontrast(cleaned)
     return cleaned
 
 

--- a/fichero-engine/tests/unit/test_fuzzy_clean_rgba.py
+++ b/fichero-engine/tests/unit/test_fuzzy_clean_rgba.py
@@ -1,0 +1,35 @@
+"""apply_fuzzy_clean must not crash on RGBA/LA/P images (#1534).
+
+Remove-Background produces an RGBA image (transparent background). Running the
+fuzzy-clean / autocontrast step on it previously raised
+`OSError: not supported for mode RGBA` from PIL.ImageOps.autocontrast.
+"""
+
+from __future__ import annotations
+
+from PIL import Image
+
+from fichero.workflows.tools.fuzzy_clean_images import apply_fuzzy_clean
+
+
+def test_fuzzy_clean_rgba_does_not_crash_and_keeps_alpha() -> None:
+    img = Image.new("RGBA", (16, 16), (120, 130, 140, 255))
+    img.putpixel((0, 0), (10, 20, 30, 0))  # a transparent pixel
+
+    out = apply_fuzzy_clean(img, despeckle_radius=3, background_clean=True)
+
+    assert out.mode == "RGBA"
+    assert out.getpixel((0, 0))[3] == 0  # alpha preserved
+
+
+def test_fuzzy_clean_la_and_palette_modes() -> None:
+    for mode in ("LA", "P"):
+        img = Image.new("RGBA", (8, 8), (90, 90, 90, 255)).convert(mode)
+        # Must not raise.
+        apply_fuzzy_clean(img, background_clean=True)
+
+
+def test_fuzzy_clean_rgb_still_autocontrasts() -> None:
+    img = Image.new("RGB", (8, 8), (100, 100, 100))
+    out = apply_fuzzy_clean(img, background_clean=True)
+    assert out.mode == "RGB"


### PR DESCRIPTION
OSError: not supported for mode RGBA from ImageOps.autocontrast when fuzzy-clean runs on Remove-Background's RGBA output. Split alpha → autocontrast RGB → re-attach alpha (handles LA/P too). Test added. Gate: pytest+ruff. Closes #1533, #1534.