### PR TITLE
fix: image-editor toolbar height/alignment + compare aspect ratio (#1555 #1556 #1558) — VISUAL VERIFY

### DIFF
--- a/fichero/fichero/Views/Library/EditorView.swift
+++ b/fichero/fichero/Views/Library/EditorView.swift
@@ -192,7 +192,12 @@ struct EditorView: View {
         .foregroundColor(isEditing ? .accentColor : .primary)
         .help(isEditing ? "Done — return to viewing" : "Edit image (crop, rotate, enhance, remove background)")
         .accessibilityIdentifier("canvasEditModeToggle")
-        .padding(10)
+        // Center within the canvas toolbar's standard band and inset from the
+        // trailing edge so the edit icon sits on the same baseline as the zoom /
+        // loupe icons in the mini-toolbar, instead of floating slightly high
+        // with its own padding (#1556).
+        .frame(height: MiniToolbar<EmptyView>.standardHeight, alignment: .center)
+        .padding(.trailing, 12)
     }
 
     // MARK: - Text Preview

--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
@@ -434,6 +434,7 @@ private extension ImageEditorView {
                             Image(nsImage: edited.image)
                                 .resizable()
                                 .interpolation(.high)
+                                .aspectRatio(contentMode: .fit)
                                 .frame(width: frame.width, height: frame.height)
                             // Original on top — clipped to the left split portion,
                             // so left = Before (original), right = After (edited)
@@ -441,6 +442,7 @@ private extension ImageEditorView {
                             Image(nsImage: original.image)
                                 .resizable()
                                 .interpolation(.high)
+                                .aspectRatio(contentMode: .fit)
                                 .frame(width: frame.width, height: frame.height)
                                 .frame(width: split * frame.width, height: frame.height, alignment: .leading)
                                 .clipped()
@@ -535,6 +537,7 @@ private extension ImageEditorView {
                 Image(nsImage: image)
                     .resizable()
                     .interpolation(.high)
+                    .aspectRatio(contentMode: .fit)
                     .frame(width: frame.width, height: frame.height)
                     .position(x: frame.midX, y: frame.midY)
             }

--- a/fichero/fichero/Views/Library/ImageViewerComponents.swift
+++ b/fichero/fichero/Views/Library/ImageViewerComponents.swift
@@ -73,8 +73,11 @@ struct ZoomableImagePreview: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Zoom toolbar
-            HStack(spacing: 12) {
+            // Zoom toolbar. Uses MiniToolbar so the image preview header is the
+            // same standard 44pt height as the PDF preview, list mode rail,
+            // knowledge surface, and inspector tab strip — instead of the short
+            // ad-hoc padded strip it used to be (#1555).
+            MiniToolbar {
                 Button(action: zoomOut) {
                     Image(systemName: "minus.magnifyingglass")
                 }
@@ -156,9 +159,6 @@ struct ZoomableImagePreview: View {
 
                 Spacer()
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 6)
-            .background(Color(.windowBackgroundColor))
 
             Divider()
 


### PR DESCRIPTION
⚠️ **Left OPEN for Daniel — these are visual fixes (alignment / height / aspect) that need an eyeball + a real Xcode build to confirm.** Worker reported `** BUILD SUCCEEDED **` (clean xcodebuild) + swiftlint 0-serious; manager is independently re-verifying the build.

## #1555 — mini-toolbar height too short
`ImageViewerComponents.swift` (`ZoomableImagePreview`): bare HStack (~28pt) → `MiniToolbar { … }` (44pt, `.bar` material), matching the sibling `PDFPageWithToolbar`.

## #1556 — edit button misaligned
`EditorView.swift` (`editModeToggle`): fixed `.padding(10)` → `.frame(height: MiniToolbar.standardHeight, alignment: .center)` + `.padding(.trailing, 12)` to share the 44pt band + trailing inset.

## #1558 — compare forces square
`ImageEditorView.swift` (`comparePane` + wipe): added `.aspectRatio(contentMode: .fit)` to all three compare images.

### Verify checklist (Daniel)
- [ ] Build in Xcode (real index) — confirm no "unable to type-check" regression (SourceKit flagged it in the un-indexed worktree; xcodebuild passed).
- [ ] Image mini-toolbar height matches PDF/other toolbars; edit (pencil) button lines up with zoom/loupe icons.
- [ ] Side-by-side + wipe compare preserve a non-square image's aspect ratio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)