### PR TITLE
docs(thinking-layer): record Workspace decisions + node-class/prototype direction

### DIFF
--- a/docs/architecture/thinking-layer.md
+++ b/docs/architecture/thinking-layer.md
@@ -110,13 +110,32 @@ Foundational backend first, then Thing 1, then Thing 2, then visibility/notes.
 12. **(fe)** Standalone Notes Browser (`NotesBrowserView`).
 13. **(fe)** Entity bio note in entity inspector (#1484–#1486 series).
 
-## Open questions (need Daniel's call before building the dependent issues)
+## Resolved decisions (Daniel, 2026-06-02)
 
-1. **Workspace == extended ResearchProject, or its own model?** (`Project`/`ProjectInclusion` already exist as an alternative.) Blueprint default: one `WorkspaceContainerView`, browser as a toggleable mode.
-2. **Does a workspace appear in the main library folder tree, or only in the Workspace sidebar mode?** (`is_workspace` supports either.)
-3. **"Book with chapters" — workspace sub-structure, or its own model type?** (Reuse `BookStructureNode`, or a new authoring-outline model?)
-4. **Source Outline — replace the existing inspector tabs, or sit alongside?**
-5. **Spatial view — a view-mode toggle inside the workspace, or a dedicated tab?** (Interacts with how #1455 resolves.)
+1. **Workspace is its OWN container, NOT an extended `ResearchProject`.** `ResearchProject` is the **AI research-agent** surface (browser + tasks + agent); a workspace is a **place to store and link materials** (sources, entities, people, notes, annotations, maps). A ResearchProject may *dock inside* a workspace or stand alone — different object. Workspace = `is_workspace` Document + `curated_items` (aliases).
+2. **Workspace lives in the library folder tree** as a special, movable folder — **and workspaces nest (sub-workspaces).** Also reachable via a Workspace sidebar mode. One source of truth, two doors in.
+3. **`BookStructureNode` is for a *source* book being analysed, NOT the workspace's own structure.** The workspace is **not a book-writing app** — it's a **materials store**. Its internal organisation comes from the **node-class + grouping/hierarchy system** (below) and is shown via **map / table / list / generated-outline** views.
+4. **Source Outline sits ALONGSIDE** the existing inspector tabs — a new additive `InspectorTab.outline`. Never replace working tabs (iterate-not-replace).
+5. **Spatial is a VIEW MODE, not a destination.** A workspace (and the library) offers map/table/list/outline as switchable views. The standalone **Mind Palace concept is retired** and becomes the **2D map (SceneKit) + 3D map (RealityKit)** view modes — see #1455 / #1569.
+
+### Workspace charter (refined)
+A workspace is a **typed, nestable bag of aliases + own notes**, viewable as **map / table / list / generated-outline**, **searchable + filterable**, with **links between items**. The researcher *grabs* pieces (sources, pages, entities, people, annotations, maps — anything) into it by alias (never copies; library stays canonical, #1487) and can also add free-standing items (notes, etc.) directly. It is a place to **store and connect materials**, the bridge from reading to writing — *not* an authoring/word-processor surface.
+
+## Node-class / prototype system (Tinderbox-style) — foundational direction (#1570)
+
+Daniel's key insight: typing isn't just a workspace nicety — it's **how we decide that a set of pages *is* an archival container** (a chapter, a book, an archive unit). We need:
+
+1. **A node class system** — any node carries a **class** (Person, Place, Source, Note, Map, Argument, Container, …) that confers **attributes (custom fields), default view, and allowed actions** — Tinderbox "prototype" semantics: changing the class changes what the node can do/show.
+2. **Grouping** — combine nodes into a **bigger thing** (a composite/container node).
+3. **Hierarchy** — lay nodes into a **nested** structure (parent/child), like folders/chapters.
+
+**Fichero is already half-way there:** fixed types exist everywhere (`DocType`, `EntityType`, `NoteKind`) and #874 shipped a **user-extensible entity-type registry** — the prototype pattern, proven. The move is to **generalise #874 into a node-class/prototype registry** spanning all node kinds.
+
+**Build order (decided): Phase 1 → then go broad (Phase 2).**
+- **Phase 1 — workspace items only.** Add a user-definable **class/prototype** to workspace `curated_items` + workspace-authored notes. Class drives table columns, map shape/colour, and the generated outline. Reuse the #874 registry pattern. Leaves the `Document`/`KnowledgeEntity` god-nodes untouched. Provable in isolation.
+- **Phase 2 — general node-class system.** Promote class/prototype + grouping + hierarchy to a first-class concept across Documents, entities, notes, pages — so "these pages form a chapter / this is an archival container" is expressed by class + grouping, not ad-hoc. Touches the god-node schema; a dedicated architectural epic.
+
+Phase 1 ships value now and de-risks Phase 2; Phase 2 is where the archival-container grouping lives.
 
 ## CONSTITUTION.md addition (proposed)
 


### PR DESCRIPTION
Docs-only design capture.