### PR TITLE
Add Word export knowledge appendix

### DIFF
--- a/fichero-engine/src/fichero/api/routes/export.py
+++ b/fichero-engine/src/fichero/api/routes/export.py
@@ -7,7 +7,11 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from fichero.api.main import get_library_database
 from fichero.db import Database
-from fichero.export_service import export_markdown_folder, export_word_docx
+from fichero.export_service import (
+    export_excel_xlsx,
+    export_markdown_folder,
+    export_word_docx,
+)
 
 router = APIRouter(prefix="/export", tags=["export"])
 
@@ -63,6 +67,28 @@ class WordExportRequest(BaseModel):
 class WordExportResponse(BaseModel):
     output_path: str
     document_count: int
+    bytes_written: int
+
+
+class ExcelExportRequest(BaseModel):
+    """Request body for Excel export."""
+
+    model_config = ConfigDict(extra="allow")
+
+    output_path: str = Field(..., description="Destination .xlsx path")
+    target_id: str | None = Field(
+        default=None,
+        description="Optional document/folder id to export; omitted exports library",
+    )
+    recursive: bool = Field(default=True, description="Include descendants of folders")
+    overwrite: bool = Field(default=False, description="Overwrite existing .xlsx")
+
+
+class ExcelExportResponse(BaseModel):
+    output_path: str
+    document_count: int
+    entity_count: int
+    claim_count: int
     bytes_written: int
 
 
@@ -123,3 +149,27 @@ async def export_word_route(
         raise HTTPException(status_code=400, detail=str(e))
 
     return WordExportResponse(**result.__dict__)
+
+
+@router.post("/excel", response_model=ExcelExportResponse)
+async def export_excel_route(
+    request: ExcelExportRequest,
+    db: Database = Depends(get_library_database),
+) -> ExcelExportResponse:
+    """Export a library, folder, or document as an Excel .xlsx workbook."""
+    try:
+        result = export_excel_xlsx(
+            db=db,
+            output_path=Path(request.output_path),
+            target_id=request.target_id,
+            recursive=request.recursive,
+            overwrite=request.overwrite,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except FileExistsError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except OSError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return ExcelExportResponse(**result.__dict__)

--- a/fichero-engine/src/fichero/api/routes/export.py
+++ b/fichero-engine/src/fichero/api/routes/export.py
@@ -54,6 +54,10 @@ class WordExportRequest(BaseModel):
     )
     recursive: bool = Field(default=True, description="Include descendants of folders")
     overwrite: bool = Field(default=False, description="Overwrite existing .docx")
+    include_knowledge_graph: bool = Field(
+        default=True,
+        description="Append relevant knowledge graph entities and claims",
+    )
 
 
 class WordExportResponse(BaseModel):
@@ -109,6 +113,7 @@ async def export_word_route(
             recursive=request.recursive,
             overwrite=request.overwrite,
             package_path=x_fichero_library_path,
+            include_knowledge_graph=request.include_knowledge_graph,
         )
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -2481,6 +2481,20 @@ def register_generated_openapi_commands(
         target_app = typer.Typer(help='Generated OpenAPI commands for export endpoints.', no_args_is_help=True)
         root_app.add_typer(target_app, name='export')
 
+    @target_app.command("excel-route")
+    def export_excel_route_post(
+        ctx: typer.Context,
+        body: Optional[str] = typer.Option(None, "--body", help="Inline JSON request body."),
+        body_file: Optional[Path] = typer.Option(None, "--body-file", exists=True, dir_okay=False, readable=True, help="Path to a JSON request body file."),
+    ) -> None:
+        """Export Excel Route (POST /api/export/excel)."""
+        def op_call(client: FicheroClient) -> Any:
+            path = "/api/export/excel"
+            params = None
+            payload = _load_json_payload(body, body_file, required=True)
+            return client.request("POST", path, params=params, json=payload)
+        invoke(ctx, op_call)
+
     @target_app.command("markdown-folder-route")
     def export_markdown_folder_route_post(
         ctx: typer.Context,

--- a/fichero-engine/src/fichero/export_service.py
+++ b/fichero-engine/src/fichero/export_service.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 import re
 import shutil
 import zipfile
+import json
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 from xml.sax.saxutils import escape
 
 from fichero.db import Database
@@ -61,6 +62,17 @@ class WordExportResult:
 
     output_path: str
     document_count: int
+    bytes_written: int
+
+
+@dataclass
+class ExcelExportResult:
+    """Result metadata for an Excel export."""
+
+    output_path: str
+    document_count: int
+    entity_count: int
+    claim_count: int
     bytes_written: int
 
 
@@ -202,6 +214,96 @@ def export_word_docx(
     )
 
 
+def export_excel_xlsx(
+    db: Database,
+    output_path: str | Path,
+    target_id: str | None = None,
+    recursive: bool = True,
+    overwrite: bool = False,
+) -> ExcelExportResult:
+    """Export documents, entities, and claims as an .xlsx workbook."""
+
+    output_file = Path(output_path).expanduser()
+    if output_file.suffix.lower() != ".xlsx":
+        output_file = output_file.with_suffix(".xlsx")
+    if output_file.exists() and not overwrite:
+        raise FileExistsError(f"Export file already exists: {output_file}")
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    _, documents = _collect_documents(db, target_id=target_id, recursive=recursive)
+    entities, claims = _knowledge_graph_rows(db, documents)
+
+    document_rows = [
+        {
+            "id": doc.id,
+            "name": doc.name,
+            "parent_id": doc.parent_id,
+            "doc_type": doc.doc_type.value,
+            "file_type": doc.file_type.value if doc.file_type else "",
+            "path": doc.path,
+            "sequence": doc.sequence,
+            "transcription": _document_text(db, doc),
+            "metadata": doc.metadata,
+            "created_at": doc.created_at,
+            "updated_at": doc.updated_at,
+        }
+        for doc in documents
+    ]
+    entity_rows = [
+        {
+            "id": entity.id,
+            "canonical_name": entity.canonical_name,
+            "entity_type": entity.entity_type.value,
+            "aliases": entity.aliases,
+            "description": entity.description,
+            "source_document_ids": entity.source_document_ids,
+            "metadata": entity.metadata,
+            "created_at": entity.created_at,
+            "updated_at": entity.updated_at,
+        }
+        for entity in entities
+    ]
+    claim_rows = [
+        {
+            "id": claim.id,
+            "text": claim.text,
+            "source_document_id": claim.source_document_id,
+            "source_page_label": claim.source_page_label,
+            "source_excerpt": claim.source_excerpt,
+            "claim_type": claim.claim_type.value if claim.claim_type else "",
+            "epistemic_status": (
+                claim.epistemic_status.value if claim.epistemic_status else ""
+            ),
+            "subject_canonical": claim.subject_canonical,
+            "predicate_verb": claim.predicate_verb,
+            "object_phrase": claim.object_phrase,
+            "entity_ids": claim.entity_ids,
+            "confidence": claim.confidence,
+            "metadata": claim.metadata,
+            "created_at": claim.created_at,
+            "updated_at": claim.updated_at,
+        }
+        for claim in claims
+    ]
+
+    _write_xlsx(
+        output_file,
+        {
+            "Documents": document_rows,
+            "Entities": entity_rows,
+            "Claims": claim_rows,
+        },
+    )
+
+    return ExcelExportResult(
+        output_path=str(output_file),
+        document_count=len(document_rows),
+        entity_count=len(entity_rows),
+        claim_count=len(claim_rows),
+        bytes_written=output_file.stat().st_size,
+    )
+
+
 @dataclass(frozen=True)
 class _AssetRef:
     path: str
@@ -302,9 +404,39 @@ def _docx_knowledge_graph_appendix(
     db: Database,
     documents: list[Document],
 ) -> list[str]:
+    entities, claims = _knowledge_graph_rows(db, documents)
+    if not claims and not entities:
+        return []
+
+    parts = [_docx_heading("Knowledge Graph Appendix", 2)]
+
+    if entities:
+        parts.append(_docx_heading("Entities", 2))
+        for entity in entities:
+            label = f"{entity.canonical_name} ({entity.entity_type.value})"
+            if entity.description:
+                label = f"{label}: {entity.description}"
+            parts.append(_docx_paragraph(label))
+
+    if claims:
+        parts.append(_docx_heading("Claims", 2))
+        for claim in claims:
+            source = claim.source_page_label or claim.source_document_id
+            label = f"{claim.text} [source: {source}]"
+            parts.append(_docx_paragraph(label))
+            if claim.source_excerpt:
+                parts.append(_docx_paragraph(f"Excerpt: {claim.source_excerpt}"))
+
+    return parts
+
+
+def _knowledge_graph_rows(
+    db: Database,
+    documents: list[Document],
+) -> tuple[list[KnowledgeEntity], list[KnowledgeClaim]]:
     doc_ids = {doc.id for doc in documents}
     if not doc_ids:
-        return []
+        return [], []
 
     claims = [
         claim
@@ -333,30 +465,7 @@ def _docx_knowledge_graph_appendix(
         or doc_ids.intersection(entity.source_document_ids)
     ]
     entities.sort(key=lambda entity: entity.canonical_name.lower())
-
-    if not claims and not entities:
-        return []
-
-    parts = [_docx_heading("Knowledge Graph Appendix", 2)]
-
-    if entities:
-        parts.append(_docx_heading("Entities", 2))
-        for entity in entities:
-            label = f"{entity.canonical_name} ({entity.entity_type.value})"
-            if entity.description:
-                label = f"{label}: {entity.description}"
-            parts.append(_docx_paragraph(label))
-
-    if claims:
-        parts.append(_docx_heading("Claims", 2))
-        for claim in claims:
-            source = claim.source_page_label or claim.source_document_id
-            label = f"{claim.text} [source: {source}]"
-            parts.append(_docx_paragraph(label))
-            if claim.source_excerpt:
-                parts.append(_docx_paragraph(f"Excerpt: {claim.source_excerpt}"))
-
-    return parts
+    return entities, claims
 
 
 def _text_artifacts(db: Database, document_id: str) -> list[Artifact]:
@@ -446,6 +555,126 @@ def _unique_filename(stem: str, used_names: set[str], suffix: str) -> str:
         index += 1
     used_names.add(candidate)
     return candidate
+
+
+def _write_xlsx(output_file: Path, sheets: dict[str, list[dict[str, Any]]]) -> None:
+    sheet_items = list(sheets.items())
+    with zipfile.ZipFile(output_file, "w", compression=zipfile.ZIP_DEFLATED) as xlsx:
+        xlsx.writestr("[Content_Types].xml", _xlsx_content_types(len(sheet_items)))
+        xlsx.writestr("_rels/.rels", _xlsx_package_rels())
+        xlsx.writestr("xl/workbook.xml", _xlsx_workbook(sheet_items))
+        xlsx.writestr("xl/_rels/workbook.xml.rels", _xlsx_workbook_rels(sheet_items))
+        for index, (_, rows) in enumerate(sheet_items, start=1):
+            xlsx.writestr(
+                f"xl/worksheets/sheet{index}.xml",
+                _xlsx_sheet(rows),
+            )
+
+
+def _xlsx_sheet(rows: list[dict[str, Any]]) -> str:
+    headers = _xlsx_headers(rows)
+    values = [headers] + [
+        [_xlsx_cell_value(row.get(header)) for header in headers]
+        for row in rows
+    ]
+    row_xml = []
+    for row_index, row in enumerate(values, start=1):
+        cells = []
+        for col_index, value in enumerate(row, start=1):
+            if value == "":
+                continue
+            ref = f"{_xlsx_col_letter(col_index)}{row_index}"
+            cells.append(
+                f'<c r="{ref}" t="inlineStr"><is><t>{escape(value)}</t></is></c>'
+            )
+        row_xml.append(f'<row r="{row_index}">{"".join(cells)}</row>')
+
+    return (
+        '<?xml version="1.0" encoding="UTF-8" standalone="yes"?>'
+        '<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">'
+        f'<sheetData>{"".join(row_xml)}</sheetData>'
+        "</worksheet>"
+    )
+
+
+def _xlsx_headers(rows: list[dict[str, Any]]) -> list[str]:
+    headers: list[str] = []
+    for row in rows:
+        for key in row:
+            if key not in headers:
+                headers.append(key)
+    return headers or ["id"]
+
+
+def _xlsx_cell_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, datetime):
+        return value.isoformat(timespec="seconds")
+    if hasattr(value, "value") and not isinstance(value, str):
+        return str(value.value)
+    if isinstance(value, (dict, list, tuple)):
+        return json.dumps(value, ensure_ascii=False, default=str)
+    return str(value)
+
+
+def _xlsx_col_letter(index: int) -> str:
+    letters = ""
+    while index:
+        index, remainder = divmod(index - 1, 26)
+        letters = chr(ord("A") + remainder) + letters
+    return letters
+
+
+def _xlsx_content_types(sheet_count: int) -> str:
+    sheets = "".join(
+        f'<Override PartName="/xl/worksheets/sheet{index}.xml" '
+        'ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>'
+        for index in range(1, sheet_count + 1)
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  {sheets}
+</Types>
+"""
+
+
+def _xlsx_package_rels() -> str:
+    return """<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>
+"""
+
+
+def _xlsx_workbook(sheet_items: list[tuple[str, list[dict[str, Any]]]]) -> str:
+    sheets = "".join(
+        f'<sheet name="{escape(name, {"\"": "&quot;"})}" sheetId="{index}" r:id="rId{index}"/>'
+        for index, (name, _) in enumerate(sheet_items, start=1)
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+    xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets>{sheets}</sheets>
+</workbook>
+"""
+
+
+def _xlsx_workbook_rels(sheet_items: list[tuple[str, list[dict[str, Any]]]]) -> str:
+    relationships = "".join(
+        f'<Relationship Id="rId{index}" '
+        'Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" '
+        f'Target="worksheets/sheet{index}.xml"/>'
+        for index, _ in enumerate(sheet_items, start=1)
+    )
+    return f"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  {relationships}
+</Relationships>
+"""
 
 
 def _escape_frontmatter(value: str) -> str:

--- a/fichero-engine/src/fichero/export_service.py
+++ b/fichero-engine/src/fichero/export_service.py
@@ -12,7 +12,14 @@ from typing import Iterable
 from xml.sax.saxutils import escape
 
 from fichero.db import Database
-from fichero.models import Artifact, DocType, Document, FileType
+from fichero.models import (
+    Artifact,
+    DocType,
+    Document,
+    FileType,
+    KnowledgeClaim,
+    KnowledgeEntity,
+)
 from fichero.storage import get_display, resolve_source
 
 
@@ -130,6 +137,7 @@ def export_word_docx(
     recursive: bool = True,
     overwrite: bool = False,
     package_path: str | Path | None = None,
+    include_knowledge_graph: bool = True,
 ) -> WordExportResult:
     """Export documents as a minimal Word .docx file.
 
@@ -162,6 +170,11 @@ def export_word_docx(
         else:
             body_parts.append(_docx_heading(doc.name, 2))
             body_parts.extend(_docx_paragraph(part) for part in _paragraphs(text))
+
+    if include_knowledge_graph:
+        appendix = _docx_knowledge_graph_appendix(db, documents)
+        if appendix:
+            body_parts.extend(appendix)
 
     document_xml = _docx_document(body_parts)
     rels_xml = _docx_document_rels(media)
@@ -283,6 +296,67 @@ def _document_text(db: Database, doc: Document) -> str:
     for artifact in _text_artifacts(db, doc.id):
         parts.append(f"{artifact.artifact_type}: {artifact.content.strip()}")
     return "\n\n".join(parts).strip() or "No text content available."
+
+
+def _docx_knowledge_graph_appendix(
+    db: Database,
+    documents: list[Document],
+) -> list[str]:
+    doc_ids = {doc.id for doc in documents}
+    if not doc_ids:
+        return []
+
+    claims = [
+        claim
+        for claim in db.all(KnowledgeClaim)
+        if claim.source_document_id in doc_ids or doc_ids.intersection(claim.source_ids)
+    ]
+    claims.sort(key=lambda claim: (claim.source_document_id, claim.text.lower()))
+
+    claim_entity_ids: set[str] = set()
+    for claim in claims:
+        claim_entity_ids.update(claim.entity_ids)
+        for entity_id in (
+            claim.subject_entity_id,
+            claim.speaker_entity_id,
+            claim.subject_of_inquiry_entity_id,
+            claim.scribe_entity_id,
+            claim.editor_entity_id,
+        ):
+            if entity_id:
+                claim_entity_ids.add(entity_id)
+
+    entities = [
+        entity
+        for entity in db.all(KnowledgeEntity)
+        if entity.id in claim_entity_ids
+        or doc_ids.intersection(entity.source_document_ids)
+    ]
+    entities.sort(key=lambda entity: entity.canonical_name.lower())
+
+    if not claims and not entities:
+        return []
+
+    parts = [_docx_heading("Knowledge Graph Appendix", 2)]
+
+    if entities:
+        parts.append(_docx_heading("Entities", 2))
+        for entity in entities:
+            label = f"{entity.canonical_name} ({entity.entity_type.value})"
+            if entity.description:
+                label = f"{label}: {entity.description}"
+            parts.append(_docx_paragraph(label))
+
+    if claims:
+        parts.append(_docx_heading("Claims", 2))
+        for claim in claims:
+            source = claim.source_page_label or claim.source_document_id
+            label = f"{claim.text} [source: {source}]"
+            parts.append(_docx_paragraph(label))
+            if claim.source_excerpt:
+                parts.append(_docx_paragraph(f"Excerpt: {claim.source_excerpt}"))
+
+    return parts
 
 
 def _text_artifacts(db: Database, document_id: str) -> list[Artifact]:

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -2588,6 +2588,16 @@
     "export": [
       {
         "method": "POST",
+        "path": "/export/excel",
+        "operation_id": "export_excel_route_api_export_excel_post",
+        "summary": "Export Excel Route",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "ExcelExportRequest",
+        "response_model": "ExcelExportResponse"
+      },
+      {
+        "method": "POST",
         "path": "/export/markdown-folder",
         "operation_id": "export_markdown_folder_route_api_export_markdown_folder_post",
         "summary": "Export Markdown Folder Route",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -8716,6 +8716,60 @@
         }
       }
     },
+    "/api/export/excel": {
+      "post": {
+        "tags": [
+          "export",
+          "export"
+        ],
+        "summary": "Export Excel Route",
+        "description": "Export a library, folder, or document as an Excel .xlsx workbook.",
+        "operationId": "export_excel_route_api_export_excel_post",
+        "parameters": [
+          {
+            "name": "X-Fichero-Library-Path",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Fichero-Library-Path"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExcelExportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExcelExportResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/folders/{folder_id}/views": {
       "get": {
         "tags": [
@@ -40097,6 +40151,73 @@
         ],
         "title": "EvidentialPlace",
         "description": "Spatial evidence for a claim/entity, from points through named sets."
+      },
+      "ExcelExportRequest": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path",
+            "description": "Destination .xlsx path"
+          },
+          "target_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Target Id",
+            "description": "Optional document/folder id to export; omitted exports library"
+          },
+          "recursive": {
+            "type": "boolean",
+            "title": "Recursive",
+            "description": "Include descendants of folders",
+            "default": true
+          },
+          "overwrite": {
+            "type": "boolean",
+            "title": "Overwrite",
+            "description": "Overwrite existing .xlsx",
+            "default": false
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "output_path"
+        ],
+        "title": "ExcelExportRequest",
+        "description": "Request body for Excel export."
+      },
+      "ExcelExportResponse": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path"
+          },
+          "document_count": {
+            "type": "integer",
+            "title": "Document Count"
+          },
+          "entity_count": {
+            "type": "integer",
+            "title": "Entity Count"
+          },
+          "claim_count": {
+            "type": "integer",
+            "title": "Claim Count"
+          },
+          "bytes_written": {
+            "type": "integer",
+            "title": "Bytes Written"
+          }
+        },
+        "type": "object",
+        "required": [
+          "output_path",
+          "document_count",
+          "entity_count",
+          "claim_count",
+          "bytes_written"
+        ],
+        "title": "ExcelExportResponse"
       },
       "ExecuteAcceptedResponse": {
         "properties": {

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -53899,6 +53899,12 @@
             "title": "Overwrite",
             "description": "Overwrite existing .docx",
             "default": false
+          },
+          "include_knowledge_graph": {
+            "type": "boolean",
+            "title": "Include Knowledge Graph",
+            "description": "Append relevant knowledge graph entities and claims",
+            "default": true
           }
         },
         "additionalProperties": true,

--- a/fichero-engine/tests/unit/test_routes_export.py
+++ b/fichero-engine/tests/unit/test_routes_export.py
@@ -1,6 +1,7 @@
 """Tests for document export routes."""
 
 from fichero.knowledge_models import ClaimType, EntityType
+from fichero.loaders.xlsx_reader import read_xlsx_records
 from fichero.models import Artifact, DocType, Document, FileType
 from fichero.models import KnowledgeClaim, KnowledgeEntity
 
@@ -229,6 +230,86 @@ class TestWordExport:
 
         r = client.post(
             "/api/export/word",
+            json={"output_path": str(output_path)},
+        )
+
+        assert r.status_code == 409
+
+
+class TestExcelExport:
+    def test_exports_xlsx_documents_entities_and_claims(self, client, db, tmp_path):
+        folder = Document(
+            id="folder-excel",
+            name="Excel Export",
+            doc_type=DocType.folder,
+        )
+        doc = Document(
+            id="excel-doc",
+            name="Excel Source",
+            parent_id=folder.id,
+            doc_type=DocType.file,
+            file_type=FileType.text,
+            page_content="Transcript text.",
+            metadata={"box": "A1"},
+        )
+        entity = KnowledgeEntity(
+            id="excel-entity",
+            canonical_name="Maria",
+            entity_type=EntityType.person,
+            aliases=["María"],
+            source_document_ids=[doc.id],
+        )
+        claim = KnowledgeClaim(
+            id="excel-claim",
+            text="Maria signed the letter.",
+            source_document_id=doc.id,
+            source_page_label="7",
+            source_excerpt="Maria signed",
+            entity_ids=[entity.id],
+            claim_type=ClaimType.fact,
+        )
+        db.save(folder)
+        db.save(doc)
+        db.save(entity)
+        db.save(claim)
+
+        output_path = tmp_path / "export.xlsx"
+        r = client.post(
+            "/api/export/excel",
+            json={
+                "target_id": folder.id,
+                "output_path": str(output_path),
+            },
+        )
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["document_count"] == 1
+        assert data["entity_count"] == 1
+        assert data["claim_count"] == 1
+        assert data["bytes_written"] > 0
+
+        documents = read_xlsx_records(output_path, sheet_index=0)
+        entities = read_xlsx_records(output_path, sheet_index=1)
+        claims = read_xlsx_records(output_path, sheet_index=2)
+
+        assert documents[0]["id"] == doc.id
+        assert documents[0]["transcription"] == "Transcript text."
+        assert documents[0]["metadata"] == '{"box": "A1"}'
+        assert entities[0]["canonical_name"] == "Maria"
+        assert entities[0]["entity_type"] == "person"
+        assert claims[0]["text"] == "Maria signed the letter."
+        assert claims[0]["source_page_label"] == "7"
+        assert claims[0]["entity_ids"] == '["excel-entity"]'
+
+    def test_excel_export_rejects_existing_file_without_overwrite(
+        self, client, tmp_path
+    ):
+        output_path = tmp_path / "export.xlsx"
+        output_path.write_bytes(b"existing")
+
+        r = client.post(
+            "/api/export/excel",
             json={"output_path": str(output_path)},
         )
 

--- a/fichero-engine/tests/unit/test_routes_export.py
+++ b/fichero-engine/tests/unit/test_routes_export.py
@@ -1,6 +1,8 @@
 """Tests for document export routes."""
 
+from fichero.knowledge_models import ClaimType, EntityType
 from fichero.models import Artifact, DocType, Document, FileType
+from fichero.models import KnowledgeClaim, KnowledgeEntity
 
 
 class TestMarkdownFolderExport:
@@ -133,6 +135,91 @@ class TestWordExport:
         assert "word/media/image1.jpg" in names
         assert "Image transcription." in document_xml
         assert "<w:tbl>" in document_xml
+
+    def test_exports_docx_with_knowledge_graph_appendix(self, client, db, tmp_path):
+        import zipfile
+
+        doc = Document(
+            id="word-kg-doc",
+            name="KG Source",
+            doc_type=DocType.file,
+            file_type=FileType.text,
+            page_content="Source text.",
+        )
+        entity = KnowledgeEntity(
+            id="entity-pedro",
+            canonical_name="Pedro",
+            entity_type=EntityType.person,
+            description="Witness",
+            source_document_ids=[doc.id],
+        )
+        claim = KnowledgeClaim(
+            id="claim-pedro",
+            text="Pedro testified in 1933.",
+            source_document_id=doc.id,
+            source_page_label="4",
+            source_excerpt="Pedro testified",
+            entity_ids=[entity.id],
+            claim_type=ClaimType.fact,
+        )
+        db.save(doc)
+        db.save(entity)
+        db.save(claim)
+
+        output_path = tmp_path / "kg.docx"
+        r = client.post(
+            "/api/export/word",
+            json={
+                "target_id": doc.id,
+                "output_path": str(output_path),
+            },
+        )
+
+        assert r.status_code == 200
+        with zipfile.ZipFile(output_path) as docx:
+            document_xml = docx.read("word/document.xml").decode()
+
+        assert "Knowledge Graph Appendix" in document_xml
+        assert "Pedro (person): Witness" in document_xml
+        assert "Pedro testified in 1933. [source: 4]" in document_xml
+        assert "Excerpt: Pedro testified" in document_xml
+
+    def test_word_export_can_omit_knowledge_graph_appendix(
+        self, client, db, tmp_path
+    ):
+        import zipfile
+
+        doc = Document(
+            id="word-no-kg-doc",
+            name="No KG Source",
+            doc_type=DocType.file,
+            file_type=FileType.text,
+            page_content="Source text.",
+        )
+        entity = KnowledgeEntity(
+            id="entity-hidden",
+            canonical_name="Hidden",
+            source_document_ids=[doc.id],
+        )
+        db.save(doc)
+        db.save(entity)
+
+        output_path = tmp_path / "no-kg.docx"
+        r = client.post(
+            "/api/export/word",
+            json={
+                "target_id": doc.id,
+                "output_path": str(output_path),
+                "include_knowledge_graph": False,
+            },
+        )
+
+        assert r.status_code == 200
+        with zipfile.ZipFile(output_path) as docx:
+            document_xml = docx.read("word/document.xml").decode()
+
+        assert "Knowledge Graph Appendix" not in document_xml
+        assert "Hidden" not in document_xml
 
     def test_word_export_rejects_existing_file_without_overwrite(
         self, client, tmp_path

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -8716,6 +8716,60 @@
         }
       }
     },
+    "/api/export/excel": {
+      "post": {
+        "tags": [
+          "export",
+          "export"
+        ],
+        "summary": "Export Excel Route",
+        "description": "Export a library, folder, or document as an Excel .xlsx workbook.",
+        "operationId": "export_excel_route_api_export_excel_post",
+        "parameters": [
+          {
+            "name": "X-Fichero-Library-Path",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Fichero-Library-Path"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExcelExportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExcelExportResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/folders/{folder_id}/views": {
       "get": {
         "tags": [
@@ -40097,6 +40151,73 @@
         ],
         "title": "EvidentialPlace",
         "description": "Spatial evidence for a claim/entity, from points through named sets."
+      },
+      "ExcelExportRequest": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path",
+            "description": "Destination .xlsx path"
+          },
+          "target_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Target Id",
+            "description": "Optional document/folder id to export; omitted exports library"
+          },
+          "recursive": {
+            "type": "boolean",
+            "title": "Recursive",
+            "description": "Include descendants of folders",
+            "default": true
+          },
+          "overwrite": {
+            "type": "boolean",
+            "title": "Overwrite",
+            "description": "Overwrite existing .xlsx",
+            "default": false
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "output_path"
+        ],
+        "title": "ExcelExportRequest",
+        "description": "Request body for Excel export."
+      },
+      "ExcelExportResponse": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path"
+          },
+          "document_count": {
+            "type": "integer",
+            "title": "Document Count"
+          },
+          "entity_count": {
+            "type": "integer",
+            "title": "Entity Count"
+          },
+          "claim_count": {
+            "type": "integer",
+            "title": "Claim Count"
+          },
+          "bytes_written": {
+            "type": "integer",
+            "title": "Bytes Written"
+          }
+        },
+        "type": "object",
+        "required": [
+          "output_path",
+          "document_count",
+          "entity_count",
+          "claim_count",
+          "bytes_written"
+        ],
+        "title": "ExcelExportResponse"
       },
       "ExecuteAcceptedResponse": {
         "properties": {

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -53899,6 +53899,12 @@
             "title": "Overwrite",
             "description": "Overwrite existing .docx",
             "default": false
+          },
+          "include_knowledge_graph": {
+            "type": "boolean",
+            "title": "Include Knowledge Graph",
+            "description": "Append relevant knowledge graph entities and claims",
+            "default": true
           }
         },
         "additionalProperties": true,


### PR DESCRIPTION
## Summary
- Adds an optional knowledge graph appendix to Word .docx exports.
- Adds /api/export/excel for .xlsx exports with Documents, Entities, and Claims sheets.
- Regenerates committed OpenAPI endpoint/schema artifacts and the Swift client schema copy.

## Verification
- PYTHONPATH=fichero-engine/src ../fichero/.venv/bin/ruff check fichero-engine/src/fichero/export_service.py fichero-engine/src/fichero/api/routes/export.py fichero-engine/tests/unit/test_routes_export.py fichero-engine/src/fichero/cli/openapi_surface_generated.py
- PYTHONPATH=fichero-engine/src ../fichero/.venv/bin/pytest fichero-engine/tests/unit/test_routes_export.py

Closes #473
Closes #474