### PR TITLE
fix: Apple on-device extraction returns empty — make _EntitiesOnly grammar permissive again (#1633)

### DIFF
--- a/fichero-engine/src/fichero/workflows/tools/extract_all.py
+++ b/fichero-engine/src/fichero/workflows/tools/extract_all.py
@@ -272,20 +272,27 @@ class _EntityOnly(BaseModel):
     """Compact entity representation for Stage 1 (NER-only pass)."""
     name: str
     aliases: list[str] = Field(default_factory=list)
-    entity_type: str  # "person", "place", "organization", etc.
+    # Optional with a sensible default so the Apple grammar stays permissive
+    # per element. Making entity_type required (#1272) forced fm-bridge to
+    # satisfy a nested all-required grammar on every chunk; on-device
+    # FoundationModels can't, so the constrained decoder collapsed to `{}`.
+    entity_type: str = "other"  # "person", "place", "organization", etc.
 
 
 class _EntitiesOnly(BaseModel):
     """Stage 1 result: all entity names extracted."""
-    # Required (no defaults) so _pydantic_to_apple_schema marks them as
-    # required in the Apple grammar schema, forcing fm-bridge to emit all
-    # category keys. With default_factory=list the grammar allowed `{}`,
-    # causing a silent 0-entity result (#1272).
-    people: list[_EntityOnly]
-    places: list[_EntityOnly]
-    organizations: list[_EntityOnly]
-    dates: list[_EntityOnly]
-    events: list[_EntityOnly]
+    # All fields optional (default_factory=list) so _pydantic_to_apple_schema
+    # marks them `optional` in the Apple grammar. #1272 made them required to
+    # stop a silent `{}` result, but an all-required nested grammar is
+    # unsatisfiable for on-device FoundationModels and made the decoder
+    # collapse to empty on EVERY chunk. We keep the grammar permissive and
+    # detect a genuinely-empty Stage 1 result explicitly via
+    # `_entities_only_is_empty` (soft failure), not by forcing the grammar.
+    people: list[_EntityOnly] = Field(default_factory=list)
+    places: list[_EntityOnly] = Field(default_factory=list)
+    organizations: list[_EntityOnly] = Field(default_factory=list)
+    dates: list[_EntityOnly] = Field(default_factory=list)
+    events: list[_EntityOnly] = Field(default_factory=list)
 
 
 class _SVOClaim(BaseModel):
@@ -994,6 +1001,23 @@ def _extraction_is_empty(extraction: _Extraction) -> bool:
     ))
 
 
+def _entities_only_is_empty(entities: _EntitiesOnly) -> bool:
+    """True when a Stage 1 result has no entities in any category.
+
+    The Apple grammar is permissive (all categories optional), so an empty
+    object is a valid decode. Detect that explicitly here and treat it as a
+    soft failure (log / route to fallback) instead of relying on required
+    grammar fields to raise — which collapsed the on-device decoder (#1272).
+    """
+    return not any((
+        entities.people,
+        entities.places,
+        entities.organizations,
+        entities.dates,
+        entities.events,
+    ))
+
+
 def _extraction_is_thin(extraction: _Extraction, source_text: str = "") -> bool:
     """Reject name-list outputs that would become generic type claims."""
     if _extraction_is_empty(extraction) and len(source_text.strip()) > 200:
@@ -1213,6 +1237,19 @@ async def _run_two_stage(
             entity_count,
             elapsed,
         )
+        # Explicit soft-fail detection: the Apple grammar is permissive, so an
+        # all-empty decode is valid (not an exception). Log it so a genuinely
+        # empty page is visible and a non-trivial page returning nothing is a
+        # detectable signal rather than a silent zero-entity result (#1272).
+        if _entities_only_is_empty(extraction) and len(chunk_text.strip()) > 200:
+            logger.warning(
+                "Stage 1 chunk %s: empty entity result on a %d-char chunk "
+                "(provider=%s/%s) — treating as soft failure.",
+                idx,
+                len(chunk_text.strip()),
+                llm_config.provider,
+                llm_config.model,
+            )
         await emit_progress_event(
             progress_callback,
             "file_complete",

--- a/fichero-engine/tests/unit/workflows/test_extract_all_twostage_per_page.py
+++ b/fichero-engine/tests/unit/workflows/test_extract_all_twostage_per_page.py
@@ -75,3 +75,79 @@ async def test_two_stage_writes_kg_rows_to_page_docs_not_folder(db, test_package
     assert len(folder_claims) == 0, "claims should be attached to page docs"
     assert len(page1_claims) > 0
     assert len(page2_claims) > 0
+
+
+# ---------------------------------------------------------------------------
+# Regression: Apple _EntitiesOnly grammar must stay permissive (#1272 revert).
+#
+# #1272 made every _EntitiesOnly field + _EntityOnly.entity_type required so the
+# Apple grammar would refuse a `{}` decode. But an all-required nested grammar
+# is unsatisfiable for on-device FoundationModels, collapsing the constrained
+# decoder to empty on EVERY chunk. The fix: keep the fields optional (permissive
+# grammar) and detect a genuinely-empty Stage 1 result via a soft-fail helper.
+# ---------------------------------------------------------------------------
+
+
+class TestEntitiesOnlyGrammarPermissive:
+    def test_entities_only_fields_optional(self):
+        """All 5 _EntitiesOnly category fields default to [] so the Apple
+        grammar marks them optional (not required) — instantiation with no
+        args must succeed."""
+        entities = extract_all_module._EntitiesOnly()
+        assert entities.people == []
+        assert entities.places == []
+        assert entities.organizations == []
+        assert entities.dates == []
+        assert entities.events == []
+
+    def test_entities_only_not_in_json_schema_required(self):
+        """The five category fields must NOT appear in the Pydantic JSON-schema
+        `required` list — that's the signal _pydantic_to_apple_schema uses to
+        mark a property `optional` in the Apple grammar tree."""
+        required = set(
+            extract_all_module._EntitiesOnly.model_json_schema().get("required", [])
+        )
+        assert required == set(), f"expected no required fields, got {required}"
+
+    def test_entity_only_entity_type_optional(self):
+        """_EntityOnly.entity_type must be optional with a sensible default so
+        each element of the nested grammar is also permissive."""
+        ent = extract_all_module._EntityOnly(name="Dr. Guerrero")
+        assert ent.entity_type == "other"
+        required = set(
+            extract_all_module._EntityOnly.model_json_schema().get("required", [])
+        )
+        # name stays required; entity_type must NOT be required.
+        assert "entity_type" not in required
+        assert "name" in required
+
+    def test_apple_schema_marks_entities_only_fields_optional(self):
+        """End-to-end: the Apple grammar tree produced from _EntitiesOnly marks
+        every category property `optional`, so fm-bridge permits an empty
+        decode instead of collapsing."""
+        from fichero.llm import _pydantic_to_apple_schema
+
+        schema = _pydantic_to_apple_schema(extract_all_module._EntitiesOnly)
+        props = {p["name"]: p for p in schema["properties"]}
+        for field in ("people", "places", "organizations", "dates", "events"):
+            assert props[field].get("optional") is True, (
+                f"{field} must be optional in the Apple grammar"
+            )
+
+    def test_empty_stage1_result_detected_as_soft_failure(self):
+        """An all-empty Stage 1 decode is a valid permissive-grammar result and
+        must be detected explicitly (soft failure), not raise."""
+        empty = extract_all_module._EntitiesOnly()
+        assert extract_all_module._entities_only_is_empty(empty) is True
+
+    def test_non_empty_stage1_result_not_flagged_empty(self):
+        """A Stage 1 result WITH entities (the real Marshall-page case) must not
+        be flagged empty."""
+        result = extract_all_module._EntitiesOnly(
+            people=[
+                extract_all_module._EntityOnly(name="Dr. Guerrero", entity_type="person"),
+                extract_all_module._EntityOnly(name="Dr. Cordoba", entity_type="person"),
+            ],
+            places=[extract_all_module._EntityOnly(name="Condoto", entity_type="place")],
+        )
+        assert extract_all_module._entities_only_is_empty(result) is False


### PR DESCRIPTION
Reverts #1272's over-constraint that made all _EntitiesOnly fields + entity_type required in the Apple grammar (on-device FoundationModels collapses to empty under an all-required nested grammar). Restores optional/defaulted fields; detects genuinely-empty Stage-1 via soft-fail instead of forcing the grammar. Live proof: permissive grammar extracts Guerrero/Cordoba/Andagoya/Condoto; #1272 grammar returns 0. ruff clean, 645 passed.