### PR TITLE
fix: catalogue stamps custom-entity claims per-child doc id (#1562 write-path)

### DIFF
--- a/fichero-engine/src/fichero/workflows/tools/extract_all.py
+++ b/fichero-engine/src/fichero/workflows/tools/extract_all.py
@@ -565,7 +565,7 @@ def _load_registry_types(db, library_path: str) -> list[str]:
 def _persist_additional_entities(
     db,
     additional_entities: dict[str, list[str]],
-    container_id: str,
+    target_doc_id: str,
 ) -> None:
     """Persist names extracted for custom registry types as KnowledgeEntity rows.
 
@@ -574,7 +574,15 @@ def _persist_additional_entities(
     appears under multiple custom types preserves all of them). Also writes a
     minimal KnowledgeClaim linking the entity to the source document so it
     participates in "which documents mention X?" queries just like built-in types.
+
+    `target_doc_id` is the per-child page/image doc id when cataloguing a folder
+    or multi-page PDF (the caller iterates chunks and passes each chunk's
+    `page_doc_id or container.id`), so both the provenance claim's
+    source_document_id and the entity's accumulated source_document_ids land on
+    the right child — the parent then compiles the union via descendants
+    (#1562 write-path).
     """
+    container_id = target_doc_id
     from fichero.knowledge_models import KnowledgeEntity, EntityType
     from fichero.workflows.tools._entity_writer import save_claim
 
@@ -595,10 +603,10 @@ def _persist_additional_entities(
                     existing_keys = [*existing_keys, type_key]
                     e.metadata = {**e.metadata, "custom_entity_type_keys": existing_keys}
                     changed = True
-                # #1562 — record the source page/doc scope. NOTE: this call
-                # site only has the container/doc id (additional_entities are
-                # merged across all chunks before persisting), so we scope to
-                # container_id here rather than a per-page target_doc_id.
+                # #1562 — record the source page/doc scope. The caller now
+                # passes the per-child target_doc_id (page/image), so this
+                # accumulates each child the name was extracted from; the parent
+                # compiles the union across descendants.
                 if container_id and container_id not in (e.source_document_ids or []):
                     e.source_document_ids = [*(e.source_document_ids or []), container_id]
                     changed = True
@@ -610,7 +618,8 @@ def _persist_additional_entities(
                     canonical_name=name,
                     entity_type=EntityType.other,
                     metadata={"custom_entity_type_keys": [type_key]},
-                    # #1562 — only the container/doc id is in scope here.
+                    # #1562 — scope to the per-child target_doc_id supplied by
+                    # the caller (page/image), not the parent container.
                     source_document_ids=[container_id] if container_id else [],
                 )
                 db.save(entity)
@@ -1843,27 +1852,50 @@ async def extract_all(
                         run_id=state.get("task_id"),
                     ))
             # Persist custom entity types from the registry (#1240).
+            #
+            # #1562 write-path: scope each custom-entity name to the CHILD doc
+            # (page/image) it was extracted from, not the parent container. We
+            # accumulate per target_doc_id (page_doc_id or container.id) so a
+            # name found on page 2 stamps page 2's id on both the provenance
+            # claim and the entity's source_document_ids. Merging across all
+            # chunks first (the old behaviour) collapsed everything onto the
+            # folder, which is exactly the bug — selecting a child then showed
+            # no per-child custom entities and the parent could not compile a
+            # real descendant union.
             if custom_entity_types and persist_kg:
                 custom_entity_type_set = set(custom_entity_types)
-                # Use sets while accumulating to keep dedup O(n).
-                seen: dict[str, set[str]] = {}
+                # target_doc_id → {type_key → set(names)}; sets keep dedup O(n).
+                by_doc: dict[str, dict[str, set[str]]] = {}
                 for chunk_idx, cr in enumerate(chunk_results):
                     await _yield_page_work(
                         "custom entity merge",
                         chunk_idx,
                         len(chunk_results),
                     )
+                    page_doc_id = (
+                        page_doc_ids[chunk_idx]
+                        if chunk_idx < len(page_doc_ids)
+                        else None
+                    )
+                    target_doc_id = page_doc_id or container.id
                     for type_key, names in (cr.get("additional_entities") or {}).items():
                         if type_key not in custom_entity_type_set:
                             continue
-                        bucket = seen.setdefault(type_key, set())
+                        bucket = by_doc.setdefault(target_doc_id, {}).setdefault(
+                            type_key, set()
+                        )
                         for name in (names or []):
                             name = name.strip() if isinstance(name, str) else ""
                             if name:
                                 bucket.add(name)
-                merged_additional = {k: list(v) for k, v in seen.items() if v}
-                if merged_additional:
-                    _persist_additional_entities(db, merged_additional, container.id)
+                for target_doc_id, type_map in by_doc.items():
+                    merged_additional = {
+                        k: list(v) for k, v in type_map.items() if v
+                    }
+                    if merged_additional:
+                        _persist_additional_entities(
+                            db, merged_additional, target_doc_id
+                        )
 
             # Drain the queued artifact writes before this node returns
             # — downstream folder-cleanup nodes read these artifacts.

--- a/fichero-engine/tests/unit/workflows/test_extract_all_registry.py
+++ b/fichero-engine/tests/unit/workflows/test_extract_all_registry.py
@@ -8,7 +8,12 @@ Covers:
 
 from __future__ import annotations
 
+import pytest
+
 from fichero.knowledge_models import KnowledgeEntity, KnowledgeClaim, EntityType, LibraryEntityType
+from fichero.llm import LLMConfig
+from fichero.models import DocType, Document
+from fichero.workflows.tools import extract_all as extract_all_module
 from fichero.workflows.tools.extract_all import (
     _load_registry_types,
     _build_instructions,
@@ -164,3 +169,123 @@ class TestPersistAdditionalEntities:
         keys = all_entities[0].metadata.get("custom_entity_type_keys", [])
         assert "crops" in keys
         assert "grains" in keys
+
+
+class TestCustomEntityPerChildScope:
+    """#1562 write-path: custom-registry entities extracted while cataloguing a
+    FOLDER (or multi-page PDF) must carry the PER-CHILD document id on their
+    provenance claim and source_document_ids — not the parent container id.
+
+    Before the fix, `extract_all` merged `additional_entities` across all chunks
+    and called `_persist_additional_entities` once with `container.id`, so every
+    custom-entity claim landed on the folder. Selecting a single child then
+    showed no per-child custom entities, and the parent could only ever show a
+    flat folder-scoped blob rather than a true union compiled from descendants.
+    """
+
+    @pytest.mark.asyncio
+    async def test_folder_catalogue_scopes_custom_entities_per_child(
+        self, db, test_package, monkeypatch
+    ):
+        folder = Document(name="Folder", path="/tmp/f", doc_type=DocType.folder)
+        page1 = Document(
+            name="p1", path="/tmp/f/p1.png", doc_type=DocType.page, parent_id=None
+        )
+        page2 = Document(
+            name="p2", path="/tmp/f/p2.png", doc_type=DocType.page, parent_id=None
+        )
+        page1.parent_id = folder.id
+        page2.parent_id = folder.id
+        db.save(folder)
+        db.save(page1)
+        db.save(page2)
+
+        lib_path = str(test_package)
+        db.save(LibraryEntityType(library_id=lib_path, entity_type_key="crops", enabled=True))
+        db.save(LibraryEntityType(library_id=lib_path, entity_type_key="minerals", enabled=True))
+
+        # Mock the LLM so each page yields a DIFFERENT custom entity: page1 ->
+        # "wheat" (crops), page2 -> "silver" (minerals). The chunk text routes
+        # which custom entity comes back, mirroring a real per-page extraction.
+        async def fake_extract(**kwargs):
+            prompt = kwargs.get("prompt", "")
+            if "WHEAT" in prompt:
+                additional = {"crops": ["wheat"]}
+            elif "SILVER" in prompt:
+                additional = {"minerals": ["silver"]}
+            else:
+                additional = {}
+            return extract_all_module._Extraction(
+                people=[],
+                places=[],
+                organizations=[],
+                dates=[],
+                events=[],
+                quotes=[],
+                keywords=[],
+                additional_entities=additional,
+            )
+
+        monkeypatch.setattr(
+            "fichero.workflows.tools.extract_all.chat_structured_with_fallback",
+            fake_extract,
+        )
+
+        state = {
+            "library_path": lib_path,
+            "selected_doc_ids": [folder.id],
+        }
+        llm_config = LLMConfig(provider="openai", model="gpt-4o-mini")
+
+        await extract_all_module.extract_all(
+            inputs={
+                "persist_kg": True,
+                "extraction_mode": "oneshot",
+                "records": [
+                    {"doc_id": page1.id, "text": "Page one mentions WHEAT in the field."},
+                    {"doc_id": page2.id, "text": "Page two mentions SILVER from the mine."},
+                ],
+            },
+            state=state,
+            llm_config=llm_config,
+        )
+
+        # Custom-entity provenance claims must be stamped per CHILD, not folder.
+        folder_claims = db.query(KnowledgeClaim, source_document_id=folder.id)
+        page1_claims = db.query(KnowledgeClaim, source_document_id=page1.id)
+        page2_claims = db.query(KnowledgeClaim, source_document_id=page2.id)
+
+        assert len(folder_claims) == 0, (
+            "custom-entity provenance claims must attach to the per-child page "
+            "doc, not the parent folder (#1562 write-path)"
+        )
+        p1_names = {c.subject_canonical for c in page1_claims}
+        p2_names = {c.subject_canonical for c in page2_claims}
+        assert "wheat" in p1_names
+        assert "silver" in p2_names
+        assert "silver" not in p1_names
+        assert "wheat" not in p2_names
+
+        # Entity rows accumulate the child doc id in source_document_ids.
+        wheat = db.query(KnowledgeEntity, canonical_name="wheat", entity_type=EntityType.other)[0]
+        silver = db.query(KnowledgeEntity, canonical_name="silver", entity_type=EntityType.other)[0]
+        assert page1.id in (wheat.source_document_ids or [])
+        assert page2.id in (silver.source_document_ids or [])
+        assert folder.id not in (wheat.source_document_ids or [])
+
+        # Read-side: selecting a single child shows only that child's custom
+        # entity; the parent/folder compiles the union across descendants.
+        from fichero.api.routes.claims import _descendant_doc_ids
+
+        page1_scope = _descendant_doc_ids(db, page1.id)
+        folder_scope = _descendant_doc_ids(db, folder.id)
+
+        def entities_for(scope):
+            names = set()
+            for ent in db.query(KnowledgeEntity, entity_type=EntityType.other):
+                if scope.intersection(ent.source_document_ids or []):
+                    names.add(ent.canonical_name)
+            return names
+
+        assert entities_for(page1_scope) == {"wheat"}
+        assert entities_for(folder_scope) == {"wheat", "silver"}


### PR DESCRIPTION
## What
Root-cause write-path fix for #1562. Custom-registry `additional_entities` were merged across all chunks and persisted once onto the parent `container.id`, collapsing every per-child provenance claim + `source_document_ids` onto the folder. Now accumulates per `target_doc_id = page_doc_id or container.id` and persists once per child, so each child's claims+entity-scope land on the right page/image and the parent compiles the union via descendants.

## Scope of defect
Only the custom-registry (`additional_entities`) write in the oneshot/folder path. Built-in and two-stage paths were already per-child (prior commit `17288ccd`). Read endpoints untouched.

## Gate
- ruff: clean
- full unit suite: **3742 passed**
- RED→GREEN: `test_extract_all_registry.py::TestCustomEntityPerChildScope::test_folder_catalogue_scopes_custom_entities_per_child`

🤖 Generated with [Claude Code](https://claude.com/claude-code)