### PR TITLE
fix(api): /children accepts doc:-prefixed document ids (#1345)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/documents.py
+++ b/fichero-engine/src/fichero/api/routes/documents.py
@@ -473,12 +473,16 @@ async def get_children(
     db: Database = Depends(get_library_database),
 ) -> DocumentListResponse:
     """Get child documents."""
-    children = list(db.query(Document, parent_id=doc_id))
+    # Callers (e.g. the catalogue workflow) sometimes pass a doc:-prefixed id
+    # (e.g. "doc:abc123").  Documents are stored with bare hex ids, so strip
+    # the prefix before every DB lookup so both forms resolve correctly (#1345).
+    normalized_id = doc_id.removeprefix("doc:")
+    children = list(db.query(Document, parent_id=normalized_id))
     if not children:
         # Verify parent exists only when there are no children to return.
         # During long-running workflows, a transient parent lookup miss can
         # race with reads; if children exist, prefer returning them over 404.
-        parent = db.get(Document, doc_id)
+        parent = db.get(Document, normalized_id)
         if not parent:
             raise HTTPException(status_code=404, detail=f"Document not found: {doc_id}")
     if limit is not None:

--- a/fichero-engine/tests/unit/test_api.py
+++ b/fichero-engine/tests/unit/test_api.py
@@ -166,6 +166,28 @@ class TestDocumentRoutes:
         assert isinstance(data, list)
         assert len(data) == 1
 
+    def test_get_children_doc_prefix(self, client, db, sample_doc, sample_collection):
+        """GET /children accepts a doc:-prefixed id and returns the same result (#1345).
+
+        During folder catalogue runs the caller sometimes URL-encodes a
+        ``doc:<hex>`` id (e.g. ``doc%3Acoll123``). FastAPI decodes the percent
+        encoding, leaving the literal ``doc:`` prefix in the path parameter.
+        The handler must strip the prefix before the DB lookup, otherwise the
+        exact-match query misses and returns 404.
+        """
+        db.save(sample_collection)
+        sample_doc.parent_id = sample_collection.id
+        db.save(sample_doc)
+
+        # Simulate caller passing the doc:-prefixed form
+        prefixed_id = f"doc:{sample_collection.id}"
+        response = client.get(f"/api/documents/{prefixed_id}/children")
+        assert response.status_code == 200
+        data = response.json()["items"]
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["id"] == sample_doc.id
+
     def test_create_document(self, client, db):
         """Create document returns new document."""
         response = client.post("/api/documents", json={


### PR DESCRIPTION
## Issue
- #1345 (P1) — `GET /api/documents/{id}/children` 404s during folder catalogue runs when the id carries a `doc:` prefix (URL-encoded `doc%3A…`).

## Fix
`get_children` now strips the prefix (`doc_id.removeprefix("doc:")`) before the `db.query(parent_id=…)` / `db.get(…)` lookups; original id preserved in the 404 message. Smallest in-place change, consistent with sibling endpoints.

## Verification (manager gate)
- `ruff check` — clean
- `pytest test_api.py -k children` — 2 passed (incl. new `test_get_children_doc_prefix`)
- Full suite green on the isolated worktree (3725 passed; only the known `test_background_tasks` random-order flake, which clears deterministically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)