### PR TITLE
feat(import): --copy-images option for canonical manifest importer

### DIFF
--- a/fichero-engine/src/fichero/__main__.py
+++ b/fichero-engine/src/fichero/__main__.py
@@ -554,13 +554,23 @@ def import_manifest_command(
         "--no-create-library",
         help="Do not POST /api/library first; assume the library exists.",
     ),
+    copy_images: bool = typer.Option(
+        False,
+        "--copy-images/--no-copy-images",
+        help=(
+            "Copy each page's preferred image INTO the library package "
+            "(thumbnails/display work) instead of merely referencing the "
+            "on-disk source path. page_content stays the manifest transcript "
+            "(provenance import — no Apple Vision OCR). Default: reference."
+        ),
+    ),
 ) -> None:
     """Import a canonical corpus manifest into a library via the engine API.
 
     Reads a general ``fichero-corpus-import-v1`` manifest (any corpus) and
-    creates folders, documents, image renditions (referenced, not copied),
-    entities, and claims through the engine's HTTP API. Idempotent — safe to
-    re-run.
+    creates folders, documents, image renditions (referenced by default, or
+    copied into the library with ``--copy-images``), entities, and claims
+    through the engine's HTTP API. Idempotent — safe to re-run.
     """
     from fichero.manifest_import import (
         DEFAULT_API_BASE,
@@ -575,6 +585,7 @@ def import_manifest_command(
             api_base=api or DEFAULT_API_BASE,
             token_file=token_file or DEFAULT_TOKEN_FILE,
             create_library=not no_create_library,
+            copy_images=copy_images,
         )
     except Exception as exc:
         typer.secho(f"Manifest import failed: {exc}", fg=typer.colors.RED, err=True)

--- a/fichero-engine/src/fichero/manifest_import.py
+++ b/fichero-engine/src/fichero/manifest_import.py
@@ -206,6 +206,27 @@ def preferred_image(node: dict[str, Any]) -> dict[str, Any] | None:
     return images[0] if images else None
 
 
+def _canonical_metadata(node: dict[str, Any]) -> dict[str, Any]:
+    """Build the canonical metadata block shared by reference and copy modes."""
+    image = preferred_image(node)
+    metadata = dict(node.get("metadata") or {})
+    metadata.update(
+        {
+            "canonical_version": node.get("canonical_version"),
+            "canonical_external_id": node.get("external_id"),
+            "canonical_parent_external_id": node.get("parent_external_id"),
+            "canonical_node_type": node.get("node_type"),
+            "corpus": node.get("corpus"),
+            "page_label": node.get("page_label"),
+            "date": node.get("date"),
+            "sequence": node.get("sequence"),
+            "images": node.get("images") or [],
+            "preferred_image_role": image.get("role") if image else None,
+        }
+    )
+    return metadata
+
+
 def document_payload(
     node: dict[str, Any], parent_id: str | None
 ) -> dict[str, Any]:
@@ -347,12 +368,77 @@ def _existing_doc_id_by_external(
 # ---------------------------------------------------------------------------
 
 
+def _copy_image_into_library(
+    client: ManifestApiClient,
+    node: dict[str, Any],
+    parent_id: str | None,
+) -> str:
+    """Copy a page's preferred image INTO the library and wire its document.
+
+    Reuses the engine's native ingest path (``POST /api/ingest/file`` with
+    ``copy_mode=True``) so the image bytes land in ``{library}/files/`` and
+    storage/thumbnail + storage/display work exactly like ``fichero import``.
+
+    ``extract_text=False`` is critical: the manifest already carries the clean
+    transcript, so we must NOT let ingest run any image text-extraction /
+    Apple Vision OCR that would compete with it. After the bytes are in place
+    we ``PUT`` the manifest fields (clean transcript as ``page_content``,
+    canonical name/metadata, ``provenance=import``) onto the freshly-created
+    document.
+
+    Returns the created document id.
+    """
+    image = preferred_image(node)
+    source_path = image.get("source_path") if image else None
+    if not source_path:
+        # No image to copy — fall back to the reference document payload.
+        created = client.request(
+            "POST", "/documents", document_payload(node, parent_id)
+        )
+        return str(created["id"])
+
+    ingested = client.request(
+        "POST",
+        "/ingest/file",
+        {
+            "path": source_path,
+            "parent_id": parent_id,
+            "copy_mode": True,
+            # Do NOT extract text on ingest — page_content comes from the
+            # manifest transcript (provenance import, not Apple Vision OCR).
+            "extract_text": False,
+            "auto_embed": False,
+        },
+    )
+    doc_id = str(ingested["id"])
+
+    metadata = _canonical_metadata(node)
+    metadata["provenance"] = "import"
+    update_body: dict[str, Any] = {
+        "name": node.get("name") or node.get("external_id"),
+        "doc_type": _NODE_TYPE_TO_DOC_TYPE[node["node_type"]],
+        "page_content": node.get("text"),
+        "metadata": metadata,
+    }
+    client.request("PUT", f"/documents/{doc_id}", update_body)
+    return doc_id
+
+
 def import_manifest(
     client: ManifestApiClient,
     manifest_path: Path,
     library_path: str,
+    *,
+    copy_images: bool = False,
 ) -> ImportSummary:
-    """Import a canonical manifest into a library through the API client."""
+    """Import a canonical manifest into a library through the API client.
+
+    When ``copy_images`` is True, each page's preferred image is copied INTO
+    the library package (so thumbnails/display work) via the engine's native
+    ingest path, while ``page_content`` is still the manifest transcript. When
+    False (the default), images are merely *referenced* by on-disk path —
+    preserving the original behaviour.
+    """
     nodes = read_manifest(manifest_path)
     validate_nodes(nodes)
 
@@ -378,10 +464,14 @@ def import_manifest(
             raise RuntimeError(
                 f"Missing parent for {external_id}: {parent_external}"
             )
-        created = client.request(
-            "POST", "/documents", document_payload(node, parent_id)
-        )
-        doc_id_by_external[external_id] = str(created["id"])
+        if copy_images and node.get("node_type") == "page" and preferred_image(node):
+            new_id = _copy_image_into_library(client, node, parent_id)
+        else:
+            created = client.request(
+                "POST", "/documents", document_payload(node, parent_id)
+            )
+            new_id = str(created["id"])
+        doc_id_by_external[external_id] = new_id
         summary.documents_created += 1
 
     # --- entities (deduped by canonical name across the whole manifest) ---
@@ -450,16 +540,25 @@ def import_manifest_via_http(
     api_base: str = DEFAULT_API_BASE,
     token_file: Path = DEFAULT_TOKEN_FILE,
     create_library: bool = True,
+    copy_images: bool = False,
 ) -> ImportSummary:
     """Convenience entry point: import a manifest into a live engine over HTTP.
 
     Reads the Bearer key from ``token_file`` and (optionally) creates the
     target ``.fichero`` library first via ``POST /api/library`` so a single
     command can bootstrap and populate a fresh library.
+
+    When ``copy_images`` is True, each page's preferred image is copied into
+    the library package (thumbnail/display work) rather than merely referenced.
     """
     token = token_file.read_text(encoding="utf-8").strip()
     library_str = str(library_path.expanduser())
     client = HttpManifestClient(api_base, token, library_str)
     if create_library:
         client.request("POST", "/library", {"path": library_str})
-    return import_manifest(client, manifest_path.expanduser(), library_str)
+    return import_manifest(
+        client,
+        manifest_path.expanduser(),
+        library_str,
+        copy_images=copy_images,
+    )

--- a/fichero-engine/tests/unit/test_manifest_import.py
+++ b/fichero-engine/tests/unit/test_manifest_import.py
@@ -203,6 +203,91 @@ def test_import_creates_documents_entities_claims(client, db, tmp_path):
     assert claim["source_document_id"] == page["id"]
 
 
+class _RecordingClient:
+    """Mock ``ManifestApiClient`` that records every request.
+
+    Returns synthetic ids for POST /documents and POST /ingest/file so the
+    importer can wire parents and continue. Used to assert copy-image
+    behaviour without a live engine.
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict | None]] = []
+        self._counter = 0
+
+    def request(self, method, path, body=None):
+        self.calls.append((method, path, body))
+        if method == "GET":
+            return {"items": []}
+        if method == "POST" and path in ("/documents", "/ingest/file"):
+            self._counter += 1
+            return {"id": f"doc-{self._counter}"}
+        if method == "POST" and path in ("/entities", "/claims"):
+            self._counter += 1
+            return {"id": f"obj-{self._counter}"}
+        if method == "PUT":
+            return {"id": path.rsplit("/", 1)[-1]}
+        return None
+
+
+def test_copy_images_triggers_ingest_copy_and_keeps_page_content(tmp_path):
+    """copy_images=True copies the image via the native ingest path AND still
+    sets the manifest transcript as page_content (provenance import)."""
+    from fichero.manifest_import import import_manifest
+
+    manifest = _fixture_manifest(tmp_path)
+    rec = _RecordingClient()
+
+    summary = import_manifest(
+        rec, manifest, str(tmp_path / "lib.fichero"), copy_images=True
+    )
+
+    assert summary.documents_created == 2
+
+    # The page image was copied INTO the library via the native ingest path
+    # (copy_mode=True), NOT referenced via POST /documents.
+    ingest_calls = [c for c in rec.calls if c[1] == "/ingest/file"]
+    assert len(ingest_calls) == 1
+    ingest_body = ingest_calls[0][2]
+    assert ingest_body["copy_mode"] is True
+    assert ingest_body["path"] == str(tmp_path / "page_001_enhanced.jpg")
+    # No OCR / text-extraction on ingest — transcript comes from the manifest.
+    assert ingest_body["extract_text"] is False
+
+    # The page document is then updated with the clean manifest transcript and
+    # provenance=import (NOT Apple Vision OCR).
+    put_calls = [c for c in rec.calls if c[0] == "PUT"]
+    assert len(put_calls) == 1
+    put_body = put_calls[0][2]
+    assert put_body["page_content"] == "Marshall went to Istmina this afternoon."
+    assert put_body["metadata"]["provenance"] == "import"
+    assert put_body["metadata"]["canonical_external_id"] == "tiny_corpus__page_001"
+
+    # The group (no image) still goes through the plain reference create path.
+    doc_posts = [c for c in rec.calls if c[1] == "/documents"]
+    assert len(doc_posts) == 1
+    assert doc_posts[0][2]["name"] == "Tiny Corpus"
+
+
+def test_no_copy_images_preserves_reference_behaviour(tmp_path):
+    """Default (copy_images=False) keeps the original reference behaviour:
+    POST /documents with path pointing at the on-disk source, no ingest copy."""
+    from fichero.manifest_import import import_manifest
+
+    manifest = _fixture_manifest(tmp_path)
+    rec = _RecordingClient()
+
+    import_manifest(rec, manifest, str(tmp_path / "lib.fichero"))
+
+    assert not [c for c in rec.calls if c[1] == "/ingest/file"]
+    assert not [c for c in rec.calls if c[0] == "PUT"]
+    page_post = next(
+        c for c in rec.calls if c[1] == "/documents" and c[2]["name"] == "page_001"
+    )
+    assert page_post[2]["path"] == str(tmp_path / "page_001_enhanced.jpg")
+    assert page_post[2]["page_content"] == "Marshall went to Istmina this afternoon."
+
+
 def test_import_is_idempotent(client, db, tmp_path):
     manifest = _fixture_manifest(tmp_path)
     adapter = _TestClientAdapter(client)


### PR DESCRIPTION
Adds opt-in `--copy-images` to `import-manifest` (default stays reference). Copy mode reuses the engine native ingest (`POST /api/ingest/file`, copy_mode=True, extract_text=False → no Apple Vision OCR), copying the preferred (enhanced) scan into the library `files/`, then writes the clean manifest transcript as page_content (provenance import). Folders/groups + image-less pages unchanged.

Gate: ruff ✅, pytest 6 passed (2 new). Verified live: 5 images copied, thumbnail+display 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)