### PR TITLE
fix(inspector): artifact text full height (#2495) + autosave trailing edit (#2536)

### DIFF
--- a/fichero/fichero-tests/ArtifactTests.swift
+++ b/fichero/fichero-tests/ArtifactTests.swift
@@ -211,4 +211,43 @@ final class ArtifactTests: XCTestCase {
         seen.insert(a)
         XCTAssertTrue(seen.contains(b))
     }
+
+    // MARK: - Inspector artifact layout / autosave regression guards
+    //
+    // `ArtifactPanel`'s sizing and autosave live in private `@State` View
+    // methods that can't be exercised in isolation without extracting them into
+    // a parallel type (which would violate iterate-never-replace). These
+    // source-level guards — the same pattern used by
+    // KnowledgeGraphInspectorSectionTests / SearchResultRowFromAPITests — lock
+    // in the two fixes so a future edit can't silently regress them.
+
+    private static func appSource(_ relativePath: String) throws -> String {
+        let url = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("fichero")
+            .appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// #2495: the selected artifact's text must fill the full inspector height,
+    /// not sit at intrinsic height inside a ScrollView (the old bottom strip).
+    func testArtifactDetailFillsAvailableHeight() throws {
+        let source = try Self.appSource("Views/Library/ArtifactDetailView.swift")
+        // The editor claims all remaining vertical space …
+        XCTAssertTrue(
+            source.contains("fillsHeight: true"),
+            "ArtifactDetailView must pass fillsHeight: true so the artifact text fills the inspector (#2495)"
+        )
+        XCTAssertTrue(
+            source.contains("maxHeight: .infinity"),
+            "ArtifactDetailView must give the panel a full-height frame (#2495)"
+        )
+        // … and is NOT re-wrapped in an outer ScrollView (every content path
+        // scrolls internally; a nested ScrollView would clamp it back to a strip).
+        XCTAssertFalse(
+            source.contains("ScrollView"),
+            "ArtifactDetailView must not wrap the panel in a ScrollView — it fights the fill-height editor (#2495)"
+        )
+    }
 }

--- a/fichero/fichero-tests/ArtifactTests.swift
+++ b/fichero/fichero-tests/ArtifactTests.swift
@@ -250,4 +250,24 @@ final class ArtifactTests: XCTestCase {
             "ArtifactDetailView must not wrap the panel in a ScrollView — it fights the fill-height editor (#2495)"
         )
     }
+
+    /// #2536: a flush during an in-flight save must still persist the latest
+    /// draft — coalesce rather than early-return on `isSaving`.
+    func testFlushAutoSaveCoalescesInsteadOfDroppingTrailingEdit() throws {
+        let source = try Self.appSource("Views/Library/ArtifactPanel.swift")
+        // The old bug: `guard let onSave, !isSaving else { return }` dropped the
+        // trailing edit. The fix marks the draft dirty and re-saves in a loop.
+        XCTAssertFalse(
+            source.contains("guard let onSave, !isSaving else { return }"),
+            "performSave must not early-return on isSaving — that dropped the trailing edit (#2536)"
+        )
+        XCTAssertTrue(
+            source.contains("pendingResave"),
+            "performSave must coalesce a trailing edit via pendingResave (#2536)"
+        )
+        XCTAssertTrue(
+            source.contains("} while pendingResave"),
+            "performSave must loop to persist the newest draft after the in-flight save (#2536)"
+        )
+    }
 }

--- a/fichero/fichero/Views/Library/ArtifactDetailView.swift
+++ b/fichero/fichero/Views/Library/ArtifactDetailView.swift
@@ -28,20 +28,27 @@ struct ArtifactDetailView: View {
     var body: some View {
         Group {
             if let artifact {
-                ScrollView {
-                    ArtifactPanel(
-                        kind: .artifact(artifact),
-                        // The detail always shows its body — there's no sibling
-                        // competing for height, so default to expanded.
-                        defaultExpanded: true,
-                        onDelete: onDelete.map { delete in { delete(artifact) } },
-                        onSave: onSave.map { save in
-                            { content in await save(artifact, content) }
-                        }
-                    )
-                    .padding(.horizontal, 4)
-                    .frame(maxWidth: .infinity, alignment: .top)
-                }
+                // #2495: the selected artifact's text must fill the full
+                // available inspector height — not sit at intrinsic height in a
+                // scroll view (the old "small bottom strip" whose size tracked
+                // panel content). `fillsHeight` makes the editor claim all
+                // remaining vertical space; every content path (editor /
+                // read-only Text / structured JSON) already scrolls internally,
+                // so no outer ScrollView is needed — and a nested ScrollView
+                // wrapping a maxHeight:.infinity editor would fight over height.
+                ArtifactPanel(
+                    kind: .artifact(artifact),
+                    // The detail always shows its body — there's no sibling
+                    // competing for height, so default to expanded.
+                    defaultExpanded: true,
+                    fillsHeight: true,
+                    onDelete: onDelete.map { delete in { delete(artifact) } },
+                    onSave: onSave.map { save in
+                        { content in await save(artifact, content) }
+                    }
+                )
+                .padding(.horizontal, 4)
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
             } else {
                 emptyState
             }

--- a/fichero/fichero/Views/Library/ArtifactPanel.swift
+++ b/fichero/fichero/Views/Library/ArtifactPanel.swift
@@ -111,6 +111,13 @@ struct ArtifactPanel: View { // swiftlint:disable:this type_body_length
     @State private var isSaving: Bool = false
     @State private var saveError: String?
     @State private var autoSaveTask: Task<Void, Never>?
+    /// The in-flight save, if any. A flush awaits this so blur/close truly
+    /// completes with the latest text on disk instead of returning early (#2536).
+    @State private var activeSave: Task<Void, Never>?
+    /// Set when an edit or flush arrives while a save is in flight. The running
+    /// save loops to persist the newest `draftText` before finishing, so the
+    /// trailing edit is never dropped by the `isSaving` guard (#2536).
+    @State private var pendingResave: Bool = false
     /// The raw stored content we last seeded the editor from — guards the
     /// `.task(id:)` reseed against our own save echoing back (#2478).
     @State private var lastLoadedRaw: String = ""
@@ -364,22 +371,48 @@ struct ArtifactPanel: View { // swiftlint:disable:this type_body_length
         await performSave()
     }
 
+    /// Persist the latest draft. Serial + coalescing: if a save is already in
+    /// flight, mark the draft dirty and await that save — which loops to persist
+    /// the newest `draftText` before returning. Without this, a flush on
+    /// blur/close *during* an in-flight save hit the old `!isSaving` early-return
+    /// and silently dropped the trailing keystrokes (#2536).
     private func performSave() async {
-        guard let onSave, !isSaving else { return }
-        let encoded = ArtifactRichTextCodec.encodeAttributed(draftText)
-        // Nothing actually changed since the last seed/save — skip the PUT.
-        guard encoded != lastSavedEncoded else { return }
-        isSaving = true
-        defer { isSaving = false }
-        // Advance BOTH watermarks before the round-trip: `lastSavedEncoded` so a
-        // later onChange doesn't re-fire, and `lastLoadedRaw` so the engine
-        // echoing the saved content back through `rawArtifactContent` short-
-        // circuits the `.task(id:)` reseed instead of resetting the cursor
-        // (#2478). Self-echo suppression in DocumentStore handles the page-
-        // content path; this covers artifacts too.
-        lastSavedEncoded = encoded
-        lastLoadedRaw = encoded
-        await onSave(encoded)
+        guard let onSave else { return }
+        // A save is already running — record that the current draft still needs
+        // persisting and await it so the flush completes with the latest text on
+        // disk. The running loop below re-saves because `pendingResave` is set.
+        if let activeSave {
+            pendingResave = true
+            await activeSave.value
+            return
+        }
+        let task = Task { @MainActor in
+            isSaving = true
+            defer {
+                isSaving = false
+                activeSave = nil
+            }
+            repeat {
+                pendingResave = false
+                let encoded = ArtifactRichTextCodec.encodeAttributed(draftText)
+                // Nothing changed since the last seed/save — skip the PUT.
+                guard encoded != lastSavedEncoded else { break }
+                // Advance BOTH watermarks before the round-trip: `lastSavedEncoded`
+                // so a later onChange doesn't re-fire, and `lastLoadedRaw` so the
+                // engine echoing the saved content back through
+                // `rawArtifactContent` short-circuits the `.task(id:)` reseed
+                // instead of resetting the cursor (#2478). Self-echo suppression
+                // in DocumentStore handles the page-content path; this covers
+                // artifacts too.
+                lastSavedEncoded = encoded
+                lastLoadedRaw = encoded
+                await onSave(encoded)
+                // A flush or edit that landed while `onSave` was awaiting set
+                // `pendingResave`; loop once more to persist that newest draft.
+            } while pendingResave
+        }
+        activeSave = task
+        await task.value
     }
 
     /// Raw content used when seeding the editor — for `.artifact` we use the


### PR DESCRIPTION
Two cohesive document-inspector fixes in the ArtifactPanel area. macOS build green via Xcode (188s, 0 errors).

- **#2495** (Daniel-flagged: "text editor height in the document inspector isn't working") — `ArtifactDetailView` sized the editor to intrinsic content height and pinned it top, leaving the pane mostly empty. Fix: pass the existing `fillsHeight: true` (gives `.frame(maxHeight: .infinity)`) and drop the redundant outer ScrollView that fought the fill-height editor. Reuses existing ArtifactPanel — no new component.
- **#2536** — `performSave` early-returned while a save was in flight, dropping trailing keystrokes on blur/tab-switch/page-nav. Fix: serial + coalescing save — a flush during an in-flight save sets `pendingResave` and awaits completion; the running save loops to re-persist the newest `draftText` until clean (terminates on `encoded == lastSavedEncoded`).

Regression tests added in ArtifactTests.swift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)