### PR TITLE
fix(library): thumbnails off main thread (#1509) + inspector RTF codec tests (#710) + repair FicheroTests compile

### DIFF
--- a/fichero/fichero-tests/AnnotationServiceTests.swift
+++ b/fichero/fichero-tests/AnnotationServiceTests.swift
@@ -1,6 +1,7 @@
 @testable import Fichero
 import XCTest
 
+@MainActor
 final class AnnotationServiceTests: XCTestCase {
 
     func testMatchesSearchByText() {

--- a/fichero/fichero-tests/ClaimSummaryCardTests.swift
+++ b/fichero/fichero-tests/ClaimSummaryCardTests.swift
@@ -1,7 +1,9 @@
 @testable import Fichero
+import FicheroAPIClient
 import Foundation
 import XCTest
 
+@MainActor
 final class ClaimSummaryCardTests: XCTestCase {
 
     func testOpenClaimSourceUserInfoIncludesProvenanceFields() {

--- a/fichero/fichero-tests/InspectorLayoutTests.swift
+++ b/fichero/fichero-tests/InspectorLayoutTests.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import AppKit
 @testable import Fichero
 import Foundation
@@ -616,5 +617,80 @@ struct FindBarSelectorTests {
         // ShowFindBarButton sets menuItem.tag = .showFindPanel.rawValue. If
         // Apple ever renumbered these, the find action would silently break.
         #expect(AppKit.NSFindPanelAction.showFindPanel.rawValue == 1)
+    }
+}
+
+// MARK: - ArtifactRichTextCodec Tests (#710)
+
+struct ArtifactRichTextCodecTests {
+
+    private func bold(_ string: String) -> NSAttributedString {
+        let font = NSFont.boldSystemFont(ofSize: 13)
+        return NSAttributedString(string: string, attributes: [.font: font])
+    }
+
+    @Test("Plain text encodes to a plain string (no RTF wrapper)")
+    func plainTextEncodesPlain() {
+        let attr = NSAttributedString(string: "Hello world")
+        let encoded = ArtifactRichTextCodec.encode(attr)
+        #expect(encoded == "Hello world")
+        #expect(!encoded.hasPrefix("{\\rtf"))
+    }
+
+    @Test("Bold attribute encodes to RTF source containing \\b")
+    func boldEncodesToRTF() {
+        let encoded = ArtifactRichTextCodec.encode(bold("Bold text"))
+        #expect(encoded.hasPrefix("{\\rtf"))
+        #expect(encoded.contains("\\b"))
+    }
+
+    @Test("Custom paragraph style encodes to RTF preserving the style")
+    func paragraphStyleEncodesToRTF() {
+        let para = NSMutableParagraphStyle()
+        para.lineSpacing = 8
+        para.firstLineHeadIndent = 24
+        let attr = NSAttributedString(
+            string: "Indented spaced paragraph",
+            attributes: [.paragraphStyle: para]
+        )
+        let encoded = ArtifactRichTextCodec.encode(attr)
+        // A non-default paragraph style must NOT be dropped on save (ruler
+        // edits silently lost before #710's predecessor fix).
+        #expect(encoded.hasPrefix("{\\rtf"))
+
+        let decoded = ArtifactRichTextCodec.decode(encoded)
+        var decodedRange = NSRange(location: 0, length: 0)
+        let decodedPara = decoded.attribute(
+            .paragraphStyle, at: 0, effectiveRange: &decodedRange
+        ) as? NSParagraphStyle
+        #expect(decodedPara?.lineSpacing == 8)
+        #expect(decodedPara?.firstLineHeadIndent == 24)
+    }
+
+    @Test("Decode of plain (non-RTF) content yields a plain attributed string")
+    func decodePlain() {
+        let decoded = ArtifactRichTextCodec.decode("just text")
+        #expect(decoded.string == "just text")
+    }
+
+    @Test("Bold round-trips: encode then decode preserves the bold trait")
+    func boldRoundTrips() {
+        let original = bold("Round trip")
+        let decoded = ArtifactRichTextCodec.decode(ArtifactRichTextCodec.encode(original))
+        #expect(decoded.string == "Round trip")
+
+        var range = NSRange(location: 0, length: 0)
+        let font = decoded.attribute(.font, at: 0, effectiveRange: &range) as? NSFont
+        let traits = font.map {
+            NSFontManager.shared.traits(of: $0)
+        } ?? []
+        #expect(traits.contains(.boldFontMask))
+    }
+
+    @Test("Plain text round-trips unchanged")
+    func plainRoundTrips() {
+        let encoded = ArtifactRichTextCodec.encode(NSAttributedString(string: "abc 123"))
+        let decoded = ArtifactRichTextCodec.decode(encoded)
+        #expect(decoded.string == "abc 123")
     }
 }

--- a/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
+++ b/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
@@ -1,6 +1,7 @@
 @testable import Fichero
 import XCTest
 
+@MainActor
 final class KnowledgeGraphInspectorSectionTests: XCTestCase {
 
     func testVisibleItemsCapsWhenCollapsed() {
@@ -26,24 +27,9 @@ final class KnowledgeGraphInspectorSectionTests: XCTestCase {
         )
     }
 
-    func testFetchButtonHelpersExposeExpectedLabelsAndIcons() {
-        XCTAssertEqual(
-            KnowledgeGraphInspectorSection.fetchButtonHelp(for: .statements),
-            "Get statements"
-        )
-        XCTAssertEqual(
-            KnowledgeGraphInspectorSection.fetchButtonHelp(for: .artifacts),
-            "Get artifacts"
-        )
-        XCTAssertEqual(
-            KnowledgeGraphInspectorSection.fetchButtonIcon(for: .statements),
-            "quote.bubble"
-        )
-        XCTAssertEqual(
-            KnowledgeGraphInspectorSection.fetchButtonIcon(for: .artifacts),
-            "shippingbox"
-        )
-    }
+    // testFetchButtonHelpersExposeExpectedLabelsAndIcons removed: the
+    // KnowledgeGraphInspectorSection.fetchButtonHelp(for:)/fetchButtonIcon(for:)
+    // helpers no longer exist in production, so the test no longer compiles.
 
     func testArtifactsTabIncludesPageArtifactsForParentPDFOnly() {
         let parentPDF = makeDocument(docType: .file, fileType: .pdf)

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -189,6 +189,7 @@
 		7800350961E1C38A10D02D54 /* ImageEditChainPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95706A3222B50B478F15D83D /* ImageEditChainPanel.swift */; };
 		7C874A46B0C0C85ACD9F23AA /* DocumentInspectorArtifactsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312845068CA928DA393E0468 /* DocumentInspectorArtifactsTab.swift */; };
 		7D8F36CB01DB7346C305CA3C /* ContentView+ReadingLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6650E28284D750D9076B0612 /* ContentView+ReadingLayout.swift */; };
+		82E00BEA3E5CAB3FF69DEEE6 /* LocalImageThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F95C40A12E1BBFFF043EED4 /* LocalImageThumbnailView.swift */; };
 		82E7E9935A5A324121ECB468 /* DocumentKGWebPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80DDED3870C2457BFD97D1E /* DocumentKGWebPane.swift */; };
 		832 /* Workflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462 /* Workflow.swift */; };
 		836 /* CacheModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4119 /* CacheModel.swift */; };
@@ -454,6 +455,7 @@
 		0F14337BE87CA15E70323ED4 /* EntityDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDetailView.swift; sourceTree = "<group>"; };
 		0F1ACEB8F688C8749B36E04B /* ClaimSummaryCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaimSummaryCardView.swift; sourceTree = "<group>"; };
 		0F1C81E90821C016E2CE3A60 /* OntologyBrowser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OntologyBrowser.swift; sourceTree = "<group>"; };
+		0F95C40A12E1BBFFF043EED4 /* LocalImageThumbnailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalImageThumbnailView.swift; sourceTree = "<group>"; };
 		100 /* Fichero.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fichero.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		101 /* FicheroApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FicheroApp.swift; sourceTree = "<group>"; };
 		1016BD8B24F412A49A3BED88 /* EntityDetailView+Biography.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "EntityDetailView+Biography.swift"; sourceTree = "<group>"; };
@@ -1566,6 +1568,7 @@
 				80E4C1042F69F06267FA6CCD /* DocumentCanvas.swift */,
 				99857D7C99E753A3405778FC /* LibraryToolbarState.swift */,
 				489A0FBA854FF9A1158996D6 /* WorkspaceItemPicker.swift */,
+				0F95C40A12E1BBFFF043EED4 /* LocalImageThumbnailView.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -2274,6 +2277,7 @@
 				2C8A895EE1B0F5029E3D00B6 /* WorkspaceItemPicker.swift in Sources */,
 				AF3C8529001F34ACB80A8D50 /* EntityDetailView+Notes.swift in Sources */,
 				495FCF3ED790C015FBF4BE70 /* NotesBrowserView.swift in Sources */,
+				82E00BEA3E5CAB3FF69DEEE6 /* LocalImageThumbnailView.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		009 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 201 /* Assets.xcassets */; };
 		010 /* SidebarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109 /* SidebarItem.swift */; };
 		011 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110 /* SearchView.swift */; };
+		011D2B0F5D8064D8ABF7A999 /* ArtifactRichTextCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25A2C92607779F4D928B8E3 /* ArtifactRichTextCodec.swift */; };
 		018 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117 /* ChatView.swift */; };
 		019 /* DocumentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118 /* DocumentStore.swift */; };
 		019CE6D6AA066E977DCB6813 /* ContentView+KnowledgeSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A698478801C79143E8D71A65 /* ContentView+KnowledgeSurface.swift */; };
@@ -843,6 +844,7 @@
 		DD03402A88F98251F388870F /* DocumentInspectorInfoTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DocumentInspectorInfoTab.swift; path = fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab.swift; sourceTree = SOURCE_ROOT; };
 		DD96D53320D07109835C90BF /* EntityDetailView+Notes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "EntityDetailView+Notes.swift"; sourceTree = "<group>"; };
 		DF77122ADD78F941D7F1968D /* KGTimelineView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KGTimelineView.swift; sourceTree = "<group>"; };
+		E25A2C92607779F4D928B8E3 /* ArtifactRichTextCodec.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArtifactRichTextCodec.swift; sourceTree = "<group>"; };
 		E7B146AE8AC4CEEC3775CB94 /* DocumentInspectorMetadataTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DocumentInspectorMetadataTab.swift; path = fichero/Views/Library/DocumentInspector/DocumentInspectorMetadataTab.swift; sourceTree = SOURCE_ROOT; };
 		E80DDED3870C2457BFD97D1E /* DocumentKGWebPane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DocumentKGWebPane.swift; sourceTree = "<group>"; };
 		EBFA9C3247C03BDCE9BE6092 /* LibraryManager+Operations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibraryManager+Operations.swift"; sourceTree = "<group>"; };
@@ -1569,6 +1571,7 @@
 				99857D7C99E753A3405778FC /* LibraryToolbarState.swift */,
 				489A0FBA854FF9A1158996D6 /* WorkspaceItemPicker.swift */,
 				0F95C40A12E1BBFFF043EED4 /* LocalImageThumbnailView.swift */,
+				E25A2C92607779F4D928B8E3 /* ArtifactRichTextCodec.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -2278,6 +2281,7 @@
 				AF3C8529001F34ACB80A8D50 /* EntityDetailView+Notes.swift in Sources */,
 				495FCF3ED790C015FBF4BE70 /* NotesBrowserView.swift in Sources */,
 				82E00BEA3E5CAB3FF69DEEE6 /* LocalImageThumbnailView.swift in Sources */,
+				011D2B0F5D8064D8ABF7A999 /* ArtifactRichTextCodec.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero/Views/Library/ArtifactRichTextCodec.swift
+++ b/fichero/fichero/Views/Library/ArtifactRichTextCodec.swift
@@ -1,0 +1,65 @@
+import AppKit
+import Foundation
+
+/// Encode/decode helpers for artifact rich-text content, extracted from
+/// `ArtifactPanel` so they can be unit-tested directly (#710).
+///
+/// Storage contract: an artifact's `content` field is either
+/// - plain text (no RTF wrapper) when the user added no formatting, or
+/// - inline RTF source (`{\rtf...}`, not base64) when formatting is present,
+///   so the field stays human-readable for plain text and round-trips
+///   losslessly when the user added bold/italic/underline or ruler edits.
+enum ArtifactRichTextCodec {
+    /// Decode a stored content string into an `NSAttributedString`. RTF source
+    /// (detected by the `{\rtf` prefix) is parsed as rich text; anything else
+    /// is treated as plain text.
+    static func decode(_ content: String) -> NSAttributedString {
+        if content.hasPrefix("{\\rtf"),
+           let data = content.data(using: .utf8),
+           let attr = try? NSAttributedString(
+            data: data,
+            options: [.documentType: NSAttributedString.DocumentType.rtf],
+            documentAttributes: nil
+           ) {
+            return attr
+        }
+        return NSAttributedString(string: content)
+    }
+
+    /// Encode an `NSAttributedString` back to a content string. Returns the
+    /// plain string when no formatting is present; otherwise inline RTF source.
+    ///
+    /// Custom paragraph styles (ruler tab stops, indents, line spacing changes)
+    /// MUST round-trip through RTF — an earlier version excluded
+    /// `.paragraphStyle` from the formatting check, which made ruler edits
+    /// silently lose on save (Daniel feedback 2026-04-26).
+    static func encode(_ attr: NSAttributedString) -> String {
+        let fullRange = NSRange(location: 0, length: attr.length)
+        let plain = attr.string
+
+        var hasFormatting = false
+        let defaultPara = NSParagraphStyle.default
+        attr.enumerateAttributes(in: fullRange) { attrs, _, stop in
+            for (key, value) in attrs {
+                if key == .paragraphStyle {
+                    if let para = value as? NSParagraphStyle, para != defaultPara {
+                        hasFormatting = true
+                    }
+                    continue
+                }
+                hasFormatting = true
+            }
+            if hasFormatting { stop.pointee = true }
+        }
+
+        if !hasFormatting { return plain }
+
+        guard let data = try? attr.data(
+            from: fullRange,
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf]
+        ), let rtfString = String(data: data, encoding: .utf8) else {
+            return plain
+        }
+        return rtfString
+    }
+}

--- a/fichero/fichero/Views/Library/DocumentInspector.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector.swift
@@ -1284,55 +1284,15 @@ struct ArtifactPanel: View { // swiftlint:disable:this type_body_length
     /// Decode an artifact's stored content into an NSAttributedString. RTF
     /// source (`{\rtf...`) is parsed; plain text becomes a styled run.
     private func decodeArtifactContent(_ content: String) -> NSAttributedString {
-        if content.hasPrefix("{\\rtf"),
-           let data = content.data(using: .utf8),
-           let attr = try? NSAttributedString(
-            data: data,
-            options: [.documentType: NSAttributedString.DocumentType.rtf],
-            documentAttributes: nil
-           ) {
-            return attr
-        }
-        return NSAttributedString(string: content)
+        ArtifactRichTextCodec.decode(content)
     }
 
     /// Encode an NSAttributedString back to a content string. Inline RTF
     /// source (not base64) so the artifact's `content` field stays human-
     /// readable when the artifact is plain text and round-trips losslessly
-    /// when the user added formatting.
-    ///
-    /// Custom paragraph styles (ruler tab stops, indents, line spacing
-    /// changes) MUST round-trip through RTF — earlier this function
-    /// excluded .paragraphStyle from the formatting check, which made
-    /// ruler edits silently lose on save (Daniel feedback 2026-04-26).
+    /// when the user added formatting. See `ArtifactRichTextCodec` (#710).
     private func encodeArtifactContent(_ attr: NSAttributedString) -> String {
-        let fullRange = NSRange(location: 0, length: attr.length)
-        let plain = attr.string
-
-        var hasFormatting = false
-        let defaultPara = NSParagraphStyle.default
-        attr.enumerateAttributes(in: fullRange) { attrs, _, stop in
-            for (key, value) in attrs {
-                if key == .paragraphStyle {
-                    if let para = value as? NSParagraphStyle, para != defaultPara {
-                        hasFormatting = true
-                    }
-                    continue
-                }
-                hasFormatting = true
-            }
-            if hasFormatting { stop.pointee = true }
-        }
-
-        if !hasFormatting { return plain }
-
-        guard let data = try? attr.data(
-            from: fullRange,
-            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf]
-        ), let rtfString = String(data: data, encoding: .utf8) else {
-            return plain
-        }
-        return rtfString
+        ArtifactRichTextCodec.encode(attr)
     }
 
     // MARK: - Computed properties

--- a/fichero/fichero/Views/Library/DocumentInspector/SourceOutlineView.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/SourceOutlineView.swift
@@ -81,7 +81,8 @@ struct SourceOutlineView: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
             Spacer(minLength: 4)
-            if row.count > 0 {
+            // `row.count` is a numeric child-count badge, not a collection — empty_count is a false positive here.
+            if row.count > 0 {  // swiftlint:disable:this empty_count
                 Text("\(row.count)")
                     .font(.caption2.monospacedDigit())
                     .foregroundStyle(.secondary)

--- a/fichero/fichero/Views/Library/LibraryViewComponents.swift
+++ b/fichero/fichero/Views/Library/LibraryViewComponents.swift
@@ -184,13 +184,11 @@ struct MailStyleRow: View {
                 )
                 .clipped()
             } else if document.fileType == .image,
-                      let path = document.path, !path.isEmpty,
-                      let nsImage = NSImage(contentsOfFile: path) {
-                // Load image directly from disk — avoids showing OCR text
-                // as a TextPreviewThumbnail when pageContent is non-empty (#1458).
-                Image(nsImage: nsImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
+                      let path = document.path, !path.isEmpty {
+                // Decode off the main thread (cached) — avoids scroll jank from
+                // synchronous NSImage(contentsOfFile:) in body (#1509). Still
+                // skips the OCR-text TextPreviewThumbnail branch for images (#1458).
+                LocalImageThumbnailView(path: path, documentId: document.id)
                     .frame(width: size.width, height: size.height)
                     .clipped()
             } else if let preview = document.pageContent, !preview.isEmpty {
@@ -324,13 +322,11 @@ struct DocumentThumbnailView: View {
                     )
                     .clipped()
                 } else if document.fileType == .image,
-                          let path = document.path, !path.isEmpty,
-                          let nsImage = NSImage(contentsOfFile: path) {
-                    // Load image directly from disk — avoids the TextPreviewThumbnail
-                    // branch showing OCR text when pageContent is non-empty (#1458).
-                    Image(nsImage: nsImage)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
+                          let path = document.path, !path.isEmpty {
+                    // Decode off the main thread (cached) — avoids scroll jank
+                    // from synchronous NSImage(contentsOfFile:) in body (#1509).
+                    // Still skips the OCR-text TextPreviewThumbnail branch (#1458).
+                    LocalImageThumbnailView(path: path, documentId: document.id)
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .clipped()
                 } else if let preview = document.pageContent, !preview.isEmpty {

--- a/fichero/fichero/Views/Library/LocalImageThumbnailView.swift
+++ b/fichero/fichero/Views/Library/LocalImageThumbnailView.swift
@@ -1,0 +1,73 @@
+import AppKit
+import SwiftUI
+
+/// Renders a local image-file thumbnail, decoding off the main thread with a
+/// small in-memory cache. Mirrors `PDFThumbnailView`'s load pattern so library
+/// list/grid scrolling never blocks the main thread on
+/// `NSImage(contentsOfFile:)`. (#1509)
+///
+/// On decode failure (missing or dead path) it falls back to the backend
+/// thumbnail — preserving the spirit of the previous
+/// `let nsImage = NSImage(...)` fall-through, while keeping #1458's rule that
+/// image docs never show their OCR text as a thumbnail.
+struct LocalImageThumbnailView: View {
+    let path: String
+    let documentId: String
+    var contentMode: ContentMode = .fill
+
+    @State private var image: NSImage?
+    @State private var didFail = false
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: contentMode)
+            } else if didFail {
+                // Local file gone — use the backend-generated thumbnail.
+                LibraryImageView(documentId: documentId, imageType: .thumbnail)
+                    .aspectRatio(contentMode: contentMode)
+            } else {
+                // Neutral placeholder while the off-main decode runs.
+                Color(.windowBackgroundColor)
+            }
+        }
+        .task(id: path) {
+            if let cached = LocalImageThumbnailCache.shared.image(forKey: path) {
+                image = cached
+                return
+            }
+            let loaded = await Task.detached(priority: .userInitiated) {
+                NSImage(contentsOfFile: path)
+            }.value
+            if let loaded {
+                LocalImageThumbnailCache.shared.set(loaded, forKey: path)
+                image = loaded
+            } else {
+                didFail = true
+            }
+        }
+    }
+}
+
+/// Process-wide decoded-thumbnail cache keyed by file path. `NSCache` evicts
+/// automatically under memory pressure, so this never grows unbounded.
+/// `@unchecked Sendable`: `NSCache` is documented thread-safe but isn't
+/// annotated `Sendable` by Foundation, so we vouch for it explicitly.
+final class LocalImageThumbnailCache: @unchecked Sendable {
+    static let shared = LocalImageThumbnailCache()
+    private let cache = NSCache<NSString, NSImage>()
+
+    private init() {
+        cache.countLimit = 512
+    }
+
+    func image(forKey key: String) -> NSImage? {
+        cache.object(forKey: key as NSString)
+    }
+
+    func set(_ image: NSImage, forKey key: String) {
+        cache.setObject(image, forKey: key as NSString)
+    }
+}


### PR DESCRIPTION
Overnight Library & Reading Surface lane (batch 1).

## Changes
- #1509 — decode image thumbnails off the main thread (scroll-jank fix)
- #710 — extract ArtifactRichTextCodec + RTF round-trip tests; add missing source + delegation
- Repairs the `FicheroTests` target compile on merged main (was broken)
- Silences an `empty_count` swiftlint false-positive on a numeric badge count in SourceOutlineView (also clears it on main, introduced via #1521)

## Verification (manager gate)
- `swiftlint lint` — 0 error-severity (pre-existing MindPalace length warnings only)
- `xcodebuild ... clean build-for-testing` — **TEST BUILD SUCCEEDED** (app + FicheroTests compile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)