### PR TITLE
docs: add scripts/launch-release.sh + bash-launch debugging note (#760)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ PYTHONPATH=fichero-engine/src .venv/bin/uvicorn fichero.api.main:app --port 8765
 **Run the SwiftUI app:**
 Open `fichero/fichero.xcodeproj` in Xcode and run.
 
+To launch an already-built `.app` from the terminal, use the helper — **not**
+a direct exec of the binary:
+```bash
+scripts/launch-release.sh            # Release build
+scripts/launch-release.sh --debug    # Debug build
+```
+> **Debugging note (#760):** direct-exec'ing the binary
+> (`./fichero/build/xcode/Products/Release/Fichero.app/Contents/MacOS/Fichero &`)
+> from a terminal does **not** draw a window on macOS 26 — AppKit's scene
+> activation runs but nothing appears, and the embedded engine never spawns.
+> This is a known macOS behavior for GUI apps exec'd by a non-Aqua parent.
+> Launch through `open` (which the helper does) or via Finder/Spotlight/Dock.
+> App logs go to the unified log: `log stream --predicate 'process == "Fichero"'`.
+
 **Use the CLI (against a running backend):**
 ```bash
 fichero --help

--- a/scripts/launch-release.sh
+++ b/scripts/launch-release.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Launch the built Fichero.app via LaunchServices (`open`) so it gets proper
+# Window Server scene activation. (#760)
+#
+# Why this script exists: direct-exec'ing the binary from a terminal —
+#   ./fichero/build/xcode/Products/Release/Fichero.app/Contents/MacOS/Fichero &
+# does NOT draw a window on macOS 26. The Swift process starts and init() runs,
+# but AppKit's scene activation lands in a state where nothing appears on
+# screen and the WindowGroup's `.task {}` never fires (so the embedded engine
+# never spawns). This is a known macOS behavior for GUI apps exec'd by a
+# non-Aqua parent (a terminal): https://developer.apple.com/forums/thread/669266
+# Launching through `open` hands the app to LaunchServices, which activates the
+# scene correctly — the same path Finder / Spotlight / Dock use.
+#
+# Usage:
+#   scripts/launch-release.sh            # launch the Release build
+#   scripts/launch-release.sh --debug    # launch the Debug build instead
+#   scripts/launch-release.sh --wait     # block until the app quits (-W)
+#
+# Build first if needed:
+#   scripts/build-release.sh             # Release (embedded engine)
+#   scripts/build-debug.sh               # Debug
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SWIFTUI_ROOT="$ROOT_DIR/fichero"
+CONFIGURATION="Release"
+WAIT=false
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/launch-release.sh            # launch the Release build
+  scripts/launch-release.sh --debug    # launch the Debug build instead
+  scripts/launch-release.sh --wait     # block until the app quits (-W)
+
+Build first if needed:
+  scripts/build-release.sh             # Release (embedded engine)
+  scripts/build-debug.sh               # Debug
+EOF
+}
+
+for arg in "$@"; do
+  case "$arg" in
+    --debug) CONFIGURATION="Debug" ;;
+    --wait|-W) WAIT=true ;;
+    --help|-h) usage; exit 0 ;;
+    *) echo "error: unknown argument '$arg'" >&2; usage; exit 2 ;;
+  esac
+done
+
+APP_PATH="$SWIFTUI_ROOT/build/xcode/Products/$CONFIGURATION/Fichero.app"
+
+if [ ! -d "$APP_PATH" ]; then
+  echo "error: $APP_PATH not found." >&2
+  if [ "$CONFIGURATION" = "Release" ]; then
+    echo "       Build it first: scripts/build-release.sh" >&2
+  else
+    echo "       Build it first: scripts/build-debug.sh" >&2
+  fi
+  exit 1
+fi
+
+echo "Launching ($CONFIGURATION) $APP_PATH via 'open -n'…" >&2
+echo "  Logs go to the unified log, not this terminal. Tail them with:" >&2
+echo "    log stream --predicate 'process == \"Fichero\"' --level debug" >&2
+
+# -n: open a new instance even if one is already running.
+# -W: wait for the app to exit before returning (opt-in via --wait).
+if $WAIT; then
+  exec open -n -W "$APP_PATH"
+else
+  exec open -n "$APP_PATH"
+fi


### PR DESCRIPTION
## Scope
Per the issue, this is **documentation + a launch helper** — fixing the underlying behavior from inside Fichero isn't possible (it's about how the launching parent process configures the child).

## Background (from the issue)
Direct-exec'ing the binary from a terminal (`./…/Fichero.app/Contents/MacOS/Fichero &`) on macOS 26 starts the process and runs `init()`, but **no window appears** and the WindowGroup's `.task {}` never fires (so the embedded engine never spawns). Launching via Finder/Spotlight/Dock works. This is a known macOS behavior for GUI apps exec'd by a non-Aqua parent (a terminal).

## Changes
- **`scripts/launch-release.sh`** — launches the built `Fichero.app` through `open -n` (LaunchServices activates the scene correctly, the same path Finder uses). Flags: `--debug` (Debug build), `--wait`/`-W` (block until quit). Errors clearly when the build is missing and prints the unified-log tail command. App path matches `build-release.sh` (`fichero/build/xcode/Products/<config>/Fichero.app`).
- **README 'Running' section** — debugging note describing the symptom and the `open`/Finder workaround, plus the `log stream` command for app logs.

## Verification
- `bash -n scripts/launch-release.sh`: clean
- `--help` prints usage; an unknown argument is rejected with exit 2; the happy path invokes `open -n` against the built app.
- No Swift changed → the app build is unaffected (nothing to compile).

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)