### PR TITLE
fix(build): resolve compile errors from the mac-inspector merge

### DIFF
--- a/fichero/fichero/Views/Components/SplittablePane.swift
+++ b/fichero/fichero/Views/Components/SplittablePane.swift
@@ -271,7 +271,7 @@ struct SplittablePane<Content: View>: View {
 
                 VStack(spacing: 0) {
                     splitPane(isSecondary: false)
-                        .frame(maxWidth: .infinity, height: primaryHeight)
+                        .frame(maxWidth: .infinity).frame(height: primaryHeight)
 
                     ResizableDivider(
                         width: $horizontalPrimaryExtent,
@@ -294,7 +294,7 @@ struct SplittablePane<Content: View>: View {
 
                 VStack(spacing: 0) {
                     splitPane(isSecondary: false)
-                        .frame(maxWidth: .infinity, height: primaryHeight)
+                        .frame(maxWidth: .infinity).frame(height: primaryHeight)
 
                     ResizableDivider(
                         width: $horizontalPrimaryExtent,
@@ -305,7 +305,7 @@ struct SplittablePane<Content: View>: View {
                     )
 
                     splitPane(isSecondary: true)
-                        .frame(maxWidth: .infinity, height: secondaryHeight)
+                        .frame(maxWidth: .infinity).frame(height: secondaryHeight)
 
                     ResizableDivider(
                         width: $horizontalSecondaryExtent,

--- a/fichero/fichero/Views/KnowledgeGraph/EntityDigestView.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/EntityDigestView.swift
@@ -188,8 +188,14 @@ struct EntityDigestView: View {
             guard let id = entity.id else { return false }
             return selectedEntityIds.contains(id)
         }
-        guard !selection.isEmpty else { return }
-        entitiesToDelete = selection
+        confirmDelete(selection)
+    }
+
+    /// Prompt to delete a specific set of entities (e.g. a right-clicked row
+    /// that isn't part of the current multi-selection).
+    private func confirmDelete(_ entities: [Components.Schemas.KnowledgeEntity]) {
+        guard !entities.isEmpty else { return }
+        entitiesToDelete = entities
         showingDeleteConfirmation = true
     }
 

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView+Claims.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView+Claims.swift
@@ -187,6 +187,19 @@ extension EntityDetailView {
         showingDeleteClaimsConfirmation = true
     }
 
+    /// Short human label for a claim in confirmation copy — SVO triple when
+    /// available, else the claim text. Mirrors EntityDigestView.provenanceSummary.
+    private func provenanceSummary(for claim: Components.Schemas.KnowledgeClaim) -> String {
+        if let svo = ClaimSummaryCard.svoTriple(for: claim) {
+            return [svo.subject, svo.verb, svo.object]
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .joined(separator: " · ")
+        }
+        let fallback = claim.text.trimmingCharacters(in: .whitespacesAndNewlines)
+        return fallback.isEmpty ? "Untitled claim" : fallback
+    }
+
     private func deleteSelectedClaims(_ claims: [Components.Schemas.KnowledgeClaim]) async {
         let claimIds = claims.compactMap(\.id)
         guard !claimIds.isEmpty else { return }


### PR DESCRIPTION
Hotfix — origin/main didn't compile after #2668 (worker commits #2519/#2481/#2521 were never built, only swiftlinted).

- **SplittablePane** ×3: `.frame(maxWidth:.infinity, height:)` is an invalid SwiftUI overload → split into two `.frame` calls
- **EntityDigestView**: added missing `confirmDelete(_:)` helper
- **EntityDetailView+Claims**: added `provenanceSummary(for:)` (was private to EntityDigestView)

✅ Xcode BuildProject green (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)