### PR TITLE
fix: allow Fichero and CloudStorage library roots (#1594)

### DIFF
--- a/fichero-engine/src/fichero/api/main.py
+++ b/fichero-engine/src/fichero/api/main.py
@@ -657,8 +657,10 @@ def _is_allowed_library_path(library_path: str) -> bool:
     Allowed roots:
     - ~/Documents
     - ~/Desktop (iCloud-syncable, natural place for libraries)
+    - ~/Fichero
     - ~/Dropbox
     - ~/Library/Application Support
+    - ~/Library/CloudStorage (Box/Dropbox/iCloud provider roots)
     - ~/Library/Mobile Documents/com~apple~CloudDocs — iCloud Drive AND
       iCloud-synced Documents/Desktop physically live here
     - test temp dirs under /var/folders and /private/var/folders (macOS)
@@ -688,8 +690,10 @@ def _is_allowed_library_path(library_path: str) -> bool:
     allowed_roots = [
         home / "Documents",
         home / "Desktop",
+        home / "Fichero",
         home / "Dropbox",
         home / "Library" / "Application Support",
+        home / "Library" / "CloudStorage",
         icloud,
         Path("/var/folders"),
         Path("/private/var/folders"),

--- a/fichero-engine/tests/unit/test_library_path_allowlist.py
+++ b/fichero-engine/tests/unit/test_library_path_allowlist.py
@@ -85,6 +85,25 @@ def test_desktop_path_allowed():
     assert _is_allowed_library_path(str(p)) is True
 
 
+def test_home_fichero_path_allowed():
+    """~/Fichero/X.fichero is allowed for Daniel's local libraries."""
+    p = Path.home() / "Fichero" / "Jesuit Mapping.fichero"
+    assert _is_allowed_library_path(str(p)) is True
+
+
+def test_cloudstorage_box_path_allowed():
+    """~/Library/CloudStorage provider roots are allowed for library packages."""
+    p = (
+        Path.home()
+        / "Library"
+        / "CloudStorage"
+        / "Box-Box"
+        / "Libraries"
+        / "Jesuit Mapping.fichero"
+    )
+    assert _is_allowed_library_path(str(p)) is True
+
+
 def test_non_fichero_suffix_rejected():
     """A path without a .fichero suffix is rejected."""
     p = Path.home() / "Documents" / "notes.txt"


### PR DESCRIPTION
## Summary
- allow `.fichero` libraries under `~/Fichero`
- allow `.fichero` libraries under `~/Library/CloudStorage` for Box/provider-backed library packages
- add regression tests for both roots

## Verification
- `PYTHONPATH=fichero-engine/src .venv/bin/pytest fichero-engine/tests/unit/test_library_path_allowlist.py -q`
- `PYTHONPATH=fichero-engine/src .venv/bin/ruff check fichero-engine/src/fichero/api/main.py fichero-engine/tests/unit/test_library_path_allowlist.py`

Fresh replacement for closed/unmerged #1598. Do not merge until reviewed.