### PR TITLE
fix(mind-palace): bound RealityKit scene to prevent GPU watchdog crash (#1400)

### DIFF
--- a/fichero/fichero/Views/MindPalace/SpatialScene3D.swift
+++ b/fichero/fichero/Views/MindPalace/SpatialScene3D.swift
@@ -32,6 +32,35 @@ struct SpatialScene3D: View {
     var onViewportChanged: (SIMD3<Double>, Double) -> Void = { _, _ in }
     @Binding var selectedNodeId: String?
 
+    /// Upper bound on entities the RealityKit scene will build at once (#1400).
+    /// A folder projection (`FolderRealityKitSurface`) can scope hundreds of
+    /// documents; each rendered node also spawns a concurrent texture
+    /// download+decode Task. Unbounded, that storm of `ModelEntity`s + image
+    /// I/O sustains GPU/CPU load and was the prime suspect for the macOS
+    /// WindowServer watchdog crashes. Beyond the cap we render a bounded prefix
+    /// and surface a banner — never a runaway scene.
+    private let maxRenderedNodes = 250
+
+    /// The bounded set actually placed in the scene. Backend order is
+    /// preserved; relative geometry of the rendered subset is untouched
+    /// (`feedback_kg_logic_in_backend`).
+    private var renderedNodes: [MindPalaceNode] {
+        nodes.count > maxRenderedNodes ? Array(nodes.prefix(maxRenderedNodes)) : nodes
+    }
+
+    private var isTruncated: Bool { nodes.count > maxRenderedNodes }
+
+    /// Honest, non-blocking notice when the scene is bounded (#1400) so a large
+    /// scope reads as "showing a subset" rather than silently dropping nodes.
+    private var truncationBanner: some View {
+        Text("Showing first \(maxRenderedNodes) of \(nodes.count) items")
+            .font(.caption)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(.regularMaterial, in: Capsule())
+            .padding(.top, 8)
+    }
+
     #if canImport(RealityKit)
     @State private var cameraDistance = 5.5
     @State private var orbitYaw = 0.0
@@ -94,6 +123,9 @@ struct SpatialScene3D: View {
             focusCamera(onNodeId: newValue)
         }
         .background(MindPalaceTheme.canvasBackground)
+        .overlay(alignment: .top) {
+            if isTruncated { truncationBanner }
+        }
         #else
         Spatial2DCanvas(nodes: nodes, connections: connections, selectedNodeId: $selectedNodeId)
         #endif
@@ -240,10 +272,11 @@ struct SpatialScene3D: View {
     /// Normalize backend positions into a bounded cube (~[-1.5, 1.5]) so the
     /// fixed camera frames any room. Uniform scale preserves relative layout.
     private func normalize() -> (scale: Float, center: SIMD3<Float>) {
-        guard !nodes.isEmpty else { return (1, .zero) }
-        let xValues = nodes.map { Float($0.positionX) }
-        let yValues = nodes.map { Float($0.positionY) }
-        let zValues = nodes.map { Float($0.positionZ) }
+        let scope = renderedNodes
+        guard !scope.isEmpty else { return (1, .zero) }
+        let xValues = scope.map { Float($0.positionX) }
+        let yValues = scope.map { Float($0.positionY) }
+        let zValues = scope.map { Float($0.positionZ) }
         let center = SIMD3<Float>(
             (xValues.min()! + xValues.max()!) / 2,
             (yValues.min()! + yValues.max()!) / 2,
@@ -268,7 +301,7 @@ struct SpatialScene3D: View {
         let root = Entity()
 
         var positions: [String: SIMD3<Float>] = [:]
-        for node in nodes {
+        for node in renderedNodes {
             let pos = position(for: node, scale: scale, center: center)
             positions[node.id] = pos
             root.addChild(makeNodeEntity(node, at: pos))


### PR DESCRIPTION
## What

Bounds the RealityKit spatial scene (`SpatialScene3D`) to a maximum number of rendered nodes to stop a runaway GPU/CPU load that is the prime suspect for the macOS WindowServer watchdog crashes in #1400.

## Why

`FolderRealityKitSurface` (the document-viewer 3D surface) projects a folder's children into the scene with **no upper bound**. A large folder (hundreds of pages — e.g. the Marshall Diaries real data) builds that many `ModelEntity`s **and** spawns that many concurrent texture download+decode `Task`s. Unbounded, that sustains GPU/CPU load and starves the display compositor → the `WATCHDOG / WindowServer main thread unresponsive 40s` crash reported in #1400.

The issue's own mitigations: #1 (default `mindPalace` flag OFF) is already in place; #2 asks for "no runaway loop / fall back to a static state" — this PR.

## Change

- `maxRenderedNodes = 250`; `buildScene()` + `normalize()` operate on a bounded prefix of `nodes`.
- Non-blocking banner *"Showing first 250 of N items"* keeps truncation honest (no silent drops).
- Relative geometry of the rendered subset is untouched (`feedback_kg_logic_in_backend`).

## Gate

- `swiftlint fichero/fichero/` — 0 serious (2 pre-existing file/type-length warnings on this file, present on `main`).
- `xcodebuild -project fichero/fichero.xcodeproj -scheme Fichero -destination 'platform=macOS' build` → **BUILD SUCCEEDED**.

## Not covered / needs runtime QA

- **Visual confirmation** that the watchdog crash no longer reproduces requires a real work session on the M1 — this PR is the code-level bound.
- The #1376 "giant blue blob" *visual* defect is a separate root-cause (failed material / RealityKit fallback) and is **not** addressed here; left an investigation note on #1376.

Closes #1400 (pending runtime QA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
