### PR TITLE
fix(kg): harden Apple structured-extraction fallbacks (#1541 #1542)

### DIFF
--- a/fichero-engine/src/fichero/api/main.py
+++ b/fichero-engine/src/fichero/api/main.py
@@ -280,6 +280,7 @@ def _seed_builtin_providers() -> None:
             # configuration. Apple Intelligence is the natural pick on
             # macOS 26+ Apple Silicon (free, on-device, always available).
             _ensure_default_ai_defaults(app_db, apple_provider.id)
+            _repair_known_bad_ai_defaults(app_db)
     except Exception as exc:
         logger.warning("Could not seed built-in providers: %s", exc)
 
@@ -327,6 +328,19 @@ def _ensure_default_ai_defaults(app_db, apple_provider_id: str) -> None:
             "Seeded Apple Intelligence as default for %d AI tier keys: %s",
             len(written),
             ", ".join(written),
+        )
+
+
+def _repair_known_bad_ai_defaults(app_db) -> None:
+    """Repair stale tier defaults from older broken seeds."""
+    large_provider = app_db.get_setting("default_large_provider")
+    large_model = app_db.get_setting("default_large_model")
+    if large_provider == "openrouter" and large_model == "openrouter/free":
+        app_db.set_setting("default_large_provider", "apple")
+        app_db.set_setting("default_large_model", "apple-intelligence")
+        logger.warning(
+            "Repaired stale AI default $large from openrouter/openrouter/free "
+            "to apple/apple-intelligence."
         )
 
 

--- a/fichero-engine/src/fichero/llm.py
+++ b/fichero-engine/src/fichero/llm.py
@@ -531,6 +531,31 @@ def _build_fallback_config(config: LLMConfig, tier: str = "large") -> LLMConfig:
     )
 
 
+def _paid_remote_fallbacks_enabled() -> bool:
+    """Whether Apple structured fallback may use paid remote providers."""
+    raw = os.environ.get("FICHERO_ALLOW_PAID_AI_FALLBACKS")
+    if raw is not None:
+        return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+    try:
+        from fichero.app_db import get_app_db
+
+        setting = get_app_db().get_setting("allow_paid_ai_fallbacks")
+    except Exception:
+        setting = None
+
+    if setting is None:
+        return False
+    return str(setting).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_local_or_builtin_provider(provider: str) -> bool:
+    from fichero.providers import get_provider_info
+
+    info = get_provider_info((provider or "").strip().lower())
+    return bool(info and (info.is_local or info.is_builtin))
+
+
 # =============================================================================
 # API Key Resolution
 # =============================================================================
@@ -1773,6 +1798,29 @@ async def chat_structured_with_fallback(
                 # retry's error as the operative cause.
                 apple_exc = retry_exc
 
+        if (
+            isinstance(apple_exc, StructuredDecodeError)
+            and include_schema_in_prompt is not False
+            and apple_exc.kind in {"context_overflow", "schema"}
+        ):
+            logger.warning(
+                "Apple Intelligence structured decode failed (%s) — "
+                "retrying once on-device with include_schema_in_prompt=False.",
+                apple_exc.kind,
+            )
+            try:
+                return await chat_structured(
+                    prompt,
+                    schema,
+                    config,
+                    system=system,
+                    include_schema_in_prompt=False,
+                    use_case=use_case,
+                    permissive_guardrails=permissive_guardrails,
+                )
+            except AppleUnavailableError as compact_retry_exc:
+                apple_exc = compact_retry_exc
+
         last_config_error: ValueError | None = None
         for tier in ("medium", "large"):
             try:
@@ -1793,6 +1841,21 @@ async def chat_structured_with_fallback(
             ):
                 # Alias resolves to the same model we just tried — no point
                 # retrying that tier. Try the next tier before surfacing.
+                continue
+
+            if (
+                not _paid_remote_fallbacks_enabled()
+                and not _is_local_or_builtin_provider(fallback_config.provider)
+            ):
+                logger.warning(
+                    "Skipping $%s structured fallback %s/%s because paid "
+                    "remote fallbacks are disabled by default. Configure "
+                    "a local provider or set "
+                    "FICHERO_ALLOW_PAID_AI_FALLBACKS=1.",
+                    tier,
+                    fallback_config.provider,
+                    fallback_config.model,
+                )
                 continue
 
             # #1001/#1308: structured extractor fallback may become a billing

--- a/fichero-engine/tests/integration/test_llm_fallback_chain.py
+++ b/fichero-engine/tests/integration/test_llm_fallback_chain.py
@@ -293,7 +293,8 @@ class TestChatStructuredWithFallbackChain:
                    new=AsyncMock(return_value=proc)), \
              patch("fichero.llm.resolve_model_alias",
                    return_value=("anthropic", "claude-sonnet-4-6")), \
-             patch("fichero.llm.get_langchain_model", return_value=base_model):
+             patch("fichero.llm.get_langchain_model", return_value=base_model), \
+             patch("fichero.llm._paid_remote_fallbacks_enabled", return_value=True):
             result = await chat_structured_with_fallback(
                 prompt="extract entities from this text",
                 schema=_Result,
@@ -324,7 +325,8 @@ class TestChatStructuredWithFallbackChain:
                    new=AsyncMock(return_value=proc)), \
              patch("fichero.llm.resolve_model_alias",
                    return_value=("openai", "gpt-5")), \
-             patch("fichero.llm.get_langchain_model", return_value=base_model):
+             patch("fichero.llm.get_langchain_model", return_value=base_model), \
+             patch("fichero.llm._paid_remote_fallbacks_enabled", return_value=True):
             result = await chat_structured_with_fallback(
                 prompt="x", schema=_Result, config=apple_cfg,
             )
@@ -356,7 +358,8 @@ class TestChatStructuredWithFallbackChain:
                    new=AsyncMock(return_value=proc)), \
              patch("fichero.llm.resolve_model_alias",
                    return_value=("anthropic", "claude-sonnet-4-6")), \
-             patch("fichero.llm.get_langchain_model", return_value=base_model):
+             patch("fichero.llm.get_langchain_model", return_value=base_model), \
+             patch("fichero.llm._paid_remote_fallbacks_enabled", return_value=True):
             result = await chat_structured_with_fallback(
                 prompt="x", schema=_Result, config=apple_cfg,
             )

--- a/fichero-engine/tests/unit/test_apple_intelligence_decode_errors.py
+++ b/fichero-engine/tests/unit/test_apple_intelligence_decode_errors.py
@@ -176,8 +176,9 @@ class TestStructuredDecodeKind:
 
     @pytest.mark.asyncio
     async def test_context_overflow_does_not_retry_on_device(self):
-        # context_overflow fails identically on retry — must go straight
-        # to the fallback path (here: no $large configured → re-raise).
+        # context_overflow gets one compact retry without schema prompt
+        # injection before the fallback path (here: no $large configured
+        # → re-raise).
         mock_structured = AsyncMock(
             side_effect=StructuredDecodeError(
                 "(context_overflow): too long", kind="context_overflow"
@@ -194,7 +195,7 @@ class TestStructuredDecodeKind:
                 await chat_structured_with_fallback(
                     prompt="p", schema=_MiniSchema, config=_apple_config(),
                 )
-        assert mock_structured.await_count == 1  # no on-device retry
+        assert mock_structured.await_count == 2
 
     @pytest.mark.asyncio
     async def test_retry_failure_falls_through_to_paid_fallback(self):

--- a/fichero-engine/tests/unit/test_chat_structured.py
+++ b/fichero-engine/tests/unit/test_chat_structured.py
@@ -653,7 +653,8 @@ class TestProviderQuotaHandling:
                 raise AppleUnavailableError("guardrail")
             return _Result(answer="from-env")
 
-        with patch("fichero.llm.chat_structured", new=fake_chat_structured):
+        with patch("fichero.llm.chat_structured", new=fake_chat_structured), \
+             patch("fichero.llm._paid_remote_fallbacks_enabled", return_value=True):
             result = await chat_structured_with_fallback(
                 prompt="x", schema=_Result, config=cfg
             )
@@ -707,7 +708,8 @@ class TestChatStructuredWithFallback:
              patch(
                  "fichero.llm.resolve_model_alias",
                  return_value=("openrouter", "openai/gpt-4o-mini"),
-             ):
+             ), \
+             patch("fichero.llm._paid_remote_fallbacks_enabled", return_value=True):
             result = await chat_structured_with_fallback(
                 prompt="x", schema=_Result, config=apple_cfg
             )
@@ -746,7 +748,8 @@ class TestChatStructuredWithFallback:
             raise AssertionError(provider)
 
         with patch("fichero.llm.chat_structured", new=fake_chat_structured), \
-             patch("fichero.llm.resolve_model_alias", side_effect=resolve_alias):
+             patch("fichero.llm.resolve_model_alias", side_effect=resolve_alias), \
+             patch("fichero.llm._paid_remote_fallbacks_enabled", return_value=True):
             result = await chat_structured_with_fallback(
                 prompt="x", schema=_Result, config=apple_cfg
             )
@@ -756,6 +759,91 @@ class TestChatStructuredWithFallback:
             ("apple", "apple-intelligence"),
             ("openrouter", "openai/gpt-4o-mini"),
             ("openai", "mlx-local"),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_schema_failure_retries_without_schema_prompt_injection(self):
+        apple_cfg = LLMConfig(provider="apple", model="apple-intelligence")
+        good = _Result(answer="from-compact-retry")
+        mock_structured = AsyncMock(
+            side_effect=[
+                StructuredDecodeError("(schema): too large", kind="schema"),
+                good,
+            ]
+        )
+
+        with patch("fichero.llm.chat_structured", new=mock_structured), \
+             patch("fichero.llm.resolve_model_alias") as mock_resolve:
+            result = await chat_structured_with_fallback(
+                prompt="x", schema=_Result, config=apple_cfg
+            )
+
+        assert result == good
+        assert mock_structured.await_count == 2
+        assert mock_structured.await_args_list[1].kwargs["include_schema_in_prompt"] is False
+        mock_resolve.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_remote_paid_fallbacks_are_skipped_by_default(self):
+        apple_cfg = LLMConfig(provider="apple", model="apple-intelligence")
+        mock_structured = AsyncMock(side_effect=GuardrailViolationError("blocked"))
+
+        def resolve_alias(provider, model):
+            if provider == "$medium":
+                return ("openrouter", "openai/gpt-4o-mini")
+            if provider == "$large":
+                return ("openai", "gpt-5")
+            raise AssertionError(provider)
+
+        with patch("fichero.llm.chat_structured", new=mock_structured), \
+             patch("fichero.llm.resolve_model_alias", side_effect=resolve_alias), \
+             patch("fichero.llm._paid_remote_fallbacks_enabled", return_value=False):
+            with pytest.raises(GuardrailViolationError, match="blocked"):
+                await chat_structured_with_fallback(
+                    prompt="x", schema=_Result, config=apple_cfg
+                )
+
+        assert mock_structured.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_local_large_fallback_still_runs_when_paid_remote_disabled(self):
+        apple_cfg = LLMConfig(provider="apple", model="apple-intelligence")
+        calls: list[LLMConfig] = []
+
+        async def fake_chat_structured(
+            prompt,
+            schema,
+            config,
+            system=None,
+            include_schema_in_prompt=None,
+            use_case=None,
+            permissive_guardrails=False,
+        ):
+            calls.append(config)
+            if config.provider == "apple":
+                raise GuardrailViolationError("blocked")
+            assert config.provider == "ollama"
+            assert config.model == "llama3.2"
+            return _Result(answer="from-local")
+
+        def resolve_alias(provider, model):
+            if provider == "$medium":
+                return ("openrouter", "openai/gpt-4o-mini")
+            if provider == "$large":
+                return ("ollama", "llama3.2")
+            raise AssertionError(provider)
+
+        with patch("fichero.llm.chat_structured", new=fake_chat_structured), \
+             patch("fichero.llm.resolve_model_alias", side_effect=resolve_alias), \
+             patch("fichero.llm._paid_remote_fallbacks_enabled", return_value=False):
+            result = await chat_structured_with_fallback(
+                prompt="x", schema=_Result, config=apple_cfg
+            )
+
+        assert result == _Result(answer="from-local")
+        assert [(c.provider, c.model) for c in calls] == [
+            ("apple", "apple-intelligence"),
+            ("ollama", "llama3.2"),
         ]
 
     @pytest.mark.asyncio
@@ -830,7 +918,8 @@ class TestChatStructuredWithFallback:
              patch(
                  "fichero.llm.resolve_model_alias",
                  return_value=("openrouter", "openai/gpt-4o-mini"),
-             ):
+             ), \
+             patch("fichero.llm._paid_remote_fallbacks_enabled", return_value=True):
             result = await chat_structured_with_fallback(
                 prompt="x", schema=_Result, config=apple_cfg
             )

--- a/fichero-engine/tests/unit/test_reset_ai_defaults.py
+++ b/fichero-engine/tests/unit/test_reset_ai_defaults.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import pytest
 
 from fichero.app_db import AppDatabase
+from fichero.api.main import _repair_known_bad_ai_defaults
 from fichero.models import Provider, Model
 from fichero.providers import ProviderType
 
@@ -65,6 +66,16 @@ class TestResetAIDefaults:
             assert defaults.get(f"default_{tier}_model") == "apple-intelligence"
         assert defaults["default_medium_provider"] == "openrouter"
         assert defaults["default_medium_model"] == "openai/gpt-4o-mini"
+
+    def test_repair_known_bad_large_default_rewrites_openrouter_free(self, app_db):
+        app_db.set_setting("default_large_provider", "openrouter")
+        app_db.set_setting("default_large_model", "openrouter/free")
+
+        _repair_known_bad_ai_defaults(app_db)
+
+        defaults = app_db.get_ai_defaults()
+        assert defaults["default_large_provider"] == "apple"
+        assert defaults["default_large_model"] == "apple-intelligence"
 
     def test_reset_does_not_touch_providers(self, app_db):
         """The #933 scope guarantee: Reset Defaults must leave the

--- a/fichero-engine/tests/unit/test_routes_settings.py
+++ b/fichero-engine/tests/unit/test_routes_settings.py
@@ -48,8 +48,8 @@ class TestSetAIDefaults:
             "small_model": "apple-intelligence",
             "medium_provider": "openrouter",
             "medium_model": "openai/gpt-4o-mini",
-            "large_provider": "openrouter",
-            "large_model": "openrouter/free",
+            "large_provider": "apple",
+            "large_model": "apple-intelligence",
             "temperature": "0.7",
             "max_tokens": "1000",
             "prompt_prefix": "",
@@ -74,8 +74,8 @@ class TestSetAIDefaults:
             "small_model": "apple-intelligence",
             "medium_provider": "openrouter",
             "medium_model": "openai/gpt-4o-mini",
-            "large_provider": "openrouter",
-            "large_model": "openrouter/free",
+            "large_provider": "apple",
+            "large_model": "apple-intelligence",
             "temperature": "",
             "max_tokens": "",
             "prompt_prefix": "",
@@ -92,8 +92,8 @@ class TestSetAIDefaults:
         assert data["small_model"] == "apple-intelligence"
         assert data["medium_provider"] == "openrouter"
         assert data["medium_model"] == "openai/gpt-4o-mini"
-        assert data["large_provider"] == "openrouter"
-        assert data["large_model"] == "openrouter/free"
+        assert data["large_provider"] == "apple"
+        assert data["large_model"] == "apple-intelligence"
 
     def test_empty_values_clear_setting(self, client):
         # Set then clear
@@ -105,7 +105,7 @@ class TestSetAIDefaults:
             "embeddings_provider": "", "embeddings_model": "",
             "small_provider": "apple", "small_model": "apple-intelligence",
             "medium_provider": "openrouter", "medium_model": "openai/gpt-4o-mini",
-            "large_provider": "openrouter", "large_model": "openrouter/free",
+            "large_provider": "apple", "large_model": "apple-intelligence",
             "temperature": "", "max_tokens": "",
             "prompt_prefix": "",
         }
@@ -121,8 +121,8 @@ class TestSetAIDefaults:
         assert data["small_model"] == "apple-intelligence"
         assert data["medium_provider"] == "openrouter"
         assert data["medium_model"] == "openai/gpt-4o-mini"
-        assert data["large_provider"] == "openrouter"
-        assert data["large_model"] == "openrouter/free"
+        assert data["large_provider"] == "apple"
+        assert data["large_model"] == "apple-intelligence"
 
 
 class TestResetAIDefaults:


### PR DESCRIPTION
Backend extraction-reliability fixes from the overnight KG & Hermeneutics lane.

## Issues
- #1541 — Claim extraction 404: invalid \$large tier (`openrouter/free`) + over-broad provider routing
- #1542 — Apple Intelligence StructuredDecodeError silently forced the paid fallback

## Verification (manager gate)
- `ruff check fichero-engine/src/` — clean
- pytest unit suite — **3728 passed, 0 failed** (21 skipped, 21 xfailed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)