### PR TITLE
feat: node-class picker + coloured chip on workspace curated items (#1570 Phase 1 FE) — VISUAL VERIFY

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		EA5A4BBFC0797C7403FB49B3 /* LibraryView+TableMapViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92773EAEE52587BBA8DEDC9F /* LibraryView+TableMapViews.swift */; };
 		ED0E3300104D4A70958C3844 /* AttributedTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 004167806445469D9A3595E4 /* AttributedTextEditor.swift */; };
 		EEE878CB5349F5D321517F55 /* ContentView+WorkflowActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923BD592D3257176C51CAC1C /* ContentView+WorkflowActions.swift */; };
+		F0B74209906E1D1F5A904335 /* NodeClassPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D11FC06A71EAC1E8C4F6897 /* NodeClassPicker.swift */; };
 		F14D9A1A889055137785068A /* PageContentPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5923B00FD0A382F8BBF21D58 /* PageContentPane.swift */; };
 		F23CD14AC5C36398DB6CCC74 /* ImageEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8EFF7D9BC634BAE18E0F47 /* ImageEditorView.swift */; };
 		F272CFE1FADD5F15F71CFC23 /* ImageMarqueeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D05E0BE3C8D1AEA1AA3A8D /* ImageMarqueeOverlay.swift */; };
@@ -619,6 +620,7 @@
 		462 /* Workflow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workflow.swift; sourceTree = "<group>"; };
 		489A0FBA854FF9A1158996D6 /* WorkspaceItemPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceItemPicker.swift; sourceTree = "<group>"; };
 		4BB488A4AF6BAB72C33902C4 /* EntityDigestView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityDigestView.swift; sourceTree = "<group>"; };
+		4D11FC06A71EAC1E8C4F6897 /* NodeClassPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NodeClassPicker.swift; sourceTree = "<group>"; };
 		506C34038F8A349C075DFBAC /* WorkflowRunProviderCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkflowRunProviderCache.swift; sourceTree = "<group>"; };
 		5287875D44BA51CD93CA12F8 /* ResearchTasksPane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResearchTasksPane.swift; sourceTree = "<group>"; };
 		53458DC3387BC4C694EE3452 /* ContradictionTriageSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ContradictionTriageSheet.swift; sourceTree = "<group>"; };
@@ -1572,6 +1574,7 @@
 				489A0FBA854FF9A1158996D6 /* WorkspaceItemPicker.swift */,
 				0F95C40A12E1BBFFF043EED4 /* LocalImageThumbnailView.swift */,
 				E25A2C92607779F4D928B8E3 /* ArtifactRichTextCodec.swift */,
+				4D11FC06A71EAC1E8C4F6897 /* NodeClassPicker.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -2282,6 +2285,7 @@
 				495FCF3ED790C015FBF4BE70 /* NotesBrowserView.swift in Sources */,
 				82E00BEA3E5CAB3FF69DEEE6 /* LocalImageThumbnailView.swift in Sources */,
 				011D2B0F5D8064D8ABF7A999 /* ArtifactRichTextCodec.swift in Sources */,
+				F0B74209906E1D1F5A904335 /* NodeClassPicker.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero/Services/ArtifactServiceGenerated.swift
+++ b/fichero/fichero/Services/ArtifactServiceGenerated.swift
@@ -1255,6 +1255,23 @@ final class EntityServiceGenerated: ObservableObject {
         return (try? JSONDecoder().decode(Envelope.self, from: data))?.items ?? []
     }
 
+    /// Fetch all classification values for the node_class dimension —
+    /// Tinderbox-style node classes for workspace curated items (#1570).
+    /// Mirrors `listDocumentPrototypes()`; `dimension=node_class`.
+    func listNodeClasses() async throws -> [Components.Schemas.ClassificationValue] {
+        guard let lib = client.currentLibraryPath else { return [] }
+        guard let url = URL(string: "\(client.baseURL)/api/classifications?dimension=node_class") else {
+            return []
+        }
+        var req = URLRequest(url: url)
+        req.addEngineAuth(libraryPath: lib)
+        let (data, _) = try await URLSession.shared.data(for: req)
+        struct Envelope: Decodable {
+            let items: [Components.Schemas.ClassificationValue]
+        }
+        return (try? JSONDecoder().decode(Envelope.self, from: data))?.items ?? []
+    }
+
     @discardableResult
     func assignDocumentPrototype(
         documentId: String,

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab.swift
@@ -42,6 +42,15 @@ struct DocumentInspectorInfoTab: View {
                     )
                 }
 
+                // Workspace curated items + per-item node class (#1570 Phase 1).
+                // Only shown for workspace folders — folded into the existing
+                // inspector Form as one more Section (conservative placement).
+                if document.isWorkspace {
+                    Section("Curated Items") {
+                        WorkspaceCuratedItemsSection(folderId: document.id)
+                    }
+                }
+
                 Section("File") {
                     LabeledContent("Kind") {
                         Text(document.docType.rawValue.capitalized)
@@ -733,7 +742,9 @@ struct DocumentPrototypePicker: View {
     }
 }
 
-private extension Color {
+// Promoted from `private` so the workspace NodeClassPicker (#1570) can reuse
+// the SAME hex parser — no second copy.
+extension Color {
     init?(hex: String) {
         let stripped = hex.trimmingCharacters(in: .whitespaces).replacingOccurrences(of: "#", with: "")
         guard stripped.count == 6, let value = UInt64(stripped, radix: 16) else { return nil }
@@ -744,7 +755,9 @@ private extension Color {
     }
 }
 
-private struct PrototypeBadge: View {
+// Promoted from `private` so the workspace NodeClassPicker (#1570) reuses the
+// SAME coloured-capsule chip — no parallel badge view.
+struct PrototypeBadge: View {
     let proto: Components.Schemas.ClassificationValue
 
     var body: some View {

--- a/fichero/fichero/Views/Library/NodeClassPicker.swift
+++ b/fichero/fichero/Views/Library/NodeClassPicker.swift
@@ -1,0 +1,171 @@
+import FicheroAPIClient
+import OSLog
+import SwiftUI
+
+// MARK: - Curated-items section (#1570 Phase 1)
+
+/// Workspace curated-items section for the document inspector. Shown only when
+/// the selected document is a workspace folder (`doc.isWorkspace == true`).
+/// Loads the folder's curated items from `GET .../workspace/items` and renders
+/// one row per item with a `NodeClassPicker` chip. Conservative, least-invasive
+/// placement: a single `Section` folded into the existing inspector `Form`,
+/// not a rewrite of LibraryView. (#1570)
+struct WorkspaceCuratedItemsSection: View {
+    let folderId: String
+
+    @StateObject private var service = WorkspacePickerService()
+    @State private var items: [WorkspaceCuratedItem] = []
+    @State private var nodeClasses: [Components.Schemas.ClassificationValue] = []
+    @State private var isLoading = false
+    @State private var loadError: String?
+
+    private let logger = Logger(
+        subsystem: "app.fichero.fichero",
+        category: "WorkspaceCuratedItemsSection"
+    )
+
+    var body: some View {
+        Group {
+            if isLoading {
+                HStack { ProgressView().controlSize(.small); Text("Loading items…") }
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else if let loadError {
+                Text(loadError)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else if items.isEmpty {
+                Text("No curated items yet")
+                    .font(.caption)
+                    .foregroundStyle(.tertiary)
+                    .help("Add documents to this workspace to classify them with a node class")
+            } else {
+                ForEach(items) { item in
+                    itemRow(item)
+                }
+            }
+        }
+        .task(id: folderId) { await load() }
+    }
+
+    @ViewBuilder
+    private func itemRow(_ item: WorkspaceCuratedItem) -> some View {
+        LabeledContent {
+            NodeClassPicker(
+                folderId: folderId,
+                item: item,
+                nodeClasses: nodeClasses,
+                onAssign: { newKey in
+                    if let idx = items.firstIndex(where: { $0.id == item.id }) {
+                        items[idx] = item.withNodeClass(newKey)
+                    }
+                }
+            )
+        } label: {
+            Text(itemLabel(item))
+                .lineLimit(1)
+                .truncationMode(.middle)
+        }
+    }
+
+    private func itemLabel(_ item: WorkspaceCuratedItem) -> String {
+        let type = item.targetType.isEmpty ? "Item" : item.targetType.capitalized
+        return "\(type) · \(item.targetId.prefix(8))"
+    }
+
+    private func load() async {
+        isLoading = true
+        loadError = nil
+        defer { isLoading = false }
+        if let svc = LibraryManager.shared.globalLibrary?.entityService {
+            nodeClasses = (try? await svc.listNodeClasses()) ?? []
+        }
+        do {
+            items = try await service.loadCuratedItems(folderId: folderId)
+        } catch {
+            loadError = error.localizedDescription
+            logger.error("loadCuratedItems failed: \(error.localizedDescription)")
+        }
+    }
+}
+
+// MARK: - Node-class picker (#1570)
+
+/// Tinderbox-style node-class picker for one workspace curated item. Modelled
+/// exactly on `DocumentPrototypePicker` — a `Menu` listing the node_class
+/// classification values, showing the reused `PrototypeBadge` chip when one is
+/// assigned, and PATCHing the item via `WorkspacePickerService.setNodeClass`
+/// on selection. (#1570)
+struct NodeClassPicker: View {
+    let folderId: String
+    let item: WorkspaceCuratedItem
+    let nodeClasses: [Components.Schemas.ClassificationValue]
+    /// Called with the newly assigned key (nil = cleared) so the parent can
+    /// keep its row in sync without a full reload.
+    var onAssign: (String?) -> Void = { _ in }
+
+    @State private var selectedKey: String?
+    @State private var isAssigning = false
+    @StateObject private var service = WorkspacePickerService()
+
+    var body: some View {
+        if nodeClasses.isEmpty && !isAssigning {
+            Text("No classes defined")
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+                .help("Define node classes in Settings → Classification to classify workspace items")
+        } else {
+            Menu {
+                Button("None") {
+                    Task { await assign(nil) }
+                }
+                Divider()
+                ForEach(nodeClasses, id: \.key) { proto in
+                    Button {
+                        Task { await assign(proto.key) }
+                    } label: {
+                        Label {
+                            Text(proto.label)
+                        } icon: {
+                            if selectedKey == proto.key {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    if isAssigning {
+                        ProgressView().scaleEffect(0.6).frame(width: 12, height: 12)
+                    }
+                    if let key = selectedKey,
+                       let proto = nodeClasses.first(where: { $0.key == key }) {
+                        PrototypeBadge(proto: proto)
+                    } else {
+                        Text("None")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .buttonStyle(.plain)
+            .help("Assign a node class to this workspace item")
+            .task { selectedKey = item.nodeClass }
+        }
+    }
+
+    private func assign(_ key: String?) async {
+        isAssigning = true
+        defer { isAssigning = false }
+        do {
+            _ = try await service.setNodeClass(folderId: folderId, item: item, nodeClass: key)
+            selectedKey = key
+            onAssign(key)
+        } catch {
+            // Leave the previous selection in place on failure.
+        }
+    }
+}

--- a/fichero/fichero/Views/Library/WorkspaceItemPicker.swift
+++ b/fichero/fichero/Views/Library/WorkspaceItemPicker.swift
@@ -68,6 +68,56 @@ final class WorkspacePickerService: ObservableObject {
         let resp = try JSONDecoder().decode(WorkspaceItemsCountResponse.self, from: data)
         return resp.count
     }
+
+    /// Load the curated items for a workspace folder, resolving each alias.
+    /// First caller of `GET /api/documents/{id}/workspace/items` (#1570).
+    func loadCuratedItems(folderId: String) async throws -> [WorkspaceCuratedItem] {
+        guard let url = URL(string: "\(documentsBase)/\(folderId)/workspace/items") else {
+            throw WorkspacePickerError.invalidURL
+        }
+        var req = URLRequest(url: url)
+        req.addEngineAuth()
+        let (data, response) = try await URLSession.shared.data(for: req)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw WorkspacePickerError.server(http.statusCode)
+        }
+        let resp = try JSONDecoder().decode(WorkspaceItemsResponse.self, from: data)
+        return resp.items
+    }
+
+    /// Set (or clear) the Tinderbox-style `node_class` on one curated item
+    /// and PATCH it back. The backend's `add` path replaces the item by id,
+    /// so we resend the *whole* item (id/target/role/notes) with the new
+    /// node_class — sending a partial payload would wipe the other fields (#1570).
+    @discardableResult
+    func setNodeClass(
+        folderId: String,
+        item: WorkspaceCuratedItem,
+        nodeClass: String?
+    ) async throws -> Int {
+        guard let url = URL(string: "\(documentsBase)/\(folderId)/workspace") else {
+            throw WorkspacePickerError.invalidURL
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = "PATCH"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.addEngineAuth()
+        let add = WorkspaceCuratedItemAdd(
+            id: item.id,
+            targetType: item.targetType,
+            targetId: item.targetId,
+            role: item.role ?? "curated_item",
+            notes: item.notes,
+            nodeClass: nodeClass
+        )
+        req.httpBody = try JSONEncoder().encode(WorkspacePatchBody(add: [add]))
+        let (data, response) = try await URLSession.shared.data(for: req)
+        if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
+            throw WorkspacePickerError.server(http.statusCode)
+        }
+        let resp = try JSONDecoder().decode(WorkspaceItemsCountResponse.self, from: data)
+        return resp.count
+    }
 }
 
 enum WorkspacePickerError: LocalizedError {
@@ -117,11 +167,14 @@ private struct WorkspaceCuratedItemAdd: Encodable {
     let targetType: String
     let targetId: String
     let role: String
+    var notes: String?
+    var nodeClass: String?
 
     enum CodingKeys: String, CodingKey {
-        case id, role
+        case id, role, notes
         case targetType = "target_type"
         case targetId = "target_id"
+        case nodeClass = "node_class"
     }
 }
 
@@ -131,6 +184,68 @@ private struct WorkspacePatchBody: Encodable {
 
 private struct WorkspaceItemsCountResponse: Codable {
     let count: Int
+}
+
+/// Typed projection of a curated workspace item (#1570). Mirrors the backend
+/// `WorkspaceCuratedItem` rows returned by `GET .../workspace/items`. Old
+/// payloads that predate `node_class` decode cleanly — every optional field
+/// tolerates absence.
+struct WorkspaceCuratedItem: Decodable, Identifiable, Hashable {
+    let id: String
+    let targetType: String
+    let targetId: String
+    let role: String?
+    let notes: String?
+    let nodeClass: String?
+
+    enum CodingKeys: String, CodingKey {
+        case id, role, notes
+        case targetType = "target_type"
+        case targetId = "target_id"
+        case nodeClass = "node_class"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        targetType = (try? container.decode(String.self, forKey: .targetType)) ?? ""
+        targetId = (try? container.decode(String.self, forKey: .targetId)) ?? ""
+        role = try? container.decodeIfPresent(String.self, forKey: .role)
+        notes = try? container.decodeIfPresent(String.self, forKey: .notes)
+        nodeClass = try? container.decodeIfPresent(String.self, forKey: .nodeClass)
+    }
+
+    private init(
+        id: String, targetType: String, targetId: String,
+        role: String?, notes: String?, nodeClass: String?
+    ) {
+        self.id = id
+        self.targetType = targetType
+        self.targetId = targetId
+        self.role = role
+        self.notes = notes
+        self.nodeClass = nodeClass
+    }
+
+    /// Returns a copy with `node_class` replaced — lets the picker update a row
+    /// in place after a successful PATCH without a full reload.
+    func withNodeClass(_ newValue: String?) -> WorkspaceCuratedItem {
+        WorkspaceCuratedItem(
+            id: id, targetType: targetType, targetId: targetId,
+            role: role, notes: notes, nodeClass: newValue
+        )
+    }
+}
+
+private struct WorkspaceItemsResponse: Decodable {
+    let documentId: String
+    let items: [WorkspaceCuratedItem]
+    let count: Int
+
+    enum CodingKeys: String, CodingKey {
+        case items, count
+        case documentId = "document_id"
+    }
 }
 
 // MARK: - View


### PR DESCRIPTION
⚠️ **Left OPEN for Daniel — visual verify.** Worker reported `** BUILD SUCCEEDED **`; manager independently re-verifying the build (SourceKit "No such module" flags are un-indexed-worktree false positives).

## What — classes/prototypes are now visible on items
First UI for the node-class system (#1570 Phase 1). Reuses the existing `DocumentPrototypePicker`/`PrototypeBadge` pattern pointed at `dimension=node_class` — no parallel picker invented.

- **`listNodeClasses()`** (mirror of `listDocumentPrototypes()`) → `GET /api/classifications?dimension=node_class`.
- **`WorkspacePickerService`**: typed `WorkspaceCuratedItem`, `loadCuratedItems(folderId:)` (first caller of `/workspace/items`), `setNodeClass(folderId:item:nodeClass:)` (resends the whole item — backend PATCH `add` replaces by id, so a partial payload would wipe siblings).
- **`PrototypeBadge` + `Color(hex:)`** promoted `private`→internal for reuse (one copy, no dup).
- **`NodeClassPicker.swift`** (new, registered via add-swift-file.rb).

## Where it appears (verify here)
Select a **workspace folder** → right-hand **DocumentInspector → Info tab** → new **"Curated Items"** section under "Class". Each item is a row with a node-class **chip picker** on the trailing edge (builtins: chapter/container/note). Empty states: "No classes defined" / "No curated items yet". No LibraryView change.

### Verify checklist (Daniel)
- [ ] Build in Xcode.
- [ ] Open a workspace folder → Info tab shows "Curated Items"; pick a class → coloured chip appears and persists (re-open confirms via `/workspace/items`).
- [ ] Decide if the Info-tab placement is right, or if it should live in the main canvas (table/map) — that's the Phase-1 follow-up.

## Follow-ups (NOT this PR)
Class-driven table columns, map shape/colour per class, outline grouping, dedicated curated-items canvas pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)