### PR TITLE
fix(ios): gate macOS-only APIs so iOS compiles (#2098)

### DIFF
--- a/fichero/fichero/App/AppInstaller.swift
+++ b/fichero/fichero/App/AppInstaller.swift
@@ -16,7 +16,7 @@ enum AppInstaller {
         return false
         #else
         let bundlePath = Bundle.main.bundleURL.resolvingSymlinksInPath().path
-        let homeApplications = FileManager.default.homeDirectoryForCurrentUser
+        let homeApplications = URL(fileURLWithPath: NSHomeDirectory())
             .appendingPathComponent("Applications").path
         return !bundlePath.hasPrefix("/Applications/") &&
             !bundlePath.hasPrefix("\(homeApplications)/")

--- a/fichero/fichero/Views/KnowledgeGraph/EntityDigestView.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/EntityDigestView.swift
@@ -112,7 +112,9 @@ struct EntityDigestView: View {
             .onChange(of: selectedEntityIds) { _, newValue in
                 selectedEntityId = newValue.first
             }
+            #if os(macOS)
             .onDeleteCommand(perform: promptDeleteSelectedEntities)
+            #endif
         }
     }
 

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView+Claims.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView+Claims.swift
@@ -116,7 +116,9 @@ extension EntityDetailView {
                 .listStyle(.plain)
                 .scrollContentBackground(.hidden)
                 .frame(minHeight: 80, maxHeight: 520)
+                #if os(macOS)
                 .onDeleteCommand(perform: promptDeleteSelectedClaims)
+                #endif
                 if filteredClaims.count > cap {
                     Button {
                         showAllClaims.toggle()

--- a/fichero/fichero/Views/Notes/NoteListView.swift
+++ b/fichero/fichero/Views/Notes/NoteListView.swift
@@ -83,7 +83,9 @@ struct NoteListView: View {
                 .disabled(selectedNoteIds.isEmpty)
             }
         }
+        #if os(macOS)
         .onDeleteCommand(perform: promptDeleteSelectedNotes)
+        #endif
         .alert("Delete Notes?", isPresented: $showingDeleteConfirmation) {
             Button("Cancel", role: .cancel) {
                 notesToDelete = []

--- a/fichero/fichero/Views/Research/ResearchProjectListView.swift
+++ b/fichero/fichero/Views/Research/ResearchProjectListView.swift
@@ -108,7 +108,9 @@ struct ResearchProjectListView: View {
                     selectedProjectIds.removeAll()
                 }
             }
+            #if os(macOS)
             .onDeleteCommand(perform: confirmDeleteSelection)
+            #endif
         }
     }
 

--- a/fichero/fichero/Views/Workflow/WorkflowChainListView/ChainListContent.swift
+++ b/fichero/fichero/Views/Workflow/WorkflowChainListView/ChainListContent.swift
@@ -101,6 +101,8 @@ struct ChainListContent: View {
                 }
             }
         }
+        #if os(macOS)
         .onDeleteCommand(perform: onConfirmDeleteSelection)
+        #endif
     }
 }

--- a/fichero/fichero/Views/Workflow/WorkflowLibraryView.swift
+++ b/fichero/fichero/Views/Workflow/WorkflowLibraryView.swift
@@ -227,7 +227,9 @@ struct WorkflowListView: View {
                 .help("Delete selection")
             }
         }
+        #if os(macOS)
         .onDeleteCommand(perform: promptDeleteSelected)
+        #endif
     }
 
     // MARK: - Icon Grid View


### PR DESCRIPTION
The iOS Simulator target did not compile on main — macOS-only APIs used unguarded. This is very likely why iPad/iPhone 'isn't working.'

Gated 7 sites behind `#if os(macOS)` (macOS behavior preserved; iOS omits):
- `.onDeleteCommand` ×6 (EntityDetailView+Claims, ChainListContent, WorkflowLibraryView, ResearchProjectListView, EntityDigestView, NoteListView)
- AppInstaller: `homeDirectoryForCurrentUser` → cross-platform `URL(fileURLWithPath: NSHomeDirectory())`

**Verified:** iOS Simulator (Debug) BUILD SUCCEEDED + macOS (Debug) BUILD SUCCEEDED (the latter re-gated here via Xcode, 0 errors).

Follow-up (separate): iOS **Release** still fails on an ungated engine-embed Run-Script phase in pbxproj (macOS bundle layout) — needs a one-line `[ "${PLATFORM_NAME}" = "macosx" ]` guard; manager handling next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)