### PR TITLE
feat: View-menu pane toggles (#1215) + order children by sort_order (#572)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/documents.py
+++ b/fichero-engine/src/fichero/api/routes/documents.py
@@ -193,6 +193,17 @@ def _workspace_doc_or_404(db: Database, doc_id: str) -> Document:
     return doc
 
 
+def _ordered_by_sort_order(docs: list[Document]) -> list[Document]:
+    """Order documents by ``sort_order`` ASC, then ``name`` ASC (#572).
+
+    The drag-drop reorder endpoint persists ``sort_order`` per document; list
+    endpoints sort by it so the client doesn't have to re-sort and a dragged
+    position survives a refresh. Reorder-unaware siblings tie at 0 and fall
+    through to case-insensitive name order, preserving the old default.
+    """
+    return sorted(docs, key=lambda d: (d.sort_order, (d.name or "").lower()))
+
+
 def _normalize_curated_items(items: list[Any] | None) -> list[dict[str, Any]]:
     normalized: list[dict[str, Any]] = []
     for item in items or []:
@@ -271,6 +282,10 @@ async def list_documents(
     else:
         docs = list(db.all(Document))
 
+    # Order by user-defined sort_order before paginating so drag-drop
+    # positions survive a refresh and clients don't re-sort (#572).
+    docs = _ordered_by_sort_order(docs)
+
     # Apply pagination (if limit is specified)
     if limit is not None:
         items = docs[offset : offset + limit]
@@ -284,14 +299,14 @@ async def list_collections(
     db: Database = Depends(get_library_database),
 ) -> DocumentListResponse:
     """List all root-level items (documents without parents)."""
-    items = list(db.query(Document, parent_id=None))
+    items = _ordered_by_sort_order(list(db.query(Document, parent_id=None)))
     return DocumentListResponse(items=items, count=len(items))
 
 
 @router.get("/roots")
 async def list_roots(db: Database = Depends(get_library_database)) -> DocumentListResponse:
     """List root documents (no parent)."""
-    items = list(db.query(Document, parent_id=None))
+    items = _ordered_by_sort_order(list(db.query(Document, parent_id=None)))
     return DocumentListResponse(items=items, count=len(items))
 
 
@@ -477,7 +492,7 @@ async def get_children(
     # (e.g. "doc:abc123").  Documents are stored with bare hex ids, so strip
     # the prefix before every DB lookup so both forms resolve correctly (#1345).
     normalized_id = doc_id.removeprefix("doc:")
-    children = list(db.query(Document, parent_id=normalized_id))
+    children = _ordered_by_sort_order(list(db.query(Document, parent_id=normalized_id)))
     if not children:
         # Verify parent exists only when there are no children to return.
         # During long-running workflows, a transient parent lookup miss can

--- a/fichero-engine/tests/unit/test_routes_documents.py
+++ b/fichero-engine/tests/unit/test_routes_documents.py
@@ -183,6 +183,67 @@ class TestGetChildren:
 
 
 # ---------------------------------------------------------------------------
+# Ordering: list + children honour sort_order (#572)
+# ---------------------------------------------------------------------------
+
+
+def _make_ordered_doc(db, name, sort_order, parent_id=None):
+    doc = Document(
+        name=name, parent_id=parent_id, doc_type=DocType.file, sort_order=sort_order
+    )
+    db.save(doc)
+    return doc
+
+
+class TestSortOrder:
+    """After a reorder persists sort_order, list endpoints must return rows in
+    sort_order ASC, name ASC order so the client doesn't have to re-sort and the
+    drag-drop position survives refresh (#572)."""
+
+    def test_children_ordered_by_sort_order(self, client, db):
+        parent = _make_doc(db, "Parent")
+        # Inserted out of order; sort_order should drive the result order.
+        _make_ordered_doc(db, "Zebra", sort_order=0, parent_id=parent.id)
+        _make_ordered_doc(db, "Apple", sort_order=1, parent_id=parent.id)
+        _make_ordered_doc(db, "Mango", sort_order=2, parent_id=parent.id)
+        r = client.get(f"/api/documents/{parent.id}/children")
+        assert r.status_code == 200
+        names = [d["name"] for d in r.json()["items"]]
+        assert names == ["Zebra", "Apple", "Mango"]
+
+    def test_children_tie_breaks_by_name(self, client, db):
+        parent = _make_doc(db, "Parent")
+        # Reorder-unaware siblings all tie at sort_order 0 → fall back to name.
+        _make_ordered_doc(db, "Charlie", sort_order=0, parent_id=parent.id)
+        _make_ordered_doc(db, "Alpha", sort_order=0, parent_id=parent.id)
+        _make_ordered_doc(db, "Bravo", sort_order=0, parent_id=parent.id)
+        r = client.get(f"/api/documents/{parent.id}/children")
+        names = [d["name"] for d in r.json()["items"]]
+        assert names == ["Alpha", "Bravo", "Charlie"]
+
+    def test_list_documents_ordered_by_sort_order(self, client, db):
+        parent = _make_doc(db, "Parent")
+        _make_ordered_doc(db, "Third", sort_order=2, parent_id=parent.id)
+        _make_ordered_doc(db, "First", sort_order=0, parent_id=parent.id)
+        _make_ordered_doc(db, "Second", sort_order=1, parent_id=parent.id)
+        r = client.get(f"/api/documents?parent_id={parent.id}")
+        names = [d["name"] for d in r.json()["items"]]
+        assert names == ["First", "Second", "Third"]
+
+    def test_reorder_then_children_reflects_new_order(self, client, db):
+        parent = _make_doc(db, "Parent")
+        a = _make_ordered_doc(db, "A", sort_order=0, parent_id=parent.id)
+        b = _make_ordered_doc(db, "B", sort_order=1, parent_id=parent.id)
+        c = _make_ordered_doc(db, "C", sort_order=2, parent_id=parent.id)
+        # Move C to the front.
+        resp = client.post("/api/documents/reorder", json=[c.id, a.id, b.id])
+        assert resp.status_code == 200
+        r = client.get(f"/api/documents/{parent.id}/children")
+        names = [d["name"] for d in r.json()["items"]]
+        assert names == ["C", "A", "B"]
+
+
+# ---------------------------------------------------------------------------
 # GET /api/documents/{doc_id}/ancestors
 # ---------------------------------------------------------------------------
 

--- a/fichero/fichero/App/ViewSettings.swift
+++ b/fichero/fichero/App/ViewSettings.swift
@@ -133,4 +133,13 @@ extension FocusedValues {
     /// the View-menu "Show/Hide Inspector" command toggles only the focused
     /// window — not every open window (#1451).
     @Entry var showInspector: Binding<Bool>?
+
+    /// Per-window visibility of the major reading-surface panes, published by
+    /// the focused ContentView so the View menu mirrors the toolbar toggles
+    /// for each pane (#1215). Same per-window rationale as `showInspector`:
+    /// each binds the focused window's @SceneStorage flag.
+    @Entry var showDocumentGrid: Binding<Bool>?
+    @Entry var showDocumentCanvas: Binding<Bool>?
+    /// The WebKit/reading content pane (transcript surface).
+    @Entry var showReadingPane: Binding<Bool>?
 }

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -319,6 +319,11 @@ struct ContentView: View {
                 // column (always present) rather than the sidebar, which leaves
                 // the hierarchy when collapsed and made ⌘⌥I no-op (#1513/#1451).
                 .focusedSceneValue(\.showInspector, $showInspectorSidebar)
+                // Publish the reading-surface pane toggles so the View menu can
+                // mirror the toolbar buttons for each pane (#1215).
+                .focusedSceneValue(\.showDocumentGrid, $showDocumentGrid)
+                .focusedSceneValue(\.showDocumentCanvas, $showDocumentCanvas)
+                .focusedSceneValue(\.showReadingPane, $showReadingPane)
         }
         // Avoid duplicate generic per-column title pills in macOS split view.
         .navigationTitle(toolbarTitle)

--- a/fichero/fichero/Views/Menu/ViewMenuCommands.swift
+++ b/fichero/fichero/Views/Menu/ViewMenuCommands.swift
@@ -29,6 +29,8 @@ struct ViewMenuCommands: View {
 
         InspectorButton()
 
+        PaneVisibilitySection()
+
         Divider()
 
         SelectionDrivenLayoutToggle()
@@ -501,6 +503,70 @@ struct InspectorButton: View {
         }
         .keyboardShortcut("i", modifiers: [.command, .option])
         .disabled(showInspector == nil)
+    }
+}
+
+// MARK: - Pane Visibility Section
+
+/// View-menu items that mirror the reading-surface pane toggles already present
+/// as toolbar buttons (#1215). Each reads the focused window's pane-visibility
+/// binding via FocusedValues so the command is per-window (same rationale as
+/// `InspectorButton`) and stays in sync with the toolbar. A binding is only
+/// published while its window is focused, so each item disables when no
+/// reading-capable window is key.
+struct PaneVisibilitySection: View {
+    @FocusedValue(\.showDocumentGrid) private var showDocumentGrid
+    @FocusedValue(\.showDocumentCanvas) private var showDocumentCanvas
+    @FocusedValue(\.showReadingPane) private var showReadingPane
+
+    var body: some View {
+        Section("Panes") {
+            PaneToggleButton(
+                binding: showDocumentGrid,
+                showLabel: "Show Document Grid",
+                hideLabel: "Hide Document Grid",
+                icon: "rectangle.split.2x1",
+                shortcut: KeyboardShortcut("g", modifiers: [.command, .shift])
+            )
+            PaneToggleButton(
+                binding: showDocumentCanvas,
+                showLabel: "Show Document Canvas",
+                hideLabel: "Hide Document Canvas",
+                icon: "doc.richtext",
+                shortcut: nil
+            )
+            PaneToggleButton(
+                binding: showReadingPane,
+                showLabel: "Show Reading Pane",
+                hideLabel: "Hide Reading Pane",
+                icon: "text.book.closed",
+                shortcut: nil
+            )
+        }
+    }
+}
+
+/// Reusable Show/Hide pane command. Mirrors `InspectorButton`: toggles the
+/// focused window's binding and disables when no window publishes it.
+struct PaneToggleButton: View {
+    let binding: Binding<Bool>?
+    let showLabel: String
+    let hideLabel: String
+    let icon: String
+    let shortcut: KeyboardShortcut?
+
+    private var isVisible: Bool {
+        binding?.wrappedValue ?? false
+    }
+
+    var body: some View {
+        Button {
+            binding?.wrappedValue.toggle()
+        } label: {
+            Label(isVisible ? hideLabel : showLabel, systemImage: icon)
+        }
+        .keyboardShortcut(shortcut)
+        .disabled(binding == nil)
     }
 }
 


### PR DESCRIPTION
Overnight Library & Reading Surface lane (batch 3).

## Issues
- #1215 — View menu gains pane-visibility items mirroring the toolbar toggles
- #572 — document list/children endpoints ordered by sort_order (backend)

## Verification (manager gate)
- backend: `ruff check` clean; pytest **3734 passed, 0 failed**
- frontend: `swiftlint` 0 errors; `xcodebuild ... clean build` **BUILD SUCCEEDED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)