### PR TITLE
fix(library): remove RealityKit/3D tab from the document/WebKit pane (#1616)

### DIFF
--- a/fichero/fichero/Views/Library/DocumentKGSurface.swift
+++ b/fichero/fichero/Views/Library/DocumentKGSurface.swift
@@ -51,7 +51,6 @@ enum KGSurfaceTab: String, CaseIterable, Identifiable {
     case claims
     case timeline
     case map
-    case realitykit
 
     var id: String { rawValue }
 
@@ -64,7 +63,6 @@ enum KGSurfaceTab: String, CaseIterable, Identifiable {
         case .claims: return "Claims"
         case .timeline: return "Timeline"
         case .map: return "Map"
-        case .realitykit: return "RealityKit"
         }
     }
 
@@ -77,7 +75,6 @@ enum KGSurfaceTab: String, CaseIterable, Identifiable {
         case .claims: return "quote.bubble"
         case .timeline: return "calendar.badge.clock"
         case .map: return "map"
-        case .realitykit: return "cube.transparent"
         }
     }
 
@@ -90,7 +87,6 @@ enum KGSurfaceTab: String, CaseIterable, Identifiable {
         case .claims: return "Claims — statements extracted from the document, grouped by source"
         case .timeline: return "Timeline — dated entities and events in chronological order"
         case .map: return "Map — entities laid out on a visual canvas"
-        case .realitykit: return "Spatial view — documents arranged in a 3D scene"
         }
     }
 
@@ -98,7 +94,7 @@ enum KGSurfaceTab: String, CaseIterable, Identifiable {
     var usesWebKit: Bool {
         switch self {
         case .transcript, .digest, .graph: return true
-        case .claims, .timeline, .map, .realitykit: return false
+        case .claims, .timeline, .map: return false
         }
     }
 }
@@ -116,11 +112,10 @@ struct DocumentKGSurface: View {
     @ObservedObject var scrollSync: DocumentScrollSyncState
 
     @State private var activeTab: KGSurfaceTab = .transcript
-    // Local state for tabs that bind to it (Map/RealityKit). Initialised from
-    // the parameter on appear; thereafter the view owns it. Distinct from the
+    // Local state for tabs that bind to it (Map). Initialised from the
+    // parameter on appear; thereafter the view owns it. Distinct from the
     // `selectedEntityId` parameter above (which is read-only from the parent).
     @State private var internalSelectedEntityId: String?
-    @State private var selectedSpatialNodeId: String?
     /// Entities for this document, loaded lazily when Timeline or Map tab activates.
     @State private var documentEntities: [Components.Schemas.KnowledgeEntity] = []
     @Environment(KGFocusState.self) private var kgFocusState
@@ -206,11 +201,6 @@ struct DocumentKGSurface: View {
                 entities: documentEntities,
                 selectedEntityId: $internalSelectedEntityId,
                 sourceDocumentId: documentId
-            )
-        case .realitykit:
-            FolderRealityKitSurface(
-                documentId: documentId,
-                selectedNodeId: $selectedSpatialNodeId
             )
         }
     }


### PR DESCRIPTION
## What

Removes the **RealityKit / 3D spatial** view from the right-hand WebKit/document pane. Per Daniel (#1616), 3D should appear **only in the Library view** as a display mode — not in the document KG-surface tab bar.

## Change (`DocumentKGSurface.swift`)

- Drop the `.realitykit` case from `KGSurfaceTab` (and its `title` / `icon` / `helpText` / `usesWebKit` arms).
- Remove the `case .realitykit:` arm from `nativeTabContent` (it rendered `FolderRealityKitSurface` in the document pane).
- Remove the now-dead `@State selectedSpatialNodeId` and fix its comment.

## What stays (the Library 3D mode)

The 3D capability is **unchanged in the Library**. A *separate* enum drives the Library display mode:
- `MainToolbar` display mode `realitykit = "RealityKit"`,
- `ContentView+Navigation`: `viewMode == .library && viewDisplayMode == .realitykit` → `FolderRealityKitSurface(...)`.

`FolderRealityKitSurface` is retained for that path. Verified no other file enumerates `KGSurfaceTab.realitykit`; all remaining `.realitykit` references belong to the Library display-mode enum.

## Gate

- `swiftlint DocumentKGSurface.swift` → **0 violations**.
- `xcodebuild -project fichero/fichero.xcodeproj -scheme Fichero -destination 'platform=macOS' build` → **BUILD SUCCEEDED**, 0 errors.

## Note

Removal of the document-pane tab is verified structurally + by build. Confirming the Library 3D mode still renders correctly is a runtime check (and intersects #1376's separate RealityKit visual issue). Relates #1455 / #1569.

Closes #1616.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
