### PR TITLE
fix: entities endpoint honors per-page source_document_ids (#1562 read-side)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/entities.py
+++ b/fichero-engine/src/fichero/api/routes/entities.py
@@ -339,9 +339,23 @@ async def list_entities(
         for c in doc_claims:
             entity_ids.update(c.entity_ids or [])
 
-        # Fetch those entities
+        # Fetch the claim-referenced entities.
         entities = [db.get(KnowledgeEntity, eid) for eid in entity_ids]
         entities = [e for e in entities if e is not None]
+
+        # #1562 — belt-and-suspenders union: also include entities whose
+        # own per-page scope (source_document_ids, recorded at upsert by
+        # _entity_writer) intersects the requested doc scope. This covers
+        # the case where an entity's CLAIMS carry the PARENT id (legacy /
+        # non-aggregate flow) but the entity itself was scoped to a page,
+        # so per-page table views still surface it. Dedup by entity id.
+        seen_ids = {e.id for e in entities}
+        for entity in db.all(KnowledgeEntity):
+            if entity.id in seen_ids:
+                continue
+            if doc_ids.intersection(entity.source_document_ids or []):
+                entities.append(entity)
+                seen_ids.add(entity.id)
     else:
         entities = (
             db.query(KnowledgeEntity, entity_type=entity_type)

--- a/fichero-engine/tests/unit/test_routes_entities.py
+++ b/fichero-engine/tests/unit/test_routes_entities.py
@@ -147,6 +147,57 @@ class TestListEntities:
             "Louise Livingstone",
         }
 
+    def test_filter_by_page_honors_entity_source_document_ids(self, client, db):
+        """#1562 read-side — an entity scoped to a page via
+        ``source_document_ids`` surfaces for that page even when its
+        CLAIMS point at the PARENT doc (legacy / non-aggregate flow)."""
+        from datetime import datetime
+
+        from fichero.knowledge_models import KnowledgeClaim, KnowledgeEntity
+        from fichero.models import DocType, Document
+
+        parent = Document(name="Chapter.pdf", doc_type=DocType.file)
+        page1 = Document(name="page 1", doc_type=DocType.page, parent_id=parent.id)
+        page2 = Document(name="page 2", doc_type=DocType.page, parent_id=parent.id)
+        db.save(parent)
+        db.save(page1)
+        db.save(page2)
+
+        # Entity scoped to page1 via the merged write-side field, but its
+        # claim carries the PARENT id (the exact #1562 failure mode).
+        ada = KnowledgeEntity(
+            canonical_name="Ada Lovelace",
+            entity_type=EntityType.person,
+            aliases=[],
+            source_document_ids=[page1.id],
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        db.save(ada)
+        db.save(
+            KnowledgeClaim(
+                text="Ada appears.",
+                source_document_id=parent.id,
+                entity_ids=[ada.id],
+            )
+        )
+
+        # Querying page1 returns Ada (via source_document_ids union)...
+        r = client.get(f"/api/entities?document_id={page1.id}")
+        assert r.status_code == 200
+        assert {e["canonical_name"] for e in r.json()["items"]} == {"Ada Lovelace"}
+
+        # ...but page2 does NOT — Ada was never scoped to it.
+        r = client.get(f"/api/entities?document_id={page2.id}")
+        assert r.status_code == 200
+        assert {e["canonical_name"] for e in r.json()["items"]} == set()
+
+        # The parent query still returns the compiled (union) set: the
+        # parent-scoped claim already references Ada.
+        r = client.get(f"/api/entities?document_id={parent.id}")
+        assert r.status_code == 200
+        assert {e["canonical_name"] for e in r.json()["items"]} == {"Ada Lovelace"}
+
     def test_default_list_hides_bare_dates_but_search_can_find_them(self, client, db):
         _make_entity(db, "Alice", EntityType.person)
         _make_entity(db, "1960", EntityType.other)


### PR DESCRIPTION
## What
Extends `list_entities`' `document_id` branch to return the UNION of (a) entities referenced by claims scoped to the requested doc + descendants (existing), and (b) entities whose own `source_document_ids` intersects that scope (new — uses the #1562 entity field merged earlier). Dedup by id; no-filter path untouched.

## Why
Read-side hygiene for #1562 so `/api/entities?document_id=` honors per-page entity scope even when an entity's claims carry the parent id. (The inspector's own path — `/api/documents/{id}/knowledge-graph` — is claim-scoped and is addressed by the write-path fix.)

## Gate
- ruff: clean
- `test_routes_entities.py`: 31 passed (new RED→GREEN `test_filter_by_page_honors_entity_source_document_ids`)
- full unit suite: 3741 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)