### PR TITLE
fix: image viewer + library thumbnail reflect edited rendition after editing (#1590) — VISUAL VERIFY

### DIFF
--- a/fichero-engine/src/fichero/api/routes/storage.py
+++ b/fichero-engine/src/fichero/api/routes/storage.py
@@ -51,6 +51,74 @@ def _inline_content_disposition(filename: str) -> str:
     return f"inline; filename=\"{ascii_fallback}\"; filename*=UTF-8''{encoded_filename}"
 
 
+def _edit_chain_mtime(db: Database, doc_id: str) -> float | None:
+    """Return the edit-chain's last-updated time as an epoch float, or None.
+
+    Used to invalidate cached thumbnail/display renditions when an image has
+    been edited (#469 non-destructive edit chain). The chain is stored
+    separately from the source, so a cached rendition generated *before* the
+    most recent edit is stale even though the on-disk source is untouched.
+    """
+    from fichero.api.routes.image_editing import _get_chain
+
+    chain = _get_chain(db, doc_id)
+    if not chain or not chain.operations:
+        return None
+    updated = getattr(chain, "updated_at", None) or getattr(chain, "created_at", None)
+    try:
+        return updated.timestamp() if updated is not None else None
+    except (AttributeError, TypeError):
+        return None
+
+
+def _edited_rendition_path(base_rendition: Path) -> Path:
+    """Sibling path that holds the edit-baked copy of a thumbnail/display image.
+
+    The base rendition stays a faithful copy of the *original* source (so revert
+    is just "stop serving the edited sibling"). The edited copy is regenerated
+    whenever the edit chain changes, which keeps the bake idempotent — we never
+    re-apply ops onto an already-baked image.
+    """
+    return base_rendition.with_name(base_rendition.stem + "_edited" + base_rendition.suffix)
+
+
+def _edited_rendition(db: Database, doc_id: str, base_rendition: Path, chain_mtime: float) -> Path | None:
+    """Return a baked-with-edits copy of ``base_rendition``, generating if stale.
+
+    Applies the page-1 edit chain (#469) onto a *fresh copy* of the original
+    rendition and caches it alongside, keyed off the chain's last-updated time.
+    Returns None on failure (caller then falls back to the original rendition).
+    """
+    try:
+        from PIL import Image as _PILImage
+    except ImportError:
+        return None
+    from fichero.api.routes.image_editing import _apply_saved_operations
+
+    edited_path = _edited_rendition_path(base_rendition)
+
+    # Reuse the cached edited copy when it is newer than both the source
+    # rendition and the most recent edit.
+    if (
+        edited_path.exists()
+        and edited_path.stat().st_mtime >= base_rendition.stat().st_mtime
+        and edited_path.stat().st_mtime >= chain_mtime
+    ):
+        return edited_path
+
+    try:
+        with _PILImage.open(base_rendition) as img:
+            img.load()
+            edited = _apply_saved_operations(db, doc_id, 1, img)
+            if edited.mode not in ("RGB", "L"):
+                edited = edited.convert("RGB")
+            edited.save(edited_path, "JPEG", quality=92)
+        return edited_path
+    except Exception as exc:  # noqa: BLE001 — never break image serving on edit-bake failure
+        logger.warning("Failed to bake edit chain onto rendition %s: %s", doc_id, exc)
+        return None
+
+
 @router.get("/thumbnail/{doc_id}")
 async def get_thumbnail(
     doc_id: str,
@@ -78,6 +146,21 @@ async def get_thumbnail(
 
     if not thumb_path or not thumb_path.exists():
         raise HTTPException(status_code=404, detail="Thumbnail not available")
+
+    # If the image has been edited (#469), the cached thumbnail was generated
+    # from the untouched source and so shows the *original*. Serve an
+    # edit-baked sibling instead, regenerated whenever the chain changes.
+    # Cache-Control is no-cache so the client re-fetches after each edit; the
+    # base rendition keeps the original, so revert just drops back to it.
+    chain_mtime = _edit_chain_mtime(db, doc_id)
+    if chain_mtime is not None:
+        edited_path = _edited_rendition(db, doc_id, thumb_path, chain_mtime)
+        if edited_path is not None and edited_path.exists():
+            return FileResponse(
+                edited_path,
+                media_type="image/jpeg",
+                headers={"Cache-Control": "no-cache"},
+            )
 
     return FileResponse(
         thumb_path,
@@ -113,6 +196,19 @@ async def get_display_image(
 
     if not display_path or not display_path.exists():
         raise HTTPException(status_code=404, detail="Display image not available")
+
+    # Serve the edit-baked sibling when the image has been edited (#469), so the
+    # browse viewer / inspector reflect edits while the base copy stays original
+    # for revert. See get_thumbnail for the same pattern.
+    chain_mtime = _edit_chain_mtime(db, doc_id)
+    if chain_mtime is not None:
+        edited_path = _edited_rendition(db, doc_id, display_path, chain_mtime)
+        if edited_path is not None and edited_path.exists():
+            return FileResponse(
+                edited_path,
+                media_type="image/jpeg",
+                headers={"Cache-Control": "no-cache"},
+            )
 
     return FileResponse(
         display_path,

--- a/fichero/fichero/Views/Components/LibraryImageView.swift
+++ b/fichero/fichero/Views/Components/LibraryImageView.swift
@@ -40,10 +40,17 @@ struct LibraryImageView: View {
             guard !Task.isCancelled else { return }
             await loadImage()
         }
+        // Re-fetch when this document is edited in the image editor (#469), so
+        // the thumbnail reflects the edit-baked rendition served by the backend.
+        .onReceive(NotificationCenter.default.publisher(for: .ficheroImageEditCompleted)) { note in
+            guard (note.object as? String) == documentId else { return }
+            image = nil
+            Task { await loadImage(force: true) }
+        }
     }
 
-    private func loadImage() async {
-        guard image == nil else { return }
+    private func loadImage(force: Bool = false) async {
+        guard force || image == nil else { return }
 
         isLoading = true
         loadError = nil

--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditorModel.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditorModel.swift
@@ -5,6 +5,16 @@ import SwiftUI
 
 private let logger = Logger(subsystem: "app.fichero.fichero", category: "ImageEditorModel")
 
+extension Notification.Name {
+    /// Posted (object = documentId String) whenever a document's image edit
+    /// chain changes — an op is applied, a batch runs, or all edits are reset
+    /// (#469). Surfaces that render the *baked* image outside the editor (the
+    /// browse viewer, the library thumbnail) observe this to invalidate their
+    /// cached rendition and re-fetch, so the edited image shows up immediately
+    /// while the original source on disk stays intact for revert.
+    static let ficheroImageEditCompleted = Notification.Name("ficheroImageEditCompleted")
+}
+
 /// View-model for the non-destructive image editor (#469).
 ///
 /// Owns the `ImageEditingServiceGenerated` and all async state so the view
@@ -212,6 +222,9 @@ final class ImageEditorModel: ObservableObject {
             errorMessage = "Batch applied with \(failures) failure(s) out of \(documentIds.count)."
         }
         await reload()
+        for id in documentIds {
+            NotificationCenter.default.post(name: .ficheroImageEditCompleted, object: id)
+        }
     }
 
     func resetAll() async {
@@ -222,6 +235,7 @@ final class ImageEditorModel: ObservableObject {
             try await service.resetChain(documentId: documentId)
             chain = ImageEditChain(documentId: documentId, operations: [], updatedAt: nil)
             await reloadPreviews()
+            notifyEditCompleted()
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -238,9 +252,17 @@ final class ImageEditorModel: ObservableObject {
             chain = try await body(service)
             showEdited = true
             await reloadPreviews()
+            notifyEditCompleted()
         } catch {
             logger.error("operation failed: \(error.localizedDescription)")
             errorMessage = error.localizedDescription
         }
+    }
+
+    /// Tell the browse viewer + library thumbnail to drop their cached
+    /// rendition and re-fetch the edit-baked image (#469).
+    private func notifyEditCompleted() {
+        guard !documentId.isEmpty else { return }
+        NotificationCenter.default.post(name: .ficheroImageEditCompleted, object: documentId)
     }
 }

--- a/fichero/fichero/Views/Library/QuickLookComponents.swift
+++ b/fichero/fichero/Views/Library/QuickLookComponents.swift
@@ -7,6 +7,7 @@ private let logger = Logger(subsystem: "app.fichero.fichero", category: "QuickLo
 
 // MARK: - Quick Look Components
 
+// swiftlint:disable:next type_body_length
 struct QuickLookDownloadView: View {
     let document: Document
 
@@ -15,6 +16,10 @@ struct QuickLookDownloadView: View {
     @State private var isLoading = true
     @State private var needsAccess = false
     @State private var error: String?
+    /// Set once this document has been edited in the image editor (#469).
+    /// While true, the viewer renders the backend's edit-baked display image
+    /// instead of the untouched local source, so edits show up immediately.
+    @State private var preferEditedRendition = false
 
     @EnvironmentObject var apiClient: APIClient
 
@@ -70,6 +75,13 @@ struct QuickLookDownloadView: View {
         }
         .task(id: document.id) {
             await loadFile()
+        }
+        // When this document is edited in the image editor, drop the cached
+        // (original) rendition and re-fetch the edit-baked image (#469).
+        .onReceive(NotificationCenter.default.publisher(for: .ficheroImageEditCompleted)) { note in
+            guard (note.object as? String) == document.id else { return }
+            preferEditedRendition = true
+            Task { await loadFile() }
         }
     }
 
@@ -133,6 +145,15 @@ struct QuickLookDownloadView: View {
         fileURL = nil
         needsAccess = false
 
+        // Edited images (#469): the on-disk source is untouched, so the local
+        // file would show the *original*. Render the backend's edit-baked
+        // display image instead. The original stays on disk for revert.
+        if preferEditedRendition {
+            logger.info("Loading edit-baked rendition for document: \(document.id)")
+            await downloadEditedRendition()
+            return
+        }
+
         // First try local path if we have access
         if let path = document.path {
             let localURL = URL(fileURLWithPath: path)
@@ -169,6 +190,51 @@ struct QuickLookDownloadView: View {
         // No local path or file doesn't exist - download from API
         logger.info("Loading file from API for document: \(document.id)")
         await downloadFromAPI()
+    }
+
+    /// Download the backend's edit-baked display image (#469) and show it.
+    ///
+    /// Cache-busts with a per-fetch query item and writes to a unique temp file
+    /// so the viewer's `NSImage(contentsOf:)` never reuses a stale cached file
+    /// after another edit. Falls back to surfacing an error; the original source
+    /// is never modified, so revert remains a pure backend operation.
+    private func downloadEditedRendition() async {
+        var components = URLComponents(
+            url: apiClient.displayURL(for: document.id),
+            resolvingAgainstBaseURL: false
+        )
+        components?.queryItems = [URLQueryItem(name: "_t", value: String(Date().timeIntervalSince1970))]
+        let url = components?.url ?? apiClient.displayURL(for: document.id)
+
+        do {
+            var request = URLRequest(url: url)
+            request.cachePolicy = .reloadIgnoringLocalCacheData
+            request.addEngineAuth(libraryPath: apiClient.currentLibraryPath)
+
+            let (data, response) = try await URLSession.shared.data(for: request)
+            if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+                throw URLError(.badServerResponse)
+            }
+
+            let cacheDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("FicheroPreview")
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+            let destURL = cacheDir.appendingPathComponent(
+                "\(document.id)_edited_\(UUID().uuidString).jpg"
+            )
+            try data.write(to: destURL)
+
+            await MainActor.run {
+                self.fileURL = destURL
+                self.isLoading = false
+            }
+        } catch {
+            logger.error("Edited-rendition download failed: \(error.localizedDescription)")
+            await MainActor.run {
+                self.error = "Failed to load edited image: \(error.localizedDescription)"
+                self.isLoading = false
+            }
+        }
     }
 
     // swiftlint:disable:next function_body_length


### PR DESCRIPTION
⚠️ **Left OPEN for Daniel's visual verify.** Worker reported BUILD SUCCEEDED + 57 backend tests; manager independently re-verifying the build.

## What (Daniel's bug: editing an image didn't update the viewer)
Browse-viewer + library thumbnail loaded the **original** (local file / `/storage/source`), never the edit chain. Now:
- **Backend** `api/routes/storage.py`: `/storage/thumbnail` + `/storage/display` serve an **edit-baked sibling rendition** (`*_edited.jpg`) when an edit chain exists, regenerated when the chain is newer (`Cache-Control: no-cache`); base stays the original so **revert still works**.
- **Swift**: editor posts `.ficheroImageEditCompleted` on apply/batch/reset → browse viewer (`QuickLookComponents`) re-fetches the baked display image (cache-busted), library thumbnail (`LibraryImageView`) reloads.

## ⚠️ Separate finding (NOT fixed here — needs your call, tracked separately)
**Workflows catalogue the ORIGINAL, not the edited image.** `storage.resolve_source()` returns the untouched original; the edit chain is only applied at `GET /api/images/{id}/preview`. So edit-then-catalogue runs OCR on the un-edited scan. A backend lane is addressing this with the PR left open for your confirmation.

## Verify checklist (Daniel)
- [ ] Edit an image (rotate/enhance/remove-bg) → the browse viewer updates to the edited version; the library thumbnail updates.
- [ ] Revert (original/edited toggle + Reset) still shows the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)