### PR TITLE
Assert automation routes ship in release tier

### DIFF
--- a/fichero-engine/tests/unit/test_feature_tier_routing.py
+++ b/fichero-engine/tests/unit/test_feature_tier_routing.py
@@ -30,6 +30,14 @@ def test_release_tier_exposes_001_routes():
     )
     assert "/api/workflows" in prefixes
     assert "/api/workflow-execution" in prefixes
+    assert any(
+        prefix == "/api" and "triggers" in tags
+        for _, prefix, tags in get_route_specs_for_tier("release")
+    )
+    assert any(
+        prefix == "/api" and "schedules" in tags
+        for _, prefix, tags in get_route_specs_for_tier("release")
+    )
     # Chains promoted from dev to core for 0.0.2 (#1151)
     chain_tags = [
         tags for _, _, tags in get_route_specs_for_tier("release") if "chains" in tags


### PR DESCRIPTION
## Summary
- add backend route-tier regressions asserting the minimal Automation slice (`triggers`, `schedules`) is exposed in the release tier

## Verification
- `PYTHONPATH=fichero-engine/src /Users/danieltubb/code/fichero/.venv/bin/ruff check fichero-engine/tests/unit/test_feature_tier_routing.py`
- `PYTHONPATH=fichero-engine/src /Users/danieltubb/code/fichero/.venv/bin/pytest fichero-engine/tests/unit/test_feature_tier_routing.py -q`

Closes #255