### PR TITLE
revert: drop legacy ca.tubb data migration (#1625) — ca.tubb no longer used

### DIFF
--- a/fichero-engine/src/fichero/paths.py
+++ b/fichero-engine/src/fichero/paths.py
@@ -7,9 +7,6 @@ from pathlib import Path
 
 _LEGACY_APP_SUPPORT_DIRS = (
     ("com.fichero.fichero",),
-    # Original development bundle id from before the app/engine converged on
-    # the canonical Fichero support directory (#320).
-    ("ca.tubb.fichero",),
     ("ca.tubb.fichero", "global.fichero"),
     # The SwiftUI app historically wrote the global library under its bundle id
     # (~/Library/Application Support/app.fichero.fichero/) — migrate it into the
@@ -42,3 +39,4 @@ def migrate_legacy_engine_state(home: Path | None = None) -> int:
             shutil.move(str(entry), str(dest))
             migrated_entries += 1
     return migrated_entries
+

--- a/fichero-engine/tests/unit/test_paths_app_fichero_migration.py
+++ b/fichero-engine/tests/unit/test_paths_app_fichero_migration.py
@@ -26,41 +26,6 @@ def test_app_fichero_bundle_dir_migrates_into_canonical(tmp_path: Path) -> None:
     assert canonical.exists(), "global.fichero should now live under Fichero/"
 
 
-def test_ca_tubb_bundle_dir_migrates_into_canonical(tmp_path: Path) -> None:
-    home = tmp_path
-    app_support = home / "Library" / "Application Support"
-    legacy_library = app_support / "ca.tubb.fichero" / "Library.fichero"
-    legacy_library.mkdir(parents=True)
-    (legacy_library / "fichero.duckdb").write_text("legacy")
-    (app_support / "ca.tubb.fichero" / ".api-key").write_text("token")
-
-    moved = migrate_legacy_engine_state(home=home)
-
-    canonical = engine_state_dir(home)
-    assert moved == 2
-    assert (canonical / "Library.fichero" / "fichero.duckdb").read_text() == "legacy"
-    assert (canonical / ".api-key").read_text() == "token"
-
-
-def test_legacy_bundle_migration_does_not_overwrite_canonical_files(
-    tmp_path: Path,
-) -> None:
-    home = tmp_path
-    app_support = home / "Library" / "Application Support"
-    legacy_library = app_support / "ca.tubb.fichero" / "Library.fichero"
-    canonical_library = engine_state_dir(home) / "Library.fichero"
-    legacy_library.mkdir(parents=True)
-    canonical_library.mkdir(parents=True)
-    (legacy_library / "fichero.duckdb").write_text("legacy")
-    (canonical_library / "fichero.duckdb").write_text("canonical")
-
-    moved = migrate_legacy_engine_state(home=home)
-
-    assert moved == 0
-    assert (canonical_library / "fichero.duckdb").read_text() == "canonical"
-    assert (legacy_library / "fichero.duckdb").read_text() == "legacy"
-
-
 def test_canonical_dir_is_application_support_fichero(tmp_path: Path) -> None:
     d = engine_state_dir(home=tmp_path)
     assert d.parts[-2:] == ("Application Support", "Fichero")


### PR DESCRIPTION
Daniel: ca.tubb is no longer used, so the #1625 support-data migration is unnecessary. Reverting it.