### PR TITLE
UX batch: #2648 header encoding, #2664 startup state, #2607 iPhone full-screen viewer

### DIFF
--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/LibraryPathMiddleware.swift
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/LibraryPathMiddleware.swift
@@ -75,7 +75,12 @@ public struct LibraryPathMiddleware: ClientMiddleware {
         if !Self.isAppWidePath(path),
            let libraryPath = currentLibraryPath(),
            !libraryPath.isEmpty {
-            request.headerFields[.init("X-Fichero-Library-Path")!] = libraryPath
+            // Percent-encode so non-ASCII paths survive the latin-1 HTTP header
+            // transport (#2648). The engine `unquote`s on read
+            // (api/library_header.py); pure-ASCII paths encode to themselves.
+            // `.urlPathAllowed` mirrors `urllib.parse.quote(path, safe="/")`.
+            let encoded = libraryPath.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? libraryPath
+            request.headerFields[.init("X-Fichero-Library-Path")!] = encoded
         }
 
         return try await next(request, body, baseURL)

--- a/fichero/fichero-tests/DocumentKGPaneRouteTests.swift
+++ b/fichero/fichero-tests/DocumentKGPaneRouteTests.swift
@@ -59,6 +59,27 @@ final class DocumentKGPaneRouteTests: XCTestCase {
         XCTAssertEqual(request.value(forHTTPHeaderField: "X-Fichero-Library-Path"), "/tmp/library")
     }
 
+    /// A non-ASCII library path (diacritics, accented home dirs) must be
+    /// percent-encoded in the transport header so it survives the latin-1 HTTP
+    /// header pipeline; the engine `unquote`s it on read (#2648). Pure-ASCII
+    /// paths are unaffected (encoding is a no-op), as the test above pins.
+    func testNonASCIILibraryPathHeaderIsPercentEncoded() throws {
+        try RemoteCertificatePinning.persistSPKIPin(pin, hostString: hostString)
+
+        let request = try XCTUnwrap(
+            DocumentKGPaneRoute.request(
+                documentId: DocumentKGPaneRoute.globalKGDocumentID,
+                libraryPath: "/tmp/Chocó.fichero"
+            )
+        )
+
+        // ó (U+00F3) → UTF-8 0xC3 0xB3 → "%C3%B3"; "/" stays unencoded.
+        XCTAssertEqual(
+            request.value(forHTTPHeaderField: "X-Fichero-Library-Path"),
+            "/tmp/Choc%C3%B3.fichero"
+        )
+    }
+
     /// A per-document reader request is likewise served over the pinned HTTPS
     /// transport, with the document id percent-encoded into the path.
     func testDocumentReaderRequestIsHTTPS() throws {

--- a/fichero/fichero/Services/APIClient+Types.swift
+++ b/fichero/fichero/Services/APIClient+Types.swift
@@ -54,7 +54,13 @@ extension URLRequest {
             setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
         if let libraryPath {
-            setValue(libraryPath, forHTTPHeaderField: "X-Fichero-Library-Path")
+            // Percent-encode so non-ASCII paths (diacritics, accented home dirs)
+            // survive the latin-1 HTTP header transport (#2648). The engine
+            // `unquote`s on read (api/library_header.py); pure-ASCII paths encode
+            // to themselves, so this is a no-op for them. `.urlPathAllowed`
+            // mirrors `urllib.parse.quote(path, safe="/")`.
+            let encoded = libraryPath.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? libraryPath
+            setValue(encoded, forHTTPHeaderField: "X-Fichero-Library-Path")
         }
     }
 }

--- a/fichero/fichero/Views/Components/BackendConnectionView.swift
+++ b/fichero/fichero/Views/Components/BackendConnectionView.swift
@@ -103,8 +103,17 @@ struct BackendConnectionView: View {
         #endif
     }
 
+    /// Red failure UI shows ONLY for an explicit terminal failure
+    /// (`status == .failed`). During normal startup the service walks
+    /// `.stopped → .starting → .running`, and `appState.isCheckingBackend`
+    /// flips false in the 5 s gaps between health polls — keying failure off
+    /// `(!isCheckingBackend && !isBackendRunning)` painted a misleading red
+    /// "Engine Not Running" flash during those gaps while the engine was still
+    /// cold-starting (#2664). Genuine failures still surface: external/custom
+    /// hosts set `.failed` immediately, and the embedded poll loop below flips
+    /// to `.failed` after the 60 s timeout.
     private var showsFailureState: Bool {
-        backendService.status == .failed || (!appState.isCheckingBackend && !appState.isBackendRunning)
+        backendService.status == .failed
     }
 
     private var titleText: String {

--- a/fichero/fichero/Views/Library/ImageViewerComponents.swift
+++ b/fichero/fichero/Views/Library/ImageViewerComponents.swift
@@ -466,11 +466,18 @@ struct ZoomableImagePreview: View {
     @State private var loupeLocked: Bool = false
     @State private var imageCoordinator: ImageWithCursorTracking.Coordinator?
 
+    /// Drives the iPhone true-full-screen presentation (#2607). Compact only.
+    @State private var showingFullScreen = false
+
     private let minScale: CGFloat = 0.01
     private let maxScale: CGFloat = 10.0
 
     private var isCompact: Bool {
         horizontalSizeClass == .compact
+    }
+
+    private var hasImage: Bool {
+        renderedImage != nil || url != nil
     }
 
     /// Image/page siblings in the current folder, in display order.
@@ -519,6 +526,18 @@ struct ZoomableImagePreview: View {
                         .font(.caption)
                         .monospacedDigit()
                         .foregroundStyle(.secondary)
+
+                    if hasImage {
+                        Button {
+                            showingFullScreen = true
+                        } label: {
+                            Image(systemName: "arrow.up.left.and.arrow.down.right")
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.leading, 8)
+                        .accessibilityIdentifier("enterFullScreenImage")
+                        .accessibilityLabel("View Full Screen")
+                    }
                 } else {
                     Button(action: zoomOut) {
                         Image(systemName: "minus.magnifyingglass")
@@ -586,6 +605,13 @@ struct ZoomableImagePreview: View {
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .background(Color(white: 0.88, opacity: 1.0))
+                // Tap the image to go true full-screen on iPhone (#2607).
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    if isCompact, hasImage {
+                        showingFullScreen = true
+                    }
+                }
 
                 // iOS touch prev/next overlay for folder image siblings (#2420).
                 if previousAction != nil || nextAction != nil {
@@ -623,6 +649,11 @@ struct ZoomableImagePreview: View {
             guard !neighbors.isEmpty else { return }
             await storageService.prefetchDisplayImages(neighbors)
         }
+        // True full-screen image/page viewer for iPhone (#2607): edge-to-edge,
+        // black background, no title/back/chrome, swipe-down or close to exit.
+        .fullScreenCover(isPresented: $showingFullScreen) {
+            FullScreenImagePreview(url: url, renderedImage: renderedImage)
+        }
     }
 
     // MARK: - Zoom Actions
@@ -657,6 +688,101 @@ struct ZoomableImagePreview: View {
 }
 
 #if canImport(UIKit)
+/// True full-screen image/page presentation for iPhone (#2607).
+///
+/// The inline `ZoomableImagePreview` lives inside a `NavigationStack` detail
+/// on iPhone, so it carries a title bar, back button, and the mini-toolbar —
+/// which waste most of a small screen when you just want to read the source.
+/// This cover fills the entire screen edge-to-edge on a black background with
+/// no chrome, reusing `ImageWithCursorTracking` so pinch-zoom/pan come for
+/// free (no parallel image stack). A close button always dismisses; a
+/// downward swipe does too when the image isn't being panned.
+struct FullScreenImagePreview: View {
+    let url: URL?
+    let renderedImage: PlatformImage?
+
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var scale: CGFloat = 1.0
+    @State private var cursorPosition: CGPoint = CGPoint(x: 0.5, y: 0.5)
+    @State private var imageSize: CGSize = .zero
+    @State private var visibleRect: CGRect = .zero
+    @State private var loupeMagnification: CGFloat = 3.0
+    @State private var loupeSize: CGFloat = 150.0
+    @State private var imageCoordinator: ImageWithCursorTracking.Coordinator?
+    @State private var dragOffset: CGFloat = 0
+
+    private let minScale: CGFloat = 0.01
+    private let maxScale: CGFloat = 10.0
+
+    var body: some View {
+        ZStack(alignment: .topTrailing) {
+            Color.black.ignoresSafeArea()
+
+            if renderedImage != nil || url != nil {
+                ImageWithCursorTracking(
+                    url: url ?? URL(fileURLWithPath: "/"),
+                    overrideImage: renderedImage,
+                    scale: $scale,
+                    cursorPosition: $cursorPosition,
+                    imageSize: $imageSize,
+                    visibleRect: $visibleRect,
+                    minScale: minScale,
+                    maxScale: maxScale,
+                    loupeEnabled: false,
+                    loupeLocked: false,
+                    loupeMagnification: $loupeMagnification,
+                    loupeSize: $loupeSize,
+                    coordinator: $imageCoordinator
+                )
+                .ignoresSafeArea()
+            } else {
+                ContentUnavailableView(
+                    "Image Preview",
+                    systemImage: "photo",
+                    description: Text("The image could not be loaded.")
+                )
+                .foregroundStyle(.white)
+            }
+
+            // Close affordance — respects the safe area so it stays tappable
+            // under the notch / Dynamic Island.
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.white)
+                    .padding(12)
+                    .background(.ultraThinMaterial, in: Circle())
+            }
+            .padding(.top, 8)
+            .padding(.trailing, 16)
+            .accessibilityIdentifier("fullScreenImageClose")
+            .accessibilityLabel("Close Full Screen")
+        }
+        .offset(y: dragOffset)
+        .gesture(
+            DragGesture(minimumDistance: 20)
+                .onChanged { value in
+                    if value.translation.height > 0 {
+                        dragOffset = value.translation.height
+                    }
+                }
+                .onEnded { value in
+                    if value.translation.height > 120 {
+                        dismiss()
+                    } else {
+                        withAnimation(.spring(response: 0.3)) { dragOffset = 0 }
+                    }
+                }
+        )
+        #if os(iOS)
+        .statusBarHidden(true)
+        #endif
+    }
+}
+
 #Preview("Compact Zoomable Image Preview") {
     ZoomableImagePreview(renderedImage: UIImage(systemName: "photo"))
         .environmentObject(StorageServiceGenerated(ficheroClient: FicheroClient(libraryPath: nil)))


### PR DESCRIPTION
Three disjoint UX fixes. macOS build green (Xcode); iOS compile-gate confirmed #2607's `ImageViewerComponents.swift` compiles — the iOS build's failures are pre-existing, unrelated (`onDeleteCommand`/`homeDirectoryForCurrentUser` ungated for iOS, tracked separately as #2098), not from this batch.

- **#2648** percent-encode `X-Fichero-Library-Path` (both raw-URLSession + OpenAPI middleware) so non-ASCII library paths work; engine already unquotes. Unit test added.
- **#2664** gate the red engine-failure UI on `status == .failed` only — no false red flash during normal startup polling.
- **#2607** true full-screen iPhone image viewer via `fullScreenCover` (compact-width only; reuses existing zoom view, no parallel stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)