### PR TITLE
feat: built-in mock provider for zero-cost catalogue debug runs (#1566)

### DIFF
--- a/fichero-engine/src/fichero/llm.py
+++ b/fichero-engine/src/fichero/llm.py
@@ -646,6 +646,22 @@ async def chat(
             use_case=use_case,
         )
 
+    # Built-in deterministic debug provider (#1566). The catalogue
+    # narrative node calls plain chat() (not chat_structured), so without
+    # this branch a full mock run would reach LangChain with a nonexistent
+    # model and error. Return a fixed canned narrative so a whole
+    # folder/PDF catalogue runs free end-to-end.
+    if config.provider == "mock":
+        if stream:
+            raise ValueError(
+                "Mock provider does not support streaming — it returns a "
+                "single deterministic response."
+            )
+        from fichero.llm_mock import mock_chat_response
+
+        prompt_text = prompt if isinstance(prompt, str) else str(prompt)
+        return mock_chat_response(prompt_text)
+
     # Get LangChain model
     model = get_langchain_model(config)
 
@@ -1644,6 +1660,13 @@ async def chat_structured(
             use_case=use_case,
             permissive_guardrails=permissive_guardrails,
         )
+
+    # Built-in deterministic debug provider (#1566): no LLM, no network,
+    # no cost. chat_structured_with_fallback inherits this automatically.
+    if config.provider == "mock":
+        from fichero.llm_mock import mock_structured_response
+
+        return mock_structured_response(schema, prompt)
 
     from langchain_core.messages import HumanMessage, SystemMessage
 

--- a/fichero-engine/src/fichero/llm_mock.py
+++ b/fichero-engine/src/fichero/llm_mock.py
@@ -1,0 +1,143 @@
+"""Built-in deterministic mock LLM provider (#1566).
+
+Backs ``LLMConfig(provider="mock")`` — a zero-cost, network-free responder
+used to debug the catalogue / extraction pipeline (output, persistence,
+per-page artifacts, UI) without spending a single paid LLM call.
+
+The mock is *deterministic*: given the same prompt prefix it always returns
+the same canned data, so a folder/PDF catalogue run is reproducible.
+
+This module deliberately keeps ``extract_all`` imports LAZY (inside the
+functions) to avoid a circular import — ``extract_all`` imports from
+``fichero.llm``, which is where the ``provider == "mock"`` branch lives.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+# A short, fixed narrative used by the plain ``chat()`` mock branch so a
+# catalogue's resumen / narrative node runs free end-to-end.
+MOCK_NARRATIVE = (
+    "Mock catalogue summary. This deterministic narrative is produced by the "
+    "built-in debug provider so a full run can be exercised at zero cost."
+)
+
+
+def _prefix(prompt: str, n: int = 24) -> str:
+    """Stable short token derived from the prompt prefix.
+
+    Lets canned values vary a little per page (so distinct pages don't all
+    collapse to byte-identical KG rows) while staying fully deterministic.
+    """
+    cleaned = " ".join((prompt or "").split())
+    return cleaned[:n] or "mock"
+
+
+def mock_chat_response(prompt: str) -> str:
+    """Deterministic stand-in for the plain (non-structured) ``chat()`` call.
+
+    The catalogue narrative node uses ``chat()`` directly, which the
+    structured ``mock`` branch wouldn't intercept — so without this a full
+    catalogue run with provider="mock" would hit LangChain with a
+    nonexistent model and error. Returns a fixed canned narrative.
+    """
+    return MOCK_NARRATIVE
+
+
+def mock_structured_response(schema: type[BaseModel], prompt: str) -> BaseModel:
+    """Deterministic structured output for ``LLMConfig(provider="mock")``.
+
+    For the extraction schemas (``_Extraction`` / ``_EntitiesOnly`` /
+    ``_EntityClaims``) return small, grounded, canned instances. For any
+    other Pydantic schema, construct it from its field defaults and fail
+    loudly on a missing required field rather than silently dropping it.
+
+    Args:
+        schema: The Pydantic model class the caller expects back.
+        prompt: The prompt text — used only to derive a stable per-call
+            token so distinct pages produce distinct (but deterministic)
+            source excerpts.
+
+    Returns:
+        An instance of ``schema``.
+    """
+    name = schema.__name__
+
+    # Extraction schemas live in workflows/tools/extract_all.py — import
+    # lazily to avoid a circular import (extract_all -> llm -> llm_mock).
+    if name in {"_Extraction", "_EntitiesOnly", "_EntityClaims"}:
+        from fichero.workflows.tools import extract_all as ea
+
+        tag = _prefix(prompt)
+        source = f"Mock source text for: {tag}"
+
+        if name == "_Extraction":
+            # Grounded SVO on every item so _extraction_is_thin() accepts
+            # it (it rejects name-only lists where <50% are grounded).
+            return ea._Extraction(
+                people=[
+                    ea._Person(
+                        name="Ada Mock",
+                        verb="signed",
+                        object="the mock ledger",
+                        source_text=source,
+                    )
+                ],
+                places=[
+                    ea._Place(
+                        name="Mockton",
+                        verb="hosted",
+                        object="the mock meeting",
+                        source_text=source,
+                    )
+                ],
+                dates=[
+                    ea._DateItem(
+                        date="1 January 2000",
+                        date_normalized="2000-01-01",
+                        verb="marked",
+                        object="the mock milestone",
+                        source_text=source,
+                    )
+                ],
+                keywords=["mock"],
+            )
+
+        if name == "_EntitiesOnly":
+            return ea._EntitiesOnly(
+                people=[ea._EntityOnly(name="Ada Mock", entity_type="person")],
+                places=[ea._EntityOnly(name="Mockton", entity_type="place")],
+                organizations=[],
+                dates=[],
+                events=[],
+            )
+
+        # _EntityClaims — one grounded claim for the requested subject.
+        return ea._EntityClaims(
+            subject="Ada Mock",
+            claims=[
+                ea._SVOClaim(
+                    subject="Ada Mock",
+                    verb="signed",
+                    object="the mock ledger",
+                    source_text=source,
+                )
+            ],
+        )
+
+    # Generic fallback: build from field defaults. Fail loudly (rather than
+    # silently dropping) on any field that has neither a default nor a
+    # default_factory — validation here surfaces the gap immediately.
+    values: dict[str, object] = {}
+    missing: list[str] = []
+    for field_name, field in schema.model_fields.items():
+        if field.is_required():
+            missing.append(field_name)
+    if missing:
+        raise ValueError(
+            f"mock_structured_response cannot construct {name}: required "
+            f"field(s) {missing!r} have no default. Add a canned branch for "
+            f"this schema in fichero.llm_mock."
+        )
+    return schema.model_construct(**values)

--- a/fichero-engine/src/fichero/providers.py
+++ b/fichero-engine/src/fichero/providers.py
@@ -34,6 +34,8 @@ class ProviderType(str, Enum):
 
     # On-device (Apple)
     apple = "apple"
+    # Built-in deterministic debug provider (no LLM, no cost) — #1566
+    mock = "mock"
     # Local servers
     ollama = "ollama"
     lmstudio = "lmstudio"
@@ -105,6 +107,32 @@ PROVIDERS: dict[ProviderType, ProviderInfo] = {
         icon="apple.logo",
         color="gray",
         sort_order=0,
+    ),
+    # ==========================================================================
+    # Built-in Debug Provider (#1566) - deterministic, zero-cost.
+    #
+    # Selected only by explicit LLMConfig(provider="mock"). Registered
+    # is_local + is_builtin so it inherits every free / no-PAID gate via
+    # _is_local_or_builtin_provider. No alias / preset / fallback ever
+    # yields "mock", so it can never activate by accident — it exists so a
+    # whole folder/PDF catalogue run can be debugged end-to-end (output,
+    # persistence, per-page artifacts, UI) with ZERO paid LLM calls.
+    # ==========================================================================
+    ProviderType.mock: ProviderInfo(
+        type=ProviderType.mock,
+        name="Mock (Debug)",
+        description="Built-in deterministic responder — zero-cost catalogue debug runs",
+        api_key_env=None,
+        api_key_url=None,
+        is_local=True,
+        is_builtin=True,  # inherits the free / no-PAID gates
+        supports_vision=False,
+        supports_embeddings=False,
+        supports_streaming=False,
+        default_model="mock",
+        icon="wrench.and.screwdriver",
+        color="gray",
+        sort_order=999,
     ),
     # ==========================================================================
     # Local Servers - sort_order 1-2

--- a/fichero-engine/tests/unit/test_api_providers.py
+++ b/fichero-engine/tests/unit/test_api_providers.py
@@ -115,7 +115,9 @@ class TestProviderCatalog:
         response = client.get(f"{API_BASE}/providers/catalog")
         data = response.json()["items"]
 
-        local_types = {"apple", "ollama", "lmstudio", "omlx"}
+        # mock (#1566) is a built-in deterministic debug provider — local,
+        # builtin, no api_key_env — so it belongs with the local set.
+        local_types = {"apple", "ollama", "lmstudio", "omlx", "mock"}
 
         for provider in data:
             if provider["type"] in local_types:

--- a/fichero-engine/tests/unit/test_mock_provider.py
+++ b/fichero-engine/tests/unit/test_mock_provider.py
@@ -1,0 +1,118 @@
+"""Tests for the built-in deterministic `mock` LLM provider (#1566).
+
+The mock provider IS the production path under test here — no
+monkeypatching of llm internals. It exists so a full catalogue /
+extraction run can be debugged end-to-end (output, persistence, per-page
+artifacts, UI) with ZERO paid LLM calls and zero network.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from fichero.llm import LLMConfig, _is_local_or_builtin_provider, chat, chat_structured
+from fichero.models import Artifact, DocType, Document
+from fichero.providers import ProviderType, get_provider_info
+from fichero.workflows.tools import extract_all as extract_all_module
+
+
+def test_mock_registers_as_local_and_builtin():
+    """mock inherits every free / no-PAID gate via _is_local_or_builtin_provider."""
+    assert _is_local_or_builtin_provider("mock") is True
+
+    info = get_provider_info("mock")
+    assert info is not None
+    assert info.type is ProviderType.mock
+    assert info.is_local is True
+    assert info.is_builtin is True
+    assert info.default_model == "mock"
+
+
+@pytest.mark.asyncio
+async def test_chat_structured_returns_extraction_instance():
+    """chat_structured with provider=mock returns the requested schema."""
+    config = LLMConfig(provider="mock", model="mock")
+    result = await chat_structured(
+        prompt="A page of mock source text describing people and places.",
+        schema=extract_all_module._Extraction,
+        config=config,
+    )
+    assert isinstance(result, extract_all_module._Extraction)
+    # Grounded SVO so the extraction is not rejected as "thin".
+    assert result.people
+    assert result.people[0].name
+    assert result.people[0].verb
+    assert result.people[0].source_text
+
+
+@pytest.mark.asyncio
+async def test_chat_returns_deterministic_string():
+    """Plain chat() (catalogue narrative path) returns a fixed string."""
+    config = LLMConfig(provider="mock", model="mock")
+    first = await chat("Summarise this folder.", config)
+    second = await chat("Summarise this folder.", config)
+    assert isinstance(first, str)
+    assert first
+    assert first == second  # deterministic
+
+
+@pytest.mark.asyncio
+async def test_mock_structured_fails_loud_on_unsupported_required_field():
+    """Unknown schema with a required-no-default field raises, never drops."""
+    from pydantic import BaseModel
+
+    from fichero.llm_mock import mock_structured_response
+
+    class _Needy(BaseModel):
+        required_field: str  # no default, no default_factory
+
+    with pytest.raises(ValueError, match="required"):
+        mock_structured_response(_Needy, "prompt")
+
+
+@pytest.mark.asyncio
+async def test_extract_all_mock_writes_claims_and_artifacts(db, test_package, caplog):
+    """A full extract_all run with provider=mock writes KG claim rows +
+    per-page Artifact rows, with no exception and no paid-cost warning."""
+    from fichero.knowledge_models import KnowledgeClaim
+
+    folder = Document(name="Folder", path="/tmp/folder", doc_type=DocType.folder)
+    page1 = Document(name="p1", path="/tmp/folder/p1.png", doc_type=DocType.page)
+    page2 = Document(name="p2", path="/tmp/folder/p2.png", doc_type=DocType.page)
+    db.save(folder)
+    db.save(page1)
+    db.save(page2)
+
+    state = {
+        "library_path": str(test_package),
+        "selected_doc_ids": [folder.id],
+    }
+    llm_config = LLMConfig(provider="mock", model="mock")
+    inputs = {
+        "text": "Ada signed the ledger in Mockton.",
+        "records": [
+            {"doc_id": page1.id, "text": "Ada signed the ledger in Mockton."},
+            {"doc_id": page2.id, "text": "Ada signed the ledger in Mockton again."},
+        ],
+        "persist_kg": True,
+    }
+
+    with caplog.at_level(logging.WARNING):
+        result = await extract_all_module.extract_all(inputs, state, llm_config)
+
+    assert "error" not in result or not result.get("error")
+
+    # KG claim rows persisted (≥1).
+    claims = db.query(KnowledgeClaim)
+    assert len(claims) >= 1, "expected at least one KnowledgeClaim row"
+
+    # Per-page Artifact rows persisted (≥1).
+    artifacts = db.query(Artifact)
+    assert len(artifacts) >= 1, "expected at least one Artifact row"
+
+    # No PAID / incurs-cost warning for a free built-in provider.
+    text = caplog.text.lower()
+    assert "paid" not in text
+    assert "incurs cost" not in text


### PR DESCRIPTION
## What
Adds a built-in deterministic `mock` LLM provider (Option 2 from the plan). Set `LLMConfig.provider="mock"` and a whole folder/PDF catalogue runs end-to-end with **zero paid LLM calls / zero network** — for debugging output rendering, persistence (esp. #1562 per-page), and UI without re-paying.

## How
- `providers.py`: `ProviderType.mock` + `PROVIDERS` entry (`is_local=True, is_builtin=True` → inherits all free/no-PAID gates; never selected by alias/preset/fallback).
- `llm_mock.py` (new): deterministic canned `_Extraction`/`_EntitiesOnly`/`_EntityClaims` (grounded SVO so `_extraction_is_thin` doesn't reject) + `mock_chat_response` for the narrative path; fail-loud on unsupported required-field schemas.
- `llm.py`: one `mock` branch in `chat_structured` (inherited by `_with_fallback`) and one in `chat` (so the narrative node runs free too). Dead code for any non-mock provider.

## Gate
- ruff clean; `test_mock_provider.py` 5 passed; full unit suite green (after fixing a stale `local_types` count in `test_api_providers.py`).
- OpenAPI unchanged (provider catalog returns untyped dicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)