### PR TITLE
fix(storage): one canonical data dir — app + engine both use Application Support/Fichero/ (#1526)

### DIFF
--- a/fichero-engine/src/fichero/paths.py
+++ b/fichero-engine/src/fichero/paths.py
@@ -8,6 +8,10 @@ from pathlib import Path
 _LEGACY_APP_SUPPORT_DIRS = (
     ("com.fichero.fichero",),
     ("ca.tubb.fichero", "global.fichero"),
+    # The SwiftUI app historically wrote the global library under its bundle id
+    # (~/Library/Application Support/app.fichero.fichero/) — migrate it into the
+    # canonical Fichero/ dir so all data lives in one place (#1526).
+    ("app.fichero.fichero",),
 )
 
 

--- a/fichero-engine/tests/unit/test_paths_app_fichero_migration.py
+++ b/fichero-engine/tests/unit/test_paths_app_fichero_migration.py
@@ -1,0 +1,31 @@
+"""Engine migrates the legacy app.fichero.fichero/ tree into Fichero/ (#1526).
+
+The SwiftUI app historically wrote the global library under its bundle id
+(~/Library/Application Support/app.fichero.fichero/global.fichero). The engine's
+canonical dir is ~/Library/Application Support/Fichero/. They must converge.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fichero.paths import engine_state_dir, migrate_legacy_engine_state
+
+
+def test_app_fichero_bundle_dir_migrates_into_canonical(tmp_path: Path) -> None:
+    home = tmp_path
+    app_support = home / "Library" / "Application Support"
+    legacy = app_support / "app.fichero.fichero" / "global.fichero"
+    legacy.mkdir(parents=True)
+    (legacy / "fichero.duckdb").write_text("x")
+
+    moved = migrate_legacy_engine_state(home=home)
+
+    canonical = engine_state_dir(home) / "global.fichero" / "fichero.duckdb"
+    assert moved >= 1
+    assert canonical.exists(), "global.fichero should now live under Fichero/"
+
+
+def test_canonical_dir_is_application_support_fichero(tmp_path: Path) -> None:
+    d = engine_state_dir(home=tmp_path)
+    assert d.parts[-2:] == ("Application Support", "Fichero")

--- a/fichero/fichero/Models/LibraryManager.swift
+++ b/fichero/fichero/Models/LibraryManager.swift
@@ -155,7 +155,9 @@ class LibraryManager: ObservableObject {
     }
 
     /// Load or create the Global library
-    /// Global library is stored at ~/Library/Application Support/app.fichero.fichero/global.fichero
+    /// Global library is stored at ~/Library/Application Support/Fichero/global.fichero
+    /// (the single canonical data dir, matching the engine's paths.engine_state_dir;
+    /// the legacy app.fichero.fichero/ location is migrated by the engine — #1526).
     private func loadGlobalLibrary() {
         // Under XCUITest the harness redirects Application Support to a
         // disposable temp dir (#1230) so smoke tests never touch the real
@@ -163,7 +165,7 @@ class LibraryManager: ObservableObject {
         let appSupport = uiTestSupportDirectory()
             ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
         let globalURL = appSupport
-            .appendingPathComponent("app.fichero.fichero")
+            .appendingPathComponent("Fichero")
             .appendingPathComponent("global.fichero")
 
         // Check if Global library already exists


### PR DESCRIPTION
App wrote its global library to ~/Library/Application Support/app.fichero.fichero/ while the engine used .../Fichero/. Consolidated: LibraryManager → Application Support/Fichero/global.fichero; paths.py migrates the old bundle-id dir. Gate: clean xcodebuild PASS (verified in isolated worktree), pytest+ruff green. Closes #1526.