### PR TITLE
docs: sweep 0.0.2 working-branch refs to main (post #2652)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,7 +7,8 @@ Fichero is a macOS document management system with LangChain-powered AI toolchai
 ## Session Configuration
 
 ```
-WORKING_BRANCH: 0.0.2          # current working branch; NOT a release gate
+WORKING_BRANCH: main           # current working branch; NOT a release gate
+                               # (0.0.2 merged to main via PR #2652 on 2026-06-26)
 AUTONOMOUS_COMMITS: true
 AUTONOMOUS_PRS: true
 TASK_TRACKING: github
@@ -60,7 +61,7 @@ This rule is embedded in every worker dispatch prompt.
 - Offload build/lint/test and bug investigation to **subagents** — the lead reads a verdict, not a log.
 - Use a **single session** for the 0.0.2 backend fix cluster (overlapping files) and SwiftUI fixes (one Xcode).
 - Use an **agent team** for the QA review gate (#1061), competing-hypothesis debugging, and 0.0.3+ cross-layer features.
-- Before committing a bug-fix sweep to `0.0.2`, run the QA review gate: stage the diff, spawn 3 review-only teammates (`backend-reviewer`, `silent-failure-hunter`, `code-reviewer`), synthesize, then commit.
+- Before committing a bug-fix sweep to `main`, run the QA review gate: stage the diff, spawn 3 review-only teammates (`backend-reviewer`, `silent-failure-hunter`, `code-reviewer`), synthesize, then commit.
 
 ## Build + Test + Lint
 
@@ -190,7 +191,7 @@ Full architecture: `docs/CLAUDE.md`, `docs/architecture/`
 8. Never start a milestone more than one ahead of what Daniel is currently testing.
 9. **0.0.x is no-migration**: schema changes go directly into `db.py` `_ensure_table` (via the Pydantic model field). Never add an `ALTER TABLE ADD COLUMN` migration function for a column that's already in the model — fresh databases pick it up automatically. Only historical structural migrations (table renames, data backfills) belong in `db_migrations.py`. Once 0.1.0 ships to real users, this rule changes.
 10. **New .swift files must be registered with `scripts/add-swift-file.rb`**: The `Fichero` main target uses traditional PBX file references — a file written to disk is invisible to the compiler until registered. Always run `ruby scripts/add-swift-file.rb <path>` after creating any new `.swift` file. The `xcodeproj` gem is installed at `~/.gem/ruby/2.6.0/gems/xcodeproj-1.27.0/`. Test-target files are the exception (sync'd groups). Never edit `project.pbxproj` by hand. The build gate (`bash scripts/verify_all.sh`) will catch unregistered files as "Cannot find type" errors.
-11. **Worktrees live ONLY under `~/code/fichero-worktrees/<name>`; never `rm` a `~/code/` sibling.** Create worktrees with `git worktree add ~/code/fichero-worktrees/<name> -b <branch> 0.0.2` — never as bare siblings `~/code/fichero-<name>`. Remove them ONLY with `git worktree remove --force <path>` (operates only on registered worktrees). **NEVER `rm -rf` a `~/code/` path and NEVER glob-delete `~/code/fichero-*`** — bare siblings such as `fichero-search`, `fichero-search-issue-*` are SEPARATE projects with their own remotes and uncommitted work (a glob `rm` of these destroyed the `fichero-search` project on 2026-06-09). Before any destructive fs op, confirm the path is under `~/code/fichero-worktrees/` AND in `git worktree list`; otherwise stop and surface it. To clear a stale bare-sibling, `mv` it aside and let Daniel delete it.
+11. **Worktrees live ONLY under `~/code/fichero-worktrees/<name>`; never `rm` a `~/code/` sibling.** Create worktrees with `git worktree add ~/code/fichero-worktrees/<name> -b <branch> main` — never as bare siblings `~/code/fichero-<name>`. Remove them ONLY with `git worktree remove --force <path>` (operates only on registered worktrees). **NEVER `rm -rf` a `~/code/` path and NEVER glob-delete `~/code/fichero-*`** — bare siblings such as `fichero-search`, `fichero-search-issue-*` are SEPARATE projects with their own remotes and uncommitted work (a glob `rm` of these destroyed the `fichero-search` project on 2026-06-09). Before any destructive fs op, confirm the path is under `~/code/fichero-worktrees/` AND in `git worktree list`; otherwise stop and surface it. To clear a stale bare-sibling, `mv` it aside and let Daniel delete it.
 
 ## Before editing backend or API-client code
 

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -71,7 +71,7 @@ Execution tracking and planning are governed in GitHub:
 
 ## Versioning
 
-The destination is **dated releases** (CalVer, e.g. `2026.05.01`) — a dated snapshot is a known-good build with document management, workflows, KG, CLI, and the autonomous loops working together. That's the model for the **final release**; it is not fully in place yet. Current development still runs on the `0.0.2` line, and day-to-day work is organized per worker/lane.
+The destination is **dated releases** (CalVer, e.g. `2026.05.01`) — a dated snapshot is a known-good build with document management, workflows, KG, CLI, and the autonomous loops working together. That's the model for the **final release**; it is not fully in place yet. Current development runs on `main` (the `0.0.2` working line was merged to `main` via PR #2652 on 2026-06-26), and day-to-day work is organized per worker/lane.
 
 - Current working branch + worktree mechanics → `.claude/CLAUDE.md`
 - Release / packaging process (signing, notarize, Sparkle, DMG) → `docs/architecture/release-process.md` (the pipeline itself lives in the separate `fichero-releases` repo)

--- a/STATE.md
+++ b/STATE.md
@@ -1,3 +1,33 @@
+# STATE — 2026-06-26 (0.0.2 → main MERGED via PR #2652; worktrees purged; TestFlight next)
+
+Branch `main` @ **6437c140** (= `origin/main`, clean). The `0.0.2` working line is merged to `main` via PR #2652 (real merge commit, parents `0f5665ad` + `1ec14343`). **`main` is now the working branch** — `.claude/CLAUDE.md` `WORKING_BRANCH` updated, `CONSTITUTION.md` + `docs/agent-workflow/*` + `scripts/check_unmerged_work.py` swept for `0.0.2` working-branch refs. All 8 stale worktrees purged (`git worktree remove --force`); only the `main` checkout remains.
+
+## DONE THIS SESSION
+- **Merge**: PR #2652 → `origin/main` = `6437c140`. Not a fast-forward (main had 2 old PR-merge commits); merged with `--merge` for a real merge commit.
+- **Worktree purge**: codex-execpkg, codex-execrunner, codex-multiplat, codex-wf2525, codex-wf2627b, codex-winchrome, integrate-batch5-20260626, integrate-frontend-batch-20260625 — all removed. Branches preserved (held `#2594` work still on codex-execpkg/codex-execrunner).
+- **Reference sweep** (`0.0.2` → `main` in active instructions): `.claude/CLAUDE.md`, `CONSTITUTION.md`, `docs/agent-workflow/skills/dispatch-worker.md`, `docs/agent-workflow/parallel-execution.md`, `docs/agent-workflow/github-conventions.md`, `docs/architecture/swiftui/workflow_checklist.md`, `scripts/check_unmerged_work.py`. Historical records (`HISTORY.md`, `MEMORY.md`, dated `docs/design/*`, `docs/archive/*`, release-notes-0.0.2.md, `v0.0.2` release tag) left as-is.
+- **Test hangs filed, NOT silently merged past**: #2650 (execute-route blocks in-process at `client.post` — `test_routes_workflow_execution.py` 16th test), #2651 (2nd hang — DuckDB/lancedb connection deadlock mid-suite). Plus #2649 (guardrail allowlist drift).
+
+## GATE STRENGTH (acknowledged debt — fix AFTER release)
+Daniel: "verify_all is important, but when there are errors we're not fixing them — our gate isn't strong enough." Accepted. The structural fix is **conftest app-DB isolation + seeding** (the backend suite shares `app.duckdb` with the live engine → contaminated when the engine is up; isolation alone breaks the suite on an empty DB). Deferred to the post-release testing-cleanup pass along with #2649/#2650/#2651. Path B for the release: merge on "no new correctness regressions," don't detour into fixing the gate now.
+
+## NEXT — TESTFLIGHT RELEASE (the goal)
+Sequence per Daniel: merge (✅) → TestFlight → GitHub release → then testing cleanup → then backend + issues on `main`.
+1. #158 — App Store Connect API key for notarization.
+2. #159 — verify Sparkle EdDSA private key matches the public key in Info.plist.
+3. #160 — build engine + signed Release app + DMG.
+4. #161 — notarize DMG + staple ticket.
+5. #162 — Sparkle-sign DMG + GitHub release on `fichero-releases` + tag source.
+6. #163 — wire real download URL in site/index.md + deploy site.
+7. #164 — smoke test: download fresh DMG on a clean Mac account / after `xattr -cr`.
+
+## POST-RELEASE (deferred)
+- Testing-cleanup pass: #2649 (guardrail allowlist), #2650 (execute-route hang root-cause), #2651 (DuckDB/lancedb deadlock — identify the test), + conftest app-DB isolation+seeding (the structural gate fix).
+- Then: proceed on backend + issues on `origin/main`.
+
+GOTCHAS: working branch is now `main` — commit work directly to `main` (PR still required to push). Worktrees branch from `main`, live ONLY under `~/code/fichero-worktrees/`. Never `rm -rf` a bare `~/code/fichero-*` sibling. The `0.0.2` branch still exists (preserved for history); do not start new work on it.
+
+---
 # STATE — 2026-06-25 (manager takeover from Claude; 0.0.2 cleaned, pushed, workers shut down)
 
 Branch `0.0.2` @ **c8775216** (= `origin/0.0.2`, clean). I took over the manager lane from Claude's rate-limited session, recovered its session history, reconciled the live worktrees/branches, pushed the two held-local `#2594` commits, cleaned the dirty tree, filed the new PDF fan-out efficiency bug, and shut down the stale worker tmux sessions (`f_knowledge`, `f_mindpalace`, `f_runner`).

--- a/docs/agent-workflow/github-conventions.md
+++ b/docs/agent-workflow/github-conventions.md
@@ -110,7 +110,7 @@ GitHub's close-as-duplicate, close-as-not-planned, and assignee fields cover wha
 - `main` — the trunk. All work merges here. No separate "release branch" — releases are dated git tags published as DMGs in `dtubb/fichero-releases`.
 - Lane branches: `<lane>-<short-scope>`. Pushed to origin; manager merges from `origin/<branch>`; branch deleted after merge.
 - `archive-main-2026-05-30` — the previous `main` before the 2026-05-30 trunk consolidation. Kept for history; do not push to it.
-- Local worktree paths (`~/code/fichero-0.0.2/`, `~/code/fichero-<lane>/`) are independent of branch names — directory naming stays stable across branch renames.
+- Local worktree paths (`~/code/fichero-worktrees/<name>/`) are independent of branch names — directory naming stays stable across branch renames. (The retired `~/code/fichero-<version>/` bare-sibling pattern is gone — worktrees live ONLY under `~/code/fichero-worktrees/`.)
 - No `feature/issue-NNN`-style branches anymore.
 
 ## Pull requests — optional, not required

--- a/docs/agent-workflow/parallel-execution.md
+++ b/docs/agent-workflow/parallel-execution.md
@@ -1,7 +1,7 @@
 # Parallel Execution & Review Process
 
 How to use single sessions, subagents, and agent teams on Fichero — and how to
-keep the lead agent's context clean during the 0.0.2 bug sweep.
+keep the lead agent's context clean during the main-branch bug sweep.
 
 ## The core problem this solves
 
@@ -39,7 +39,7 @@ Agent teams are **enabled** in `~/.claude/settings.json`
 
 ### Do NOT use an agent team
 
-- **The 0.0.2 backend fix cluster** — fixes overlap in the same files
+- **The backend fix cluster** — fixes overlap in the same files
   (`extract_all.py`, `extractors.py`, `runner.py`). Parallel teammates overwrite
   each other. Single session; use subagents only for the read-only investigation.
 - **The SwiftUI bug cluster** — one Xcode, one DerivedData, one `⌘R`. Teammates
@@ -53,13 +53,13 @@ Agent teams are **enabled** in `~/.claude/settings.json`
 | Build / lint / test a change | **subagent** (`test-runner`) | report-back task; keeps lead context clean |
 | Investigate a bug / trace a path | **subagent** (`Explore`, `feature-dev:code-explorer`) | result-only, no coordination cost |
 | Review a finished sweep before commit | **agent team** (3 reviewers) | independent lenses, the QA gate |
-| 0.0.2 backend fix sweep | **single session** + investigation subagents | overlapping files kill team parallelism |
-| 0.0.2 SwiftUI fixes | **single session** | serialized on one Xcode |
+| backend fix sweep | **single session** + investigation subagents | overlapping files kill team parallelism |
+| SwiftUI fixes | **single session** | serialized on one Xcode |
 | 0.0.3+ cross-layer feature | **agent team** (backend / swift / test) | disjoint file ownership = real parallelism |
 
 ## QA review gate (issue #1061)
 
-Before committing a sweep of bug fixes to `0.0.2`, run a review team instead of
+Before committing a sweep of bug fixes to `main`, run a review team instead of
 self-certifying. This is the safest place to use agent teams and the fix for the
 "no review gate" gap.
 

--- a/docs/agent-workflow/skills/dispatch-worker.md
+++ b/docs/agent-workflow/skills/dispatch-worker.md
@@ -13,7 +13,7 @@ from in-repo worktrees; false-green incremental builds; stale-tree pytest).
 - **Worktrees live ONLY under `<worktrees-root>/<name>`** — a single isolated
   parent dir, NEVER bare siblings `<code-dir>/fichero-<name>`. NEVER the Agent tool's
   `isolation: worktree` (lands in `.claude/worktrees/` inside the repo, which
-  `uvicorn --reload` watches). Create: `git worktree add <worktrees-root>/<name> -b <branch> 0.0.2`.
+  `uvicorn --reload` watches). Create: `git worktree add <worktrees-root>/<name> -b <branch> main`.
 - **DELETION SAFETY:**
   remove worktrees with `git worktree remove --force <path>` ONLY (touches only registered
   worktrees). **NEVER `rm -rf` a `<code-dir>/` path, and NEVER glob-delete `<code-dir>/fichero-*`** —
@@ -45,7 +45,7 @@ from in-repo worktrees; false-green incremental builds; stale-tree pytest).
 
 ## 1. Create the external worktree
 ```bash
-git worktree add <worktrees-root>/<name> -b <branch> 0.0.2
+git worktree add <worktrees-root>/<name> -b <branch> main
 ```
 
 ## 2. Launch via tmux + send-keys (NOT `codex exec` — it hangs headless)

--- a/docs/architecture/swiftui/workflow_checklist.md
+++ b/docs/architecture/swiftui/workflow_checklist.md
@@ -8,7 +8,7 @@
 > - **Tasks are tracked in GitHub Issues + Milestones**, not `docs/agent-workflow/TODO.md`
 >   (retired). Ignore the "check / update TODO.md" steps.
 > - **Branch discipline**: commit milestone work directly to the milestone branch
->   (e.g. `0.0.2`); do **not** create per-task `feature-branch-name` branches and do
+>   (e.g. `main`); do **not** create per-task `feature-branch-name` branches and do
 >   not `git pull origin main` into your work — see `.claude/CLAUDE.md` → "Branch discipline".
 > - **AppKit**: "100% SwiftUI" is aspirational. SwiftUI-first with ~8 sanctioned
 >   `NSViewRepresentable` bridges (PDFKit, magnifier, text editors, …). The

--- a/scripts/check_unmerged_work.py
+++ b/scripts/check_unmerged_work.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Manager/integrator check for finished worker work not merged to 0.0.2.
+"""Manager/integrator check for finished worker work not merged to main.
 
 This is intentionally not part of scripts/verify_all.sh --fast. Dirty or active
 worktree state should not fail a per-commit code-quality gate; managers and
@@ -19,7 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
-BASE_REF = "origin/0.0.2"
+BASE_REF = "origin/main"
 WORKTREE_ROOTS = (
     Path.home() / "code" / "fichero-worktrees",
     ROOT / ".claude" / "worktrees",
@@ -56,7 +56,7 @@ def _ensure_base_ref() -> str | None:
     result = _git(["rev-parse", "--verify", "--quiet", BASE_REF], check=False)
     if result.returncode == 0:
         return None
-    return f"Missing comparison ref {BASE_REF}. Run `git fetch origin 0.0.2` and retry."
+    return f"Missing comparison ref {BASE_REF}. Run `git fetch origin main` and retry."
 
 
 def _ahead_commits(ref: str, cwd: Path = ROOT) -> tuple[str, ...]:
@@ -166,7 +166,7 @@ def main(argv: list[str]) -> int:
     print(f"Worker branch patterns: {', '.join(WORKER_BRANCH_PATTERNS)}")
 
     if not findings:
-        print("\nPASS: no worker work found ahead of 0.0.2.")
+        print("\nPASS: no worker work found ahead of main.")
         return 0
 
     print(f"\nFAIL: {len(findings)} unmerged worker work item(s) found.\n")


### PR DESCRIPTION
After PR #2652 merged the 0.0.2 working line to main (6437c140), main is the working branch. This sweeps the **active instruction surface** for stale 0.0.2 working-branch refs.

**Updated:**
- `.claude/CLAUDE.md` — WORKING_BRANCH, worktree base ref, sweep target
- `CONSTITUTION.md` — current development runs on main + PR #2652 note
- `docs/agent-workflow/skills/dispatch-worker.md` — worktree base ref
- `docs/agent-workflow/parallel-execution.md` — present-tense guidance
- `docs/agent-workflow/github-conventions.md` — drop retired `~/code/fichero-0.0.2/` bare-sibling example
- `docs/architecture/swiftui/workflow_checklist.md` — branch example
- `scripts/check_unmerged_work.py` — `BASE_REF` → `origin/main`
- `STATE.md` — new 2026-06-26 entry (merge, worktree purge, TestFlight next)

**Left as-is (historical records):** HISTORY.md, MEMORY.md, `.agents/handoffs/next-session.md`, dated `docs/design/*` + `docs/archive/*` proposals, `v0.0.2` release tag, `docs/release-notes-0.0.2.md`.

Docs-only + one script (BASE_REF). No code, no tests, no openapi change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)