### PR TITLE
library-reading-surface milestone — overnight worker batch

### DIFF
--- a/fichero/fichero/Models/DocumentStore+Helpers.swift
+++ b/fichero/fichero/Models/DocumentStore+Helpers.swift
@@ -183,4 +183,23 @@ extension DocumentStore {
             return doc
         }
     }
+
+    /// Re-fetch the given documents by ID from the backend and merge each fresh
+    /// record into the in-memory caches via `refreshLocalContent`. Called after a
+    /// workflow completes so backend-written content (e.g. a Transcribe
+    /// transcript) replaces the stale in-memory `pageContent` without forcing a
+    /// full folder reload. (#1445)
+    func refreshDocumentsByIds(_ ids: [String]) async {
+        for id in ids {
+            do {
+                let fresh: Document = try await api.get("/documents/\(id)")
+                refreshLocalContent(fresh)
+            } catch {
+                let logger = Logger(subsystem: "app.fichero.fichero", category: "DocumentStore")
+                logger.warning(
+                    "refreshDocumentsByIds: failed to refresh \(id, privacy: .public): \(error.localizedDescription, privacy: .public)"
+                )
+            }
+        }
+    }
 }

--- a/fichero/fichero/Views/ContentView+WorkflowActions.swift
+++ b/fichero/fichero/Views/ContentView+WorkflowActions.swift
@@ -293,11 +293,7 @@ extension ContentView {
                     workflowId: workflowId,
                     streamCompleted: streamCompleted
                 )
-
-                let finalStatus = workflowFinalStatus(for: workflowId)
-                executionObserver.endExecution(workflowId: workflowId, status: finalStatus)
-                workflowLogger.info("Workflow \(workflowId) finished with status: \(String(describing: finalStatus))")
-
+                await finishWorkflowExecution(workflowId: workflowId, docIds: docIds, streamCompleted: streamCompleted)
             } catch {
                 importProgress = nil
                 importError = "Workflow failed to start: \(error.localizedDescription)"
@@ -305,6 +301,28 @@ extension ContentView {
                 executionObserver.endExecution(workflowId: workflowId, status: .failed)
             }
         }
+    }
+
+    /// Post-completion bookkeeping for a workflow run. A completed workflow
+    /// (e.g. Transcribe) may have written new per-page content backend-side, so
+    /// re-fetch the affected documents before ending execution — the Content/
+    /// transcript pane then shows fresh text instead of stale in-memory content,
+    /// and the inspector's `workflowCompletedCount` observers see the refreshed
+    /// data. (#1445)
+    @MainActor
+    private func finishWorkflowExecution(
+        workflowId: String,
+        docIds: [String],
+        streamCompleted: Bool
+    ) async {
+        if streamCompleted {
+            await documentStore.refreshDocumentsByIds(docIds)
+        }
+        let finalStatus = workflowFinalStatus(for: workflowId)
+        executionObserver.endExecution(workflowId: workflowId, status: finalStatus)
+        workflowLogger.info(
+            "Workflow \(workflowId) finished with status: \(String(describing: finalStatus))"
+        )
     }
 
     private func handleWorkflowStreamEvent(


### PR DESCRIPTION
Autonomous milestone-worker output (library-reading-surface). Worker gated before commit; manager merging in overnight loop. 🤖