### PR TITLE
Add JSON export endpoint

### DIFF
--- a/fichero-engine/src/fichero/api/routes/export.py
+++ b/fichero-engine/src/fichero/api/routes/export.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from fichero.api.main import get_library_database
 from fichero.db import Database
 from fichero.export_service import (
+    export_html_site,
     export_json_file,
     export_markdown_folder,
     export_word_docx,
@@ -87,6 +88,30 @@ class JsonExportResponse(BaseModel):
     entity_count: int
     claim_count: int
     bytes_written: int
+
+
+class HtmlExportRequest(BaseModel):
+    """Request body for static HTML website export."""
+
+    model_config = ConfigDict(extra="allow")
+
+    output_path: str = Field(..., description="Destination folder for site files")
+    target_id: str | None = Field(
+        default=None,
+        description="Optional document/folder id to export; omitted exports library",
+    )
+    recursive: bool = Field(default=True, description="Include descendants of folders")
+    include_assets: bool = Field(default=True, description="Copy image assets")
+    overwrite: bool = Field(
+        default=False, description="Allow writing into non-empty folder"
+    )
+
+
+class HtmlExportResponse(BaseModel):
+    output_path: str
+    files: list[ExportedFileResponse]
+    assets: list[ExportedFileResponse]
+    document_count: int
 
 
 @router.post("/markdown-folder", response_model=MarkdownFolderExportResponse)
@@ -169,3 +194,35 @@ async def export_json_route(
         raise HTTPException(status_code=400, detail=str(e))
 
     return JsonExportResponse(**result.__dict__)
+
+
+@router.post("/html", response_model=HtmlExportResponse)
+async def export_html_route(
+    request: HtmlExportRequest,
+    db: Database = Depends(get_library_database),
+    x_fichero_library_path: str | None = Header(None, alias="X-Fichero-Library-Path"),
+) -> HtmlExportResponse:
+    """Export a library, folder, or document as a static HTML website."""
+    try:
+        result = export_html_site(
+            db=db,
+            output_path=Path(request.output_path),
+            target_id=request.target_id,
+            recursive=request.recursive,
+            include_assets=request.include_assets,
+            overwrite=request.overwrite,
+            package_path=x_fichero_library_path,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except FileExistsError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except OSError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return HtmlExportResponse(
+        output_path=result.output_path,
+        files=[ExportedFileResponse(**file.__dict__) for file in result.files],
+        assets=[ExportedFileResponse(**asset.__dict__) for asset in result.assets],
+        document_count=result.document_count,
+    )

--- a/fichero-engine/src/fichero/api/routes/export.py
+++ b/fichero-engine/src/fichero/api/routes/export.py
@@ -7,7 +7,11 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from fichero.api.main import get_library_database
 from fichero.db import Database
-from fichero.export_service import export_markdown_folder, export_word_docx
+from fichero.export_service import (
+    export_json_file,
+    export_markdown_folder,
+    export_word_docx,
+)
 
 router = APIRouter(prefix="/export", tags=["export"])
 
@@ -59,6 +63,29 @@ class WordExportRequest(BaseModel):
 class WordExportResponse(BaseModel):
     output_path: str
     document_count: int
+    bytes_written: int
+
+
+class JsonExportRequest(BaseModel):
+    """Request body for structured JSON export."""
+
+    model_config = ConfigDict(extra="allow")
+
+    output_path: str = Field(..., description="Destination .json path")
+    target_id: str | None = Field(
+        default=None,
+        description="Optional document/folder id to export; omitted exports library",
+    )
+    recursive: bool = Field(default=True, description="Include descendants of folders")
+    overwrite: bool = Field(default=False, description="Overwrite existing .json")
+
+
+class JsonExportResponse(BaseModel):
+    output_path: str
+    document_count: int
+    artifact_count: int
+    entity_count: int
+    claim_count: int
     bytes_written: int
 
 
@@ -118,3 +145,27 @@ async def export_word_route(
         raise HTTPException(status_code=400, detail=str(e))
 
     return WordExportResponse(**result.__dict__)
+
+
+@router.post("/json", response_model=JsonExportResponse)
+async def export_json_route(
+    request: JsonExportRequest,
+    db: Database = Depends(get_library_database),
+) -> JsonExportResponse:
+    """Export a library, folder, or document as structured JSON."""
+    try:
+        result = export_json_file(
+            db=db,
+            output_path=Path(request.output_path),
+            target_id=request.target_id,
+            recursive=request.recursive,
+            overwrite=request.overwrite,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except FileExistsError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except OSError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return JsonExportResponse(**result.__dict__)

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -2481,6 +2481,20 @@ def register_generated_openapi_commands(
         target_app = typer.Typer(help='Generated OpenAPI commands for export endpoints.', no_args_is_help=True)
         root_app.add_typer(target_app, name='export')
 
+    @target_app.command("json-route")
+    def export_json_route_post(
+        ctx: typer.Context,
+        body: Optional[str] = typer.Option(None, "--body", help="Inline JSON request body."),
+        body_file: Optional[Path] = typer.Option(None, "--body-file", exists=True, dir_okay=False, readable=True, help="Path to a JSON request body file."),
+    ) -> None:
+        """Export Json Route (POST /api/export/json)."""
+        def op_call(client: FicheroClient) -> Any:
+            path = "/api/export/json"
+            params = None
+            payload = _load_json_payload(body, body_file, required=True)
+            return client.request("POST", path, params=params, json=payload)
+        invoke(ctx, op_call)
+
     @target_app.command("markdown-folder-route")
     def export_markdown_folder_route_post(
         ctx: typer.Context,

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -2481,6 +2481,20 @@ def register_generated_openapi_commands(
         target_app = typer.Typer(help='Generated OpenAPI commands for export endpoints.', no_args_is_help=True)
         root_app.add_typer(target_app, name='export')
 
+    @target_app.command("html-route")
+    def export_html_route_post(
+        ctx: typer.Context,
+        body: Optional[str] = typer.Option(None, "--body", help="Inline JSON request body."),
+        body_file: Optional[Path] = typer.Option(None, "--body-file", exists=True, dir_okay=False, readable=True, help="Path to a JSON request body file."),
+    ) -> None:
+        """Export Html Route (POST /api/export/html)."""
+        def op_call(client: FicheroClient) -> Any:
+            path = "/api/export/html"
+            params = None
+            payload = _load_json_payload(body, body_file, required=True)
+            return client.request("POST", path, params=params, json=payload)
+        invoke(ctx, op_call)
+
     @target_app.command("json-route")
     def export_json_route_post(
         ctx: typer.Context,

--- a/fichero-engine/src/fichero/export_service.py
+++ b/fichero-engine/src/fichero/export_service.py
@@ -2,17 +2,25 @@
 
 from __future__ import annotations
 
+import json
 import re
 import shutil
 import zipfile
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Iterable
+from typing import Any, Iterable
 from xml.sax.saxutils import escape
 
 from fichero.db import Database
-from fichero.models import Artifact, DocType, Document, FileType
+from fichero.models import (
+    Artifact,
+    DocType,
+    Document,
+    FileType,
+    KnowledgeClaim,
+    KnowledgeEntity,
+)
 from fichero.storage import get_display, resolve_source
 
 
@@ -54,6 +62,18 @@ class WordExportResult:
 
     output_path: str
     document_count: int
+    bytes_written: int
+
+
+@dataclass
+class JsonExportResult:
+    """Result metadata for a structured JSON export."""
+
+    output_path: str
+    document_count: int
+    artifact_count: int
+    entity_count: int
+    claim_count: int
     bytes_written: int
 
 
@@ -189,6 +209,54 @@ def export_word_docx(
     )
 
 
+def export_json_file(
+    db: Database,
+    output_path: str | Path,
+    target_id: str | None = None,
+    recursive: bool = True,
+    overwrite: bool = False,
+) -> JsonExportResult:
+    """Export documents, artifacts, and scoped KG data as a JSON file."""
+
+    output_file = Path(output_path).expanduser()
+    if output_file.suffix.lower() != ".json":
+        output_file = output_file.with_suffix(".json")
+    if output_file.exists() and not overwrite:
+        raise FileExistsError(f"Export file already exists: {output_file}")
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+
+    root, documents = _collect_documents(db, target_id=target_id, recursive=recursive)
+    document_ids = {doc.id for doc in documents}
+    artifacts = _collect_artifacts(db, document_ids)
+    claims = _collect_claims(db, document_ids)
+    entities = _collect_entities(db, document_ids, claims)
+
+    payload = {
+        "doc": _dump_model(root or documents[0]) if root or documents else None,
+        "documents": [_dump_model(doc) for doc in documents],
+        "transcription": _combined_transcription(db, documents),
+        "artifacts": [_dump_model(artifact) for artifact in artifacts],
+        "kg": {
+            "entities": [_dump_model(entity) for entity in entities],
+            "claims": [_dump_model(claim) for claim in claims],
+        },
+        "exported_at": datetime.now().isoformat(timespec="seconds"),
+    }
+    output_file.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    return JsonExportResult(
+        output_path=str(output_file),
+        document_count=len(documents),
+        artifact_count=len(artifacts),
+        entity_count=len(entities),
+        claim_count=len(claims),
+        bytes_written=output_file.stat().st_size,
+    )
+
+
 @dataclass(frozen=True)
 class _AssetRef:
     path: str
@@ -236,6 +304,67 @@ def _descendants(db: Database, root_id: str) -> list[Document]:
         queue.extend(db.query(Document, parent_id=doc.id))
 
     return result
+
+
+def _collect_artifacts(db: Database, document_ids: set[str]) -> list[Artifact]:
+    artifacts = [
+        artifact
+        for artifact in db.all(Artifact)
+        if artifact.document_id in document_ids
+        or artifact.source_document_id in document_ids
+    ]
+    artifacts.sort(key=lambda artifact: (artifact.document_id, artifact.created_at))
+    return artifacts
+
+
+def _collect_claims(
+    db: Database,
+    document_ids: set[str],
+) -> list[KnowledgeClaim]:
+    claims = [
+        claim
+        for claim in db.all(KnowledgeClaim)
+        if claim.source_document_id in document_ids
+        or bool(set(claim.source_ids or []) & document_ids)
+    ]
+    claims.sort(key=lambda claim: (claim.source_document_id, claim.created_at, claim.id))
+    return claims
+
+
+def _collect_entities(
+    db: Database,
+    document_ids: set[str],
+    claims: list[KnowledgeClaim],
+) -> list[KnowledgeEntity]:
+    claim_entity_ids = {
+        entity_id
+        for claim in claims
+        for entity_id in [
+            *claim.entity_ids,
+            claim.subject_entity_id,
+            claim.speaker_entity_id,
+            claim.subject_of_inquiry_entity_id,
+            claim.scribe_entity_id,
+            claim.editor_entity_id,
+        ]
+        if entity_id
+    }
+    entities = [
+        entity
+        for entity in db.all(KnowledgeEntity)
+        if entity.id in claim_entity_ids
+        or bool(set(entity.source_document_ids or []) & document_ids)
+    ]
+    entities.sort(key=lambda entity: (entity.canonical_name.lower(), entity.id))
+    return entities
+
+
+def _combined_transcription(db: Database, documents: list[Document]) -> str:
+    return "\n\n".join(_document_text(db, doc) for doc in documents).strip()
+
+
+def _dump_model(model: Any) -> dict[str, Any]:
+    return model.model_dump(mode="json")
 
 
 def _render_document_markdown(

--- a/fichero-engine/src/fichero/export_service.py
+++ b/fichero-engine/src/fichero/export_service.py
@@ -77,6 +77,16 @@ class JsonExportResult:
     bytes_written: int
 
 
+@dataclass
+class HtmlWebsiteExportResult:
+    """Result metadata for a static HTML website export."""
+
+    output_path: str
+    files: list[ExportedFile] = field(default_factory=list)
+    assets: list[ExportedFile] = field(default_factory=list)
+    document_count: int = 0
+
+
 def export_markdown_folder(
     db: Database,
     output_path: str | Path,
@@ -257,6 +267,92 @@ def export_json_file(
     )
 
 
+def export_html_site(
+    db: Database,
+    output_path: str | Path,
+    target_id: str | None = None,
+    recursive: bool = True,
+    include_assets: bool = True,
+    overwrite: bool = False,
+    package_path: str | Path | None = None,
+) -> HtmlWebsiteExportResult:
+    """Export a library, folder, or document as a static HTML website."""
+
+    output_dir = Path(output_path).expanduser()
+    if output_dir.exists() and any(output_dir.iterdir()) and not overwrite:
+        raise FileExistsError(
+            f"Export folder already exists and is not empty: {output_dir}"
+        )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    docs_dir = output_dir / "docs"
+    assets_dir = output_dir / "assets"
+    js_dir = output_dir / "js"
+    docs_dir.mkdir(exist_ok=True)
+    if include_assets:
+        assets_dir.mkdir(exist_ok=True)
+    js_dir.mkdir(exist_ok=True)
+
+    root, documents = _collect_documents(db, target_id=target_id, recursive=recursive)
+    document_ids = {doc.id for doc in documents}
+    claims = _collect_claims(db, document_ids)
+    entities = _collect_entities(db, document_ids, claims)
+    package = Path(package_path).expanduser() if package_path else None
+
+    result = HtmlWebsiteExportResult(
+        output_path=str(output_dir),
+        document_count=len(documents),
+    )
+    used_slugs: set[str] = set()
+    pages: list[tuple[Document, str, str]] = []
+    search_items: list[dict[str, str]] = []
+
+    for doc in documents:
+        slug = _unique_slug(_slugify(doc.name).lower(), used_slugs)
+        relative_url = f"docs/{slug}/index.html"
+        page_dir = docs_dir / slug
+        page_dir.mkdir(parents=True, exist_ok=True)
+        asset_refs = (
+            _copy_document_assets(doc, assets_dir, package) if include_assets else []
+        )
+        page_html = _render_html_document_page(
+            db=db,
+            doc=doc,
+            assets=asset_refs,
+            entities=_entities_for_document(doc.id, entities, claims),
+            claims=_claims_for_document(doc.id, claims),
+        )
+        page_path = page_dir / "index.html"
+        page_path.write_text(page_html, encoding="utf-8")
+        result.files.append(
+            ExportedFile(path=str(page_path), kind="html", document_id=doc.id)
+        )
+        result.assets.extend(
+            ExportedFile(path=str(asset.path), kind="asset", document_id=doc.id)
+            for asset in asset_refs
+        )
+        pages.append((doc, slug, relative_url))
+        search_items.append(
+            {
+                "title": doc.name,
+                "url": relative_url,
+                "text": _document_text(db, doc),
+            }
+        )
+
+    search_path = js_dir / "search.js"
+    search_path.write_text(_render_search_js(search_items), encoding="utf-8")
+    result.files.append(ExportedFile(path=str(search_path), kind="search-index"))
+
+    index_path = output_dir / "index.html"
+    index_path.write_text(
+        _render_html_index(root=root, pages=pages),
+        encoding="utf-8",
+    )
+    result.files.insert(0, ExportedFile(path=str(index_path), kind="index"))
+
+    return result
+
+
 @dataclass(frozen=True)
 class _AssetRef:
     path: str
@@ -365,6 +461,243 @@ def _combined_transcription(db: Database, documents: list[Document]) -> str:
 
 def _dump_model(model: Any) -> dict[str, Any]:
     return model.model_dump(mode="json")
+
+
+def _claims_for_document(
+    document_id: str,
+    claims: list[KnowledgeClaim],
+) -> list[KnowledgeClaim]:
+    return [
+        claim
+        for claim in claims
+        if claim.source_document_id == document_id
+        or document_id in (claim.source_ids or [])
+    ]
+
+
+def _entities_for_document(
+    document_id: str,
+    entities: list[KnowledgeEntity],
+    claims: list[KnowledgeClaim],
+) -> list[KnowledgeEntity]:
+    doc_claims = _claims_for_document(document_id, claims)
+    claim_entity_ids = {
+        entity_id
+        for claim in doc_claims
+        for entity_id in [
+            *claim.entity_ids,
+            claim.subject_entity_id,
+            claim.speaker_entity_id,
+            claim.subject_of_inquiry_entity_id,
+            claim.scribe_entity_id,
+            claim.editor_entity_id,
+        ]
+        if entity_id
+    }
+    return [
+        entity
+        for entity in entities
+        if entity.id in claim_entity_ids
+        or document_id in (entity.source_document_ids or [])
+    ]
+
+
+def _render_html_index(
+    root: Document | None,
+    pages: list[tuple[Document, str, str]],
+) -> str:
+    title = root.name if root else "Library Export"
+    links = "\n".join(
+        (
+            f'<li><a href="{_html_attr(url)}">{_html(doc.name)}</a></li>'
+            for doc, _, url in pages
+        )
+    )
+    if not links:
+        links = "<li>No documents exported.</li>"
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{_html(title)}</title>
+  <style>{_html_css()}</style>
+</head>
+<body>
+  <main>
+    <header>
+      <p class="eyebrow">Fichero static export</p>
+      <h1>{_html(title)}</h1>
+      <p>{len(pages)} documents exported.</p>
+    </header>
+    <section>
+      <h2>Search</h2>
+      <input id="search" type="search" placeholder="Search documents" autocomplete="off">
+      <ul id="search-results"></ul>
+    </section>
+    <section>
+      <h2>Documents</h2>
+      <ul class="doc-list">
+        {links}
+      </ul>
+    </section>
+  </main>
+  <script src="js/search.js"></script>
+</body>
+</html>
+"""
+
+
+def _render_html_document_page(
+    db: Database,
+    doc: Document,
+    assets: Iterable[_AssetRef],
+    entities: list[KnowledgeEntity],
+    claims: list[KnowledgeClaim],
+) -> str:
+    text = _document_text(db, doc)
+    gallery = _render_html_gallery(doc, assets)
+    entity_list = _render_html_entities(entities)
+    claim_list = _render_html_claims(claims)
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{_html(doc.name)}</title>
+  <style>{_html_css()}</style>
+</head>
+<body>
+  <main>
+    <nav><a href="../../index.html">Index</a></nav>
+    <article>
+      <header>
+        <p class="eyebrow">{_html(doc.doc_type.value)}</p>
+        <h1>{_html(doc.name)}</h1>
+      </header>
+      {gallery}
+      <section>
+        <h2>Transcription</h2>
+        {_html_paragraphs(text)}
+      </section>
+      <section>
+        <h2>Knowledge Graph Entities</h2>
+        {entity_list}
+      </section>
+      <section>
+        <h2>Claims</h2>
+        {claim_list}
+      </section>
+    </article>
+  </main>
+</body>
+</html>
+"""
+
+
+def _render_html_gallery(doc: Document, assets: Iterable[_AssetRef]) -> str:
+    images = "\n".join(
+        (
+            '<figure>'
+            f'<img src="../../assets/{_html_attr(Path(asset.path).name)}" '
+            f'alt="{_html_attr(doc.name)}">'
+            f"<figcaption>{_html(doc.name)}</figcaption>"
+            "</figure>"
+            for asset in assets
+        )
+    )
+    if not images:
+        return ""
+    return f"<section><h2>Images</h2><div class=\"gallery\">{images}</div></section>"
+
+
+def _render_html_entities(entities: list[KnowledgeEntity]) -> str:
+    if not entities:
+        return "<p>No linked entities.</p>"
+    items = "\n".join(
+        (
+            f'<li id="entity-{_html_attr(entity.id)}">'
+            f"<strong>{_html(entity.canonical_name)}</strong>"
+            f" <span>{_html(entity.entity_type.value)}</span>"
+            "</li>"
+            for entity in entities
+        )
+    )
+    return f"<ul>{items}</ul>"
+
+
+def _render_html_claims(claims: list[KnowledgeClaim]) -> str:
+    if not claims:
+        return "<p>No linked claims.</p>"
+    items = "\n".join(
+        (
+            f'<li id="claim-{_html_attr(claim.id)}">'
+            f"{_html(claim.text)}"
+            f" <span>{claim.confidence:.2f}</span>"
+            "</li>"
+            for claim in claims
+        )
+    )
+    return f"<ul>{items}</ul>"
+
+
+def _render_search_js(items: list[dict[str, str]]) -> str:
+    payload = json.dumps(items, ensure_ascii=False, sort_keys=True)
+    return f"""const FICHERO_SEARCH_INDEX = {payload};
+
+const input = document.getElementById("search");
+const results = document.getElementById("search-results");
+
+function renderSearch(query) {{
+  if (!results) return;
+  const terms = query.trim().toLowerCase().split(/\\s+/).filter(Boolean);
+  const matches = FICHERO_SEARCH_INDEX.filter((item) => {{
+    const haystack = `${{item.title}} ${{item.text}}`.toLowerCase();
+    return terms.length === 0 || terms.every((term) => haystack.includes(term));
+  }}).slice(0, 50);
+  results.innerHTML = matches.map((item) =>
+    `<li><a href="${{item.url}}">${{item.title}}</a></li>`
+  ).join("");
+}}
+
+if (input) {{
+  input.addEventListener("input", () => renderSearch(input.value));
+  renderSearch("");
+}}
+"""
+
+
+def _html_css() -> str:
+    return """
+body{font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;margin:0;background:#f8f8f6;color:#202020;line-height:1.55}
+main{max-width:960px;margin:0 auto;padding:32px 20px}
+header{border-bottom:1px solid #d8d5cf;margin-bottom:24px}
+h1{font-size:32px;line-height:1.2;margin:4px 0 16px}
+h2{font-size:20px;margin-top:28px}
+a{color:#075a8f}
+input[type=search]{box-sizing:border-box;width:100%;max-width:560px;padding:10px 12px;border:1px solid #aaa;border-radius:6px;font:inherit;background:white}
+.eyebrow{color:#666;text-transform:uppercase;font-size:12px;letter-spacing:.08em}
+.doc-list li,#search-results li{margin:8px 0}
+.gallery{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:16px}
+figure{margin:0}
+img{max-width:100%;height:auto;border:1px solid #d8d5cf;background:white}
+figcaption,span{color:#666;font-size:13px}
+pre{white-space:pre-wrap;background:white;border:1px solid #d8d5cf;padding:16px;overflow:auto}
+"""
+
+
+def _html_paragraphs(text: str) -> str:
+    if not text.strip():
+        return "<p>No text content available.</p>"
+    return f"<pre>{_html(text)}</pre>"
+
+
+def _html(value: object) -> str:
+    return escape(str(value))
+
+
+def _html_attr(value: object) -> str:
+    return escape(str(value), {'"': "&quot;"})
 
 
 def _render_document_markdown(
@@ -500,6 +833,16 @@ def _unique_filename(stem: str, used_names: set[str], suffix: str) -> str:
         candidate = f"{stem}-{index}{suffix}"
         index += 1
     used_names.add(candidate)
+    return candidate
+
+
+def _unique_slug(stem: str, used_slugs: set[str]) -> str:
+    candidate = stem or "document"
+    index = 2
+    while candidate in used_slugs:
+        candidate = f"{stem}-{index}"
+        index += 1
+    used_slugs.add(candidate)
     return candidate
 
 

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -2588,6 +2588,16 @@
     "export": [
       {
         "method": "POST",
+        "path": "/export/json",
+        "operation_id": "export_json_route_api_export_json_post",
+        "summary": "Export Json Route",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "JsonExportRequest",
+        "response_model": "JsonExportResponse"
+      },
+      {
+        "method": "POST",
         "path": "/export/markdown-folder",
         "operation_id": "export_markdown_folder_route_api_export_markdown_folder_post",
         "summary": "Export Markdown Folder Route",

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -2588,6 +2588,16 @@
     "export": [
       {
         "method": "POST",
+        "path": "/export/html",
+        "operation_id": "export_html_route_api_export_html_post",
+        "summary": "Export Html Route",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "HtmlExportRequest",
+        "response_model": "HtmlExportResponse"
+      },
+      {
+        "method": "POST",
         "path": "/export/json",
         "operation_id": "export_json_route_api_export_json_post",
         "summary": "Export Json Route",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -8770,6 +8770,60 @@
         }
       }
     },
+    "/api/export/html": {
+      "post": {
+        "tags": [
+          "export",
+          "export"
+        ],
+        "summary": "Export Html Route",
+        "description": "Export a library, folder, or document as a static HTML website.",
+        "operationId": "export_html_route_api_export_html_post",
+        "parameters": [
+          {
+            "name": "X-Fichero-Library-Path",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Fichero-Library-Path"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HtmlExportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HtmlExportResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/folders/{folder_id}/views": {
       "get": {
         "tags": [
@@ -41244,6 +41298,80 @@
         },
         "type": "object",
         "title": "HeuristicRequest"
+      },
+      "HtmlExportRequest": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path",
+            "description": "Destination folder for site files"
+          },
+          "target_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Target Id",
+            "description": "Optional document/folder id to export; omitted exports library"
+          },
+          "recursive": {
+            "type": "boolean",
+            "title": "Recursive",
+            "description": "Include descendants of folders",
+            "default": true
+          },
+          "include_assets": {
+            "type": "boolean",
+            "title": "Include Assets",
+            "description": "Copy image assets",
+            "default": true
+          },
+          "overwrite": {
+            "type": "boolean",
+            "title": "Overwrite",
+            "description": "Allow writing into non-empty folder",
+            "default": false
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "output_path"
+        ],
+        "title": "HtmlExportRequest",
+        "description": "Request body for static HTML website export."
+      },
+      "HtmlExportResponse": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path"
+          },
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/ExportedFileResponse"
+            },
+            "type": "array",
+            "title": "Files"
+          },
+          "assets": {
+            "items": {
+              "$ref": "#/components/schemas/ExportedFileResponse"
+            },
+            "type": "array",
+            "title": "Assets"
+          },
+          "document_count": {
+            "type": "integer",
+            "title": "Document Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "output_path",
+          "files",
+          "assets",
+          "document_count"
+        ],
+        "title": "HtmlExportResponse"
       },
       "IIIFManifest": {
         "properties": {

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -8716,6 +8716,60 @@
         }
       }
     },
+    "/api/export/json": {
+      "post": {
+        "tags": [
+          "export",
+          "export"
+        ],
+        "summary": "Export Json Route",
+        "description": "Export a library, folder, or document as structured JSON.",
+        "operationId": "export_json_route_api_export_json_post",
+        "parameters": [
+          {
+            "name": "X-Fichero-Library-Path",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Fichero-Library-Path"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonExportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonExportResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/folders/{folder_id}/views": {
       "get": {
         "tags": [
@@ -42039,6 +42093,78 @@
         ],
         "title": "InterpretiveFramework",
         "description": "An interpretive lens applied to claims and evidence.\n\nFrameworks are reusable lenses that shape how evidence is interpreted.\nExample: \"Marxist historical materialism\" as a framework for analyzing\nlabor relations in historical documents."
+      },
+      "JsonExportRequest": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path",
+            "description": "Destination .json path"
+          },
+          "target_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Target Id",
+            "description": "Optional document/folder id to export; omitted exports library"
+          },
+          "recursive": {
+            "type": "boolean",
+            "title": "Recursive",
+            "description": "Include descendants of folders",
+            "default": true
+          },
+          "overwrite": {
+            "type": "boolean",
+            "title": "Overwrite",
+            "description": "Overwrite existing .json",
+            "default": false
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "output_path"
+        ],
+        "title": "JsonExportRequest",
+        "description": "Request body for structured JSON export."
+      },
+      "JsonExportResponse": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path"
+          },
+          "document_count": {
+            "type": "integer",
+            "title": "Document Count"
+          },
+          "artifact_count": {
+            "type": "integer",
+            "title": "Artifact Count"
+          },
+          "entity_count": {
+            "type": "integer",
+            "title": "Entity Count"
+          },
+          "claim_count": {
+            "type": "integer",
+            "title": "Claim Count"
+          },
+          "bytes_written": {
+            "type": "integer",
+            "title": "Bytes Written"
+          }
+        },
+        "type": "object",
+        "required": [
+          "output_path",
+          "document_count",
+          "artifact_count",
+          "entity_count",
+          "claim_count",
+          "bytes_written"
+        ],
+        "title": "JsonExportResponse"
       },
       "KGEntityGroup": {
         "properties": {

--- a/fichero-engine/tests/unit/test_routes_export.py
+++ b/fichero-engine/tests/unit/test_routes_export.py
@@ -1,6 +1,15 @@
 """Tests for document export routes."""
 
-from fichero.models import Artifact, DocType, Document, FileType
+import json
+
+from fichero.models import (
+    Artifact,
+    DocType,
+    Document,
+    FileType,
+    KnowledgeClaim,
+    KnowledgeEntity,
+)
 
 
 class TestMarkdownFolderExport:
@@ -146,3 +155,114 @@ class TestWordExport:
         )
 
         assert r.status_code == 409
+
+
+class TestJsonExport:
+    def test_exports_document_artifacts_and_scoped_kg(self, client, db, tmp_path):
+        folder = Document(
+            id="folder-json",
+            name="JSON Export",
+            doc_type=DocType.folder,
+        )
+        doc = Document(
+            id="doc-json",
+            name="Letter JSON",
+            parent_id=folder.id,
+            doc_type=DocType.file,
+            file_type=FileType.text,
+            page_content="Primary transcription.",
+        )
+        other_doc = Document(
+            id="doc-other",
+            name="Other",
+            doc_type=DocType.file,
+            file_type=FileType.text,
+        )
+        artifact = Artifact(
+            id="artifact-json",
+            document_id=doc.id,
+            artifact_type="summary",
+            content="Artifact summary.",
+        )
+        entity = KnowledgeEntity(
+            id="entity-json",
+            canonical_name="Maria Perez",
+            source_document_ids=[doc.id],
+        )
+        other_entity = KnowledgeEntity(
+            id="entity-other",
+            canonical_name="Unrelated",
+            source_document_ids=[other_doc.id],
+        )
+        claim = KnowledgeClaim(
+            id="claim-json",
+            text="Maria Perez testified.",
+            source_document_id=doc.id,
+            entity_ids=[entity.id],
+            confidence=0.8,
+        )
+        other_claim = KnowledgeClaim(
+            id="claim-other",
+            text="Unrelated claim.",
+            source_document_id=other_doc.id,
+        )
+        for item in [
+            folder,
+            doc,
+            other_doc,
+            artifact,
+            entity,
+            other_entity,
+            claim,
+            other_claim,
+        ]:
+            db.save(item)
+
+        output_path = tmp_path / "export.json"
+        r = client.post(
+            "/api/export/json",
+            json={
+                "target_id": folder.id,
+                "output_path": str(output_path),
+            },
+        )
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["document_count"] == 1
+        assert data["artifact_count"] == 1
+        assert data["entity_count"] == 1
+        assert data["claim_count"] == 1
+        assert data["bytes_written"] > 0
+
+        payload = json.loads(output_path.read_text(encoding="utf-8"))
+        assert payload["doc"]["id"] == folder.id
+        assert [item["id"] for item in payload["documents"]] == [doc.id]
+        assert payload["transcription"] == "Primary transcription.\n\nsummary: Artifact summary."
+        assert [item["id"] for item in payload["artifacts"]] == [artifact.id]
+        assert [item["id"] for item in payload["kg"]["entities"]] == [entity.id]
+        assert [item["id"] for item in payload["kg"]["claims"]] == [claim.id]
+
+    def test_json_export_rejects_existing_file_without_overwrite(
+        self, client, tmp_path
+    ):
+        output_path = tmp_path / "export.json"
+        output_path.write_text("{}", encoding="utf-8")
+
+        r = client.post(
+            "/api/export/json",
+            json={"output_path": str(output_path)},
+        )
+
+        assert r.status_code == 409
+
+    def test_json_export_missing_target_returns_404(self, client, tmp_path):
+        r = client.post(
+            "/api/export/json",
+            json={
+                "target_id": "no-such-doc",
+                "output_path": str(tmp_path / "export.json"),
+            },
+        )
+
+        assert r.status_code == 404

--- a/fichero-engine/tests/unit/test_routes_export.py
+++ b/fichero-engine/tests/unit/test_routes_export.py
@@ -266,3 +266,100 @@ class TestJsonExport:
         )
 
         assert r.status_code == 404
+
+
+class TestHtmlExport:
+    def test_exports_static_site_with_search_assets_and_kg(
+        self, client, db, tmp_path
+    ):
+        folder = Document(
+            id="folder-html",
+            name="HTML Export",
+            doc_type=DocType.folder,
+        )
+        image_path = tmp_path / "source.jpg"
+        image_path.write_bytes(b"image bytes")
+        doc = Document(
+            id="doc-html",
+            name="Photo Letter",
+            parent_id=folder.id,
+            doc_type=DocType.file,
+            file_type=FileType.image,
+            path=str(image_path),
+            page_content="Searchable transcription.",
+        )
+        artifact = Artifact(
+            id="artifact-html",
+            document_id=doc.id,
+            artifact_type="summary",
+            content="HTML summary.",
+        )
+        entity = KnowledgeEntity(
+            id="entity-html",
+            canonical_name="Juan Perez",
+            source_document_ids=[doc.id],
+        )
+        claim = KnowledgeClaim(
+            id="claim-html",
+            text="Juan Perez appears in the letter.",
+            source_document_id=doc.id,
+            entity_ids=[entity.id],
+        )
+        for item in [folder, doc, artifact, entity, claim]:
+            db.save(item)
+
+        output_path = tmp_path / "site"
+        r = client.post(
+            "/api/export/html",
+            json={
+                "target_id": folder.id,
+                "output_path": str(output_path),
+            },
+        )
+
+        assert r.status_code == 200
+        data = r.json()
+        assert data["document_count"] == 1
+        assert data["assets"][0]["document_id"] == doc.id
+
+        assert (output_path / "index.html").exists()
+        assert (output_path / "js" / "search.js").exists()
+        assert (output_path / "assets" / "Photo-Letter.jpg").read_bytes() == b"image bytes"
+
+        index_html = (output_path / "index.html").read_text(encoding="utf-8")
+        page_html = (
+            output_path / "docs" / "photo-letter" / "index.html"
+        ).read_text(encoding="utf-8")
+        search_js = (output_path / "js" / "search.js").read_text(encoding="utf-8")
+
+        assert "Photo Letter" in index_html
+        assert "Searchable transcription." in page_html
+        assert "../../assets/Photo-Letter.jpg" in page_html
+        assert "Juan Perez" in page_html
+        assert "Juan Perez appears in the letter." in page_html
+        assert "Searchable transcription." in search_js
+
+    def test_html_export_rejects_non_empty_output_without_overwrite(
+        self, client, tmp_path
+    ):
+        output_path = tmp_path / "site"
+        output_path.mkdir()
+        (output_path / "index.html").write_text("existing", encoding="utf-8")
+
+        r = client.post(
+            "/api/export/html",
+            json={"output_path": str(output_path)},
+        )
+
+        assert r.status_code == 409
+
+    def test_html_export_missing_target_returns_404(self, client, tmp_path):
+        r = client.post(
+            "/api/export/html",
+            json={
+                "target_id": "no-such-doc",
+                "output_path": str(tmp_path / "site"),
+            },
+        )
+
+        assert r.status_code == 404

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -8770,6 +8770,60 @@
         }
       }
     },
+    "/api/export/html": {
+      "post": {
+        "tags": [
+          "export",
+          "export"
+        ],
+        "summary": "Export Html Route",
+        "description": "Export a library, folder, or document as a static HTML website.",
+        "operationId": "export_html_route_api_export_html_post",
+        "parameters": [
+          {
+            "name": "X-Fichero-Library-Path",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Fichero-Library-Path"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HtmlExportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HtmlExportResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/folders/{folder_id}/views": {
       "get": {
         "tags": [
@@ -41244,6 +41298,80 @@
         },
         "type": "object",
         "title": "HeuristicRequest"
+      },
+      "HtmlExportRequest": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path",
+            "description": "Destination folder for site files"
+          },
+          "target_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Target Id",
+            "description": "Optional document/folder id to export; omitted exports library"
+          },
+          "recursive": {
+            "type": "boolean",
+            "title": "Recursive",
+            "description": "Include descendants of folders",
+            "default": true
+          },
+          "include_assets": {
+            "type": "boolean",
+            "title": "Include Assets",
+            "description": "Copy image assets",
+            "default": true
+          },
+          "overwrite": {
+            "type": "boolean",
+            "title": "Overwrite",
+            "description": "Allow writing into non-empty folder",
+            "default": false
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "output_path"
+        ],
+        "title": "HtmlExportRequest",
+        "description": "Request body for static HTML website export."
+      },
+      "HtmlExportResponse": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path"
+          },
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/ExportedFileResponse"
+            },
+            "type": "array",
+            "title": "Files"
+          },
+          "assets": {
+            "items": {
+              "$ref": "#/components/schemas/ExportedFileResponse"
+            },
+            "type": "array",
+            "title": "Assets"
+          },
+          "document_count": {
+            "type": "integer",
+            "title": "Document Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "output_path",
+          "files",
+          "assets",
+          "document_count"
+        ],
+        "title": "HtmlExportResponse"
       },
       "IIIFManifest": {
         "properties": {

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -8716,6 +8716,60 @@
         }
       }
     },
+    "/api/export/json": {
+      "post": {
+        "tags": [
+          "export",
+          "export"
+        ],
+        "summary": "Export Json Route",
+        "description": "Export a library, folder, or document as structured JSON.",
+        "operationId": "export_json_route_api_export_json_post",
+        "parameters": [
+          {
+            "name": "X-Fichero-Library-Path",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "X-Fichero-Library-Path"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/JsonExportRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JsonExportResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/folders/{folder_id}/views": {
       "get": {
         "tags": [
@@ -42039,6 +42093,78 @@
         ],
         "title": "InterpretiveFramework",
         "description": "An interpretive lens applied to claims and evidence.\n\nFrameworks are reusable lenses that shape how evidence is interpreted.\nExample: \"Marxist historical materialism\" as a framework for analyzing\nlabor relations in historical documents."
+      },
+      "JsonExportRequest": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path",
+            "description": "Destination .json path"
+          },
+          "target_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Target Id",
+            "description": "Optional document/folder id to export; omitted exports library"
+          },
+          "recursive": {
+            "type": "boolean",
+            "title": "Recursive",
+            "description": "Include descendants of folders",
+            "default": true
+          },
+          "overwrite": {
+            "type": "boolean",
+            "title": "Overwrite",
+            "description": "Overwrite existing .json",
+            "default": false
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "output_path"
+        ],
+        "title": "JsonExportRequest",
+        "description": "Request body for structured JSON export."
+      },
+      "JsonExportResponse": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path"
+          },
+          "document_count": {
+            "type": "integer",
+            "title": "Document Count"
+          },
+          "artifact_count": {
+            "type": "integer",
+            "title": "Artifact Count"
+          },
+          "entity_count": {
+            "type": "integer",
+            "title": "Entity Count"
+          },
+          "claim_count": {
+            "type": "integer",
+            "title": "Claim Count"
+          },
+          "bytes_written": {
+            "type": "integer",
+            "title": "Bytes Written"
+          }
+        },
+        "type": "object",
+        "required": [
+          "output_path",
+          "document_count",
+          "artifact_count",
+          "entity_count",
+          "claim_count",
+          "bytes_written"
+        ],
+        "title": "JsonExportResponse"
       },
       "KGEntityGroup": {
         "properties": {


### PR DESCRIPTION
## Summary
- Adds POST /api/export/json for structured JSON exports of document, transcription, artifacts, and scoped KG data.
- Adds POST /api/export/html for static website exports with index.html, per-document pages, copied image assets, scoped KG lists, and client-side search.
- Regenerates OpenAPI contracts and Swift API client schema.
- Covers JSON and HTML export success, overwrite rejection, and missing-target errors.

## Verification
- PYTHONPATH=fichero-engine/src /Users/danieltubb/code/fichero/.venv/bin/ruff check fichero-engine/src/
- PYTHONPATH=fichero-engine/src /Users/danieltubb/code/fichero/.venv/bin/pytest fichero-engine/tests/unit/ --ignore=fichero-engine/tests/unit/_archived

Closes #471
Closes #475