### PR TITLE
fix: on-device Apple Intelligence not labeled PAID (#1560) + /children doc: prefix regression tests (#1345)

### DIFF
--- a/fichero-engine/src/fichero/llm.py
+++ b/fichero-engine/src/fichero/llm.py
@@ -746,10 +746,11 @@ async def chat_with_fallback(
 
         # #1001: warning, not info — falling back is an offline-mode
         # regression, and to a cloud provider it's also a billing event.
-        # Local providers (omlx/ollama/lmstudio) are free, so don't cry cost.
+        # #1560: local (omlx/ollama/lmstudio) AND builtin (apple) providers
+        # run on-device for free, so don't mislabel them as PAID.
         _cost_note = (
-            "a local model — no API cost"
-            if large_config.provider in _KEYLESS_OPENAI_COMPATIBLE
+            "an on-device model — no API cost"
+            if _is_local_or_builtin_provider(large_config.provider)
             else "a PAID remote model — this request now incurs cost"
         )
         logger.warning(
@@ -1861,9 +1862,11 @@ async def chat_structured_with_fallback(
             # #1001/#1308: structured extractor fallback may become a billing
             # event. $medium is intentionally a capable cloud model by
             # default; local providers (omlx/ollama/lmstudio) remain free.
+            # #1560: builtin (apple) providers are also on-device/free —
+            # don't mislabel them as PAID.
             _cost_note = (
-                "a local model — no API cost"
-                if fallback_config.provider in _KEYLESS_OPENAI_COMPATIBLE
+                "an on-device model — no API cost"
+                if _is_local_or_builtin_provider(fallback_config.provider)
                 else "a PAID remote model — this request now incurs cost"
             )
             logger.warning(

--- a/fichero-engine/tests/integration/test_llm_fallback_chain.py
+++ b/fichero-engine/tests/integration/test_llm_fallback_chain.py
@@ -188,6 +188,39 @@ class TestChatWithFallbackChain:
         assert "incurs cost" in fallback_warnings[0].message
 
     @pytest.mark.asyncio
+    async def test_local_builtin_fallback_not_labeled_paid(self, apple_cfg, caplog):
+        """#1560: when the $large fallback resolves to an on-device /
+        builtin provider (e.g. Apple Intelligence or a local omlx/ollama
+        server — all free), the cost note must NOT claim it is PAID or
+        that it incurs cost. Mislabeling free local inference as paid is a
+        false billing scare on every catalogue run."""
+        proc = _fake_subprocess(
+            stdout=b"", stderr=_bridge_guardrail_err(), returncode=1,
+        )
+        cloud = MagicMock()
+        cloud_response = MagicMock()
+        cloud_response.content = "ok"
+        cloud_response.usage_metadata = None
+        cloud.ainvoke = AsyncMock(return_value=cloud_response)
+
+        # $large resolves to a LOCAL provider — free, on-device.
+        with patch("asyncio.create_subprocess_exec",
+                   new=AsyncMock(return_value=proc)), \
+             patch("fichero.llm.resolve_model_alias",
+                   return_value=("ollama", "llama3.1")), \
+             patch("fichero.llm.get_langchain_model", return_value=cloud), \
+             caplog.at_level(logging.WARNING, logger="fichero.llm"):
+            await chat_with_fallback("text", config=apple_cfg)
+
+        msgs = [r.message for r in caplog.records]
+        assert not any("PAID" in m or "incurs cost" in m for m in msgs), (
+            f"local fallback wrongly labeled PAID: {msgs}"
+        )
+        assert any("no API cost" in m for m in msgs), (
+            f"expected a free/on-device cost note, got: {msgs}"
+        )
+
+    @pytest.mark.asyncio
     async def test_decoding_error_routes_to_large(self, apple_cfg):
         """Grammar-decode failures ARE fallback-eligible since #949/#962:
         StructuredDecodeError is an AppleUnavailableError subclass so the

--- a/fichero-engine/tests/unit/test_routes_documents.py
+++ b/fichero-engine/tests/unit/test_routes_documents.py
@@ -158,6 +158,29 @@ class TestGetChildren:
         r = client.get("/api/documents/no-such-parent/children")
         assert r.status_code == 404
 
+    def test_doc_prefixed_id_resolves_same_as_bare(self, client, db):
+        """#1345: callers (e.g. the catalogue workflow) sometimes pass a
+        ``doc:``-prefixed id. It must normalize to the bare hex id so the
+        children lookup returns the same result instead of 404ing."""
+        parent = _make_doc(db, "Parent")
+        child = _make_doc(db, "Child 1", parent_id=parent.id)
+
+        bare = client.get(f"/api/documents/{parent.id}/children")
+        prefixed = client.get(f"/api/documents/doc:{parent.id}/children")
+
+        assert bare.status_code == 200
+        assert prefixed.status_code == 200  # not 404
+        bare_ids = sorted(d["id"] for d in bare.json()["items"])
+        prefixed_ids = sorted(d["id"] for d in prefixed.json()["items"])
+        assert bare_ids == prefixed_ids
+        assert child.id in prefixed_ids
+
+    def test_doc_prefixed_missing_parent_still_404(self, client):
+        """A ``doc:``-prefixed id for a genuinely-absent parent still 404s
+        (normalization must not mask real misses)."""
+        r = client.get("/api/documents/doc:no-such-parent/children")
+        assert r.status_code == 404
+
     def test_returns_children_when_parent_lookup_is_transiently_missing(
         self, client, db, monkeypatch
     ):


### PR DESCRIPTION
## #1560 — on-device Apple Intelligence mislabeled PAID
The fallback cost-note gated the "free" wording on `_KEYLESS_OPENAI_COMPATIBLE` (ollama/lmstudio/omlx only), so the builtin `apple` provider (on-device, free) was labeled "a PAID remote model — incurs cost". Now gated on `_is_local_or_builtin_provider(...)` at both fallback sites; reads "an on-device model — no API cost". Remote paid providers keep the PAID warning.

## #1345 — /children 404 on `doc:`-prefixed id
Source already fixed on main (`removeprefix("doc:")` in the children route). Added the missing regression tests asserting prefixed == bare (no 404) + missing-parent still 404.

## Gate
- ruff: clean
- unit suite: **3748 passed**
- integration fallback file: 12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)