### PR TITLE
fix: allow Fichero and CloudStorage library roots (#1594)

### DIFF
--- a/fichero-engine/src/fichero/api/main.py
+++ b/fichero-engine/src/fichero/api/main.py
@@ -655,10 +655,12 @@ def _is_allowed_library_path(library_path: str) -> bool:
     """Validate that a library path is in an allowed location.
 
     Allowed roots:
+    - ~/Fichero (Daniel's real-data library root)
     - ~/Documents
     - ~/Desktop (iCloud-syncable, natural place for libraries)
     - ~/Dropbox
     - ~/Library/Application Support
+    - ~/Library/CloudStorage — macOS File Provider roots such as Box
     - ~/Library/Mobile Documents/com~apple~CloudDocs — iCloud Drive AND
       iCloud-synced Documents/Desktop physically live here
     - test temp dirs under /var/folders and /private/var/folders (macOS)
@@ -685,11 +687,14 @@ def _is_allowed_library_path(library_path: str) -> bool:
 
     home = Path.home().resolve()
     icloud = home / "Library" / "Mobile Documents" / "com~apple~CloudDocs"
+    cloud_storage = home / "Library" / "CloudStorage"
     allowed_roots = [
+        home / "Fichero",
         home / "Documents",
         home / "Desktop",
         home / "Dropbox",
         home / "Library" / "Application Support",
+        cloud_storage,
         icloud,
         Path("/var/folders"),
         Path("/private/var/folders"),

--- a/fichero-engine/tests/unit/test_library_path_allowlist.py
+++ b/fichero-engine/tests/unit/test_library_path_allowlist.py
@@ -79,6 +79,25 @@ def test_documents_plain_path_allowed():
     assert _is_allowed_library_path(str(p)) is True
 
 
+def test_home_fichero_path_allowed():
+    """~/Fichero/X.fichero is allowed for Daniel's real-data libraries."""
+    p = Path.home() / "Fichero" / "Jesuit Mapping.fichero"
+    assert _is_allowed_library_path(str(p)) is True
+
+
+def test_cloudstorage_box_path_allowed():
+    """Box File Provider libraries under ~/Library/CloudStorage are allowed."""
+    p = (
+        Path.home()
+        / "Library"
+        / "CloudStorage"
+        / "Box-Box"
+        / "Fichero"
+        / "Marshall.fichero"
+    )
+    assert _is_allowed_library_path(str(p)) is True
+
+
 def test_desktop_path_allowed():
     """~/Desktop/X.fichero is allowed (Desktop is iCloud-syncable)."""
     p = Path.home() / "Desktop" / "X.fichero"


### PR DESCRIPTION
## Summary
- allow libraries under `~/Fichero`
- allow libraries under `~/Library/CloudStorage` for Box/iCloud-style provider roots
- add regression coverage for both allowlisted roots

## Real-data validation
- Used a private backend on port 8876 with `FICHERO_BASE_PATH=/tmp/fichero-codex-1594-app`; did not touch the live `f_backend` session.
- Imported `NCM_Diary_1923.docx` from Box into `/Users/danieltubb/Fichero/Marshall Diaries.fichero` via the CLI.
- Set the private app AI defaults to `mock` and ran `NER per-page (local)` on the imported document.
- Workflow completed through `kg_writer`; `docs kg` returned 4 claims and `docs inspector` returned 3 canonical entities.
- Jesuit Mapping was not present under `/Users/danieltubb/Fichero` or `/Users/danieltubb/Documents/Fichero` during this pass.

## Verification
- `PYTHONPATH=fichero-engine/src .venv/bin/pytest fichero-engine/tests/unit/test_library_path_allowlist.py -q`
- `PYTHONPATH=fichero-engine/src .venv/bin/ruff check fichero-engine/src/fichero/api/main.py fichero-engine/tests/unit/test_library_path_allowlist.py`

Stacked on #1596 / issue #1593; do not merge until the P0 branch is reviewed.