### PR TITLE
fix: guard DuckDB entity upserts against ART-index crash

### DIFF
--- a/fichero-engine/src/fichero/db.py
+++ b/fichero-engine/src/fichero/db.py
@@ -364,7 +364,7 @@ class Database(DatabaseEmbeddingMixin):
 
         path.parent.mkdir(parents=True, exist_ok=True)
         self.path = path
-        self.conn = duckdb.connect(str(path))
+        self.conn = self._connect()
         self.duck = self.conn  # Alias used by ActionStore and other direct SQL callers
         self._lance_path = path.parent / "vectors"
         self._lance_db = None  # Lazy init
@@ -390,6 +390,55 @@ class Database(DatabaseEmbeddingMixin):
         migrate_library_entity_types_table(self.conn)
         migrate_references_table(self.conn)
         migrate_reference_provenance_table(self.conn)
+
+    def _connect(self) -> duckdb.DuckDBPyConnection:
+        """Open a DuckDB connection for this library path."""
+        return duckdb.connect(str(self.path))
+
+    @staticmethod
+    def _is_invalidated_error(exc: Exception) -> bool:
+        message = str(exc).lower()
+        return "database has been invalidated" in message
+
+    def _reconnect_after_invalidated(self) -> None:
+        """Replace a DuckDB connection poisoned by a prior FatalException."""
+        try:
+            self.conn.close()
+        except Exception:
+            pass
+        self.conn = self._connect()
+        self.duck = self.conn
+        # Table/index setup may not have run on the fresh connection in this
+        # process. Force the next _ensure_table call to reconcile schema and
+        # drop unsafe indexes again.
+        self._tables_created.clear()
+        try:
+            from fichero.db_migrations import migrate_knowledge_indices
+
+            migrate_knowledge_indices(self.conn)
+        except Exception as exc:
+            logger.warning(
+                "Knowledge index reconciliation after reconnect failed: %s",
+                exc,
+            )
+
+    def _execute(self, sql: str, params: Any | None = None):
+        """Execute SQL, reopening once if DuckDB invalidated this connection."""
+        try:
+            if params is None:
+                return self.conn.execute(sql)
+            return self.conn.execute(sql, params)
+        except duckdb.Error as exc:
+            if not self._is_invalidated_error(exc):
+                raise
+            logger.warning(
+                "DuckDB connection for %s was invalidated; reopening and retrying",
+                self.path,
+            )
+            self._reconnect_after_invalidated()
+            if params is None:
+                return self.conn.execute(sql)
+            return self.conn.execute(sql, params)
 
     # =========================================================================
     # Core CRUD Operations
@@ -483,7 +532,7 @@ class Database(DatabaseEmbeddingMixin):
                 f"ON CONFLICT (id) DO NOTHING"
             )
 
-        self.conn.execute(sql, data)
+        self._execute(sql, data)
 
         # Auto-embed if requested and has content
         if auto_embed and hasattr(obj, "page_content") and obj.page_content:
@@ -494,7 +543,7 @@ class Database(DatabaseEmbeddingMixin):
         sql_table = self._sql_table_name(model)
         self._ensure_table(model)
 
-        result = self.conn.execute(
+        result = self._execute(
             f"SELECT * FROM {sql_table} WHERE id = $id", {"id": id}
         ).fetchone()
 
@@ -510,7 +559,7 @@ class Database(DatabaseEmbeddingMixin):
         sql_table = self._sql_table_name(model)
         self._ensure_table(model)
 
-        rows = self.conn.execute(f"SELECT * FROM {sql_table}").fetchall()
+        rows = self._execute(f"SELECT * FROM {sql_table}").fetchall()
 
         if not rows:
             return []
@@ -551,7 +600,7 @@ class Database(DatabaseEmbeddingMixin):
                 where_clauses.append(f"{k} = ${k}")
 
         where = " AND ".join(where_clauses)
-        rows = self.conn.execute(
+        rows = self._execute(
             f"SELECT * FROM {sql_table} WHERE {where}", query_filters
         ).fetchall()
 
@@ -569,7 +618,7 @@ class Database(DatabaseEmbeddingMixin):
         sql_table = self._sql_table_name(obj)
         self._ensure_table(type(obj))
 
-        self.conn.execute(f"DELETE FROM {sql_table} WHERE id = $id", {"id": obj.id})
+        self._execute(f"DELETE FROM {sql_table} WHERE id = $id", {"id": obj.id})
 
     def count(self, model: Type[T], **filters) -> int:
         """Count objects matching filters."""
@@ -577,7 +626,7 @@ class Database(DatabaseEmbeddingMixin):
         self._ensure_table(model)
 
         if not filters:
-            result = self.conn.execute(f"SELECT COUNT(*) FROM {sql_table}").fetchone()
+            result = self._execute(f"SELECT COUNT(*) FROM {sql_table}").fetchone()
         else:
             # Validate column names to prevent SQL injection
             for k in filters.keys():
@@ -585,7 +634,7 @@ class Database(DatabaseEmbeddingMixin):
                     raise ValueError(f"Invalid column name: {k}")
 
             where = " AND ".join(f"{k} = ${k}" for k in filters.keys())
-            result = self.conn.execute(
+            result = self._execute(
                 f"SELECT COUNT(*) FROM {sql_table} WHERE {where}", filters
             ).fetchone()
 
@@ -1598,7 +1647,7 @@ class Database(DatabaseEmbeddingMixin):
             col_type = self._python_to_duckdb_type(field_info.annotation)
             columns.append(f"{name} {col_type}")
 
-        self.conn.execute(f"""
+        self._execute(f"""
             CREATE TABLE IF NOT EXISTS {sql_table} (
                 {", ".join(columns)},
                 PRIMARY KEY (id)
@@ -1616,7 +1665,7 @@ class Database(DatabaseEmbeddingMixin):
         # mechanism that makes the no-migration rule hold for existing DBs too.
         existing = {
             row[0]
-            for row in self.conn.execute(
+            for row in self._execute(
                 f"SELECT column_name FROM information_schema.columns "
                 f"WHERE table_name = '{table}'"
             ).fetchall()
@@ -1624,7 +1673,7 @@ class Database(DatabaseEmbeddingMixin):
         for name, field_info in model.model_fields.items():
             if name not in existing:
                 col_type = self._python_to_duckdb_type(field_info.annotation)
-                self.conn.execute(
+                self._execute(
                     f"ALTER TABLE {sql_table} ADD COLUMN {name} {col_type}"
                 )
 

--- a/fichero-engine/src/fichero/db_migrations.py
+++ b/fichero-engine/src/fichero/db_migrations.py
@@ -313,6 +313,17 @@ def migrate_knowledge_indices(conn) -> None:
     silently no-ops and the next call picks it up after the tables get
     lazily created by ``_ensure_table``. (#991 — scaling-review bottleneck 2)
     """
+    # DuckDB ART secondary indexes can become desynchronised from the table
+    # heap after sustained update/delete churn and then raise a FATAL
+    # "Failed to delete all rows from index" error. KnowledgeEntity rows churn
+    # heavily during catalogue dedup/alias/source-page accumulation, so keep
+    # canonical-name lookup on a table scan until DuckDB's ART delete path is
+    # safe for this workload. Dropping this index is data-safe.
+    try:
+        conn.execute("DROP INDEX IF EXISTS idx_entities_name")
+    except Exception as exc:
+        logger.warning("Knowledge entity name index drop skipped: %s", exc)
+
     statements = [
         # Claims by source document — drives every per-doc inspector
         # section + the "open source" navigation path.
@@ -322,11 +333,6 @@ def migrate_knowledge_indices(conn) -> None:
         # source preview (View 4).
         ("idx_claims_page", "CREATE INDEX IF NOT EXISTS idx_claims_page "
             "ON knowledgeclaims(source_document_id, source_page_label)"),
-        # Entity name lookup — alias resolution at object-phrase →
-        # entity-URI time (kg.graph.build_graph), entity-curation/
-        # semantic search, KG explorer search field.
-        ("idx_entities_name", "CREATE INDEX IF NOT EXISTS idx_entities_name "
-            "ON knowledgeentitys(canonical_name)"),
         # Claim filtering by type / status — claim card status+kind
         # filter bar in the inspector.
         ("idx_claims_type", "CREATE INDEX IF NOT EXISTS idx_claims_type "

--- a/fichero-engine/src/fichero/workflows/tools/_entity_writer.py
+++ b/fichero-engine/src/fichero/workflows/tools/_entity_writer.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import logging
 import re
+import threading
+from functools import wraps
 from typing import Optional
 
 from fichero.db import Database
@@ -37,6 +39,18 @@ from fichero.knowledge_models import (
 )
 
 logger = logging.getLogger(__name__)
+
+_ENTITY_UPSERT_LOCK = threading.RLock()
+
+
+def _serialized_entity_upsert(func):
+    """Run KnowledgeEntity dedup/update work through one process-local lane."""
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        with _ENTITY_UPSERT_LOCK:
+            return func(*args, **kwargs)
+
+    return wrapper
 
 
 # Admin-subdivision qualifier vocabulary (#1114 issue 2)
@@ -755,6 +769,7 @@ def _record_source_page(
     db.save(entity)
 
 
+@_serialized_entity_upsert
 def upsert_entity(
     db: Database,
     canonical_name: str,

--- a/fichero-engine/tests/unit/workflows/test_entity_index_corruption_guard.py
+++ b/fichero-engine/tests/unit/workflows/test_entity_index_corruption_guard.py
@@ -1,0 +1,132 @@
+"""Regression coverage for DuckDB ART-index invalidation in entity writes."""
+
+from __future__ import annotations
+
+import duckdb
+
+from fichero.db import Database
+from fichero.knowledge_models import EntityType, KnowledgeEntity
+from fichero.workflows.tools._entity_writer import upsert_entity
+
+
+def _duckdb_index_names(db: Database) -> set[str]:
+    rows = db.conn.execute(
+        "SELECT index_name FROM duckdb_indexes() WHERE table_name = 'knowledgeentitys'"
+    ).fetchall()
+    return {row[0] for row in rows}
+
+
+def test_knowledge_entity_name_index_is_removed(tmp_path):
+    """Existing libraries drop the unsafe secondary ART index on open."""
+    db = Database(tmp_path / "entities.duckdb")
+    try:
+        db.save(
+            KnowledgeEntity(
+                canonical_name="Don Alfonso",
+                entity_type=EntityType.person,
+            )
+        )
+        db.conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_entities_name "
+            "ON knowledgeentitys(canonical_name)"
+        )
+        assert "idx_entities_name" in _duckdb_index_names(db)
+
+        db._tables_created.clear()
+        db.query(KnowledgeEntity, canonical_name="Don Alfonso")
+
+        assert "idx_entities_name" not in _duckdb_index_names(db)
+    finally:
+        db.close()
+
+
+def test_entity_upsert_churn_on_persistent_duckdb_stays_queryable(tmp_path):
+    """Repeated entity updates do not leave an on-disk DuckDB invalidated."""
+    db = Database(tmp_path / "churn.duckdb")
+    try:
+        entity_id = upsert_entity(
+            db,
+            canonical_name="Don Alfonso",
+            entity_type=EntityType.concept,
+            source_document_id="page-000",
+        )
+
+        promoted_id = upsert_entity(
+            db,
+            canonical_name="Don Alfonso",
+            entity_type=EntityType.person,
+            aliases=["Alfonso"],
+            source_document_id="page-001",
+        )
+        assert promoted_id == entity_id
+
+        for i in range(2, 80):
+            returned_id = upsert_entity(
+                db,
+                canonical_name="Don Alfonso",
+                entity_type=EntityType.person,
+                aliases=[f"Don Alfonso alias {i}"],
+                source_document_id=f"page-{i:03d}",
+            )
+            assert returned_id == entity_id
+
+        alias_id = upsert_entity(
+            db,
+            canonical_name="el Don Alfonso",
+            entity_type=EntityType.person,
+            aliases=["Don A."],
+            source_document_id="page-999",
+        )
+        assert alias_id == entity_id
+
+        rows = db.query(
+            KnowledgeEntity,
+            canonical_name="Don Alfonso",
+            entity_type=EntityType.person,
+        )
+        assert len(rows) == 1
+        entity = rows[0]
+        assert len(entity.source_document_ids) == 81
+        assert "page-999" in entity.source_document_ids
+        assert "idx_entities_name" not in _duckdb_index_names(db)
+
+        # A fresh connection can still read the library after the churn.
+        db.close()
+        reopened = Database(tmp_path / "churn.duckdb")
+        try:
+            assert reopened.get(KnowledgeEntity, entity_id) is not None
+        finally:
+            reopened.close()
+    finally:
+        try:
+            db.close()
+        except Exception:
+            pass
+
+
+def test_invalidated_connection_reopens_and_retries_next_query(tmp_path):
+    db = Database(tmp_path / "recover.duckdb")
+    try:
+        entity = KnowledgeEntity(
+            canonical_name="Recovered Entity",
+            entity_type=EntityType.person,
+        )
+        db.save(entity)
+
+        class PoisonedConnection:
+            def execute(self, *_args, **_kwargs):
+                raise duckdb.FatalException("database has been invalidated")
+
+            def close(self):
+                pass
+
+        db.conn = PoisonedConnection()
+        db.duck = db.conn
+
+        loaded = db.get(KnowledgeEntity, entity.id)
+
+        assert loaded is not None
+        assert loaded.id == entity.id
+        assert not isinstance(db.conn, PoisonedConnection)
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- drop the unsafe `knowledgeentitys(canonical_name)` secondary index and remove it from future knowledge-index setup
- reopen/retry core `Database` operations when DuckDB reports an invalidated connection
- serialize workflow `upsert_entity` writes to reduce catalogue-time entity churn races
- add persistent on-disk DuckDB coverage for source-document/alias/type-promotion churn and invalidated-connection recovery

Fixes #1593.

## Verification
- `PYTHONPATH=fichero-engine/src .venv/bin/ruff check fichero-engine/src/fichero/db.py fichero-engine/src/fichero/db_migrations.py fichero-engine/src/fichero/workflows/tools/_entity_writer.py fichero-engine/tests/unit/workflows/test_entity_index_corruption_guard.py`
- `PYTHONPATH=fichero-engine/src .venv/bin/pytest fichero-engine/tests/unit/workflows/test_entity_index_corruption_guard.py fichero-engine/tests/unit/test_entity_page_scope.py fichero-engine/tests/unit/workflows/test_entity_writer.py -q`
- `PYTHONPATH=fichero-engine/src .venv/bin/pytest fichero-engine/tests/unit/workflows/test_entity_index_corruption_guard.py fichero-engine/tests/unit/test_check_duplicate_paths.py::test_repo_duplicate_gate_has_no_unallowlisted_concerns -q`
- `PYTHONPATH=fichero-engine/src .venv/bin/pytest fichero-engine/tests/unit/test_mock_provider.py -q`
- Full unit suite rerun: `3762 passed, 21 skipped, 21 xfailed`; one intermittent failure in `test_mock_provider.py::test_extract_all_mock_writes_claims_and_artifacts[asyncio]` logged `DBWriter save op failed: Catalog Error: Column with name id already exists!`; rerunning `test_mock_provider.py` alone passed 5/5.
