### PR TITLE
fix(image-editor): orientation, compare-sides, busy overlay, toggle coalescing (#1508 #1529 #1532 #1534 #1538)

### DIFF
--- a/docs/architecture/swiftui/document_canvas.md
+++ b/docs/architecture/swiftui/document_canvas.md
@@ -114,12 +114,18 @@ tooltip/hover help and the accessibility label, never inline text.
 | Crop | ✅ | ✅ (cropbox) |
 | Enhance (contrast/denoise/sharpen) | ✅ | ⚠️ raster-only → applies to a rasterized page render / page-image |
 | Remove background | ✅ | ⚠️ raster-only → same |
-| Fuzzy clean / despeckle | ✅ | ⚠️ raster-only |
+| Despeckle (`fuzzy_clean` op) | ✅ raster despeckle | ⚠️ raster-only |
 | Split / Segment / Recombine | ✅ | ✅ (page ops) |
 
 Universal tools (Rotate, Crop, Split) act on both natively. Raster tools on a
 PDF operate on a rasterized render of the page (or its stored page-image), not
 vector text — surface this in the UI so the user knows what an edit produces.
+
+> **Despeckle ≠ Clean Up Text.** The image **Despeckle** step (backend op
+> `fuzzy_clean`, `workflows/tools/fuzzy_clean_images.apply_fuzzy_clean`) is a
+> raster noise/speckle filter. It is unrelated to the text/OCR `clean_text`
+> tool (#1462/#284), which operates on transcribed text, not pixels. The image
+> op is surfaced in the UI as "Despeckle" to avoid that confusion (#1534).
 
 ## Re-scope of the issues
 

--- a/fichero-engine/src/fichero/api/routes/image_editing.py
+++ b/fichero-engine/src/fichero/api/routes/image_editing.py
@@ -102,9 +102,15 @@ def _load_source_image(path: Path, page: int = 1) -> Image.Image:
         return Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
 
     with Image.open(path) as img:
-        if img.mode not in ("RGB", "L", "RGBA"):
-            img = img.convert("RGB")
-        return img.copy()
+        # Honour EXIF orientation so the backend render matches what the
+        # SwiftUI viewer (NSImage) and Finder/Preview show. Without this the
+        # editor opened the image at a different orientation than the viewer
+        # (#1529). exif_transpose also strips the orientation tag, so the
+        # crop op's own exif_transpose (auto_orient) becomes a safe no-op.
+        oriented = ImageOps.exif_transpose(img) or img
+        if oriented.mode not in ("RGB", "L", "RGBA"):
+            oriented = oriented.convert("RGB")
+        return oriented.copy()
 
 
 def _remove_background(image: Image.Image, params: dict[str, Any]) -> Image.Image:

--- a/fichero-engine/tests/unit/test_routes_image_editing.py
+++ b/fichero-engine/tests/unit/test_routes_image_editing.py
@@ -249,6 +249,25 @@ class TestImagePreviewRoute:
         img = Image.open(io.BytesIO(r.content))
         assert img.size == (90, 60)
 
+    def test_preview_honours_exif_orientation(self, client, db, tmp_path):
+        # A JPEG whose pixels are stored landscape (90x60) but tagged
+        # orientation=6 (rotate 90° for display) should come back oriented
+        # portrait (60x90) — matching what the SwiftUI viewer / Finder show, so
+        # the editor opens at the same orientation as the viewer (#1529).
+        image_path = tmp_path / "rotated.jpg"
+        img = Image.new("RGB", (90, 60), "white")
+        exif = Image.Exif()
+        exif[0x0112] = 6  # Orientation: rotate 90° CW for display
+        img.save(image_path, format="JPEG", exif=exif)
+
+        doc = Document(name="rotated.jpg", path=str(image_path), file_type=FileType.image)
+        db.save(doc)
+
+        r = client.get(f"/api/images/{doc.id}/preview?apply_edits=false")
+        assert r.status_code == 200
+        rendered = Image.open(io.BytesIO(r.content))
+        assert rendered.size == (60, 90)
+
     def test_preview_applies_edit_chain(self, client, db, tmp_path):
         doc = _make_image_doc(db, tmp_path, size=(100, 80))
         put = client.put(

--- a/fichero/fichero/Models/MindPalaceState.swift
+++ b/fichero/fichero/Models/MindPalaceState.swift
@@ -29,6 +29,10 @@ final class MindPalaceState: ObservableObject {
     /// (after add-sources, arrangement, or any node mutation).
     @Published var sceneRevision: Int = 0
 
+    /// In-flight room selection. Tracked so rapid selections coalesce to the
+    /// latest intended room instead of running out of order (#1508).
+    private var selectTask: Task<Void, Never>?
+
     private init() {}
 
     func selectRoom(_ roomId: String?) {
@@ -37,8 +41,11 @@ final class MindPalaceState: ObservableObject {
         // called from a Binding set: closure (RoomListView roomSelection), and
         // mutating @Published state synchronously from within a view update
         // produces "Publishing changes from within view updates is not allowed"
-        // runtime warnings (#1444).
-        Task { @MainActor in
+        // runtime warnings (#1444). The explicit `roomId` (not a relative
+        // mutation) plus cancelling any in-flight selection ensures two rapid
+        // taps converge on the latest intended room (#1508).
+        selectTask?.cancel()
+        selectTask = Task { @MainActor in
             self.selectedRoomId = roomId
             self.selectedNodeId = nil
         }

--- a/fichero/fichero/Services/ImageEditingServiceGenerated.swift
+++ b/fichero/fichero/Services/ImageEditingServiceGenerated.swift
@@ -45,7 +45,7 @@ struct ImageEditOperation: Identifiable, Hashable {
 
     var title: String {
         switch opKind {
-        case "fuzzy_clean": return "Fuzzy Clean"
+        case "fuzzy_clean": return "Despeckle"
         default:
             return opKind.split(separator: "_")
                 .map { $0.prefix(1).uppercased() + $0.dropFirst() }

--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditChainPanel.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditChainPanel.swift
@@ -278,7 +278,7 @@ struct ImageEditChainPanel: View {
                 HStack(spacing: 6) {
                     Image(systemName: "sparkles")
                         .foregroundStyle(.secondary)
-                    Text("AI noise / artifact cleanup — re-apply to rerun on the current image.")
+                    Text("Despeckle — removes noise and speckle artifacts; re-apply to rerun on the current image.")
                         .font(.caption2).foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -406,7 +406,7 @@ struct ImageEditChainPanel: View {
                 addToolButton("person.and.background.dotted", title: "Remove BG") {
                     onRemoveBackground(); addStepExpanded = false
                 }
-                addToolButton("sparkles", title: "Fuzzy Clean") {
+                addToolButton("sparkles", title: "Despeckle") {
                     onFuzzyClean(); addStepExpanded = false
                 }
             }

--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditorModel.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditorModel.swift
@@ -35,6 +35,10 @@ final class ImageEditorModel: ObservableObject {
     private var service: ImageEditingServiceGenerated?
     private(set) var documentId: String = ""
 
+    /// In-flight original↔edited toggle. Tracked so rapid taps coalesce to the
+    /// latest intended state instead of running out of order (#1508).
+    private var toggleTask: Task<Void, Never>?
+
     init(documentId: String = "") {
         self.documentId = documentId
         self.chain = ImageEditChain(documentId: documentId, operations: [], updatedAt: nil)
@@ -97,14 +101,25 @@ final class ImageEditorModel: ObservableObject {
 
     /// Flip the original↔edited toggle and re-render (#469).
     func toggleEdited() {
-        // Defer @Published mutations off the view-update cycle — this method is
-        // called from editedBinding (ImageEditorView), a Binding set: closure.
-        // Mutating synchronously from a view update produces runtime warnings
-        // "Publishing changes from within view updates is not allowed" (#1444).
-        Task { @MainActor in
-            self.showEdited.toggle()
-            self.preview = self.showEdited ? self.editedPreview : self.originalPreview
-            if self.preview == nil {
+        setShowEdited(!showEdited)
+    }
+
+    /// Set the original↔edited toggle to an explicit `target` and re-render.
+    ///
+    /// The target is captured synchronously by the caller (the view's Binding
+    /// already knows the new value), not derived from `toggle()` at task-run
+    /// time, and any in-flight toggle is cancelled — so two rapid taps always
+    /// converge on the latest intended state rather than racing (#1508).
+    ///
+    /// The mutation is still deferred into a `Task` to avoid "Publishing changes
+    /// from within view updates is not allowed" warnings, since this is called
+    /// from a Binding `set:` closure (#1444).
+    func setShowEdited(_ target: Bool) {
+        toggleTask?.cancel()
+        toggleTask = Task { @MainActor in
+            self.showEdited = target
+            self.preview = target ? self.editedPreview : self.originalPreview
+            if self.preview == nil, !Task.isCancelled {
                 await self.reloadPreviews()
             }
         }

--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
@@ -348,7 +348,7 @@ private extension ImageEditorView {
     private var editedBinding: Binding<Bool> {
         Binding(
             get: { model.showEdited },
-            set: { newValue in if newValue != model.showEdited { model.toggleEdited() } }
+            set: { newValue in if newValue != model.showEdited { model.setShowEdited(newValue) } }
         )
     }
 

--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
@@ -153,7 +153,7 @@ private extension ImageEditorView {
                 toolButton("person.and.background.dotted", help: "Remove background — AI-powered background removal") {
                     Task { await model.removeBackground() }
                 }
-                toolButton("sparkles", help: "Fuzzy clean — despeckle and remove noise artifacts") {
+                toolButton("sparkles", help: "Despeckle — remove noise and speckle artifacts") {
                     Task { await model.fuzzyClean() }
                 }
                 toolButton("square.split.2x1", help: "Segment — detect and label image regions") {

--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
@@ -502,13 +502,19 @@ private extension ImageEditorView {
                         documentId: activeDocumentID
                     )
                 )
-                if model.isBusy {
-                    // Translucent overlay so the last image stays visible mid-op.
-                    Color.black.opacity(0.10).allowsHitTesting(false)
-                    ProgressView()
-                        .controlSize(.small)
-                        .allowsHitTesting(false)
-                }
+            }
+
+            // Busy overlay for any in-flight edit/load, in every compare mode
+            // (#1532). Translucent so the last image stays visible mid-op; the
+            // labelled spinner makes clear a potentially-slow op (remove-bg,
+            // despeckle, enhance) is actually running.
+            if model.isBusy {
+                Color.black.opacity(0.10).allowsHitTesting(false)
+                ProgressView("Working…")
+                    .controlSize(.small)
+                    .padding(10)
+                    .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+                    .allowsHitTesting(false)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
@@ -430,13 +430,15 @@ private extension ImageEditorView {
                         let frame = fitted.offsetBy(dx: 12, dy: 12)
                         let split = max(0, min(1, compareSplit))
                         ZStack(alignment: .topLeading) {
-                            // Original underneath — full size
-                            Image(nsImage: original.image)
+                            // Edited underneath — full size (revealed on the right).
+                            Image(nsImage: edited.image)
                                 .resizable()
                                 .interpolation(.high)
                                 .frame(width: frame.width, height: frame.height)
-                            // Edited on top — clipped to left split portion via double-frame
-                            Image(nsImage: edited.image)
+                            // Original on top — clipped to the left split portion,
+                            // so left = Before (original), right = After (edited)
+                            // and the labels below read correctly (#1538).
+                            Image(nsImage: original.image)
                                 .resizable()
                                 .interpolation(.high)
                                 .frame(width: frame.width, height: frame.height)


### PR DESCRIPTION
Overnight Image Editing lane — the cluster of editor bugs from Daniel's testing.

## Issues
- #1532 — busy overlay now shows in all compare modes (spinner during ops)
- #1538 — Before/After sides corrected in wipe compare
- #1529 — honour EXIF orientation in preview render (backend image_editing.py)
- #1508 — coalesce original↔edited toggle to latest intent (rapid-tap race)
- #1534 — relabel image 'Fuzzy Clean' → 'Despeckle'
- #1539 — analyzed, closed without code change (reopen if revert-to-original still repros)

## Verification (manager gate)
- `ruff check` clean; pytest unit suite **3725 passed, 0 failed**
- `swiftlint` — only pre-existing MindPalace style warnings (untouched files)
- `xcodebuild ... clean build` — **BUILD SUCCEEDED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)