### PR TITLE
fix: allow iCloud-synced Documents/Desktop in library-path allowlist (#1585)

### DIFF
--- a/fichero-engine/src/fichero/api/main.py
+++ b/fichero-engine/src/fichero/api/main.py
@@ -656,31 +656,53 @@ def _is_allowed_library_path(library_path: str) -> bool:
 
     Allowed roots:
     - ~/Documents
+    - ~/Desktop (iCloud-syncable, natural place for libraries)
     - ~/Dropbox
     - ~/Library/Application Support
+    - ~/Library/Mobile Documents/com~apple~CloudDocs — iCloud Drive AND
+      iCloud-synced Documents/Desktop physically live here
     - test temp dirs under /var/folders and /private/var/folders (macOS)
     - /tmp and /private/tmp — Linux CI and macOS sandbox pytest tmp_path
+
+    Symlink tolerance: when "Desktop & Documents in iCloud" is ON, ~/Documents
+    is a symlink into ~/Library/Mobile Documents/com~apple~CloudDocs/Documents.
+    Path.resolve() follows that symlink, moving the path outside the literal
+    ~/Documents root. We therefore test BOTH the resolved path and the
+    un-resolved (expanded) path against the allowed roots and allow if EITHER
+    is under an allowed root — so ~/Documents/... passes whether or not it is
+    symlinked into iCloud, and the iCloud root catches the resolved form.
     """
     try:
-        resolved = Path(library_path).expanduser().resolve()
+        expanded = Path(library_path).expanduser()
+        resolved = expanded.resolve()
     except Exception:
         return False
 
-    if resolved.suffix != ".fichero":
+    # Use the expanded (un-resolved) suffix so a symlinked or not-yet-created
+    # .fichero package still reads as a .fichero package.
+    if expanded.suffix != ".fichero":
         return False
 
     home = Path.home().resolve()
+    icloud = home / "Library" / "Mobile Documents" / "com~apple~CloudDocs"
     allowed_roots = [
         home / "Documents",
+        home / "Desktop",
         home / "Dropbox",
         home / "Library" / "Application Support",
+        icloud,
         Path("/var/folders"),
         Path("/private/var/folders"),
         Path("/tmp"),
         Path("/private/tmp"),
     ]
 
-    return any(resolved.is_relative_to(root) for root in allowed_roots)
+    candidates = [resolved, expanded]
+    return any(
+        candidate.is_relative_to(root)
+        for candidate in candidates
+        for root in allowed_roots
+    )
 
 
 async def get_library_database(

--- a/fichero-engine/tests/unit/test_library_path_allowlist.py
+++ b/fichero-engine/tests/unit/test_library_path_allowlist.py
@@ -1,0 +1,97 @@
+"""Unit tests for the library-path allowlist (_is_allowed_library_path).
+
+Regression coverage for the iCloud-synced ~/Documents 403 bug: when macOS
+"Desktop & Documents in iCloud" is ON, ~/Documents is a symlink into
+~/Library/Mobile Documents/com~apple~CloudDocs/Documents. Path.resolve()
+follows that symlink, so a library at ~/Documents/Fichero/X.fichero resolved
+to a path outside every allowed root and got a 403. The allowlist must now:
+
+- accept the iCloud physical container path,
+- accept ~/Documents/... whether or not Documents is symlinked into iCloud
+  (dual-check of resolved + un-resolved path),
+- still require a .fichero suffix,
+- still reject un-allowed roots.
+"""
+
+from pathlib import Path
+
+from fichero.api.main import _is_allowed_library_path
+
+
+def test_icloud_physical_documents_path_allowed():
+    """A .fichero under the iCloud physical container is allowed."""
+    home = Path.home()
+    p = (
+        home
+        / "Library"
+        / "Mobile Documents"
+        / "com~apple~CloudDocs"
+        / "Documents"
+        / "Fichero"
+        / "Marshall.fichero"
+    )
+    assert _is_allowed_library_path(str(p)) is True
+
+
+def test_icloud_drive_root_path_allowed():
+    """A .fichero directly under iCloud Drive is allowed."""
+    home = Path.home()
+    p = (
+        home
+        / "Library"
+        / "Mobile Documents"
+        / "com~apple~CloudDocs"
+        / "X.fichero"
+    )
+    assert _is_allowed_library_path(str(p)) is True
+
+
+def test_documents_symlinked_into_icloud_allowed(tmp_path, monkeypatch):
+    """~/Documents/X.fichero is allowed even when Documents is a symlink
+    into the iCloud container (resolve() leaves the literal Documents root)."""
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+
+    # Real iCloud-style container that Documents will point into.
+    icloud_documents = (
+        fake_home
+        / "Library"
+        / "Mobile Documents"
+        / "com~apple~CloudDocs"
+        / "Documents"
+    )
+    icloud_documents.mkdir(parents=True)
+
+    # ~/Documents -> the iCloud container (the macOS sync behaviour).
+    documents = fake_home / "Documents"
+    documents.symlink_to(icloud_documents, target_is_directory=True)
+
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+    # Path expressed via the symlinked Documents folder.
+    p = fake_home / "Documents" / "Fichero" / "Marshall.fichero"
+    assert _is_allowed_library_path(str(p)) is True
+
+
+def test_documents_plain_path_allowed():
+    """A plain ~/Documents/X.fichero is allowed (non-iCloud Macs)."""
+    p = Path.home() / "Documents" / "Fichero" / "X.fichero"
+    assert _is_allowed_library_path(str(p)) is True
+
+
+def test_desktop_path_allowed():
+    """~/Desktop/X.fichero is allowed (Desktop is iCloud-syncable)."""
+    p = Path.home() / "Desktop" / "X.fichero"
+    assert _is_allowed_library_path(str(p)) is True
+
+
+def test_non_fichero_suffix_rejected():
+    """A path without a .fichero suffix is rejected."""
+    p = Path.home() / "Documents" / "notes.txt"
+    assert _is_allowed_library_path(str(p)) is False
+
+
+def test_unallowed_root_rejected():
+    """A .fichero under an un-allowed root (e.g. ~/Downloads) is rejected."""
+    p = Path.home() / "Downloads" / "Y.fichero"
+    assert _is_allowed_library_path(str(p)) is False


### PR DESCRIPTION
P0: `~/Documents` under iCloud 'Desktop & Documents' is a symlink to `~/Library/Mobile Documents/com~apple~CloudDocs/Documents`; the allowlist's `.resolve()` followed it outside the allowed roots → 403 on every library request (Daniel's Marshall Diaries at `~/Documents/Fichero`). Fix: add the iCloud container + ~/Desktop as allowed roots and check BOTH resolved and un-resolved paths (symlink-tolerant); keep the `.fichero` suffix rule. 7 new allowlist tests + suite 3760 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)