### PR TITLE
fix: shrink Library list-row thumbnail so the title gets more width (#1459)

### DIFF
--- a/fichero/fichero/Views/Library/LibraryViewComponents.swift
+++ b/fichero/fichero/Views/Library/LibraryViewComponents.swift
@@ -16,8 +16,10 @@ struct MailStyleRow: View {
 
     @EnvironmentObject private var documentStore: DocumentStore
 
-    private static let thumbWidth: CGFloat = 40
-    private static let thumbHeight: CGFloat = 50
+    // Compact leading thumbnail so the title/text gets the row's width
+    // (Mail-style — the icon was previously 40×50 and crowded the title). (#1459)
+    private static let thumbWidth: CGFloat = 28
+    private static let thumbHeight: CGFloat = 36
 
     var body: some View {
         HStack(alignment: .top, spacing: 12) {
@@ -168,7 +170,7 @@ struct MailStyleRow: View {
 
             if document.docType == .folder {
                 Image(systemName: "folder.fill")
-                    .font(.system(size: 28))
+                    .font(.system(size: 20))
                     .foregroundColor(.accentColor)
             } else if document.fileType == .pdf,
                       let path = document.path,


### PR DESCRIPTION
## Issue
In the Library **list view**, the leading icon/thumbnail (`MailStyleRow`) was too large (40×50) and crowded the document title/text.

## Fix (in place, per the issue)
- `MailStyleRow.thumbWidth`/`thumbHeight`: **40×50 → 28×36** (keeps the ~3:4 portrait aspect used by PDF/image thumbnails).
- Folder glyph: **28pt → 20pt** to fit the smaller frame.

The reclaimed ~12pt of leading width flows to the title automatically through the existing `HStack` (title uses the remaining space). No layout/structure changes — single file, +5/−3.

## Verification
- swiftlint: clean
- `xcodebuild -scheme Fichero -configuration Debug -destination 'platform=macOS' build`: **BUILD SUCCEEDED**
- Exact sizing is a quick visual check for @dtubb; easy to nudge (e.g. 24×32 or 32×40) if he wants it smaller/larger.

Closes #1459

🤖 Generated with [Claude Code](https://claude.com/claude-code)