### PR TITLE
feat: general 'fichero import-manifest' command (canonical corpus importer, via API)

### DIFF
--- a/fichero-engine/src/fichero/__main__.py
+++ b/fichero-engine/src/fichero/__main__.py
@@ -527,6 +527,79 @@ def import_istmina_mineria_command(
     typer.echo(f"skipped: {summary.skipped}")
 
 
+@app.command(name="import-manifest")
+def import_manifest_command(
+    manifest: Path = typer.Option(
+        ...,
+        "--manifest",
+        help="Path to a fichero-corpus-import-v1 manifest.jsonl.",
+    ),
+    library: Path = typer.Option(
+        ...,
+        "--library",
+        help="Target .fichero package to create/populate.",
+    ),
+    api: str = typer.Option(
+        None,
+        "--api",
+        help="Engine API base URL (default http://127.0.0.1:8765/api).",
+    ),
+    token_file: Path = typer.Option(
+        None,
+        "--token-file",
+        help="Path to the engine API key (default the app's .api-key).",
+    ),
+    no_create_library: bool = typer.Option(
+        False,
+        "--no-create-library",
+        help="Do not POST /api/library first; assume the library exists.",
+    ),
+) -> None:
+    """Import a canonical corpus manifest into a library via the engine API.
+
+    Reads a general ``fichero-corpus-import-v1`` manifest (any corpus) and
+    creates folders, documents, image renditions (referenced, not copied),
+    entities, and claims through the engine's HTTP API. Idempotent — safe to
+    re-run.
+    """
+    from fichero.manifest_import import (
+        DEFAULT_API_BASE,
+        DEFAULT_TOKEN_FILE,
+        import_manifest_via_http,
+    )
+
+    try:
+        summary = import_manifest_via_http(
+            manifest_path=manifest,
+            library_path=library,
+            api_base=api or DEFAULT_API_BASE,
+            token_file=token_file or DEFAULT_TOKEN_FILE,
+            create_library=not no_create_library,
+        )
+    except Exception as exc:
+        typer.secho(f"Manifest import failed: {exc}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(code=1) from exc
+
+    if summary.warnings:
+        typer.secho(
+            f"Imported with {len(summary.warnings)} warning(s).",
+            fg=typer.colors.YELLOW,
+            err=True,
+        )
+        for warning in summary.warnings[:10]:
+            typer.echo(f"  {warning}", err=True)
+
+    typer.echo(f"library: {summary.library_path}")
+    typer.echo(f"nodes_seen: {summary.nodes_seen}")
+    typer.echo(f"pages_seen: {summary.pages_seen}")
+    typer.echo(f"documents_created: {summary.documents_created}")
+    typer.echo(f"documents_skipped: {summary.documents_skipped}")
+    typer.echo(f"entities_created: {summary.entities_created}")
+    typer.echo(f"entities_reused: {summary.entities_reused}")
+    typer.echo(f"claims_created: {summary.claims_created}")
+    typer.echo(f"claims_skipped: {summary.claims_skipped}")
+
+
 @app.command(name="import-archivo-judicial-medellin")
 def import_archivo_judicial_medellin_command(
     library_path: Path = typer.Option(

--- a/fichero-engine/src/fichero/manifest_import.py
+++ b/fichero-engine/src/fichero/manifest_import.py
@@ -1,0 +1,465 @@
+"""Import a canonical corpus manifest into a Fichero library via the API.
+
+This is the engine-side backing for the ``fichero import-manifest`` CLI
+command. It reads a ``fichero-corpus-import-v1`` manifest (a general
+interchange format produced by corpus-specific converters — *not*
+Marshall-specific) and creates the corresponding folders, documents, image
+renditions, entities, and claims **through the same FastAPI routes the
+SwiftUI app uses** (``POST /api/documents``, ``/api/entities``,
+``/api/claims``). It never writes ``db.save`` / SQL directly.
+
+Design notes
+------------
+* **Transport-agnostic.** All HTTP goes through a tiny ``ManifestApiClient``
+  protocol (``request(method, path, body) -> Any``). The default
+  implementation is a urllib client that talks to a running engine with the
+  Bearer key from ``~/Library/Application Support/Fichero/.api-key`` and the
+  ``X-Fichero-Library-Path`` header. Tests inject a FastAPI ``TestClient``
+  adapter so the importer can be exercised end-to-end against the real routes
+  with no live server.
+* **Images are referenced, never copied.** Each document's ``path`` points at
+  the rendition's existing ``source_path`` on disk; the full ``images[]`` list
+  (with every role + source path) is preserved under document metadata.
+* **Idempotent.** Re-running against the same library skips documents whose
+  ``canonical_external_id`` already exists, reuses entities by canonical name,
+  and skips claims already recorded (matched by ``canonical_claim_external_id``
+  in claim metadata). Safe to re-run after a partial import.
+* **Validated.** The manifest's ``canonical_version`` must match; nodes must
+  appear parent-before-child; a missing parent is a hard error.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Protocol
+
+CANONICAL_VERSION = "fichero-corpus-import-v1"
+DEFAULT_API_BASE = "http://127.0.0.1:8765/api"
+DEFAULT_TOKEN_FILE = Path(
+    "~/Library/Application Support/Fichero/.api-key"
+).expanduser()
+
+# Preferred display rendition for a document's primary ``path`` reference.
+IMAGE_ROLE_PREFERENCE = (
+    "enhanced",
+    "background_removed",
+    "rotated",
+    "crop",
+    "original",
+)
+
+_VALID_ENTITY_TYPES = {
+    "person",
+    "location",
+    "organization",
+    "event",
+    "concept",
+    "citation",
+    "other",
+}
+_NODE_TYPE_TO_DOC_TYPE = {"folder": "folder", "group": "group", "page": "page"}
+
+
+class ManifestApiClient(Protocol):
+    """Minimal request surface the importer needs from any HTTP transport."""
+
+    def request(
+        self, method: str, path: str, body: dict[str, Any] | None = None
+    ) -> Any:
+        """Perform an API call. ``path`` is relative to the ``/api`` base."""
+        ...
+
+
+class HttpManifestClient:
+    """urllib-based :class:`ManifestApiClient` for a running engine."""
+
+    def __init__(
+        self, api_base: str, token: str, library_path: str, timeout: int = 120
+    ) -> None:
+        self.api_base = api_base.rstrip("/")
+        self.token = token
+        self.library_path = library_path
+        self.timeout = timeout
+
+    def request(
+        self, method: str, path: str, body: dict[str, Any] | None = None
+    ) -> Any:
+        url = f"{self.api_base}{path}"
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "X-Fichero-Library-Path": self.library_path,
+        }
+        data = None
+        if body is not None:
+            data = json.dumps(body, ensure_ascii=False).encode("utf-8")
+            headers["Content-Type"] = "application/json"
+        req = urllib.request.Request(url, data=data, headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                payload = resp.read().decode("utf-8")
+                return json.loads(payload) if payload else None
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise RuntimeError(
+                f"{method} {url} failed: HTTP {exc.code}: {detail}"
+            ) from exc
+
+
+@dataclass
+class ImportSummary:
+    """Outcome of an import run."""
+
+    manifest: str
+    library_path: str
+    nodes_seen: int = 0
+    pages_seen: int = 0
+    documents_created: int = 0
+    documents_skipped: int = 0
+    entities_created: int = 0
+    entities_reused: int = 0
+    claims_created: int = 0
+    claims_skipped: int = 0
+    warnings: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "manifest": self.manifest,
+            "library_path": self.library_path,
+            "nodes_seen": self.nodes_seen,
+            "pages_seen": self.pages_seen,
+            "documents_created": self.documents_created,
+            "documents_skipped": self.documents_skipped,
+            "entities_created": self.entities_created,
+            "entities_reused": self.entities_reused,
+            "claims_created": self.claims_created,
+            "claims_skipped": self.claims_skipped,
+            "warnings": self.warnings,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Manifest reading + validation
+# ---------------------------------------------------------------------------
+
+
+def read_manifest(path: Path) -> list[dict[str, Any]]:
+    """Read a JSONL manifest into a list of node dicts."""
+    nodes: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, 1):
+            if not line.strip():
+                continue
+            try:
+                nodes.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Invalid JSONL at {path}:{line_no}: {exc}"
+                ) from exc
+    return nodes
+
+
+def validate_nodes(nodes: list[dict[str, Any]]) -> None:
+    """Validate canonical version, required fields, and parent ordering."""
+    if not nodes:
+        raise ValueError("Manifest is empty")
+    seen: set[str] = set()
+    for index, node in enumerate(nodes):
+        version = node.get("canonical_version")
+        if version != CANONICAL_VERSION:
+            raise ValueError(
+                f"Node {index} has canonical_version={version!r}, "
+                f"expected {CANONICAL_VERSION!r}"
+            )
+        external_id = node.get("external_id")
+        if not external_id:
+            raise ValueError(f"Node {index} is missing external_id")
+        node_type = node.get("node_type")
+        if node_type not in _NODE_TYPE_TO_DOC_TYPE:
+            raise ValueError(
+                f"Node {external_id} has unknown node_type={node_type!r}"
+            )
+        parent = node.get("parent_external_id")
+        if parent and parent not in seen:
+            raise ValueError(
+                f"Node {external_id} references parent {parent!r} that does "
+                "not appear before it (manifest must be parent-before-child)"
+            )
+        seen.add(external_id)
+
+
+# ---------------------------------------------------------------------------
+# Payload builders
+# ---------------------------------------------------------------------------
+
+
+def preferred_image(node: dict[str, Any]) -> dict[str, Any] | None:
+    images = node.get("images") or []
+    for role in IMAGE_ROLE_PREFERENCE:
+        for image in images:
+            if image.get("role") == role:
+                return image
+    return images[0] if images else None
+
+
+def document_payload(
+    node: dict[str, Any], parent_id: str | None
+) -> dict[str, Any]:
+    """Build a ``POST /api/documents`` body for a manifest node.
+
+    Images are *referenced*: ``path`` points at the chosen rendition's
+    existing ``source_path`` on disk. The full ``images[]`` list (every role +
+    source path) is preserved under metadata so renditions survive the round
+    trip without any file being copied.
+    """
+    image = preferred_image(node)
+    metadata = dict(node.get("metadata") or {})
+    metadata.update(
+        {
+            "canonical_version": node.get("canonical_version"),
+            "canonical_external_id": node.get("external_id"),
+            "canonical_parent_external_id": node.get("parent_external_id"),
+            "canonical_node_type": node.get("node_type"),
+            "corpus": node.get("corpus"),
+            "page_label": node.get("page_label"),
+            "date": node.get("date"),
+            "sequence": node.get("sequence"),
+            "images": node.get("images") or [],
+            "preferred_image_role": image.get("role") if image else None,
+        }
+    )
+    payload: dict[str, Any] = {
+        "name": node.get("name") or node.get("external_id"),
+        "parent_id": parent_id,
+        "doc_type": _NODE_TYPE_TO_DOC_TYPE[node["node_type"]],
+        "path": image.get("source_path") if image else metadata.get("source_assets"),
+        "page_content": node.get("text"),
+        "metadata": metadata,
+    }
+    if node.get("node_type") == "page" and image is not None:
+        payload["file_type"] = "image"
+    return payload
+
+
+def entity_payload(entity: dict[str, Any], node: dict[str, Any]) -> dict[str, Any]:
+    entity_type = entity.get("entity_type") or "other"
+    if entity_type not in _VALID_ENTITY_TYPES:
+        entity_type = "other"
+    metadata = dict(entity.get("metadata") or {})
+    if entity.get("external_id"):
+        metadata.setdefault("canonical_entity_external_id", entity["external_id"])
+    return {
+        "canonical_name": entity["canonical_name"],
+        "entity_type": entity_type,
+        "aliases": entity.get("aliases") or [],
+        "description": entity.get("description"),
+        "language": entity.get("language") or node.get("language"),
+        "metadata": metadata,
+    }
+
+
+def claim_payload(
+    claim: dict[str, Any],
+    node: dict[str, Any],
+    source_document_id: str | None,
+    entity_ids: list[str],
+) -> dict[str, Any]:
+    metadata = dict(claim.get("metadata") or {})
+    if claim.get("external_id"):
+        metadata["canonical_claim_external_id"] = claim["external_id"]
+    payload: dict[str, Any] = {
+        "text": claim["text"],
+        "source_document_id": source_document_id,
+        "source_page_label": node.get("page_label"),
+        "source_excerpt": claim.get("source_excerpt"),
+        "source_ref": claim.get("source_ref") or node.get("external_id"),
+        "entity_ids": entity_ids,
+        "confidence": claim.get("confidence", 0.5),
+        "language": claim.get("language") or node.get("language"),
+        "metadata": metadata,
+        "created_by": "manifest-importer",
+        "claim_type": claim.get("claim_type"),
+        "subject_canonical": claim.get("subject_canonical"),
+        "predicate_verb": claim.get("predicate_verb"),
+        "object_phrase": claim.get("object_phrase"),
+        "claim_recorded_at": claim.get("claim_recorded_at") or node.get("date"),
+    }
+    return {k: v for k, v in payload.items() if v is not None}
+
+
+# ---------------------------------------------------------------------------
+# API helpers (idempotency lookups)
+# ---------------------------------------------------------------------------
+
+
+def _list_documents(client: ManifestApiClient) -> list[dict[str, Any]]:
+    response = client.request("GET", "/documents?limit=500")
+    if isinstance(response, dict):
+        return list(response.get("items") or [])
+    if isinstance(response, list):
+        return response
+    return []
+
+
+def _list_entities(client: ManifestApiClient) -> list[dict[str, Any]]:
+    response = client.request("GET", "/entities?limit=500")
+    if isinstance(response, dict):
+        return list(response.get("items") or response.get("entities") or [])
+    if isinstance(response, list):
+        return response
+    return []
+
+
+def _list_claim_external_ids(client: ManifestApiClient) -> set[str]:
+    response = client.request("GET", "/claims?limit=500")
+    items: list[dict[str, Any]] = []
+    if isinstance(response, dict):
+        items = list(response.get("items") or [])
+    elif isinstance(response, list):
+        items = response
+    existing: set[str] = set()
+    for claim in items:
+        meta = claim.get("metadata") or {}
+        ext = meta.get("canonical_claim_external_id")
+        if ext:
+            existing.add(str(ext))
+    return existing
+
+
+def _existing_doc_id_by_external(
+    docs: list[dict[str, Any]],
+) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for doc in docs:
+        meta = doc.get("metadata") or {}
+        external = meta.get("canonical_external_id")
+        if external and doc.get("id"):
+            mapping[str(external)] = str(doc["id"])
+    return mapping
+
+
+# ---------------------------------------------------------------------------
+# Import driver
+# ---------------------------------------------------------------------------
+
+
+def import_manifest(
+    client: ManifestApiClient,
+    manifest_path: Path,
+    library_path: str,
+) -> ImportSummary:
+    """Import a canonical manifest into a library through the API client."""
+    nodes = read_manifest(manifest_path)
+    validate_nodes(nodes)
+
+    summary = ImportSummary(
+        manifest=str(manifest_path),
+        library_path=library_path,
+        nodes_seen=len(nodes),
+        pages_seen=sum(1 for n in nodes if n.get("node_type") == "page"),
+    )
+
+    # --- documents (folders/groups/pages), parent-before-child ---
+    existing_docs = _list_documents(client)
+    doc_id_by_external = _existing_doc_id_by_external(existing_docs)
+
+    for node in nodes:
+        external_id = node["external_id"]
+        if external_id in doc_id_by_external:
+            summary.documents_skipped += 1
+            continue
+        parent_external = node.get("parent_external_id")
+        parent_id = doc_id_by_external.get(parent_external) if parent_external else None
+        if parent_external and not parent_id:
+            raise RuntimeError(
+                f"Missing parent for {external_id}: {parent_external}"
+            )
+        created = client.request(
+            "POST", "/documents", document_payload(node, parent_id)
+        )
+        doc_id_by_external[external_id] = str(created["id"])
+        summary.documents_created += 1
+
+    # --- entities (deduped by canonical name across the whole manifest) ---
+    entity_id_by_key: dict[str, str] = {}
+    for existing in _list_entities(client):
+        name = existing.get("canonical_name")
+        if name and existing.get("id"):
+            entity_id_by_key[str(name)] = str(existing["id"])
+
+    for node in nodes:
+        for entity in node.get("entities") or []:
+            name = entity.get("canonical_name")
+            if not name:
+                continue
+            ext = entity.get("external_id")
+            if name in entity_id_by_key:
+                # Reuse — register the external_id alias for claim refs.
+                if ext:
+                    entity_id_by_key[ext] = entity_id_by_key[name]
+                summary.entities_reused += 1
+                continue
+            created = client.request(
+                "POST", "/entities", entity_payload(entity, node)
+            )
+            new_id = str(created["id"])
+            entity_id_by_key[name] = new_id
+            if ext:
+                entity_id_by_key[ext] = new_id
+            summary.entities_created += 1
+
+    # --- claims ---
+    existing_claim_externals = _list_claim_external_ids(client)
+    for node in nodes:
+        source_document_id = doc_id_by_external.get(node["external_id"])
+        for claim in node.get("claims") or []:
+            ext = claim.get("external_id")
+            if ext and ext in existing_claim_externals:
+                summary.claims_skipped += 1
+                continue
+            refs = claim.get("entity_refs") or []
+            entity_ids = [
+                entity_id_by_key[ref] for ref in refs if ref in entity_id_by_key
+            ]
+            missing = [ref for ref in refs if ref not in entity_id_by_key]
+            if missing:
+                summary.warnings.append(
+                    f"Claim {ext or claim.get('text', '')[:40]!r} references "
+                    f"unknown entities: {missing}"
+                )
+            client.request(
+                "POST",
+                "/claims",
+                claim_payload(claim, node, source_document_id, entity_ids),
+            )
+            if ext:
+                existing_claim_externals.add(ext)
+            summary.claims_created += 1
+
+    return summary
+
+
+def import_manifest_via_http(
+    *,
+    manifest_path: Path,
+    library_path: Path,
+    api_base: str = DEFAULT_API_BASE,
+    token_file: Path = DEFAULT_TOKEN_FILE,
+    create_library: bool = True,
+) -> ImportSummary:
+    """Convenience entry point: import a manifest into a live engine over HTTP.
+
+    Reads the Bearer key from ``token_file`` and (optionally) creates the
+    target ``.fichero`` library first via ``POST /api/library`` so a single
+    command can bootstrap and populate a fresh library.
+    """
+    token = token_file.read_text(encoding="utf-8").strip()
+    library_str = str(library_path.expanduser())
+    client = HttpManifestClient(api_base, token, library_str)
+    if create_library:
+        client.request("POST", "/library", {"path": library_str})
+    return import_manifest(client, manifest_path.expanduser(), library_str)

--- a/fichero-engine/tests/unit/test_manifest_import.py
+++ b/fichero-engine/tests/unit/test_manifest_import.py
@@ -1,0 +1,228 @@
+"""Tests for the canonical manifest importer (`fichero import-manifest`).
+
+The importer drives the real FastAPI routes (`POST /api/documents`,
+`/api/entities`, `/api/claims`) through a transport-agnostic client. Here we
+adapt the conftest `client` (a FastAPI ``TestClient`` bound to a temp library)
+into the importer's ``ManifestApiClient`` interface, so the import runs
+end-to-end against the actual routes + a real temp DB — no live server, no raw
+``db.save``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from fichero.manifest_import import import_manifest, validate_nodes
+
+
+CANONICAL_VERSION = "fichero-corpus-import-v1"
+
+
+class _TestClientAdapter:
+    """Adapt a FastAPI ``TestClient`` to the ``ManifestApiClient`` protocol."""
+
+    def __init__(self, test_client) -> None:
+        self._client = test_client
+
+    def request(
+        self, method: str, path: str, body: dict[str, Any] | None = None
+    ) -> Any:
+        url = f"/api{path}"
+        if method == "GET":
+            resp = self._client.get(url)
+        elif method == "POST":
+            resp = self._client.post(url, json=body)
+        else:  # pragma: no cover - importer only uses GET/POST
+            raise AssertionError(f"unexpected method {method}")
+        assert resp.status_code < 400, (method, url, resp.status_code, resp.text)
+        if resp.content:
+            return resp.json()
+        return None
+
+
+def _fixture_manifest(tmp_path: Path) -> Path:
+    """Write a tiny 2-document manifest: a group + one page under it."""
+    img_src = tmp_path / "page_001_enhanced.jpg"
+    img_src.write_bytes(b"not-a-real-image")  # referenced, never copied
+
+    nodes = [
+        {
+            "canonical_version": CANONICAL_VERSION,
+            "node_type": "group",
+            "external_id": "tiny_corpus",
+            "parent_external_id": None,
+            "corpus": "tiny_corpus",
+            "name": "Tiny Corpus",
+            "page_label": None,
+            "date": "1923",
+            "language": "en",
+            "text": None,
+            "images": [],
+            "entities": [],
+            "claims": [],
+            "metadata": {"source_assets": str(tmp_path)},
+        },
+        {
+            "canonical_version": CANONICAL_VERSION,
+            "node_type": "page",
+            "external_id": "tiny_corpus__page_001",
+            "parent_external_id": "tiny_corpus",
+            "corpus": "tiny_corpus",
+            "name": "page_001",
+            "sequence": 1,
+            "page_label": "001",
+            "date": "1923-02-05",
+            "language": "en",
+            "text": "Marshall went to Istmina this afternoon.",
+            "images": [
+                {
+                    "role": "enhanced",
+                    "path": "images/enhanced/page_001.jpg",
+                    "source_path": str(img_src),
+                    "is_representative": True,
+                    "metadata": {},
+                }
+            ],
+            "entities": [
+                {
+                    "external_id": "Marshall",
+                    "canonical_name": "Marshall",
+                    "entity_type": "person",
+                    "aliases": [],
+                    "language": "en",
+                    "metadata": {"source": "test"},
+                },
+                {
+                    "external_id": "Istmina",
+                    "canonical_name": "Istmina",
+                    "entity_type": "location",
+                    "aliases": [],
+                    "language": "en",
+                    "metadata": {"source": "test"},
+                },
+            ],
+            "claims": [
+                {
+                    "external_id": "tiny_corpus__page_001__claim_0",
+                    "text": "Marshall went to Istmina",
+                    "source_excerpt": "Marshall went to Istmina this afternoon.",
+                    "source_ref": "tiny_corpus__page_001",
+                    "entity_refs": ["Marshall", "Istmina"],
+                    "claim_type": "fact",
+                    "confidence": 0.4,
+                    "language": "en",
+                    "subject_canonical": "Marshall",
+                    "predicate_verb": "went to",
+                    "object_phrase": "Istmina this afternoon",
+                    "claim_recorded_at": "1923-02-05",
+                    "metadata": {"source": "test"},
+                }
+            ],
+        },
+    ]
+
+    manifest = tmp_path / "manifest.jsonl"
+    with manifest.open("w", encoding="utf-8") as handle:
+        for node in nodes:
+            handle.write(json.dumps(node) + "\n")
+    return manifest
+
+
+def test_validate_rejects_wrong_version():
+    bad = [{"canonical_version": "other-v9", "external_id": "x", "node_type": "page"}]
+    try:
+        validate_nodes(bad)
+    except ValueError as exc:
+        assert "canonical_version" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError for wrong canonical_version")
+
+
+def test_validate_rejects_out_of_order_parent():
+    nodes = [
+        {
+            "canonical_version": CANONICAL_VERSION,
+            "external_id": "child",
+            "node_type": "page",
+            "parent_external_id": "missing_parent",
+        }
+    ]
+    try:
+        validate_nodes(nodes)
+    except ValueError as exc:
+        assert "parent" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected ValueError for out-of-order parent")
+
+
+def test_import_creates_documents_entities_claims(client, db, tmp_path):
+    manifest = _fixture_manifest(tmp_path)
+    adapter = _TestClientAdapter(client)
+
+    summary = import_manifest(adapter, manifest, str(tmp_path / "lib.fichero"))
+
+    # Counts from the run summary.
+    assert summary.nodes_seen == 2
+    assert summary.pages_seen == 1
+    assert summary.documents_created == 2
+    assert summary.entities_created == 2
+    assert summary.claims_created == 1
+    assert summary.warnings == []
+
+    # Verify through the live routes that the data actually landed.
+    docs = client.get("/api/documents?limit=500").json()
+    items = docs["items"] if isinstance(docs, dict) else docs
+    by_name = {d["name"]: d for d in items}
+    assert "Tiny Corpus" in by_name
+    assert "page_001" in by_name
+
+    page = by_name["page_001"]
+    # Parent wiring: page -> group.
+    assert page["parent_id"] == by_name["Tiny Corpus"]["id"]
+    # Image is referenced (path points at the existing source file), not copied.
+    assert page["path"] == str(tmp_path / "page_001_enhanced.jpg")
+    assert Path(page["path"]).exists()
+    # Renditions preserved in metadata.
+    assert page["metadata"]["canonical_external_id"] == "tiny_corpus__page_001"
+    assert page["metadata"]["images"][0]["role"] == "enhanced"
+
+    entities = client.get("/api/entities?limit=500").json()
+    ent_items = entities["items"] if isinstance(entities, dict) else entities
+    names = {e["canonical_name"] for e in ent_items}
+    assert {"Marshall", "Istmina"} <= names
+
+    claims = client.get("/api/claims?limit=500").json()
+    claim_items = claims["items"] if isinstance(claims, dict) else claims
+    assert len(claim_items) == 1
+    claim = claim_items[0]
+    assert claim["text"] == "Marshall went to Istmina"
+    # Claim links to both entities (resolved from entity_refs -> ids).
+    assert len(claim["entity_ids"]) == 2
+    assert claim["source_document_id"] == page["id"]
+
+
+def test_import_is_idempotent(client, db, tmp_path):
+    manifest = _fixture_manifest(tmp_path)
+    adapter = _TestClientAdapter(client)
+
+    first = import_manifest(adapter, manifest, str(tmp_path / "lib.fichero"))
+    second = import_manifest(adapter, manifest, str(tmp_path / "lib.fichero"))
+
+    assert first.documents_created == 2
+    # Second run skips everything already present.
+    assert second.documents_created == 0
+    assert second.documents_skipped == 2
+    assert second.entities_created == 0
+    assert second.entities_reused == 2
+    assert second.claims_created == 0
+    assert second.claims_skipped == 1
+
+    # No duplication on disk.
+    docs = client.get("/api/documents?limit=500").json()
+    items = docs["items"] if isinstance(docs, dict) else docs
+    assert len([d for d in items if d["name"] in {"Tiny Corpus", "page_001"}]) == 2
+    claims = client.get("/api/claims?limit=500").json()
+    claim_items = claims["items"] if isinstance(claims, dict) else claims
+    assert len(claim_items) == 1


### PR DESCRIPTION
General importer for the fichero-corpus-import-v1 manifest format — creates folders/docs/entities/claims through the engine routes (no raw db.save), images referenced not copied, idempotent. Replaces the hard-coded per-corpus import-* scripts. 5 tests, 33 passed, ruff clean. Used to import Marshall 1923.