### PR TITLE
Support SSH-loopback remote backend mode

### DIFF
--- a/docs/remote-backend-acenet.md
+++ b/docs/remote-backend-acenet.md
@@ -13,6 +13,8 @@ On the ACENET host:
 
 ```bash
 cd ~/code/fichero
+export FICHERO_REMOTE_BACKEND=1
+export FICHERO_REMOTE_BACKEND_BIND_HOST=127.0.0.1
 PYTHONPATH=fichero-engine/src /path/to/.venv/bin/python -m fichero engine start --port 8765
 ```
 
@@ -20,6 +22,8 @@ If you want foreground logs instead of the detached engine manager:
 
 ```bash
 cd ~/code/fichero
+export FICHERO_REMOTE_BACKEND=1
+export FICHERO_REMOTE_BACKEND_BIND_HOST=127.0.0.1
 PYTHONPATH=fichero-engine/src /path/to/.venv/bin/uvicorn fichero.api.main:app \
   --host 127.0.0.1 \
   --port 8765
@@ -112,6 +116,24 @@ From the Mac, with the tunnel running:
 ```bash
 curl -s http://127.0.0.1:8765/api/health
 ```
+
+The health payload includes `remote_backend` diagnostics. In remote mode,
+expect:
+
+```json
+{
+  "remote_backend": {
+    "enabled": true,
+    "connection_model": "ssh-loopback",
+    "token_configured": true,
+    "library_path_configured": true
+  }
+}
+```
+
+If `FICHERO_REMOTE_BACKEND=1` is set with
+`FICHERO_REMOTE_BACKEND_BIND_HOST=0.0.0.0` or another non-loopback host, startup
+fails. Remote mode is intentionally SSH-loopback only.
 
 For CLI validation against an alternate local tunnel port:
 

--- a/fichero-engine/src/fichero/api/main.py
+++ b/fichero-engine/src/fichero/api/main.py
@@ -60,6 +60,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from fichero.db import Database, db_manager
 from fichero.paths import migrate_legacy_engine_state
+from fichero.remote_backend import build_remote_backend_status
 
 logger = logging.getLogger(__name__)
 
@@ -533,6 +534,18 @@ async def lifespan(app: FastAPI):
     logger.info("Fichero API starting up...")
     logger.info("Engine binary: %s", sys.executable)
     logger.info("DatabaseManager initialized")
+    remote_backend_status = build_remote_backend_status()
+    app.state.remote_backend = remote_backend_status
+    if remote_backend_status.enabled:
+        logger.info(
+            "Remote backend mode enabled via %s; token_configured=%s; "
+            "library_path_configured=%s",
+            remote_backend_status.connection_model,
+            remote_backend_status.token_configured,
+            remote_backend_status.library_path_configured,
+        )
+        for warning in remote_backend_status.warnings:
+            logger.warning("Remote backend setup: %s", warning)
     migrated_entries = migrate_legacy_engine_state()
     if migrated_entries:
         logger.info(
@@ -784,6 +797,7 @@ async def health_check(
             "status": "healthy",
             "backend_version": "0.1.0",
             "active_libraries": db_manager.active_count,
+            "remote_backend": build_remote_backend_status().as_dict(),
         }
 
 

--- a/fichero-engine/src/fichero/remote_backend.py
+++ b/fichero-engine/src/fichero/remote_backend.py
@@ -1,0 +1,111 @@
+"""Remote backend configuration helpers.
+
+Fichero's supported remote-backend model is SSH loopback forwarding: the
+engine still binds to 127.0.0.1 on the remote host, and the client reaches it
+through a local tunnel. This module keeps that contract explicit and testable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from os import environ
+from typing import Mapping
+from urllib.parse import urlparse
+
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_LOOPBACK_HOSTS = {"127.0.0.1", "::1", "localhost"}
+SUPPORTED_CONNECTION_MODEL = "ssh-loopback"
+
+
+@dataclass(frozen=True)
+class RemoteBackendStatus:
+    """Remote-backend startup status exposed through health diagnostics."""
+
+    enabled: bool
+    connection_model: str
+    api_url: str | None
+    library_path_configured: bool
+    token_configured: bool
+    warnings: list[str]
+
+    def as_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
+def _is_truthy(value: str | None) -> bool:
+    return (value or "").strip().lower() in _TRUE_VALUES
+
+
+def _host_from_url(raw_url: str | None) -> str | None:
+    if not raw_url:
+        return None
+    parsed = urlparse(raw_url)
+    return parsed.hostname
+
+
+def build_remote_backend_status(
+    env: Mapping[str, str] | None = None,
+) -> RemoteBackendStatus:
+    """Validate and summarize the configured remote-backend mode.
+
+    ``FICHERO_REMOTE_BACKEND=1`` opts into remote mode. Remote mode supports
+    only SSH loopback forwarding; a public bind host is rejected because auth is
+    designed as a local shared-secret, not an internet-facing API boundary.
+    """
+
+    source = env if env is not None else environ
+    enabled = _is_truthy(source.get("FICHERO_REMOTE_BACKEND"))
+    model = source.get("FICHERO_REMOTE_BACKEND_MODEL", SUPPORTED_CONNECTION_MODEL)
+    model = model.strip() or SUPPORTED_CONNECTION_MODEL
+    api_url = source.get("FICHERO_API_URL")
+    library_path = source.get("FICHERO_LIBRARY_PATH")
+    token = source.get("FICHERO_API_KEY")
+    bind_host = source.get("FICHERO_REMOTE_BACKEND_BIND_HOST")
+    warnings: list[str] = []
+
+    if not enabled:
+        return RemoteBackendStatus(
+            enabled=False,
+            connection_model=SUPPORTED_CONNECTION_MODEL,
+            api_url=api_url,
+            library_path_configured=bool(library_path),
+            token_configured=bool(token),
+            warnings=[],
+        )
+
+    if model != SUPPORTED_CONNECTION_MODEL:
+        raise ValueError(
+            "Unsupported FICHERO_REMOTE_BACKEND_MODEL. "
+            f"Expected {SUPPORTED_CONNECTION_MODEL!r}; got {model!r}."
+        )
+
+    if bind_host and bind_host not in _LOOPBACK_HOSTS:
+        raise ValueError(
+            "Remote backend mode requires loopback binding. "
+            "Start the engine on 127.0.0.1 and use SSH -L forwarding; "
+            f"got FICHERO_REMOTE_BACKEND_BIND_HOST={bind_host!r}."
+        )
+
+    api_host = _host_from_url(api_url)
+    if api_host and api_host not in _LOOPBACK_HOSTS:
+        warnings.append(
+            "FICHERO_API_URL is not loopback. Prefer an SSH tunnel such as "
+            "http://127.0.0.1:18765 rather than exposing the backend host."
+        )
+    if not token:
+        warnings.append("FICHERO_API_KEY is not set; protected endpoints will return 401.")
+    if not library_path:
+        warnings.append(
+            "FICHERO_LIBRARY_PATH is not set; library-specific endpoints need a "
+            "remote .fichero path."
+        )
+
+    return RemoteBackendStatus(
+        enabled=True,
+        connection_model=model,
+        api_url=api_url,
+        library_path_configured=bool(library_path),
+        token_configured=bool(token),
+        warnings=warnings,
+    )

--- a/fichero-engine/tests/unit/test_remote_backend_acenet.py
+++ b/fichero-engine/tests/unit/test_remote_backend_acenet.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fichero.api.main import app
+from fichero.remote_backend import build_remote_backend_status
+
+
+def test_remote_backend_status_defaults_to_disabled() -> None:
+    status = build_remote_backend_status({})
+
+    assert status.enabled is False
+    assert status.connection_model == "ssh-loopback"
+    assert status.warnings == []
+
+
+def test_remote_backend_status_accepts_ssh_loopback_configuration() -> None:
+    status = build_remote_backend_status(
+        {
+            "FICHERO_REMOTE_BACKEND": "1",
+            "FICHERO_API_URL": "http://127.0.0.1:18765",
+            "FICHERO_API_KEY": "remote-token",
+            "FICHERO_LIBRARY_PATH": "/remote/project/Library.fichero",
+            "FICHERO_REMOTE_BACKEND_BIND_HOST": "127.0.0.1",
+        }
+    )
+
+    assert status.enabled is True
+    assert status.connection_model == "ssh-loopback"
+    assert status.api_url == "http://127.0.0.1:18765"
+    assert status.token_configured is True
+    assert status.library_path_configured is True
+    assert status.warnings == []
+
+
+def test_remote_backend_status_warns_when_token_or_library_path_missing() -> None:
+    status = build_remote_backend_status(
+        {
+            "FICHERO_REMOTE_BACKEND": "true",
+            "FICHERO_API_URL": "http://127.0.0.1:18765",
+        }
+    )
+
+    assert status.enabled is True
+    assert any("FICHERO_API_KEY is not set" in item for item in status.warnings)
+    assert any("FICHERO_LIBRARY_PATH is not set" in item for item in status.warnings)
+
+
+def test_remote_backend_status_rejects_public_bind_host() -> None:
+    with pytest.raises(ValueError, match="requires loopback binding"):
+        build_remote_backend_status(
+            {
+                "FICHERO_REMOTE_BACKEND": "1",
+                "FICHERO_REMOTE_BACKEND_BIND_HOST": "0.0.0.0",
+            }
+        )
+
+
+def test_health_reports_remote_backend_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FICHERO_REMOTE_BACKEND", "1")
+    monkeypatch.setenv("FICHERO_API_URL", "http://127.0.0.1:18765")
+    monkeypatch.setenv("FICHERO_API_KEY", "remote-token")
+    monkeypatch.setenv("FICHERO_LIBRARY_PATH", "/remote/project/Library.fichero")
+
+    response = TestClient(app).get("/api/health")
+
+    assert response.status_code == 200
+    remote_backend = response.json()["remote_backend"]
+    assert remote_backend["enabled"] is True
+    assert remote_backend["connection_model"] == "ssh-loopback"
+    assert remote_backend["api_url"] == "http://127.0.0.1:18765"
+    assert remote_backend["token_configured"] is True
+    assert remote_backend["library_path_configured"] is True


### PR DESCRIPTION
## Summary
- add a backend remote-mode helper for the supported SSH loopback connection model
- surface remote-backend diagnostics in `/api/health`
- document ACENET startup env vars and unsafe bind rejection
- add unit tests for default, valid, warning, and unsafe remote configurations

## Verification
- `PYTHONPATH=fichero-engine/src /Users/danieltubb/code/fichero/.venv/bin/ruff check fichero-engine/src/ fichero-engine/tests/unit/test_remote_backend_acenet.py fichero-engine/tests/unit/test_api_auth.py`
- `PYTHONPATH=fichero-engine/src /Users/danieltubb/code/fichero/.venv/bin/pytest fichero-engine/tests/unit/test_remote_backend_acenet.py fichero-engine/tests/unit/test_api_auth.py -q`
- `PYTHONPATH=fichero-engine/src /Users/danieltubb/code/fichero/.venv/bin/pytest fichero-engine/tests/unit/ --ignore=fichero-engine/tests/unit/_archived -q`

Closes #1239