### PR TITLE
Library & Reading Surface: sidebar test coverage (#583) + bounded thumbnail prefetch cache (#719)

### DIFF
--- a/fichero/fichero-tests/ActivityRunMappingTests.swift
+++ b/fichero/fichero-tests/ActivityRunMappingTests.swift
@@ -1,0 +1,157 @@
+//
+//  ActivityRunMappingTests.swift
+//  FicheroTests
+//
+//  Sidebar test coverage sprint (#583). Covers the previously-untested
+//  Activity-run mapping logic: ActivityRunStatus icon/color/toStatusType,
+//  ActivityRun.toSelectedRun field mapping, SelectedActivityRun.with, and
+//  ActivityChildType label/icon. These are the pure value-mappers that feed
+//  the Activity sidebar → viewMode navigation; the rest of the sidebar
+//  surface is already exercised by DragDropTests / SidebarItemTests /
+//  DocumentStoreAndSidebarTypesTests.
+//
+
+@testable import Fichero
+import Foundation
+import SwiftUI
+import Testing
+
+// MARK: - ActivityRunStatus
+
+struct ActivityRunStatusMappingTests {
+
+    @Test("toStatusType maps every case to its matching ActivityRunStatusType")
+    func toStatusTypeMapsAllCases() {
+        #expect(ActivityRunStatus.running.toStatusType() == .running)
+        #expect(ActivityRunStatus.completed.toStatusType() == .completed)
+        #expect(ActivityRunStatus.failed.toStatusType() == .failed)
+        #expect(ActivityRunStatus.cancelled.toStatusType() == .cancelled)
+    }
+
+    @Test("icon is the expected SF Symbol for every case")
+    func iconValues() {
+        #expect(ActivityRunStatus.running.icon == "play.circle.fill")
+        #expect(ActivityRunStatus.completed.icon == "checkmark.circle.fill")
+        #expect(ActivityRunStatus.failed.icon == "xmark.circle.fill")
+        #expect(ActivityRunStatus.cancelled.icon == "stop.circle.fill")
+    }
+
+    @Test("color is the expected accent for every case")
+    func colorValues() {
+        #expect(ActivityRunStatus.running.color == .blue)
+        #expect(ActivityRunStatus.completed.color == .green)
+        #expect(ActivityRunStatus.failed.color == .red)
+        #expect(ActivityRunStatus.cancelled.color == .orange)
+    }
+
+    @Test("every icon is non-empty")
+    func iconsNonEmpty() {
+        let all: [ActivityRunStatus] = [.running, .completed, .failed, .cancelled]
+        for status in all {
+            #expect(!status.icon.isEmpty)
+        }
+    }
+}
+
+// MARK: - ActivityRun.toSelectedRun
+
+struct ActivityRunToSelectedRunTests {
+
+    private func makeRun(
+        status: ActivityRunStatus = .running,
+        isLive: Bool = true
+    ) -> ActivityRun {
+        ActivityRun(
+            id: "lib-scoped:run-1",
+            runId: "thread-42",
+            workflowId: "wf-7",
+            threadId: "thread-42",
+            workflowName: "Transcribe",
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            status: status,
+            progress: 0.5,
+            currentStep: "ocr",
+            errorCount: 0,
+            fileCount: 3,
+            isLive: isLive
+        )
+    }
+
+    @Test("toSelectedRun uses the logical runId as id, not the sidebar id")
+    func usesRunIdNotSidebarId() {
+        let selected = makeRun().toSelectedRun()
+        #expect(selected.id == "thread-42")
+        #expect(selected.id != "lib-scoped:run-1")
+    }
+
+    @Test("toSelectedRun preserves name / workflowId / threadId / timestamp / isLive")
+    func preservesScalarFields() {
+        let selected = makeRun(isLive: false).toSelectedRun()
+        #expect(selected.name == "Transcribe")
+        #expect(selected.workflowId == "wf-7")
+        #expect(selected.threadId == "thread-42")
+        #expect(selected.timestamp == Date(timeIntervalSince1970: 1_000))
+        #expect(selected.isLive == false)
+    }
+
+    @Test("toSelectedRun converts status via toStatusType")
+    func convertsStatus() {
+        #expect(makeRun(status: .failed).toSelectedRun().status == .failed)
+        #expect(makeRun(status: .cancelled).toSelectedRun().status == .cancelled)
+    }
+
+    @Test("toSelectedRun starts with no selected child (overview)")
+    func childTypeStartsNil() {
+        #expect(makeRun().toSelectedRun().childType == nil)
+    }
+}
+
+// MARK: - SelectedActivityRun.with
+
+struct SelectedActivityRunWithTests {
+
+    @Test("with(childType:) sets the child and preserves every other field")
+    func withSetsChildPreservesRest() {
+        let base = SelectedActivityRun(
+            id: "thread-42",
+            name: "Transcribe",
+            workflowId: "wf-7",
+            threadId: "thread-42",
+            timestamp: Date(timeIntervalSince1970: 1_000),
+            status: .completed,
+            isLive: false,
+            childType: nil
+        )
+        let withLog = base.with(childType: .log)
+        #expect(withLog.childType == .log)
+        #expect(withLog.id == base.id)
+        #expect(withLog.name == base.name)
+        #expect(withLog.workflowId == base.workflowId)
+        #expect(withLog.threadId == base.threadId)
+        #expect(withLog.timestamp == base.timestamp)
+        #expect(withLog.status == base.status)
+        #expect(withLog.isLive == base.isLive)
+    }
+}
+
+// MARK: - ActivityChildType
+
+struct ActivityChildTypeMappingTests {
+
+    @Test("label is the expected human-readable string for every case")
+    func labels() {
+        #expect(ActivityChildType.console.label == "Console")
+        #expect(ActivityChildType.progress.label == "Progress")
+        #expect(ActivityChildType.log.label == "Log")
+    }
+
+    @Test("icon is a non-empty SF Symbol for every case")
+    func icons() {
+        #expect(ActivityChildType.console.icon == "text.alignleft")
+        #expect(ActivityChildType.progress.icon == "chart.bar.fill")
+        #expect(ActivityChildType.log.icon == "doc.text")
+        for child in ActivityChildType.allCases {
+            #expect(!child.icon.isEmpty)
+        }
+    }
+}

--- a/fichero/fichero-tests/StorageThumbnailCacheTests.swift
+++ b/fichero/fichero-tests/StorageThumbnailCacheTests.swift
@@ -1,0 +1,71 @@
+//
+//  StorageThumbnailCacheTests.swift
+//  FicheroTests
+//
+//  Bounded thumbnail-cache eviction (#719). The eager-prefetch path warms
+//  StorageServiceGenerated.thumbnailCache for every image in a folder; this
+//  verifies the cache stays bounded (FIFO, oldest-first) so a folder with
+//  thousands of images can't grow it without limit.
+//
+
+@testable import Fichero
+import FicheroAPIClient
+import Foundation
+import SwiftUI
+import Testing
+
+@MainActor
+struct StorageThumbnailCacheTests {
+
+    private func makeService() -> StorageServiceGenerated {
+        StorageServiceGenerated(ficheroClient: FicheroClient(libraryPath: nil))
+    }
+
+    private let dummy = Image(systemName: "photo")
+
+    @Test("cache count never exceeds the limit")
+    func cacheStaysBounded() {
+        let service = makeService()
+        let limit = StorageServiceGenerated.thumbnailCacheLimit
+        for index in 0..<(limit + 50) {
+            service.cacheThumbnail(dummy, for: "doc-\(index)")
+        }
+        #expect(service.thumbnailCacheCount == limit)
+    }
+
+    @Test("oldest entries are evicted first; newest survive")
+    func evictsOldestFirst() {
+        let service = makeService()
+        let limit = StorageServiceGenerated.thumbnailCacheLimit
+        for index in 0..<(limit + 5) {
+            service.cacheThumbnail(dummy, for: "doc-\(index)")
+        }
+        // doc-0...doc-4 were the first inserted → evicted.
+        #expect(service.cachedThumbnail(for: "doc-0") == nil)
+        #expect(service.cachedThumbnail(for: "doc-4") == nil)
+        // doc-5 onward survive.
+        #expect(service.cachedThumbnail(for: "doc-5") != nil)
+        #expect(service.cachedThumbnail(for: "doc-\(limit + 4)") != nil)
+    }
+
+    @Test("re-caching an existing id does not grow order / double-evict")
+    func reCachingSameIdIsStable() {
+        let service = makeService()
+        for _ in 0..<10 {
+            service.cacheThumbnail(dummy, for: "stable")
+        }
+        #expect(service.thumbnailCacheCount == 1)
+        #expect(service.cachedThumbnail(for: "stable") != nil)
+    }
+
+    @Test("invalidate removes the entry from cache and order")
+    func invalidateClearsEntry() {
+        let service = makeService()
+        service.cacheThumbnail(dummy, for: "doc-a")
+        service.cacheThumbnail(dummy, for: "doc-b")
+        service.invalidateImageCache(for: "doc-a")
+        #expect(service.cachedThumbnail(for: "doc-a") == nil)
+        #expect(service.cachedThumbnail(for: "doc-b") != nil)
+        #expect(service.thumbnailCacheCount == 1)
+    }
+}

--- a/fichero/fichero/Services/StorageServiceGenerated.swift
+++ b/fichero/fichero/Services/StorageServiceGenerated.swift
@@ -32,6 +32,21 @@ class StorageServiceGenerated: ObservableObject {
     private var thumbnailCache: [String: Image] = [:]
     private var displayCache: [String: Image] = [:]
 
+    /// Upper bound on the thumbnail cache so opening a folder with thousands
+    /// of images can't grow it without limit (#719). When exceeded, the
+    /// oldest-inserted entries are evicted first (FIFO) — by the time the
+    /// cache is this full the user has scrolled well past those rows.
+    static let thumbnailCacheLimit = 1000
+    /// Insertion order of thumbnail-cache keys, oldest first. Drives FIFO
+    /// eviction in `cacheThumbnail`.
+    private var thumbnailCacheOrder: [String] = []
+
+    /// Number of cached thumbnails. Exposed for tests (#719 eviction).
+    var thumbnailCacheCount: Int { thumbnailCache.count }
+
+    /// Cached thumbnail for `docId`, if present. Exposed for tests (#719).
+    func cachedThumbnail(for docId: String) -> Image? { thumbnailCache[docId] }
+
     init(ficheroClient: FicheroClient, baseURL: URL = URL(string: "http://127.0.0.1:8765/api")!) {
         self.client = ficheroClient
         self.baseURL = baseURL
@@ -53,8 +68,22 @@ class StorageServiceGenerated: ObservableObject {
         logger.info("Loading thumbnail for document: \(docId)")
         let data = try await fetchImageData(from: thumbnailURL(for: docId))
         let image = try await Self.decodeImage(from: data)
-        thumbnailCache[docId] = image
+        cacheThumbnail(image, for: docId)
         return image
+    }
+
+    /// Insert a thumbnail into the cache, evicting the oldest entries (FIFO)
+    /// once the cache exceeds `thumbnailCacheLimit`. Internal so the eviction
+    /// bound can be unit-tested without a live backend. (#719)
+    func cacheThumbnail(_ image: Image, for docId: String) {
+        if thumbnailCache[docId] == nil {
+            thumbnailCacheOrder.append(docId)
+        }
+        thumbnailCache[docId] = image
+        while thumbnailCacheOrder.count > Self.thumbnailCacheLimit {
+            let oldest = thumbnailCacheOrder.removeFirst()
+            thumbnailCache.removeValue(forKey: oldest)
+        }
     }
 
     /// Get display-quality image for a document. Memoised per-service-instance.
@@ -96,6 +125,7 @@ class StorageServiceGenerated: ObservableObject {
     func invalidateImageCache(for docId: String) {
         thumbnailCache.removeValue(forKey: docId)
         displayCache.removeValue(forKey: docId)
+        thumbnailCacheOrder.removeAll { $0 == docId }
     }
 
     /// Fetch raw image bytes from the backend. Suspends during the


### PR DESCRIPTION
Milestone batch on `ms/library-reading-surface`. Two independent, gated changes:

## #583 — Activity-run sidebar test coverage
Adds `ActivityRunMappingTests.swift` (10 tests) covering the previously-untested Activity-run value mappers: `ActivityRunStatus.toStatusType/icon/color`, `ActivityRun.toSelectedRun` field mapping, `SelectedActivityRun.with`, `ActivityChildType.label/icon`. The broader sidebar already had strong coverage (DragDropTests / SidebarItemTests / DocumentStoreAndSidebarTypesTests); these are the remaining high-value gaps.

## #719 — Bound the eager thumbnail prefetch cache (FIFO)
The folder-thumbnail prefetch was already wired (`LibraryView+DisplayModes` `.task(id:)` → `StorageServiceGenerated.prefetchThumbnails`, file-scoped, cancel-on-folder-change, capped at 6 concurrent), but the underlying `thumbnailCache` was an **unbounded** dictionary. Adds a 1000-entry FIFO cap (`cacheThumbnail` evicts oldest; `invalidateImageCache` keeps the order list in sync) so huge image folders can't grow the cache without limit. Adds `StorageThumbnailCacheTests` (4 tests).

## Verification
- swiftlint: clean on all changed files
- `xcodebuild test` (FicheroTests: ActivityRun* + SelectedActivityRunWith + ActivityChildType* + StorageThumbnailCacheTests): **TEST SUCCEEDED**

Closes #583
Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)