### PR TITLE
fix: restore Library table/column mode for folders + rename list/table → List/Column (#1613)

### DIFF
--- a/fichero/fichero/Views/ContentView+State.swift
+++ b/fichero/fichero/Views/ContentView+State.swift
@@ -182,7 +182,7 @@ extension ContentView {
         switch sidebarMode {
         case .library:
             if let doc = libraryViewDocument, doc.docType == .folder || doc.isWorkspace {
-                return [.icon, .list, .map, .realitykit]
+                return [.icon, .list, .table, .map, .realitykit]
             }
             if !featureManager.isLibraryAdvancedViewsEnabled {
                 return [.icon]

--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -173,8 +173,9 @@ extension ContentView {
                 .fill(isSelected ? Color.accentColor.opacity(0.15) : Color.clear)
         )
         .foregroundStyle(isSelected ? Color.accentColor : Color.secondary)
-        .help("\(mode.rawValue) view — \(mode.description.lowercased())")
-        // Stable per-mode XCUITest hook, e.g. "viewMode-List" (#1230).
+        .help("\(mode.label) view — \(mode.description.lowercased())")
+        // Stable per-mode XCUITest hook, e.g. "viewMode-Table" (#1230) — keeps
+        // rawValue so the renamed "Column" label doesn't break the test hook.
         .accessibilityIdentifier("viewMode-\(mode.rawValue)")
     }
 

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -506,13 +506,13 @@ extension ContentView {
                 if showViewModePicker && availableViewDisplayModes.count > 1 && !showModeRail {
                     Picker("View", selection: $viewDisplayMode) {
                         ForEach(availableViewDisplayModes) { mode in
-                            Label(mode.rawValue, systemImage: mode.icon)
+                            Label(mode.label, systemImage: mode.icon)
                                 .labelStyle(.iconOnly)
                                 .tag(mode)
                         }
                     }
                     .pickerStyle(.segmented)
-                    .help("View: \(viewDisplayMode.rawValue)")
+                    .help("View: \(viewDisplayMode.label)")
                 }
 
                 // Add menu (Plus button)

--- a/fichero/fichero/Views/Menu/ViewMenuCommands.swift
+++ b/fichero/fichero/Views/Menu/ViewMenuCommands.swift
@@ -274,7 +274,7 @@ struct LibraryLayoutSection: View {
                 if availableLayouts.contains(.table) {
                     LibraryLayoutButton(
                         layout: .table,
-                        label: "as Table",
+                        label: "as Column",
                         icon: "tablecells",
                         shortcut: "3",
                         current: viewSettings.libraryLayout

--- a/fichero/fichero/Views/Toolbars/MainToolbar.swift
+++ b/fichero/fichero/Views/Toolbars/MainToolbar.swift
@@ -68,10 +68,10 @@ struct MainToolbar: View {
                 // View mode picker (Icon/List/Table/Map)
                 Picker("View mode", selection: $viewMode) {
                     ForEach(ViewDisplayMode.allCases) { mode in
-                        Label(mode.rawValue, systemImage: mode.icon)
+                        Label(mode.label, systemImage: mode.icon)
                             .labelStyle(.iconOnly)
                             .tag(mode)
-                            .accessibilityLabel(mode.rawValue + " — " + mode.description)
+                            .accessibilityLabel(mode.label + " — " + mode.description)
                     }
                 }
                 .pickerStyle(.segmented)
@@ -94,6 +94,16 @@ enum ViewDisplayMode: String, CaseIterable, Identifiable {
 
     var id: String { rawValue }
 
+    /// Mail-style display label shown in pickers/menus. `table` → "Column"
+    /// (#1613). `rawValue` deliberately stays "Table" so persisted per-folder
+    /// modes and the XCUITest hooks (`viewMode-Table`) don't churn.
+    var label: String {
+        switch self {
+        case .table: "Column"
+        default: rawValue
+        }
+    }
+
     var icon: String {
         switch self {
         case .icon: "square.grid.2x2"
@@ -108,12 +118,16 @@ enum ViewDisplayMode: String, CaseIterable, Identifiable {
         switch self {
         case .icon: "Grid of icons"
         case .list: "Linear list"
-        case .table: "Table view"
+        case .table: "Column view"
         case .map: "Visual map"
         case .realitykit: "Spatial 3D view"
         }
     }
 }
+
+// `.table` renders as the multi-column table view (`LibraryView.tableView`);
+// its user-facing name is "Column" (Mail-style, #1613) while the enum case and
+// rawValue stay `.table`/"Table".
 
 #Preview {
     @Previewable @State var viewMode: ViewDisplayMode = .icon


### PR DESCRIPTION
## Regression
The **table view mode disappeared** from the Library for a normal folder (e.g. Preface, `isWorkspace:false`). Root cause: `availableViewDisplayModes` (`ContentView+State.swift`) returned `[.icon, .list, .map, .realitykit]` for the folder/workspace branch — `.table` was dropped (likely in last night's toolbar/library merges). With `.table` absent from the available set, the mode rail / toolbar picker never offered it, and `normalizedViewDisplayMode` bumped any remembered `.table` selection → `.list`.

**Fix:** restore `.table` to that branch → `[.icon, .list, .table, .map, .realitykit]`. `LibraryView` already renders `case .table: tableView` (`LibraryView.swift:192`), so the view returns immediately.

## Rename (Mail-style — labels/icons only, enum cases unchanged)
Per Daniel: `list` → **List**, `table` → **Column**.
- Added `ViewDisplayMode.label`: `.table` shows as "Column"; everything else uses `rawValue` (`.list` is already "List").
- `rawValue` deliberately **stays** "Table" so persisted per-folder modes (`folderViewDisplayModes` JSON) and the XCUITest hooks (`viewMode-Table`, #1230) don't churn.
- Pickers (MainToolbar, ContentView), the mode-rail help, and `ViewDisplayMode.description` ("Column view") now use the label; the View-menu item reads "as Column". `accessibilityIdentifier` keeps `rawValue`.

5 files, +24/−9. No behavior change beyond restoring the mode + display strings.

## Verification
- swiftlint: clean (only two **pre-existing** file-length warnings on `ContentView+State`/`ContentView+ViewBuilders`, not introduced here)
- `xcodebuild -scheme Fichero -configuration Debug -destination 'platform=macOS' build`: **BUILD SUCCEEDED**
- Visual confirmation (the Column tab appears + selects on a folder) is a quick check for @dtubb.

Closes #1613

🤖 Generated with [Claude Code](https://claude.com/claude-code)