### PR TITLE
fix(crash): forward WorkflowExecutionObserver into ContentView host (#1561)

### DIFF
--- a/fichero/fichero/Views/DocumentTabView.swift
+++ b/fichero/fichero/Views/DocumentTabView.swift
@@ -24,6 +24,11 @@ struct DocumentTabView: View {
     @EnvironmentObject var storageService: StorageServiceGenerated
     @EnvironmentObject var windowState: WindowState
 
+    // @Observable objects injected by LibraryWindow — must be forwarded explicitly
+    // when ContentView() is constructed below (SwiftUI does not re-propagate
+    // @Environment(T.self) values across an explicit .environmentObject() chain).
+    @Environment(WorkflowExecutionObserver.self) var executionObserver
+
     // Get the library reference
     private var library: LibraryManager.LibraryReference? {
         LibraryManager.shared.getLibrary(id: libraryId)
@@ -91,6 +96,13 @@ struct DocumentTabView: View {
                     .environmentObject(documentService)
                     .environmentObject(storageService)
                     .environmentObject(windowState)
+                    // Forward the @Observable observer so ContentView and its subtree
+                    // (DocumentInspector → ArtifactEntityViews) can read it via
+                    // @Environment(WorkflowExecutionObserver.self). Without this the
+                    // environment chain breaks at the ContentView() host and crashes
+                    // with "No Observable object of type WorkflowExecutionObserver found."
+                    // (#1561). Single shared instance — no new object created here.
+                    .environment(executionObserver)
 
             case .workflow:
                 // Workflow tab view (will create later)


### PR DESCRIPTION
P1 crash fix. Selecting a catalogued document and opening its inspector/artifacts hard-crashed with `No Observable object of type WorkflowExecutionObserver found`.

## Root cause
`DocumentTabView` constructs `ContentView()` with an explicit `.environmentObject(...)` chain, which breaks automatic `@Environment(WorkflowExecutionObserver.self)` propagation. `LibraryWindow.swift:61` injected the observer onto `DocumentTabView`, but `DocumentTabView` never forwarded it to `ContentView` — so `ContentView` → `DocumentInspector` → `ArtifactEntityViews` crashed on access.

## Fix
`DocumentTabView.swift`: read the observer from the environment and forward `.environment(executionObserver)` onto `ContentView()`. **Single shared instance** — no new `WorkflowExecutionObserver()` created (would split state). 12 lines, one file.

## Verification (manager gate)
- `swiftlint` — 0 error-severity
- `xcodebuild ... clean build` — **BUILD SUCCEEDED**

🤖 Generated with [Claude Code](https://claude.com/claude-code)