### PR TITLE
fix(scripts): spawn-worker.sh worktree path → fichero-worktrees/ (rule #11)

### DIFF
--- a/scripts/spawn-worker.sh
+++ b/scripts/spawn-worker.sh
@@ -34,7 +34,10 @@ slug() { echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-
 MSLUG="$(slug "$MILESTONE")"
 SESSION="${3:-f_${MODEL}_${MSLUG}}"
 BRANCH="ms/${MSLUG}"
-WORKTREE="${HOME}/code/fichero-${MSLUG}"
+# Worktrees live ONLY under ~/code/fichero-worktrees/<name> — NEVER a bare
+# ~/code/fichero-<name> sibling (constitution rule #11: a glob-rm of bare
+# siblings destroyed the fichero-search project on 2026-06-09).
+WORKTREE="${HOME}/code/fichero-worktrees/${MSLUG}"
 
 # --- pick the agent launch command + skill-invocation prefix -----------------
 # Claude invokes skills with a leading '/', Codex with a leading '$'.


### PR DESCRIPTION
spawn-worker.sh:37 created worktrees as bare `~/code/fichero-<slug>` siblings — the forbidden pattern per constitution rule #11 (a glob-rm of bare `~/code/fichero-*` siblings destroyed the `fichero-search` project on 2026-06-09). Paths now go under `~/code/fichero-worktrees/<slug>` with a comment naming the rule.

Branching was already off `origin/main` (not stale 0.0.2) — no change there. No behavioral change to the agent launch sequence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)