### PR TITLE
docs: drop last stale 0.0.2 ref in .claude/CLAUDE.md (#2653 followup)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -59,7 +59,7 @@ This rule is embedded in every worker dispatch prompt.
 
 **Parallel execution & context hygiene** (full guide: `docs/agent-workflow/parallel-execution.md`):
 - Offload build/lint/test and bug investigation to **subagents** — the lead reads a verdict, not a log.
-- Use a **single session** for the 0.0.2 backend fix cluster (overlapping files) and SwiftUI fixes (one Xcode).
+- Use a **single session** for the backend fix cluster (overlapping files) and SwiftUI fixes (one Xcode).
 - Use an **agent team** for the QA review gate (#1061), competing-hypothesis debugging, and 0.0.3+ cross-layer features.
 - Before committing a bug-fix sweep to `main`, run the QA review gate: stage the diff, spawn 3 review-only teammates (`backend-reviewer`, `silent-failure-hunter`, `code-reviewer`), synthesize, then commit.
 


### PR DESCRIPTION
One-line follow-up to #2653: present-tense guidance referenced the 0.0.2 fix cluster. Aligned with parallel-execution.md. Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)