### PR TITLE
docs: strip em-dashes/negative-contrast from public docs + reframe USER.md for public

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,15 @@
-# AGENTS.md — Operational Manual
+# AGENTS.md: Operational Manual
 
 How to *operate* on Fichero: verify, commit, ship-safety. The product north-star is `CONSTITUTION.md`; code-navigation policy, hard rules, and key paths live in `.claude/CLAUDE.md` (already in every session's context); the detailed guide is `docs/CLAUDE.md`. The session-start / manager skills tell each lane its job. None of that is repeated here.
 
-Every agent starts with `/session-start` (or a lane variant — `-manager`, `-worker`, `-integrator`, `-auto`); it loads context and reports state. Work happens on the milestone branch this worktree is on — commit directly, no per-task branches.
+Every agent starts with `/session-start` (or a lane variant: `-manager`, `-worker`, `-integrator`, `-auto`); it loads context and reports state. Work happens on the milestone branch this worktree is on. Commit directly, no per-task branches.
 
 ---
 
 ## Who Verifies What
 
-- **Worker** — lints and tests **only its own diff**, then commits. Backend: `ruff check` + `pytest` on the area you touched. Swift: `swiftlint`. A worker does not compile the whole app or run the full suite.
-- **Manager / integrator** — owns the Xcode build, the full `FicheroTests` run, and the cross-stack gate before anything merges (one Xcode, the backend on :8765).
+- **Worker**: lints and tests **only its own diff**, then commits. Backend: `ruff check` + `pytest` on the area you touched. Swift: `swiftlint`. A worker does not compile the whole app or run the full suite.
+- **Manager / integrator**: owns the Xcode build, the full `FicheroTests` run, and the cross-stack gate before anything merges (one Xcode, the backend on :8765).
 
 ```bash
 # Backend — PYTHONPATH=fichero-engine/src on every Python command
@@ -22,17 +22,17 @@ swiftlint lint fichero/fichero/
 ```
 
 - **Backend API changed?** Regenerate the committed client or the Swift build breaks: `./fichero-engine/scripts/sync_openapi_schema.sh` (change API → sync → commit regen).
-- **Ship tests with the change.** Every SwiftUI fix or feature lands with new/updated unit tests in the same commit — write the failing test first for a bug. Test the logic (state, predicates, builders, ID parsing), not the rendered pixels; eyeball pixels by running the built app.
+- **Ship tests with the change.** Every SwiftUI fix or feature lands with new/updated unit tests in the same commit; write the failing test first for a bug. Test the logic (state, predicates, builders, ID parsing) rather than the rendered pixels, and eyeball pixels by running the built app.
 - **Risky diff?** Anything touching auth, file I/O, network, secrets, or keychain → run `/security-review`.
 
 ---
 
 ## Pydantic + OpenAPI Discipline
 
-Three failure modes that bite *silently* — no exception, no test failure, just data that vanishes or rows that hide. Load-bearing, not style:
+Three failure modes that bite *silently*, with no exception and no test failure, just data that vanishes or rows that hide. Load-bearing, not style:
 
 1. **Declare every field on the Pydantic model.** `extra="allow"` lets unknown fields write at runtime, but `model_dump()` only serializes declared fields, so the next read drops them. Add the DB column + the model field + the OpenAPI-typed schema field in the same commit. (`feedback_pydantic_field_must_be_declared.md`)
-2. **Swift wrappers set OpenAPI-typed fields, not `additionalProperties`.** Declared fields dumped into `additionalProperties` round-trip on the wire, but the backend Pydantic model ignores them — the write is lost. (`docs/architecture/swiftui/api_client.md`)
+2. **Swift wrappers set OpenAPI-typed fields, not `additionalProperties`.** Declared fields dumped into `additionalProperties` round-trip on the wire, but the backend Pydantic model ignores them, so the write is lost. (`docs/architecture/swiftui/api_client.md`)
 3. **Endpoint defaults matched by strict equality against seed data are foot-guns.** A `folder_path: str = "/"` default silently stops returning rows the moment seed JSON shape changes. Default `Optional[T] = None`, filter only when the caller passes a value, add a regression test. (#722 → #723)
 
 When seed-data shape changes, the shape change and every filter that reads it ship together.
@@ -43,4 +43,4 @@ When seed-data shape changes, the shape change and every filter that reads it sh
 
 Before completing a backend route change: does OpenAPI need updating? Do the Swift generated files need regenerating? Do frontend callers need updating? Plan first for architectural, OpenAPI-schema, feature-flag-tier, or database-schema changes; proceed directly on clear-root-cause fixes, tests, and lint/build fixes.
 
-**Engine bug or rendering bug?** The typed `fichero` CLI (`python -m fichero`) mirrors every endpoint reachable from SwiftUI. Reproduce against the CLI first — if it fails the same way, the engine owns it.
+**Engine bug or rendering bug?** The typed `fichero` CLI (`python -m fichero`) mirrors every endpoint reachable from SwiftUI. Reproduce against the CLI first; if it fails the same way, the engine owns it.

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -1,12 +1,12 @@
-# Constitution — Fichero
+# Constitution: Fichero
 
 ## What This Is
 
-*Fichero* (Spanish: file cabinet, card index) is a native macOS document management system with AI processing. It gives a researcher's document corpus — PDFs, fieldwork notes, audio recordings, images, transcripts, references — a single home with semantic understanding. You can ask a question and find the relevant passage, not just the filename.
+*Fichero* (Spanish: file cabinet, card index) is a native macOS document management system with AI processing. It gives a researcher's document corpus (PDFs, fieldwork notes, audio recordings, images, transcripts, references) a single home with semantic understanding. You can ask a question and find the relevant passage by its content.
 
 ## The Problem
 
-A researcher accumulates a large, heterogeneous document corpus over years of fieldwork — PDFs, fieldwork notes, audio, transcripts, references. These files are scattered across tools and folders. Finding something means remembering where you put it. Connecting a document to a manuscript note means manual work. There is no single place that understands what the documents contain. Fichero solves this: import everything, extract text and meaning, make it searchable by content, and connect it to the rest of the research stack.
+A researcher accumulates a large, heterogeneous document corpus over years of fieldwork: PDFs, fieldwork notes, audio, transcripts, references. These files are scattered across tools and folders. Finding something means remembering where you put it. Connecting a document to a manuscript note means manual work. There is no single place that understands what the documents contain. Fichero solves this: import everything, extract text and meaning, make it searchable by content, and connect it to the rest of the research stack.
 
 ## Where Fichero Fits
 
@@ -17,20 +17,20 @@ Fichero begins as the **document layer**. It imports, provides semantic search, 
 A macOS app a researcher actually uses daily:
 
 1. **Imports any document type** in a research corpus (37+ formats: PDF, DOCX, audio, video, images, archives)
-2. **Semantic search** across the full corpus — find documents by meaning, not just filename
-3. **Graph and RAG-based Q&A** — ask questions about documents, get answers with source citations
-4. **Native notes + AI workspace** — first-class notes created by the user or AI, with explicit links and provenance
-5. **Spatial knowledge layer** — list, icon, table, map, and future spatial/3D views over the same research model
-6. **AI workflows** — visual node editor for document processing pipelines (LangGraph)
-7. **Offline-first** — works with local models (Apple Intelligence, embedded, Ollama, OMLX, LM Studio) without internet; cloud providers optional
-8. **Native Mac quality** — SwiftUI for front end, Python for engine.
+2. **Semantic search** across the full corpus: find documents by their content and meaning
+3. **Graph and RAG-based Q&A**: ask questions about documents, get answers with source citations
+4. **Native notes + AI workspace**: first-class notes created by the user or AI, with explicit links and provenance
+5. **Spatial knowledge layer**: list, icon, table, map, and future spatial/3D views over the same research model
+6. **AI workflows**: visual node editor for document processing pipelines (LangGraph)
+7. **Offline-first**: works with local models (Apple Intelligence, embedded, Ollama, OMLX, LM Studio) without internet; cloud providers optional
+8. **Native Mac quality**: SwiftUI for front end, Python for engine.
 
 ## How It Works
 
 One engine, many surfaces.
 
 ```
-SwiftUI app    fichero CLI    MCP server    (iPad / web — future)
+SwiftUI app    fichero CLI    MCP server    (iPad / web: future)
        ↘           ↓            ↙
    HTTPS on 127.0.0.1:8765  (TLS, pinned fail-closed)
                  ↓
@@ -44,12 +44,12 @@ SwiftUI app    fichero CLI    MCP server    (iPad / web — future)
                            LiteLLM is cost/pricing only, not routing)
 ```
 
-- **`fichero-engine/`** — Python FastAPI engine. All logic lives here: storage, AI processing, search, workflow execution, knowledge graph, LLM orchestration.
-- **`fichero/`** — SwiftUI macOS app (Xcode project at `fichero/fichero.xcodeproj`).
-- **`fichero` CLI** — typed Python CLI at `fichero-engine/src/fichero/cli/` (ships inside the engine package; invoked as `python -m fichero`).
-- **MCP server** — live (`fichero-mcp` entry point at `fichero-engine/src/fichero/mcp_server.py`); another thin client on the engine.
+- **`fichero-engine/`**: Python FastAPI engine. All logic lives here: storage, AI processing, search, workflow execution, knowledge graph, LLM orchestration.
+- **`fichero/`**: SwiftUI macOS app (Xcode project at `fichero/fichero.xcodeproj`).
+- **`fichero` CLI**: typed Python CLI at `fichero-engine/src/fichero/cli/` (ships inside the engine package; invoked as `python -m fichero`).
+- **MCP server**: live (`fichero-mcp` entry point at `fichero-engine/src/fichero/mcp_server.py`); another thin client on the engine.
 
-- **OpenAPI schema** — the contract between the engine and every surface. The Swift client is auto-generated from the engine's schema; the CLI is typed against it. When the engine changes, regenerate — never edit generated code by hand.
+- **OpenAPI schema**: the contract between the engine and every surface. The Swift client is auto-generated from the engine's schema; the CLI is typed against it. When the engine changes, regenerate. Never edit generated code by hand.
 
 ## Hard Constraints
 
@@ -60,7 +60,7 @@ These don't change:
 3. **The researcher writes; Fichero processes.** The app never writes prose in the user's voice.
 4. **No data leaves the machine by default.** Cloud LLM providers are opt-in, clearly labeled.
 5. **Stability before features.** What works must keep working. New features don't break existing ones.
-6. **All logic lives in the engine; clients render only.** Aggregation, dedup, scoping, summarization, KG/entity logic, validation — all backend. A surface (SwiftUI, CLI, MCP, future iPad/web) calls an endpoint and displays the result. If a surface needs to compute something that another surface would also need, it belongs in the engine.
+6. **All logic lives in the engine; clients render only.** Aggregation, dedup, scoping, summarization, KG/entity logic, and validation all live in the backend. A surface (SwiftUI, CLI, MCP, future iPad/web) calls an endpoint and displays the result. If a surface needs to compute something that another surface would also need, it belongs in the engine.
 
 ## Execution Governance
 
@@ -72,7 +72,7 @@ Execution tracking and planning are governed in GitHub:
 
 ## Versioning
 
-The destination is **dated releases** (CalVer, e.g. `2026.05.01`) — a dated snapshot is a known-good build with document management, workflows, KG, CLI, and the autonomous loops working together. That's the model for the **final release**; it is not fully in place yet. Current development runs on `main` (the `0.0.2` working line was merged to `main` via PR #2652 on 2026-06-26), and day-to-day work is organized per worker/lane.
+The destination is **dated releases** (CalVer, e.g. `2026.05.01`). A dated snapshot is a known-good build with document management, workflows, KG, CLI, and the autonomous loops working together. That's the model for the **final release**; it is not fully in place yet. Current development runs on `main` (the `0.0.2` working line was merged to `main` via PR #2652 on 2026-06-26), and day-to-day work is organized per worker/lane.
 
 - Current working branch + worktree mechanics → `.claude/CLAUDE.md`
 - Release / packaging process (signing, notarize, Sparkle, DMG) → `docs/architecture/release-process.md` (the pipeline itself lives in the separate `fichero-releases` repo)

--- a/USER.md
+++ b/USER.md
@@ -1,17 +1,17 @@
-# USER.md — About Daniel
+# USER.md: About Daniel
 
-Daniel Tubb directs Fichero. Think **creative director**, not architect: he decides what gets built and how it should feel; the agents implement it. He is **not a programmer** — he does not write or read code, and he does not review diffs or PRs. He judges Fichero by *using* it.
+Daniel Tubb directs Fichero. Think of him as a **creative director** rather than an architect: he decides what gets built and how it should feel, and the agents implement it. He is **not a programmer**; he does not write or read code, and he does not review diffs or PRs. He judges Fichero by *using* it.
 
 ## How To Work With Him
 
-- **He directs; you implement.** He sets priorities and approves direction in plain language. Don't hand him code to review — show him the working app, or describe behavior and trade-offs without jargon.
-- **He runs the app himself.** The QA that matters most — does it feel right, does the flow actually work on his Mac — only he can do. Ship something he can launch and try.
+- **He directs; you implement.** He sets priorities and approves direction in plain language. Don't hand him code to review. Show him the working app, or describe behavior and trade-offs without jargon.
+- **He runs the app himself.** The QA that matters most (does it feel right, does the flow actually work on his Mac) only he can do. Ship something he can launch and try.
 
 ## What He Cares About
 
-- **It actually works** — solid over flashy; be honest about what's real vs. half-built.
-- **Native Mac quality** — SwiftUI, fast, light. Not Electron, not a web wrapper.
+- **It actually works**: solid over flashy; be honest about what's real vs. half-built.
+- **Native Mac quality**: SwiftUI, fast, light. Not Electron, not a web wrapper.
 
 ## The One Boundary
 
-Never write his manuscript prose — he is the Creative Director; Fichero processes documents and stops there. Never act on his behalf in the outside world (emails, posts, production systems). Other operational rules live in `.claude/CLAUDE.md`. (You can update the GitHub branch though.)
+Never write his manuscript prose. He is the Creative Director; Fichero processes documents and stops there. Never act on his behalf in the outside world (emails, posts, production systems). Other operational rules live in `.claude/CLAUDE.md`. (You can update the GitHub branch though.)

--- a/USER.md
+++ b/USER.md
@@ -1,17 +1,36 @@
-# USER.md: About Daniel
+# About Daniel Tubb
 
-Daniel Tubb directs Fichero. Think of him as a **creative director** rather than an architect: he decides what gets built and how it should feel, and the agents implement it. He is **not a programmer**; he does not write or read code, and he does not review diffs or PRs. He judges Fichero by *using* it.
+Fichero is made by Daniel Tubb. Daniel is an anthropologist and an Associate
+Professor of Anthropology at the University of New Brunswick, and he runs the
+[Tubb Lab](https://tubblab.com). Fichero grew out of his own research processing
+historical archives and fieldwork material, so its design comes from a
+humanities researcher's needs.
 
-## How To Work With Him
+## Where Fichero comes from
 
-- **He directs; you implement.** He sets priorities and approves direction in plain language. Don't hand him code to review. Show him the working app, or describe behavior and trade-offs without jargon.
-- **He runs the app himself.** The QA that matters most (does it feel right, does the flow actually work on his Mac) only he can do. Ship something he can launch and try.
+Daniel works with primary sources: scanned archives, field notes, interview
+transcripts, historical documents. Fichero is the tool he wanted for that work.
+He directs what gets built and how it should feel, and he builds it
+conversationally with AI coding agents (see [How It's Built](site/docs/how-its-built.md)
+and the [FAQ](site/docs/faq.md)). He does not write the code by hand, and he
+judges every release by using the app on his own Mac. Direction comes in plain
+language: what the app should do, where it feels wrong, what to work on next.
 
-## What He Cares About
+## What he cares about
 
-- **It actually works**: solid over flashy; be honest about what's real vs. half-built.
-- **Native Mac quality**: SwiftUI, fast, light. Not Electron, not a web wrapper.
+- **It actually works.** Solid over flashy, and honest about what is real and
+  what is still half-built. Fichero is alpha software, and it says so.
+- **Native Mac quality.** SwiftUI, fast, and light. Not Electron, not a web
+  wrapper.
+- **The researcher stays in charge.** Fichero processes documents and surfaces
+  what the sources say. It does not write your prose or interpret your evidence
+  for you. That work is yours.
 
-## The One Boundary
+## Contributing and contact
 
-Never write his manuscript prose. He is the Creative Director; Fichero processes documents and stops there. Never act on his behalf in the outside world (emails, posts, production systems). Other operational rules live in `.claude/CLAUDE.md`. (You can update the GitHub branch though.)
+Fichero is open source and built in the open. Issues and pull requests are
+welcome on [GitHub](https://github.com/dtubb/fichero). For how the project is
+developed, see [How It's Built](site/docs/how-its-built.md). For setup and
+conventions, see the [developer docs](site/docs/developer/).
+
+[Tubb Lab](https://tubblab.com) · [Daniel Tubb](https://dtubb.github.io)

--- a/site/docs/architecture/api/overview.md
+++ b/site/docs/architecture/api/overview.md
@@ -33,7 +33,7 @@ fichero-engine/src/
 
 Routes are registered at startup based on the `FICHERO_FEATURE_TIER` environment variable (`release` | `dev`, default `release`).
 
-### Core Routes (always registered — 23 total)
+### Core Routes (always registered, 23 total)
 
 | Prefix | Module | Purpose |
 |---|---|---|
@@ -116,7 +116,7 @@ These are also gated behind `FICHERO_FEATURE_TIER=dev`. They are complete but no
 | Module | Purpose |
 |---|---|
 | `api/main.py` | FastAPI app, route registration, feature-tier resolver |
-| `db.py` | Database layer — DuckDB (relational) + LanceDB (vectors) |
+| `db.py` | Database layer: DuckDB (relational) + LanceDB (vectors) |
 | `models.py` | Pydantic models shared across API and database |
 | `app_db.py` | App-level settings database (separate from per-library DB) |
 | `ingest.py` | File ingestion pipeline (LINK/COPY modes, 37+ file types) |
@@ -161,11 +161,11 @@ These are also gated behind `FICHERO_FEATURE_TIER=dev`. They are complete but no
 ## Loaders
 
 Text extraction engines in `loaders/`:
-- `document_loader.py` — PDFs, DOCX, TXT, Markdown
-- `image_loader.py` — JPEG, PNG, HEIC, JPEG-XL with OCR
-- `audio_loader.py`, `video_loader.py` — Media transcription
-- `iiif_loader.py` — IIIF manifest fetching
-- `unified.py` — Dispatcher across all loader types
+- `document_loader.py`: PDFs, DOCX, TXT, Markdown
+- `image_loader.py`: JPEG, PNG, HEIC, JPEG-XL with OCR
+- `audio_loader.py`, `video_loader.py`: Media transcription
+- `iiif_loader.py`: IIIF manifest fetching
+- `unified.py`: Dispatcher across all loader types
 
 ## Development
 
@@ -188,4 +188,4 @@ ruff check fichero-engine/src/
 
 ## Related Contract Docs
 
-- `docs/architecture/api/capture_sessions_resumable_upload_contract.md` — mobile/offline capture session and resumable-upload contract slice (`#2352`)
+- `docs/architecture/api/capture_sessions_resumable_upload_contract.md`: mobile/offline capture session and resumable-upload contract slice (`#2352`)

--- a/site/docs/architecture/release-process.md
+++ b/site/docs/architecture/release-process.md
@@ -27,7 +27,7 @@ Tag + ship
 
 ---
 
-## Step 1 — Backend Tests
+## Step 1: Backend Tests
 
 Run before any frontend work begins. The backend must be green before wiring.
 
@@ -44,7 +44,7 @@ ruff check fichero-engine/src/
 
 ---
 
-## Step 2 — Frontend: Enable + Integrate
+## Step 2: Frontend Enable + Integrate
 
 1. Enable the feature flag in `FeatureManager.swift` (or `resetToV0X()` tier)
 2. Verify Xcode build compiles without errors:
@@ -64,7 +64,7 @@ ruff check fichero-engine/src/
 
 ---
 
-## Step 3 — Automated API Tests (Claude)
+## Step 3: Automated API Tests (Claude)
 
 Claude calls the backend API directly via MCP tools to verify the feature's endpoints work correctly.
 
@@ -80,7 +80,7 @@ Results recorded as a comment on the release gate issue.
 
 ---
 
-## Step 4 — Visual Tests (Peekaboo)
+## Step 4: Visual Tests (Peekaboo)
 
 With the app running and the feature enabled, Claude uses Peekaboo to take screenshots.
 
@@ -94,9 +94,9 @@ Screenshots attached to the release gate issue as evidence.
 
 ---
 
-## Step 5 — Human Test (Daniel)
+## Step 5: Human Test (Daniel)
 
-Each release gate issue contains a **Daniel Test Checklist** — specific steps to follow in the running app.
+Each release gate issue contains a **Daniel Test Checklist** with specific steps to follow in the running app.
 
 **Format:**
 ```
@@ -110,7 +110,7 @@ When all items are checked and no P0 bugs remain open: release is approved.
 
 ---
 
-## Step 6 — Bug Loop
+## Step 6: Bug Loop
 
 Bugs found during Steps 3–5 are filed via `/bug` skill.
 Each bug gets a GitHub issue with label `type:bug` + current milestone.
@@ -118,7 +118,7 @@ Claude fixes bugs, re-runs Steps 3–5 for affected areas.
 
 ---
 
-## Step 7 — Tag + Ship
+## Step 7: Tag + Ship
 
 Once Daniel approves:
 ```bash

--- a/site/docs/architecture/swiftui/overview.md
+++ b/site/docs/architecture/swiftui/overview.md
@@ -1,7 +1,7 @@
 # Frontend Overview
 
 **Last Updated**: 2026-05-24
-**Status**: ✅ Swift 6 Compatible | SwiftUI-first (AppKit only behind contained `NSViewRepresentable` bridges — see `SWIFTUI_PRINCIPLES.md` §8)
+**Status**: ✅ Swift 6 Compatible | SwiftUI-first (AppKit only behind contained `NSViewRepresentable` bridges; see `SWIFTUI_PRINCIPLES.md` §8)
 
 ## What Fichero Frontend Does
 

--- a/site/docs/developer/README.md
+++ b/site/docs/developer/README.md
@@ -35,7 +35,7 @@ That architecture shapes almost every contributor task:
 
 For environment setup, build commands, and branch discipline, see [Setup and Contributing](./setup-and-contributing.md). The key mechanics: commit directly to the milestone branch, register new Swift files with `scripts/add-swift-file.rb`, use conventional commits with issue references, and never push to `main` without a PR.
 
-For all backend mutations, the starting point is the action registry. Every write goes through `registry.invoke` — not directly to DuckDB. See [Action Registry](./action-registry.md) for how to define actions, write the required tests, and use the generic invocation endpoint. The [Security Model](./security-model.md) covers the shared-secret token, multi-user ACL, Tailscale transport, and audit attribution.
+For all backend mutations, the starting point is the action registry. Every write goes through `registry.invoke` rather than directly to DuckDB. See [Action Registry](./action-registry.md) for how to define actions, write the required tests, and use the generic invocation endpoint. The [Security Model](./security-model.md) covers the shared-secret token, multi-user ACL, Tailscale transport, and audit attribution.
 
 ## Core Reference Material In This Repo
 

--- a/site/docs/developer/action-registry.md
+++ b/site/docs/developer/action-registry.md
@@ -15,7 +15,7 @@ The action registry is the single audited write path for every mutation in Fiche
 
 This pattern was introduced to fix an entire class of bugs at once: the merge-bug class (mutations that silently succeeded but left the UI stale), missing UI verification (no before/after diff available), chat-tool and App Intents invocations that had no audit trail, and the absence of a reliable undo path.
 
-Actions are named `<domain>.<verb>`: `entity.merge`, `document.ingest`, `claim.delete`, and so on. Every domain — documents, entities, claims, folders, workflows, sources, artifacts, tasks — has its actions registered at startup.
+Actions are named `<domain>.<verb>`: `entity.merge`, `document.ingest`, `claim.delete`, and so on. Every domain (documents, entities, claims, folders, workflows, sources, artifacts, tasks) has its actions registered at startup.
 
 ## How to Add a New Action
 
@@ -93,7 +93,7 @@ The `before`/`after` fields make it possible to answer "what changed and when" w
 
 ## Generic Invocation
 
-Any caller — a route handler, a chat tool, an App Intent, a test — can invoke an action through the generic HTTP endpoint:
+Any caller (a route handler, a chat tool, an App Intent, a test) can invoke an action through the generic HTTP endpoint:
 
 ```
 POST /api/actions/invoke

--- a/site/docs/developer/security-model.md
+++ b/site/docs/developer/security-model.md
@@ -54,7 +54,7 @@ Contributor rule: never use a client-supplied identity field as the actor. Alway
 
 For iPad or remote access, the setup is:
 
-1. The engine continues to bind to `127.0.0.1:8765` — no change there.
+1. The engine continues to bind to `127.0.0.1:8765`, with no change there.
 2. `tailscale serve` creates a tailnet-private HTTPS URL that proxies to localhost.
 
 ```bash
@@ -65,7 +65,7 @@ This exposes the API only to devices on your Tailscale tailnet. It is not public
 
 Do not use `tailscale funnel`. Funnel exposes the service to the public internet.
 
-Tailscale is transport. It provides network-level access control (tailnet vs. internet). It is not user-vs-user authorization — that is the `FICHERO_MULTIUSER` / `authz.py` layer. The two concerns are independent.
+Tailscale is transport. It provides network-level access control (tailnet vs. internet). User-vs-user authorization is a separate concern, handled by the `FICHERO_MULTIUSER` / `authz.py` layer. The two concerns are independent.
 
 `FICHERO_BIND_HOST` is loopback-only by default. Binding the engine directly to
 a non-loopback address requires the explicit escape hatch

--- a/site/docs/developer/setup-and-contributing.md
+++ b/site/docs/developer/setup-and-contributing.md
@@ -80,7 +80,7 @@ The `Fichero` main target uses traditional PBX file references. A `.swift` file 
 ruby scripts/add-swift-file.rb fichero/fichero/Views/MyFolder/MyView.swift
 ```
 
-`scripts/add-swift-file.rb` uses the `xcodeproj` Ruby gem (installed at `~/.gem/ruby/2.6.0/gems/xcodeproj-1.27.0/`). Never edit `project.pbxproj` by hand. Test-target files are the exception — those use sync'd groups and are picked up automatically.
+`scripts/add-swift-file.rb` uses the `xcodeproj` Ruby gem (installed at `~/.gem/ruby/2.6.0/gems/xcodeproj-1.27.0/`). Never edit `project.pbxproj` by hand. Test-target files are the exception; those use sync'd groups and are picked up automatically.
 
 ### No per-task branches
 
@@ -104,7 +104,7 @@ All work goes through a PR. Create it and merge it yourself once the build gate 
 
 Backend schema changes go into `db.py` `_ensure_table` via the Pydantic model field. Fresh databases pick up new columns automatically.
 
-Do not add `ALTER TABLE ADD COLUMN` migration functions for columns that are already declared in the model. Only structural historical changes — table renames, data backfills — belong in `db_migrations.py`. This rule applies for the entire 0.0.x series and will change when 0.1.0 ships to real users.
+Do not add `ALTER TABLE ADD COLUMN` migration functions for columns that are already declared in the model. Only structural historical changes (table renames, data backfills) belong in `db_migrations.py`. This rule applies for the entire 0.0.x series and will change when 0.1.0 ships to real users.
 
 ### Feature tier
 

--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -2,15 +2,15 @@
 
 ### What is Fichero?
 
-Fichero is a work in progress. At its core, it's an app that lets you use cutting-edge machine-learning techniques and prompts in a repeatable, programmatic way on documents. Rather than have an AI control how things are done in ways that are hard to understand, Fichero gives you a way to visually build the steps yourself — and then reproduce them across your collection.
+Fichero is a work in progress. At its core, it's an app that lets you use cutting-edge machine-learning techniques and prompts in a repeatable, programmatic way on documents. Rather than have an AI control how things are done in ways that are hard to understand, Fichero gives you a way to visually build the steps yourself, and then reproduce them across your collection.
 
 ### What does "Fichero" mean?
 
-Fichero is Spanish for "card-file cabinet" — the physical index card filing system used by researchers, archivists, and notably by Niklas Luhmann in his Zettelkasten method. The name references both the archival tradition and Fichero's roots in processing historical archival images.
+Fichero is Spanish for "card-file cabinet," the physical index card filing system used by researchers, archivists, and notably by Niklas Luhmann in his Zettelkasten method. The name references both the archival tradition and Fichero's roots in processing historical archival images.
 
 ### How does it work?
 
-Fichero is two apps in one: a native SwiftUI frontend for browsing and managing your documents, and a Python FastAPI backend that handles AI processing, search, and data storage. The backend is embedded inside the Mac app and starts automatically — you never need to think about it.
+Fichero is two apps in one: a native SwiftUI frontend for browsing and managing your documents, and a Python FastAPI backend that handles AI processing, search, and data storage. The backend is embedded inside the Mac app and starts automatically, so you never need to think about it.
 
 ### What AI models does it support?
 
@@ -38,7 +38,7 @@ Fichero is currently free during early development. Pricing for future versions 
 
 ### How is Fichero built?
 
-Fichero is vibe-coded. Daniel is an anthropologist, not a software engineer — he doesn't write Swift or Python from scratch. Instead, he sits down with [Claude](https://www.anthropic.com/claude) (Anthropic's AI assistant) and describes what he wants in plain language. Claude does the typing; Daniel directs: what the app should do, where it's broken, what to work on next. Sessions are conversational and long, and code, tests, and commits all come out the other end.
+Fichero is vibe-coded. Daniel is an anthropologist rather than a software engineer, and he doesn't write Swift or Python from scratch. Instead, he sits down with [Claude](https://www.anthropic.com/claude) (Anthropic's AI assistant) and describes what he wants in plain language. Claude does the typing; Daniel directs: what the app should do, where it's broken, what to work on next. Sessions are conversational and long, and code, tests, and commits all come out the other end.
 
 ### What is the relationship between Fichero and Fichero Toolbox?
 

--- a/site/docs/how-its-built.md
+++ b/site/docs/how-its-built.md
@@ -1,7 +1,7 @@
 # How Fichero Is Built
 
 Fichero is built openly with the help of AI coding agents. This page documents
-how that actually works — not as a marketing claim, but as the concrete process
+how that actually works, as the concrete process
 the project follows. It is grounded in the workflow files that live in the
 repository: `CLAUDE.md`, `.claude/CLAUDE.md` (the agent constitution), `AGENTS.md`,
 `MEMORY.md`, and the skills under `docs/agent-workflow/`.
@@ -19,27 +19,27 @@ unreviewed code.
 Work is organized around a **manager / worker** split, defined as session-start
 skills in `docs/agent-workflow/skills/`:
 
-- **Manager** (`session-start-manager`) — the control lane. It reads project
+- **Manager** (`session-start-manager`): the control lane. It reads project
   state and the roadmap, triages GitHub issues, decides what to do next, and
   dispatches work. The manager **does not write product code**; it coordinates.
-- **Worker** (`session-start-worker`) — the implementation lane. A worker picks
+- **Worker** (`session-start-worker`): the implementation lane. A worker picks
   up exactly one assigned issue, implements it completely, writes tests, runs the
   required verification gates, commits, and reports back.
 
 GitHub Issues and Milestones are the source of truth for the backlog. The
-project works **one milestone at a time** — groom it, work it to done, then move
-on — rather than against a version number.
+project works **one milestone at a time** (groom it, work it to done, then move
+on) rather than against a version number.
 
 ## The manager loop
 
 The manager runs a deterministic loop built from two skills:
 
-1. **`choose-next`** — reads `docs/ROADMAP.md` (the priority tiers: Gates →
+1. **`choose-next`**: reads `docs/ROADMAP.md` (the priority tiers: Gates →
    Infrastructure → Observable approaches → Features → Domain → Mac polish →
    Testing → Profiling → UI consistency) and the open GitHub milestones, then
    returns the next batch: either one large keystone issue, or 3–10 small issues
    from the **same** milestone, sized to fit a worker's context.
-2. **`dispatch-worker`** — spawns that batch the right way, then integrates the
+2. **`dispatch-worker`**: spawns that batch the right way, then integrates the
    result.
 
 ## Worktree-isolated workers
@@ -52,7 +52,7 @@ collides:
   filesystem operations are gated by an explicit safety rule (`git worktree
   remove --force` only; never `rm -rf` a sibling path).
 - Before fanning out more than one worker, the manager **partitions work by
-  file-set** so lanes touch disjoint files — parallelism is only free when two
+  file-set** so lanes touch disjoint files; parallelism is only free when two
   lanes don't both rewrite the same module.
 - Cheap models are the default; more capable models are reserved for keystones
   (new data stores, the action layer, high-blast-radius changes).
@@ -77,20 +77,20 @@ The workflow picks the lightest tool that fits the task
 | Mode | What it is | Use when |
 |---|---|---|
 | **Single session** | The lead does the work inline | Sequential edits, overlapping files, many dependencies |
-| **Subagent** | A helper spawned to report one result back | Focused build/lint/test or "trace why X happens" — only the result matters |
+| **Subagent** | A helper spawned to report one result back | Focused build/lint/test or "trace why X happens" where only the result matters |
 | **Agent team** | Peer sessions sharing a task list | Work that needs discussion: parallel review, competing-hypothesis debugging, disjoint cross-layer features |
 
 ## The QA review gate
 
 Before a sweep of changes is committed, the project runs a **review gate** rather
 than self-certifying. A small review team inspects the staged diff through
-distinct, non-overlapping lenses — for example:
+distinct, non-overlapping lenses, for example:
 
-- **backend-reviewer** — correctness and the recurring bug patterns recorded in
+- **backend-reviewer**: correctness and the recurring bug patterns recorded in
   `MEMORY.md`;
-- **silent-failure-hunter** — catch blocks, fallbacks, and "success" returned on
+- **silent-failure-hunter**: catch blocks, fallbacks, and "success" returned on
   systemic failure;
-- **code-reviewer** — style, conventions, and the standards in
+- **code-reviewer**: style, conventions, and the standards in
   `docs/architecture/`.
 
 The lead **synthesizes** the findings, applies fixes, and only then commits. In
@@ -106,13 +106,13 @@ Two non-negotiable rules close the loop:
   `ruff` for Python, `swiftlint` and an Xcode build for Swift).
 - **Never push on top of an unverified commit.** The verification summary is read
   and parsed; work is pushed **only** when the suite is green. A change always
-  reaches `main` through a pull request — never a direct push.
+  reaches `main` through a pull request, never a direct push.
 
 ## Durable memory
 
 What the agents learn persists. `MEMORY.md` indexes durable lessons and decisions
-— recurring bug patterns, hard rules (for example, "iterate, never replace"
-existing code), and architectural facts — so that future sessions start informed
+(recurring bug patterns, hard rules such as "iterate, never replace"
+existing code, and architectural facts) so that future sessions start informed
 rather than relearning the same mistakes. The `session-end` skill is what writes
 those lessons down at the end of a working session.
 

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -6,7 +6,7 @@ hide:
 
 <!-- Landing copy salvaged from the previous 11ty site (Daniel's own words).
      Adapted to MkDocs/Material. Release-specific bits (version string, download
-     link, release notes) are marked PLACEHOLDER — update them each release. -->
+     link, release notes) are marked PLACEHOLDER; update them each release. -->
 
 <p align="center">
   <img src="assets/icon.png" alt="Fichero icon" width="128">
@@ -22,14 +22,14 @@ workflows, entirely on your Mac.**
 [Get started :material-rocket-launch:](user/getting-started.md){ .md-button }
 
 Fichero turns scanned archives, PDFs, field notes, and historical documents into
-a searchable research library — using visual AI workflows you build yourself. To
+a searchable research library, using visual AI workflows you build yourself. To
 learn more about how Fichero works, read the [FAQ](faq.md). Fichero is available
 as a free Alpha download.
 
 !!! warning "This is Alpha software"
     Fichero is in active daily development. Things will change. Things will
-    break. Don't put irreplaceable work in it yet — keep originals elsewhere,
-    treat each release as an experiment.
+    break. Don't put irreplaceable work in it yet. Keep originals elsewhere,
+    and treat each release as an experiment.
 
 !!! note "Fichero is vibe-coded"
     Every line is written conversationally with
@@ -40,7 +40,7 @@ as a free Alpha download.
 ## What is Fichero?
 
 "Fichero" is Spanish for a card-file cabinet. The name recalls the index-card
-filing systems used by researchers, archivists, and scholars — from Niklas
+filing systems used by researchers, archivists, and scholars, from Niklas
 Luhmann's Zettelkasten to the physical card catalogues of archives and
 libraries, to the field notes ethnographers write, to Walter Benjamin's
 *Arcades Project*.
@@ -51,11 +51,11 @@ documents.
 It's an app that lets you use machine-learning techniques and prompts in a
 repeatable, programmatic way. I've built it to do transcription of handwritten
 documents using vision language models, to extract named entities, and to
-produce catalogues — but the approach could be used for other tasks.
+produce catalogues, though the approach could be used for other tasks.
 
-The basic idea: rather than have an AI do things — where it controls how things
-are done, in ways that are harder to understand — Fichero lets you, the user,
-visually build these steps yourself, and connect them together. Fichero is built
+The basic idea: an AI that does things on its own controls how they are done, in
+ways that are harder to understand. Fichero instead lets you, the user, visually
+build these steps yourself, and connect them together. Fichero is built
 on a Python backend, with a powerful database, a vector database, a knowledge
 graph, and an ontological layer, so it can be extended in new directions.
 
@@ -64,22 +64,22 @@ talks to model providers through LangChain, and runs workflows with LangGraph.
 
 ## Who it's for
 
-I've written Fichero primarily for anthropologists, historians, and archivists —
-but it's a tool, ultimately, to experiment with using large language models in a
+I've written Fichero primarily for anthropologists, historians, and archivists.
+Ultimately it's a tool to experiment with using large language models in a
 programmatic, methodological, step-by-step way.
 
 It is a desktop app, built on SwiftUI. It is useful to:
 
 - Work with archival materials, field notes, interviews, or historical documents;
 - Process scanned PDFs, images, and mixed-format collections;
-- Search your documents by meaning, not just keywords;
-- Run AI workflows — transcription, extraction, summarization — on batches of files;
+- Search your documents by meaning as well as keywords;
+- Run AI workflows (transcription, extraction, summarization) on batches of files;
 - Care about keeping your data local and under your control.
 
 ## Model agnostic
 
 Fichero is model agnostic. It works with open-source models as well as
-commercial providers — you just get yourself an API key. If you want to run
+commercial providers; you just get yourself an API key. If you want to run
 models locally, you can do so with Ollama or LM Studio.
 
 ## Beyond chat, beyond agents
@@ -93,7 +93,7 @@ reproduce steps across multiple documents.
 
 AIs are incredibly powerful. Fichero aims to make them more navigable, more
 transparent, and more accessible as tools for research. Currently, agents are
-not transparent — they are invisible to the user, hidden in a database or a
+not transparent; they are invisible to the user, hidden in a database or a
 backend, so it's hard to know what's going on under the covers. With Fichero, the
 aim is to be more transparent, and therefore more accessible.
 
@@ -143,7 +143,7 @@ The latest Alpha release is **Fichero 2026.04.29 Alpha**.
 [Download the latest Alpha :material-apple:](https://github.com/dtubb/fichero-releases/releases/latest){ .md-button .md-button--primary }
 
 Releases are dated by ship date (calendar versioning). Versions before 1.0 are
-Alpha — features change, bugs happen, expect rough edges.
+Alpha, so features change, bugs happen, and you should expect rough edges.
 
 Until Fichero hits version 1.0:
 

--- a/site/docs/user/ai-and-privacy.md
+++ b/site/docs/user/ai-and-privacy.md
@@ -4,7 +4,7 @@
 
 Fichero stores everything in a `.fichero` library package on your disk. There is no telemetry, no analytics, and no cloud sync. Fichero does not require an account.
 
-The only network traffic is to the AI provider you choose — and only when you run a workflow that calls that provider. If you run everything locally, Fichero makes no network calls at all.
+The only network traffic is to the AI provider you choose, and only when you run a workflow that calls that provider. If you run everything locally, Fichero makes no network calls at all.
 
 ---
 
@@ -27,7 +27,7 @@ For sensitive research materials, local models are the right choice.
 
 ### Cloud options
 
-Fichero uses [LiteLLM](https://github.com/BerriAI/litellm) to connect to cloud providers. You supply your own API key. Fichero does not proxy requests through any intermediary — your API calls go directly to the provider.
+Fichero uses [LiteLLM](https://github.com/BerriAI/litellm) to connect to cloud providers. You supply your own API key. Fichero does not proxy requests through any intermediary; your API calls go directly to the provider.
 
 Available providers include OpenAI, Anthropic (Claude), Google, Mistral, Groq, DeepSeek, OpenRouter, Azure, Amazon Bedrock, and others. See Settings for the full list.
 
@@ -37,7 +37,7 @@ Cloud models are billed by your API provider at their standard rates.
 
 For transcription of historical handwriting or difficult scripts, cloud vision models (GPT-4o, Claude) typically produce better results than local OCR. For entity extraction on clean typed or printed text, Apple Intelligence works well and keeps everything on-device.
 
-If you are processing sensitive materials — unpublished fieldwork, confidential documents, materials with legal or ethical restrictions — use local models.
+If you are processing sensitive materials (unpublished fieldwork, confidential documents, materials with legal or ethical restrictions), use local models.
 
 ---
 
@@ -45,13 +45,13 @@ If you are processing sensitive materials — unpublished fieldwork, confidentia
 
 Fichero AI extracts structured facts from your documents:
 
-- **Entities** — people, places, organizations, events, concepts, dates, keywords
-- **Claims** — statements with subject-verb-object structure, tied to specific pages
-- **Citations** — page-level provenance on every extracted item
+- **Entities**: people, places, organizations, events, concepts, dates, keywords
+- **Claims**: statements with subject-verb-object structure, tied to specific pages
+- **Citations**: page-level provenance on every extracted item
 
 Every extracted item carries provenance: which page it came from, which workflow produced it, which model was used.
 
-You review the output. You can approve, reject, suppress, or merge any entity or claim. Suppression rules persist — if you reject a spurious entity, the suppression applies to future runs on that document.
+You review the output. You can approve, reject, suppress, or merge any entity or claim. Suppression rules persist: if you reject a spurious entity, the suppression applies to future runs on that document.
 
 ## What the AI does not do
 
@@ -63,7 +63,7 @@ The AI is an extraction instrument. Interpretation is yours.
 
 ## iPad and remote access (advanced)
 
-The Fichero engine runs on your Mac only. It binds to `127.0.0.1` (loopback) — it is not reachable from the internet or from other devices on your local network by default.
+The Fichero engine runs on your Mac only. It binds to `127.0.0.1` (loopback), so it is not reachable from the internet or from other devices on your local network by default.
 
 If you want to use Fichero from an iPad or a second Mac, you can expose the loopback engine to your personal [Tailscale](https://tailscale.com) network:
 

--- a/site/docs/user/install.md
+++ b/site/docs/user/install.md
@@ -29,7 +29,7 @@ Fichero is signed and notarized. On first launch, macOS may show a Gatekeeper al
 
 You only need to do this once. After that, Fichero opens normally.
 
-When Fichero starts, the backend engine launches automatically in the background. You may see "Connecting to backend…" briefly in the title bar while it starts. This is normal — it takes a few seconds the first time.
+When Fichero starts, the backend engine launches automatically in the background. You may see "Connecting to backend…" briefly in the title bar while it starts. This is normal, and it takes a few seconds the first time.
 
 No separate Python installation is required. The engine is embedded in the app.
 
@@ -37,4 +37,4 @@ No separate Python installation is required. The engine is embedded in the app.
 
 ## Alpha software
 
-Fichero is in active development. The library format may change between releases. Keep original copies of any documents you import — do not use Fichero as your only copy of anything.
+Fichero is in active development. The library format may change between releases. Keep original copies of any documents you import, and do not use Fichero as your only copy of anything.

--- a/site/docs/user/what-fichero-is.md
+++ b/site/docs/user/what-fichero-is.md
@@ -1,6 +1,6 @@
 # What Fichero Is
 
-Fichero is a document library for researchers. It runs on your Mac. It is built for working with primary sources — scanned archives, PDFs, field notes, historical documents, interview transcripts — the raw material of research.
+Fichero is a document library for researchers. It runs on your Mac. It is built for working with primary sources (scanned archives, PDFs, field notes, historical documents, interview transcripts), the raw material of research.
 
 You import your sources, read them, extract structured information from them, annotate them, and write from them. The whole process stays on your computer.
 
@@ -16,23 +16,23 @@ You import your sources, read them, extract structured information from them, an
 
 Fichero organizes research around three phases, each grounded in the source.
 
-### READ — Hermeneutic layer
+### READ: Hermeneutic layer
 
-The READ layer decomposes a source into structured facts: entities, claims, dates, citations, each anchored to the specific page it comes from. This is AI-assisted extraction. Fichero runs workflows — transcription, entity extraction, catalogue generation — across your documents.
+The READ layer decomposes a source into structured facts: entities, claims, dates, citations, each anchored to the specific page it comes from. This is AI-assisted extraction. Fichero runs workflows (transcription, entity extraction, catalogue generation) across your documents.
 
 The extraction is systematic. Every item carries provenance: which page, which document, which workflow produced it, which model was used. You can review the output, approve it, reject it, or correct it.
 
 This layer answers: *what does this source actually say?*
 
-### THINK — Interpretative layer
+### THINK: Interpretative layer
 
 The THINK layer is yours. It is your notes and annotations on a reading: what you observed, what you found significant, how this source connects to others in your collection. Fichero gives you annotation tools, a notes system, and an inspector for every document.
 
 This layer answers: *what do I make of this source?*
 
-### WRITE — Synthesis layer *(in development)*
+### WRITE: Synthesis layer *(in development)*
 
-The WRITE layer is where research becomes argument: Zettelkasten-style atomic notes, an outliner, and a writing space connected to your citations and knowledge graph — so you build an argument from your sources and export it with citations intact.
+The WRITE layer is where research becomes argument: Zettelkasten-style atomic notes, an outliner, and a writing space connected to your citations and knowledge graph, so you build an argument from your sources and export it with citations intact.
 
 This layer is **planned, not yet built** (the READ and THINK layers exist today; export with citations is partially available). It answers: *what do I want to say about these sources?*
 
@@ -63,7 +63,7 @@ Fichero runs as much as possible locally and privately. Where possible, use Appl
 
 Your data stays on your Mac. Fichero stores everything in a `.fichero` library package on your disk. There is no telemetry, no analytics, no cloud sync, and no account required.
 
-The only network traffic is to the AI provider you choose — and only when you run a workflow. If you run everything locally (Apple Intelligence or Ollama), Fichero makes no network calls at all.
+The only network traffic is to the AI provider you choose, and only when you run a workflow. If you run everything locally (Apple Intelligence or Ollama), Fichero makes no network calls at all.
 
 ---
 


### PR DESCRIPTION
Two docs passes (markdown only):
- **Voice cleanup** (84cedbac): removed em dashes + 'not-X-but-Y' negative-contrast across 14 public/governance docs (CONSTITUTION/AGENTS/site/docs); Daniel's north-star phrasing (e.g. 'instrument, not an interlocutor') deliberately preserved.
- **USER.md** (23f425d4): reframed from a private agent-instruction file into public-facing 'About Daniel Tubb' context for an open-source repo; pulled internal agent-safety lines OUT of the public file (flagged to move to .claude/CLAUDE.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)