### PR TITLE
docs: update architecture for real-data library discipline

### DIFF
--- a/docs/architecture/api/development_standards.md
+++ b/docs/architecture/api/development_standards.md
@@ -19,6 +19,25 @@
 - **LanceDB**: Use for vector search and semantic operations
 - **Transactions**: Use proper transaction management for data consistency
 
+### Real-Data Library Discipline
+
+Daniel is using real libraries in `~/Documents/Fichero` and iCloud-synced
+`.fichero` packages. Treat every local DuckDB file as user data:
+
+- **Never nuke or recreate a library database** to fix a schema or index issue.
+- **Structural changes go through `db_migrations.py`** when existing libraries
+  need table rewrites, backfills, index drops/rebuilds, or other durable state
+  changes.
+- **Pydantic model fields still define the fresh-database shape**, but existing
+  real libraries need an idempotent compatibility path. `_ensure_table()` handles
+  additive columns; non-additive changes belong in a migration.
+- **Secondary DuckDB indexes are performance aids, not data contracts.** If an
+  index becomes unsafe under real write churn, drop/rebuild the index rather than
+  touching user rows.
+- **Regression tests for storage bugs should use persistent on-disk DuckDB
+  files**, not only `:memory:`, because WAL replay, index maintenance, and
+  multi-connection behavior differ on disk.
+
 ## Testing Standards
 
 ### Unit Testing
@@ -278,4 +297,3 @@ when the provider returned `usage_metadata`.
 The runner integration (writing the bucket into Activity.metadata at
 node-end) is the final wiring step — landing it requires the runner
 to set up a per-node collector around each LangGraph tool call.
-

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -16,6 +16,29 @@ fichero-engine (FastAPI)
     -> LLM providers
 ```
 
+## Library and Data Locations
+
+Fichero libraries are `.fichero` package directories. The backend accepts
+library paths only under the allowlisted user-data roots:
+
+- `~/Documents`
+- `~/Desktop`
+- `~/Dropbox`
+- `~/Library/Application Support`
+- `~/Library/Mobile Documents/com~apple~CloudDocs` for iCloud Drive and
+  iCloud-synced Desktop/Documents
+- test/temp roots used by CI and local pytest
+
+The `.fichero` suffix is still required. When Desktop/Documents are synced to
+iCloud, macOS may expose `~/Documents` as a symlink into Mobile Documents; the
+allowlist checks both the expanded path and the resolved path so real user
+libraries in `~/Documents/Fichero` continue to open.
+
+Inside a library package, DuckDB lives at `fichero.duckdb` and vector data lives
+under `vectors/`. These are real user data once Daniel is working against live
+libraries, so repair schema/index problems with idempotent migrations rather
+than deleting databases.
+
 ## Canonical architecture docs
 
 - API/backend architecture: `docs/architecture/api/overview.md`


### PR DESCRIPTION
## Summary
- document current real-data `.fichero` discipline for backend/storage work
- add iCloud/Mobile Documents library roots and package data locations to the architecture overview
- call out idempotent migrations/index repair for existing user DuckDB files

## Verification
- `git diff --check docs/architecture/api/development_standards.md docs/architecture/overview.md`
