### PR TITLE
fix: label the search-result relevance badge (#1476 part 3)

### DIFF
--- a/fichero/fichero/Views/Search/SearchResultRowFromAPI.swift
+++ b/fichero/fichero/Views/Search/SearchResultRowFromAPI.swift
@@ -38,13 +38,16 @@ struct SearchResultRowFromAPI: View {
 
                 // Score badge + match-source pill
                 HStack(spacing: 6) {
-                    Text(String(format: "%.0f%%", result.score * 100))
+                    // Label the bare percentage so it reads as a relevance
+                    // score, not e.g. a completion percentage (#1476).
+                    Text(String(format: "relevance %.0f%%", result.score * 100))
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .padding(.horizontal, 6)
                         .padding(.vertical, 2)
                         .background(Color.accentColor.opacity(0.15))
                         .cornerRadius(4)
+                        .help("How closely this result matches your search (higher is closer).")
 
                     if let label = matchSourceLabel {
                         Text(label)


### PR DESCRIPTION
## Scope
Addresses **part 3** of #1476 (the bare '100%' is unclear). The other two parts are noted below.

## Change
`SearchResultRowFromAPI` showed a bare percentage badge (e.g. `100%`). Relabel it as `relevance NN%` and add a `.help()` tooltip ("How closely this result matches your search"). One file, +5/−2.

## State of the other two parts (factual)
- **Part 2** (matched-text snippet under each row): already implemented. `SearchResultRowFromAPI` renders `result.highlights` (with `**term**` highlighting) or `result.contentPreview` beneath the title, and the search **list view** (`SearchResultsDisplay.listView`) uses this row. No change needed.
- **Part 1** (click → open the document scrolled to the matched page + highlight): **backend-dependent** — the issue itself notes it 'Depends on the backend returning page id + text offset per hit', reusing the entity/claim click-through target (#1464/#1463). Out of scope for this frontend PR; left open.

## Verification
- swiftlint: clean
- `xcodebuild -scheme Fichero -configuration Debug -destination 'platform=macOS' build`: **BUILD SUCCEEDED**

Refs #1476 (does not close — part 1 remains, pending the backend page-offset work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)