### PR TITLE
feat: node-class dimension + workspace-item node_class (#1570 Phase 1 backend)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/classifications.py
+++ b/fichero-engine/src/fichero/api/routes/classifications.py
@@ -51,6 +51,9 @@ _BUILTIN_SEEDS: list[tuple[ClassificationDimension, str, str, str | None]] = [
     (ClassificationDimension.document_prototype, "secondary_source", "Secondary Source", "#AF52DE"),
     (ClassificationDimension.document_prototype, "map", "Map", "#64D2FF"),
     (ClassificationDimension.document_prototype, "translation", "Translation", "#FFD60A"),
+    (ClassificationDimension.node_class, "chapter", "Chapter", "#0A84FF"),
+    (ClassificationDimension.node_class, "container", "Container", "#5856D6"),
+    (ClassificationDimension.node_class, "note", "Note", "#FF9500"),
 ]
 
 

--- a/fichero-engine/src/fichero/api/routes/documents.py
+++ b/fichero-engine/src/fichero/api/routes/documents.py
@@ -170,6 +170,7 @@ class WorkspaceCuratedItem(BaseModel):
     x: float | None = None
     y: float | None = None
     notes: str | None = None
+    node_class: str | None = None
 
 
 class WorkspacePatchRequest(BaseModel):
@@ -224,6 +225,7 @@ def _normalize_curated_items(items: list[Any] | None) -> list[dict[str, Any]]:
                 "x": item.get("x"),
                 "y": item.get("y"),
                 "notes": item.get("notes"),
+                "node_class": item.get("node_class"),
             }
         )
     return normalized

--- a/fichero-engine/src/fichero/knowledge_models.py
+++ b/fichero-engine/src/fichero/knowledge_models.py
@@ -720,12 +720,17 @@ class EntityMergeAudit(BaseModel):
 
 
 class ClassificationDimension(str, Enum):
-    """Which classification axis a registry value belongs to (#915)."""
+    """Which classification axis a registry value belongs to (#915).
+
+    ``node_class`` (#1570) is the Tinderbox-style prototype/class axis for
+    workspace curated items; values key off ``ClassificationValue.key``.
+    """
 
     epistemic_status = "epistemic_status"
     claim_type = "claim_type"
     entity_type = "entity_type"
     document_prototype = "document_prototype"
+    node_class = "node_class"
 
 
 class ClassificationValue(BaseModel):

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -36529,10 +36529,11 @@
           "epistemic_status",
           "claim_type",
           "entity_type",
-          "document_prototype"
+          "document_prototype",
+          "node_class"
         ],
         "title": "ClassificationDimension",
-        "description": "Which classification axis a registry value belongs to (#915)."
+        "description": "Which classification axis a registry value belongs to (#915).\n\n``node_class`` (#1570) is the Tinderbox-style prototype/class axis for\nworkspace curated items; values key off ``ClassificationValue.key``."
       },
       "ClassificationListResponse": {
         "properties": {
@@ -54666,6 +54667,11 @@
             "type": "string",
             "nullable": true,
             "title": "Notes"
+          },
+          "node_class": {
+            "type": "string",
+            "nullable": true,
+            "title": "Node Class"
           }
         },
         "type": "object",

--- a/fichero-engine/tests/unit/test_node_class.py
+++ b/fichero-engine/tests/unit/test_node_class.py
@@ -1,0 +1,107 @@
+"""Phase 1 node-class dimension + workspace-item node_class (#1570).
+
+Workspace-items only. Proves the Tinderbox-style prototype/class axis rides
+on the existing generic classification registry and that a curated item
+round-trips its ``node_class`` through patch -> get, while old items without
+the field still load (backward compatible).
+"""
+
+from __future__ import annotations
+
+from fichero.models import DocType, Document
+
+
+def test_node_class_value_create_and_list(client):
+    """A node_class ClassificationValue is created + listed via the generic route."""
+    created = client.post(
+        "/api/classifications",
+        json={
+            "dimension": "node_class",
+            "key": "chapter",
+            "label": "Chapter",
+            "color": "#0A84FF",
+        },
+    )
+    # 201/200 on create, or 409 if the built-in seed already claimed the key.
+    assert created.status_code in (200, 201, 409)
+
+    listed = client.get("/api/classifications", params={"dimension": "node_class"})
+    assert listed.status_code == 200
+    items = listed.json()["items"]
+    assert items, "expected at least one node_class value"
+    assert all(v["dimension"] == "node_class" for v in items)
+    assert any(v["key"] == "chapter" for v in items)
+
+
+def test_node_class_custom_value_roundtrips(client):
+    """A user-defined node_class value persists and is retrievable."""
+    created = client.post(
+        "/api/classifications",
+        json={
+            "dimension": "node_class",
+            "key": "fieldnote",
+            "label": "Field Note",
+            "color": "#FF2D55",
+        },
+    )
+    assert created.status_code in (200, 201)
+    body = created.json()
+    assert body["dimension"] == "node_class"
+    assert body["key"] == "fieldnote"
+    assert body["is_builtin"] is False
+
+    listed = client.get("/api/classifications", params={"dimension": "node_class"})
+    keys = {v["key"] for v in listed.json()["items"]}
+    assert "fieldnote" in keys
+
+
+def test_workspace_item_node_class_roundtrips(client, db):
+    """A curated item persists + returns its node_class through patch -> get."""
+    workspace = Document(
+        id="ws-nc-1", name="Workspace", doc_type=DocType.folder, is_workspace=True
+    )
+    db.save(workspace)
+
+    patched = client.patch(
+        f"/api/documents/{workspace.id}/workspace",
+        json={
+            "add": [
+                {
+                    "id": "item-a",
+                    "target_type": "document",
+                    "target_id": "doc-a",
+                    "role": "source",
+                    "node_class": "chapter",
+                }
+            ]
+        },
+    )
+    assert patched.status_code == 200
+    assert patched.json()["items"][0]["node_class"] == "chapter"
+
+    fetched = client.get(f"/api/documents/{workspace.id}/workspace/items")
+    assert fetched.status_code == 200
+    item = fetched.json()["items"][0]
+    assert item["id"] == "item-a"
+    assert item["node_class"] == "chapter"
+
+
+def test_workspace_item_without_node_class_still_loads(client, db):
+    """Old curated items lacking node_class load (backward compatible)."""
+    workspace = Document(
+        id="ws-nc-2",
+        name="Legacy Workspace",
+        doc_type=DocType.folder,
+        is_workspace=True,
+        curated_items=[
+            # Persisted before node_class existed — no such key.
+            {"id": "legacy", "target_type": "document", "target_id": "doc-1"}
+        ],
+    )
+    db.save(workspace)
+
+    fetched = client.get(f"/api/documents/{workspace.id}/workspace/items")
+    assert fetched.status_code == 200
+    item = fetched.json()["items"][0]
+    assert item["id"] == "legacy"
+    assert item["node_class"] is None

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -36529,10 +36529,11 @@
           "epistemic_status",
           "claim_type",
           "entity_type",
-          "document_prototype"
+          "document_prototype",
+          "node_class"
         ],
         "title": "ClassificationDimension",
-        "description": "Which classification axis a registry value belongs to (#915)."
+        "description": "Which classification axis a registry value belongs to (#915).\n\n``node_class`` (#1570) is the Tinderbox-style prototype/class axis for\nworkspace curated items; values key off ``ClassificationValue.key``."
       },
       "ClassificationListResponse": {
         "properties": {
@@ -54666,6 +54667,11 @@
             "type": "string",
             "nullable": true,
             "title": "Notes"
+          },
+          "node_class": {
+            "type": "string",
+            "nullable": true,
+            "title": "Node Class"
           }
         },
         "type": "object",


### PR DESCRIPTION
## What
#1570 Phase 1 (backend). Adds the Tinderbox-style node-class/prototype axis as a new `ClassificationDimension.node_class` on the existing #915 user-extensible classification system — no new registry. Adds optional `node_class` to `WorkspaceCuratedItem` (round-trips patch→get, backward compatible). Seeds 3 idempotent built-ins (chapter/container/note). Generic `/api/classifications?dimension=node_class` CRUD already serves it.

## Iterate-not-replace
Extends the existing classification store + curated-item model in place. God-nodes (Document/KnowledgeEntity) untouched, per Phase 1 charter.

## Frontend (Phase 1)
- Class list: `GET /api/classifications?dimension=node_class`; create via `POST /api/classifications` with `dimension:"node_class"`.
- Classify an item: set `node_class` (a `ClassificationValue.key`) in the `PATCH /api/documents/{id}/workspace` add payload.

## Gate
- ruff: clean
- full unit suite: **3744 passed**
- OpenAPI regenerated (sync_openapi_schema.sh); Swift client builds clean
- new `test_node_class.py`: 4 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)