### PR TITLE
fix: drop corrupting knowledgeclaims ART indexes (#1611, follow-up to #1596)

### DIFF
--- a/fichero-engine/src/fichero/db_migrations.py
+++ b/fichero-engine/src/fichero/db_migrations.py
@@ -315,34 +315,42 @@ def migrate_knowledge_indices(conn) -> None:
     """
     # DuckDB ART secondary indexes can become desynchronised from the table
     # heap after sustained update/delete churn and then raise a FATAL
-    # "Failed to delete all rows from index" error. KnowledgeEntity rows churn
-    # heavily during catalogue dedup/alias/source-page accumulation, so keep
-    # canonical-name lookup on a table scan until DuckDB's ART delete path is
-    # safe for this workload. Dropping this index is data-safe.
-    try:
-        conn.execute("DROP INDEX IF EXISTS idx_entities_name")
-    except Exception as exc:
-        logger.warning("Knowledge entity name index drop skipped: %s", exc)
-
-    statements = [
-        # Claims by source document — drives every per-doc inspector
-        # section + the "open source" navigation path.
-        ("idx_claims_source_doc", "CREATE INDEX IF NOT EXISTS idx_claims_source_doc "
-            "ON knowledgeclaims(source_document_id)"),
-        # Claims by (doc, page) — drives the "On this page" sidecar on
-        # source preview (View 4).
-        ("idx_claims_page", "CREATE INDEX IF NOT EXISTS idx_claims_page "
-            "ON knowledgeclaims(source_document_id, source_page_label)"),
-        # Claim filtering by type / status — claim card status+kind
-        # filter bar in the inspector.
-        ("idx_claims_type", "CREATE INDEX IF NOT EXISTS idx_claims_type "
-            "ON knowledgeclaims(claim_type)"),
-        ("idx_claims_status", "CREATE INDEX IF NOT EXISTS idx_claims_status "
-            "ON knowledgeclaims(epistemic_status)"),
-        # Claim by creation time — recency sort + activity timeline.
-        ("idx_claims_created", "CREATE INDEX IF NOT EXISTS idx_claims_created "
-            "ON knowledgeclaims(created_at)"),
+    # "Failed to delete all rows from index" error. Both KnowledgeEntity AND
+    # KnowledgeClaim rows churn heavily during catalogue dedup/rewrite (the
+    # catalogue churns claims hardest of all), so keep their lookups on a table
+    # scan until DuckDB's ART delete path is safe for this workload. Dropping
+    # these indexes is data-safe — they only bought lookup speed, and at
+    # Fichero's single-library scale a plain table scan is fine; correctness is
+    # unaffected. The PRIMARY KEY index on ``id`` stays on each table: ``id`` is
+    # a stable UUID that is never UPDATEd, so its ART delete path isn't churned
+    # the same way, and dropping a PK is not safe.
+    #
+    # #1596 dropped ``idx_entities_name`` for exactly this reason. The claims
+    # ART indexes (``idx_claims_*``) hit the same corruption on the
+    # ``knowledgeclaims`` table during real-data catalogue use (#1611), so they
+    # are dropped here too. Existing libraries that already created any of these
+    # (and are therefore one bad catalogue away from the crash) shed them here
+    # — DROP INDEX IF EXISTS is idempotent and a no-op on fresh DBs.
+    drop_indexes = [
+        "idx_entities_name",
+        "idx_claims_source_doc",
+        "idx_claims_page",
+        "idx_claims_type",
+        "idx_claims_status",
+        "idx_claims_created",
     ]
+    for index_name in drop_indexes:
+        try:
+            conn.execute(f"DROP INDEX IF EXISTS {index_name}")
+        except Exception as exc:
+            logger.warning("Knowledge index %s drop skipped: %s", index_name, exc)
+
+    # All knowledgeclaims/knowledgeentitys secondary ART indexes are now
+    # dropped above (corruption risk). No CREATE INDEX statements remain for
+    # these tables — queries fall back to table scans, which is correct and
+    # fine at single-user scale. Keep this list empty rather than re-adding any
+    # claims/entity index until DuckDB's ART delete path is safe for the churn.
+    statements: list[tuple[str, str]] = []
     created = 0
     for name, ddl in statements:
         try:

--- a/fichero-engine/tests/unit/workflows/test_entity_index_corruption_guard.py
+++ b/fichero-engine/tests/unit/workflows/test_entity_index_corruption_guard.py
@@ -5,15 +5,20 @@ from __future__ import annotations
 import duckdb
 
 from fichero.db import Database
-from fichero.knowledge_models import EntityType, KnowledgeEntity
+from fichero.knowledge_models import EntityType, KnowledgeClaim, KnowledgeEntity
 from fichero.workflows.tools._entity_writer import upsert_entity
 
 
-def _duckdb_index_names(db: Database) -> set[str]:
+def _duckdb_index_names(db: Database, table_name: str = "knowledgeentitys") -> set[str]:
     rows = db.conn.execute(
-        "SELECT index_name FROM duckdb_indexes() WHERE table_name = 'knowledgeentitys'"
+        "SELECT index_name FROM duckdb_indexes() WHERE table_name = ?",
+        [table_name],
     ).fetchall()
     return {row[0] for row in rows}
+
+
+def _claim_index_names(db: Database) -> set[str]:
+    return _duckdb_index_names(db, "knowledgeclaims")
 
 
 def test_knowledge_entity_name_index_is_removed(tmp_path):
@@ -95,6 +100,108 @@ def test_entity_upsert_churn_on_persistent_duckdb_stays_queryable(tmp_path):
         reopened = Database(tmp_path / "churn.duckdb")
         try:
             assert reopened.get(KnowledgeEntity, entity_id) is not None
+        finally:
+            reopened.close()
+    finally:
+        try:
+            db.close()
+        except Exception:
+            pass
+
+
+def test_knowledge_claim_indices_are_removed(tmp_path):
+    """Existing libraries drop the unsafe secondary ART indexes on knowledgeclaims.
+
+    The claims ART indexes hit the same "Failed to delete all rows from index"
+    corruption as ``idx_entities_name`` during real-data catalogue churn, so
+    ``migrate_knowledge_indices`` drops them too (follow-up to #1596).
+    """
+    db = Database(tmp_path / "claims.duckdb")
+    try:
+        db.save(
+            KnowledgeClaim(
+                text="Don Alfonso served as alcalde.",
+                source_document_id="page-000",
+            )
+        )
+        # Recreate the indexes an old library would still carry.
+        for ddl in (
+            "CREATE INDEX IF NOT EXISTS idx_claims_source_doc "
+            "ON knowledgeclaims(source_document_id)",
+            "CREATE INDEX IF NOT EXISTS idx_claims_page "
+            "ON knowledgeclaims(source_document_id, source_page_label)",
+            "CREATE INDEX IF NOT EXISTS idx_claims_type "
+            "ON knowledgeclaims(claim_type)",
+            "CREATE INDEX IF NOT EXISTS idx_claims_status "
+            "ON knowledgeclaims(epistemic_status)",
+            "CREATE INDEX IF NOT EXISTS idx_claims_created "
+            "ON knowledgeclaims(created_at)",
+        ):
+            db.conn.execute(ddl)
+        present = _claim_index_names(db)
+        assert {
+            "idx_claims_source_doc",
+            "idx_claims_page",
+            "idx_claims_type",
+            "idx_claims_status",
+            "idx_claims_created",
+        } <= present
+
+        # Re-running the lazy table migration must shed every claims index.
+        db._tables_created.clear()
+        db.query(KnowledgeClaim, source_document_id="page-000")
+
+        remaining = _claim_index_names(db)
+        assert not any(name.startswith("idx_claims_") for name in remaining)
+    finally:
+        db.close()
+
+
+def test_claim_churn_on_persistent_duckdb_stays_queryable(tmp_path):
+    """Repeated claim upsert/delete churn does not invalidate an on-disk DuckDB.
+
+    Mirrors the entity churn test for the ``knowledgeclaims`` table — the
+    catalogue churns claims hardest of all (dedup/rewrite). With the corrupting
+    ``idx_claims_*`` ART indexes dropped, sustained save/delete cycles complete
+    without a FatalException and the library is still readable on reopen.
+    """
+    db_path = tmp_path / "claim_churn.duckdb"
+    db = Database(db_path)
+    try:
+        # Many upserts (overwrite same ids) interleaved with deletes — the
+        # exact churn pattern that poisoned the ART delete path on real data.
+        for i in range(120):
+            claim = KnowledgeClaim(
+                id=f"claim-{i % 20:03d}",
+                text=f"Churn claim {i}",
+                source_document_id=f"page-{i % 5:03d}",
+                source_page_label=f"p{i % 5}",
+                claim_type=None,
+            )
+            db.save(claim)  # repeated ids → UPDATE path, churns the heap
+            if i % 3 == 0:
+                db.delete(claim)
+
+        # No claims index should have been re-created by the churn.
+        assert not any(
+            name.startswith("idx_claims_") for name in _claim_index_names(db)
+        )
+
+        # The library is still queryable (no invalidated connection).
+        rows = db.query(KnowledgeClaim, source_document_id="page-000")
+        assert isinstance(rows, list)
+
+        # A fresh connection can still read the library after the churn.
+        db.close()
+        reopened = Database(db_path)
+        try:
+            assert not any(
+                name.startswith("idx_claims_")
+                for name in _claim_index_names(reopened)
+            )
+            # At least one of the surviving claims is still retrievable.
+            survivors = reopened.query(KnowledgeClaim, source_document_id="page-001")
+            assert isinstance(survivors, list)
         finally:
             reopened.close()
     finally:


### PR DESCRIPTION
P0 follow-up: the DuckDB ART-index corruption (#1596 fixed for entities) recurs on knowledgeclaims during real-data churn. Drops idx_claims_source_doc/page/type/status/created (data-safe, speed-only). 3770 tests pass. 🤖