### PR TITLE
feat(search): page-scoped indexed search hits with proper ranking (#1478)

### DIFF
--- a/fichero-engine/src/fichero/db.py
+++ b/fichero-engine/src/fichero/db.py
@@ -822,6 +822,30 @@ class Database(DatabaseEmbeddingMixin):
         """Wrap the free helper so callers don't reach into module level."""
         return _collect_folder_descendants_helper(self.conn, folder_id)
 
+    def _has_indexed_page_children(self, document_id: str | None) -> bool:
+        """True when a file-level document has page children in the vector index.
+
+        Search should rank and return the matching page rows when they exist,
+        not the parent PDF's whole-document text blob. If a legacy library has
+        only the parent embedded, keep the parent result so search still works.
+        """
+        if not document_id:
+            return False
+
+        try:
+            from fichero.models import DocType, Document
+
+            doc = self.get(Document, document_id)
+            if doc is None or doc.doc_type != DocType.file:
+                return False
+
+            pages = self.query(Document, parent_id=document_id, doc_type=DocType.page)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Page-child lookup failed for search result %s: %s", document_id, exc)
+            return False
+
+        return any(self.has_embedding(page.id) for page in pages)
+
     def enrich_search_results_with_kg(
         self, results: list[SearchResult], query: str
     ) -> list[SearchResult]:
@@ -1050,6 +1074,10 @@ class Database(DatabaseEmbeddingMixin):
 
                     # Convert to SearchResult, filter by score
                     for r in raw_results:
+                        document_id = r.get("document_id") or r.get("id")
+                        if self._has_indexed_page_children(document_id):
+                            continue
+
                         # LanceDB returns _distance (L2; lower is better).
                         # Vectors are L2-normalised at index + query time
                         # (see db_embeddings._l2_normalize), so L2² = 2 - 2·cos.
@@ -1066,7 +1094,7 @@ class Database(DatabaseEmbeddingMixin):
 
                         semantic_results.append(
                             {
-                                "document_id": r.get("document_id") or r.get("id"),
+                                "document_id": document_id,
                                 "score": score,
                                 "content": r.get("text", ""),
                                 "metadata": {
@@ -1113,14 +1141,17 @@ class Database(DatabaseEmbeddingMixin):
 
                         # Convert to results format
                         for _, row in fulltext_docs.sort_values("bm25", ascending=False).iterrows():
+                            document_id = row.get("document_id") or row.get("id")
+                            if self._has_indexed_page_children(document_id):
+                                continue
+
                             lexical_score = float(row.get("bm25", 0.0))
                             normalised = (
                                 lexical_score / max_bm25 if max_bm25 > 0 else 1.0
                             )
                             fulltext_results.append(
                                 {
-                                    "document_id": row.get("document_id")
-                                    or row.get("id"),
+                                    "document_id": document_id,
                                     "score": max(0.0, min(1.0, normalised)),
                                     "content": row.get("text", ""),
                                     "metadata": {

--- a/fichero-engine/tests/unit/test_backend_integration.py
+++ b/fichero-engine/tests/unit/test_backend_integration.py
@@ -14,7 +14,7 @@ from unittest.mock import patch, MagicMock
 
 from fichero.db import Database, SearchResult
 from fichero.knowledge_models import KnowledgeClaim, KnowledgeEntity
-from fichero.models import Document
+from fichero.models import DocType, Document, FileType
 from fichero.ingest import ingest_file, ingest_folder, IngestMode
 
 
@@ -70,6 +70,93 @@ class TestDatabaseSearch:
         assert len(results) >= 1
         assert total_count >= 1
         assert results[0].document_id == doc.id
+        db.close()
+
+    def test_search_prefers_indexed_pdf_pages_over_parent_document(self, tmp_path):
+        """PDF search should return page-scoped hits when page embeddings exist."""
+        db = Database(tmp_path / "test.duckdb")
+
+        parent = Document(
+            id="pdf-parent",
+            name="archive.pdf",
+            doc_type=DocType.file,
+            file_type=FileType.pdf,
+            page_content=(
+                "Whole PDF text blob mentioning Camilo. "
+                "This should not be returned when pages are indexed."
+            ),
+        )
+        page1 = Document(
+            id="pdf-parent-page-1",
+            parent_id=parent.id,
+            name="archive.pdf - Page 1",
+            doc_type=DocType.page,
+            sequence=1,
+            page_content="A page about unrelated correspondence.",
+        )
+        page2 = Document(
+            id="pdf-parent-page-2",
+            parent_id=parent.id,
+            name="archive.pdf - Page 2",
+            doc_type=DocType.page,
+            sequence=2,
+            page_content="Camilo appears in this passage with context.",
+        )
+        db.save(parent)
+        db.save(page1)
+        db.save(page2)
+
+        query_vector = [1.0, 0.0]
+        db.save_embedding(parent, query_vector, parent.page_content)
+        db.save_embedding(page1, [0.0, 1.0], page1.page_content)
+        db.save_embedding(page2, query_vector, page2.page_content)
+
+        with patch.object(db, "_embed_text", return_value=query_vector):
+            results, total_count, _stats = db.search(
+                "Camilo",
+                min_score=0.55,
+                search_type="semantic",
+            )
+
+        assert total_count == 1
+        assert [result.document_id for result in results] == [page2.id]
+        assert results[0].content_preview == page2.page_content
+        db.close()
+
+    def test_search_keeps_pdf_parent_when_page_children_are_not_indexed(self, tmp_path):
+        """Legacy libraries with only parent embeddings still return results."""
+        db = Database(tmp_path / "test.duckdb")
+
+        parent = Document(
+            id="pdf-parent",
+            name="archive.pdf",
+            doc_type=DocType.file,
+            file_type=FileType.pdf,
+            page_content="Whole PDF text blob mentioning Camilo.",
+        )
+        page = Document(
+            id="pdf-parent-page-1",
+            parent_id=parent.id,
+            name="archive.pdf - Page 1",
+            doc_type=DocType.page,
+            sequence=1,
+            page_content="Camilo appears here but has no embedding yet.",
+        )
+        db.save(parent)
+        db.save(page)
+
+        query_vector = [1.0, 0.0]
+        db.save_embedding(parent, query_vector, parent.page_content)
+
+        with patch.object(db, "_embed_text", return_value=query_vector):
+            results, total_count, _stats = db.search(
+                "Camilo",
+                min_score=0.55,
+                search_type="semantic",
+            )
+
+        assert total_count == 1
+        assert [result.document_id for result in results] == [parent.id]
         db.close()
 
     def test_search_empty_query_returns_empty(self, tmp_path):


### PR DESCRIPTION
Overnight Search lane.

## Issue
- #1478 — search returned whole-document / too many results. Now returns page-scoped indexed hits with proper embedding ranking.

## Verification (manager gate)
- `ruff check` clean; pytest **3732 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)