### PR TITLE
fix(toolbar): move PDF page-nav to doc toolbar + restyle edit-toggle (#1531 #1528)

### DIFF
--- a/fichero/fichero/Views/ContentView+State.swift
+++ b/fichero/fichero/Views/ContentView+State.swift
@@ -14,19 +14,12 @@ extension ContentView {
         let viewName: String
         switch viewMode {
         case .library(let document):
-            let baseName = document?.name ?? "Library"
-            // For a PDF, append the page the user is currently reading so the
-            // window/tab title tracks scroll + page-flip. Reuses the page-focus
-            // signal from #1463 (pageFocusDocument) rather than a parallel
-            // tracker, and the page-child count for the "of M" total. (#1482)
-            if let page = pageFocusDocument, page.docType == .page, let seq = page.sequence {
-                let total = pdfDocPages.count
-                viewName = total > 0
-                    ? "\(baseName) — Page \(seq) of \(total)"
-                    : "\(baseName) — Page \(seq)"
-            } else {
-                viewName = baseName
-            }
+            // Window/tab title shows only the document or library name. The
+            // current page ("4 / 31") is document-scoped, so it lives on the
+            // document toolbar over the canvas (PDFPageWithToolbar), not on the
+            // window chrome — keeping window back/forward (navigation history)
+            // and document page-flip on separate toolbars. (#1531, was #1482)
+            viewName = document?.name ?? "Library"
         case .search(let savedSearch):
             viewName = savedSearch?.name ?? "Search"
         case .chat(let conversation):

--- a/fichero/fichero/Views/Library/EditorView.swift
+++ b/fichero/fichero/Views/Library/EditorView.swift
@@ -182,12 +182,14 @@ struct EditorView: View {
                 isEditing.toggle()
             }
         } label: {
-            Image(systemName: isEditing ? "checkmark.circle.fill" : "pencil.tip.crop.circle")
-                .font(.title3)
-                .padding(6)
-                .background(.thinMaterial, in: Circle())
+            // Plain icon button matching the canvas toolbar convention (the
+            // PDF loupe toggle): a filled/outline `pencil.circle` pair shows the
+            // selected state via accent tint instead of a grey filled circle, at
+            // the same default icon size as its neighbours. (#1528)
+            Image(systemName: isEditing ? "pencil.circle.fill" : "pencil.circle")
         }
         .buttonStyle(.plain)
+        .foregroundColor(isEditing ? .accentColor : .primary)
         .help(isEditing ? "Done — return to viewing" : "Edit image (crop, rotate, enhance, remove background)")
         .accessibilityIdentifier("canvasEditModeToggle")
         .padding(10)

--- a/fichero/fichero/Views/Library/PDFPageView.swift
+++ b/fichero/fichero/Views/Library/PDFPageView.swift
@@ -24,6 +24,27 @@ final class PDFZoomController: ObservableObject {
     }
 }
 
+// MARK: - PDF Page Controller
+
+/// Bridges the SwiftUI document toolbar's page-navigation cluster (◀ N / M ▶)
+/// with PDFKit's AppKit `PDFView`, mirroring `PDFZoomController` for zoom. The
+/// page indicator is document-scoped, so it belongs on the canvas toolbar
+/// rather than the window toolbar. (#1531)
+@MainActor
+final class PDFPageController: ObservableObject {
+    /// 0-based index of the page PDFKit is currently showing.
+    @Published var pageIndex: Int = 0
+    /// Total page count of the loaded document (0 until a document loads).
+    @Published var pageCount: Int = 0
+    weak var pdfView: PDFView?
+
+    var canGoPrevious: Bool { pageIndex > 0 }
+    var canGoNext: Bool { pageIndex < pageCount - 1 }
+
+    func goToPrevious() { pdfView?.goToPreviousPage(nil) }
+    func goToNext() { pdfView?.goToNextPage(nil) }
+}
+
 // MARK: - PDFPageView
 
 /// Interactive PDF preview using PDFKit's `PDFView`.
@@ -45,6 +66,9 @@ struct PDFPageView: NSViewRepresentable {
     var onPageIndexChange: ((Int) -> Void)?
     /// Optional zoom controller — set by PDFPageWithToolbar to sync the toolbar.
     var zoomController: PDFZoomController?
+    /// Optional page controller — set by PDFPageWithToolbar so the document
+    /// toolbar's ◀ N/M ▶ cluster can drive and reflect the current page. (#1531)
+    var pageController: PDFPageController?
     var onCursorMoved: ((CGPoint) -> Void)?
 
     // MARK: - Loupe State
@@ -80,7 +104,9 @@ struct PDFPageView: NSViewRepresentable {
         view.delegate = context.coordinator
         context.coordinator.pdfView = view
         context.coordinator.zoomController = zoomController
+        context.coordinator.pageController = pageController
         zoomController?.pdfView = view
+        pageController?.pdfView = view
         NotificationCenter.default.addObserver(
             context.coordinator,
             selector: #selector(Coordinator.pageDidChange(_:)),
@@ -128,7 +154,9 @@ struct PDFPageView: NSViewRepresentable {
     func updateNSView(_ view: PDFView, context: Context) {
         context.coordinator.owner = self
         context.coordinator.zoomController = zoomController
+        context.coordinator.pageController = pageController
         zoomController?.pdfView = view
+        pageController?.pdfView = view
         loadAndNavigate(view)
     }
 
@@ -155,6 +183,16 @@ struct PDFPageView: NSViewRepresentable {
         if view.currentPage != page {
             view.go(to: page)
         }
+        // Sync the document toolbar's page cluster. Deferred to the next
+        // runloop tick so the @Published writes land after the current SwiftUI
+        // update pass commits (same reasoning as the scale observer). (#1531)
+        if let pageController {
+            let total = doc.pageCount
+            Task { @MainActor in
+                pageController.pageCount = total
+                pageController.pageIndex = pageIndex
+            }
+        }
     }
 
     /// Bridges AppKit notifications / delegate into the SwiftUI callback.
@@ -165,6 +203,7 @@ struct PDFPageView: NSViewRepresentable {
         var owner: PDFPageView
         weak var pdfView: PDFView?
         var zoomController: PDFZoomController?
+        var pageController: PDFPageController?
         // Accumulated horizontal translation for the current pan gesture.
         private var panAccumulated: CGFloat = 0
 
@@ -232,6 +271,15 @@ struct PDFPageView: NSViewRepresentable {
                   let page = view.currentPage,
                   let doc = view.document else { return }
             let index = doc.index(for: page)
+            // Keep the document toolbar's page cluster in sync on every flip,
+            // including pan/swipe turns the parent's pageIndex doesn't drive. (#1531)
+            if let pageController {
+                let total = doc.pageCount
+                Task { @MainActor in
+                    pageController.pageCount = total
+                    pageController.pageIndex = index
+                }
+            }
             guard index != owner.pageIndex else { return }
             // PDFKit can post PDFViewPageChanged while SwiftUI is updating
             // the representable. Defer the callback so ContentView updates

--- a/fichero/fichero/Views/Library/PDFPageWithToolbar.swift
+++ b/fichero/fichero/Views/Library/PDFPageWithToolbar.swift
@@ -14,6 +14,7 @@ struct PDFPageWithToolbar: View {
     var onPageIndexChange: ((Int) -> Void)?
 
     @StateObject private var zoom = PDFZoomController()
+    @StateObject private var pageNav = PDFPageController()
 
     // Loupe settings — same AppStorage keys as PDFPageView.Coordinator reads,
     // so both stay in sync automatically via shared UserDefaults storage.
@@ -42,6 +43,39 @@ struct PDFPageWithToolbar: View {
             // PDF preview header is the same 44pt height as the list mode rail,
             // image preview, knowledge surface, and inspector tab strip (#1228).
             MiniToolbar {
+                // Page-within-document navigation (◀ N / M ▶). Document-scoped,
+                // so it lives here on the canvas toolbar rather than the window
+                // toolbar. Only shown for multi-page documents. (#1531)
+                if pageNav.pageCount > 1 {
+                    Button {
+                        pageNav.goToPrevious()
+                    } label: {
+                        Image(systemName: "chevron.left")
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!pageNav.canGoPrevious)
+                    .help("Previous Page")
+                    .accessibilityIdentifier("pdfPreviousPage")
+
+                    Text("\(pageNav.pageIndex + 1) / \(pageNav.pageCount)")
+                        .font(.caption)
+                        .monospacedDigit()
+                        .foregroundStyle(.secondary)
+                        .frame(minWidth: 48)
+
+                    Button {
+                        pageNav.goToNext()
+                    } label: {
+                        Image(systemName: "chevron.right")
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!pageNav.canGoNext)
+                    .help("Next Page")
+                    .accessibilityIdentifier("pdfNextPage")
+
+                    Divider().frame(height: 16)
+                }
+
                 Spacer(minLength: 0)
                 Button {
                     zoom.zoomOut()
@@ -130,6 +164,7 @@ struct PDFPageWithToolbar: View {
                     pageIndex: pageIndex,
                     onPageIndexChange: onPageIndexChange,
                     zoomController: zoom,
+                    pageController: pageNav,
                     onCursorMoved: { pos in loupePosition = pos }
                 )
 


### PR DESCRIPTION
Overnight Window Chrome & Toolbars lane.

## Issues
- #1531 — PDF page back/forward (4/31) moved from window toolbar to the document toolbar (new PDFPageController bridge, mirrors PDFZoomController; stays in sync on trackpad page-turns via PDFViewPageChanged)
- #1528 — edit-mode toggle restyled to match other toolbar items (no more grey-circle annotation look)

## Verification (manager gate)
- `swiftlint lint` — 0 error-severity (43 pre-existing length warnings)
- `xcodebuild ... clean build` — **BUILD SUCCEEDED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)