### PR TITLE
feat(release): auto-stamp today's date + same-day sub-number

### DIFF
--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -25,6 +25,23 @@ for arg in "$@"; do
   esac
 done
 
+# ── 0. Auto-stamp the dated release version ─────────────────────────────────
+# Every release auto-stamps TODAY's date (set-release-version.sh with no arg);
+# a second build the same day bumps a sub-number. Opt out by exporting
+# FICHERO_RELEASE_VERSION (the operator has stamped a specific version already).
+# Channel defaults to beta (the current distribution channel); set
+# FICHERO_RELEASE_BETA=0 for a stable stamp. Skipped when not rebuilding the app.
+if [ "$SKIP_APP_BUILD" = true ]; then
+  echo "[0/6] Skipping version stamp (--skip-app-build; using already-built app)"
+elif [ -n "${FICHERO_RELEASE_VERSION:-}" ]; then
+  echo "[0/6] FICHERO_RELEASE_VERSION=$FICHERO_RELEASE_VERSION set — operator controls version, not auto-stamping"
+else
+  echo "[0/6] Auto-stamp dated release version"
+  STAMP_ARGS=()
+  [ "${FICHERO_RELEASE_BETA:-1}" != "0" ] && STAMP_ARGS+=(--beta)
+  "$ROOT_DIR/scripts/set-release-version.sh" "${STAMP_ARGS[@]+"${STAMP_ARGS[@]}"}"
+fi
+
 # ── 1. Build Release app ────────────────────────────────────────────────────
 if [ "$SKIP_APP_BUILD" = true ]; then
   echo "[1/6] Skipping Release app build (--skip-app-build)"

--- a/scripts/release-all.sh
+++ b/scripts/release-all.sh
@@ -97,6 +97,26 @@ mkdir -p "$RELEASE_DIR"
 echo "=== Fichero release ==="
 echo "Sparkle feed: $SPARKLE_FEED_URL"
 
+# ── Auto-stamp the dated release version (once, up front) ────────────────────
+# Stamp TODAY's date across frontend + backend before any build path runs, so
+# both the DMG and the TestFlight archive carry the same auto-incremented dated
+# version. Opt out by exporting FICHERO_RELEASE_VERSION (operator controls it);
+# channel defaults to beta — set FICHERO_RELEASE_BETA=0 for a stable stamp. We
+# export FICHERO_RELEASE_VERSION afterward so the nested build-release-dmg.sh
+# sees the version already set and does not re-stamp.
+if [ -n "${FICHERO_RELEASE_VERSION:-}" ]; then
+  echo
+  echo "── Version: FICHERO_RELEASE_VERSION=$FICHERO_RELEASE_VERSION set — not auto-stamping ──"
+else
+  echo
+  echo "── Version: auto-stamp dated release ──"
+  STAMP_ARGS=()
+  [ "${FICHERO_RELEASE_BETA:-1}" != "0" ] && STAMP_ARGS+=(--beta)
+  "$ROOT_DIR/scripts/set-release-version.sh" "${STAMP_ARGS[@]+"${STAMP_ARGS[@]}"}"
+  # Pin the just-stamped MARKETING_VERSION so downstream scripts don't re-stamp.
+  export FICHERO_RELEASE_VERSION="$(project_setting MARKETING_VERSION)"
+fi
+
 if [ "$SKIP_DMG" = false ]; then
   echo
   echo "── DMG: build + Developer ID sign ──"

--- a/scripts/set-release-version.sh
+++ b/scripts/set-release-version.sh
@@ -4,44 +4,181 @@
 # Releases are dated (CalVer), not semantic. This is the single command that
 # keeps frontend and backend on the same version so they track together.
 #
-#   Frontend (Xcode):   MARKETING_VERSION       = <date>[-beta]   (Apple display string)
-#                       CURRENT_PROJECT_VERSION = <YYYYMMDD>      (Sparkle build int, monotonic)
-#   Backend (pyproject): version = "<PEP440>"   (e.g. 2026.6.26 or 2026.6.26b0)
+# AUTOMATIC by default: with no date argument it stamps TODAY. A second release
+# on the same calendar day automatically bumps a sub-number (.2, .3, …) so each
+# build is distinct and Sparkle's build integer stays strictly increasing.
 #
-# PEP 440 forbids leading zeros (2026.06.26 is invalid) and the literal "-beta",
-# so the engine uses the canonical form: strip leading zeros on month/day, beta -> b0.
-# The app keeps the human-readable -beta suffix (Apple + Sparkle accept it; Sparkle
-# orders updates by the build INTEGER, not the short string, so the suffix is display-only).
+#   Frontend (Xcode):   MARKETING_VERSION       = <date>[.N][-beta]   (Apple display string)
+#                       CURRENT_PROJECT_VERSION = <YYYYMMDD><NN>       (Sparkle build int, monotonic)
+#   Backend (pyproject): version = "<PEP440>"   (e.g. 2026.6.27, 2026.6.27.2, 2026.6.27b1)
+#
+# Same-day sub-number N is derived from how many release tags already exist for
+# today: N = (count of `v<DATE>*` tags) + 1.
+#   N == 1 → display  YYYY.MM.DD[-beta]
+#   N  > 1 → display  YYYY.MM.DD.N[-beta]
+#
+# Build integer is a 10-digit YYYYMMDD + 2-digit NN (2026062701, 2026062702,
+# next day 2026062801). This is strictly greater than the OLD 8-digit YYYYMMDD
+# scheme (20260627) for every plausible date, so Sparkle monotonicity survives
+# the scheme change.
+#
+# PEP 440 forbids leading zeros (2026.06.27 is invalid) and the literal "-beta",
+# so the engine uses the canonical form: strip leading zeros on month/day; a
+# beta release maps to bN (2026.6.27b1, b2, …); a non-beta sub-build maps to an
+# extra release segment (2026.6.27.2). The app keeps the human-readable -beta
+# suffix (Apple + Sparkle accept it; Sparkle orders updates by the build
+# INTEGER, not the short string, so the suffix is display-only).
 #
 # Usage:
-#   scripts/set-release-version.sh 2026.06.26 --beta   # daily beta (current channel)
-#   scripts/set-release-version.sh 2026.06.26          # stable
+#   scripts/set-release-version.sh                 # auto: today, stable, next sub-number
+#   scripts/set-release-version.sh --beta          # auto: today, beta channel
+#   scripts/set-release-version.sh 2026.06.27      # explicit date, stable
+#   scripts/set-release-version.sh 2026.06.27 --beta
+#   scripts/set-release-version.sh --dry-run       # print computed versions, touch nothing
+#   scripts/set-release-version.sh --self-check    # assert N=1 vs N=2 produce expected strings
+#
+# Env:
+#   FICHERO_RELEASE_SEQ=N   force the same-day sub-number (skip tag counting)
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PBX="$ROOT/fichero/fichero.xcodeproj/project.pbxproj"
 PY="$ROOT/fichero-engine/pyproject.toml"
 
-DATE="${1:?usage: set-release-version.sh <YYYY.MM.DD> [--beta]}"
+# ── arg parsing ──────────────────────────────────────────────────────────────
+# The date is optional and positional; flags may appear in any order.
+DATE=""
 BETA=false
-[ "${2:-}" = "--beta" ] && BETA=true
+DRY_RUN=false
+SELF_CHECK=false
+for arg in "$@"; do
+  case "$arg" in
+    --beta)       BETA=true ;;
+    --dry-run|-n) DRY_RUN=true ;;
+    --self-check) SELF_CHECK=true ;;
+    --help|-h)    sed -n '32,41p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    -*)           echo "error: unknown flag: $arg" >&2; exit 2 ;;
+    *)
+      [ -z "$DATE" ] || { echo "error: unexpected extra argument: $arg" >&2; exit 2; }
+      DATE="$arg" ;;
+  esac
+done
 
-[[ "$DATE" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}$ ]] || { echo "error: date must be YYYY.MM.DD (got '$DATE')" >&2; exit 1; }
+# Default to TODAY when no date was supplied.
+[ -n "$DATE" ] || DATE="$(date +%Y.%m.%d)"
 
-APP_VERSION="$DATE"; [ "$BETA" = true ] && APP_VERSION="$DATE-beta"
-BUILD_INT="${DATE//./}"                       # 2026.06.26 -> 20260626
+[[ "$DATE" =~ ^[0-9]{4}\.[0-9]{2}\.[0-9]{2}$ ]] \
+  || { echo "error: date must be YYYY.MM.DD (got '$DATE')" >&2; exit 1; }
 
-# PEP 440: drop leading zeros on month/day; beta -> b0
-YYYY="${DATE%%.*}"; rest="${DATE#*.}"; MM="${rest%%.*}"; DD="${rest#*.}"
-MM="${MM#0}"; DD="${DD#0}"
-ENGINE_VERSION="$YYYY.$MM.$DD"; [ "$BETA" = true ] && ENGINE_VERSION="${ENGINE_VERSION}b0"
+# ── same-day sequence ────────────────────────────────────────────────────────
+# Count existing release tags for this date (tags are v<MARKETING_VERSION>, e.g.
+# v2026.06.27-beta or v2026.06.27.2-beta) — the next build is count + 1.
+seq_for_date() {
+  local d="$1"
+  if [ -n "${FICHERO_RELEASE_SEQ:-}" ]; then echo "$FICHERO_RELEASE_SEQ"; return; fi
+  local n
+  n="$(git -C "$ROOT" tag -l "v$d*" 2>/dev/null | grep -c . || true)"
+  echo "$(( n + 1 ))"
+}
 
+# ── version computation (pure; sets the three globals) ───────────────────────
+# Args: <date> <beta:true|false> <N>
+compute_versions() {
+  local d="$1" beta="$2" n="$3"
+  local yyyy rest mm dd nn
+
+  # display sub-number suffix: empty for N==1, ".N" for N>1
+  local subdisp=""
+  [ "$n" -gt 1 ] && subdisp=".$n"
+
+  APP_VERSION="$d$subdisp"
+  [ "$beta" = true ] && APP_VERSION="$APP_VERSION-beta"
+
+  # build int: YYYYMMDD + zero-padded NN  (2026.06.27, N=1 -> 2026062701)
+  printf -v nn '%02d' "$n"
+  BUILD_INT="${d//./}$nn"
+
+  # PEP 440: drop leading zeros on month/day
+  yyyy="${d%%.*}"; rest="${d#*.}"; mm="${rest%%.*}"; dd="${rest#*.}"
+  mm="${mm#0}"; dd="${dd#0}"
+  ENGINE_VERSION="$yyyy.$mm.$dd"
+  if [ "$beta" = true ]; then
+    ENGINE_VERSION="${ENGINE_VERSION}b$n"          # 2026.6.27b1, b2, …
+  elif [ "$n" -gt 1 ]; then
+    ENGINE_VERSION="${ENGINE_VERSION}.$n"          # 2026.6.27.2 (extra release segment)
+  fi
+}
+
+# ── PEP 440 validity check (best-effort: uses repo venv, then python3) ────────
+pep440_check() {
+  local v="$1" py=""
+  if [ -x "$ROOT/.venv/bin/python" ]; then py="$ROOT/.venv/bin/python"
+  elif command -v python3 >/dev/null 2>&1; then py="python3"; fi
+  if [ -n "$py" ]; then
+    "$py" -c "from packaging.version import Version; x=Version('$v'); print('  PEP 440 OK:', x, '| prerelease:', x.is_prerelease)" 2>/dev/null \
+      || echo "  (packaging lib not available — '$v' is canonical PEP 440 regardless)"
+  else
+    echo "  (no python available — '$v' is canonical PEP 440 regardless)"
+  fi
+}
+
+# ── self-check: assert the N=1 / N=2 strings, no file writes ─────────────────
+if [ "$SELF_CHECK" = true ]; then
+  fails=0
+  assert_eq() {  # <label> <got> <want>
+    if [ "$2" = "$3" ]; then
+      echo "  ok: $1 = $2"
+    else
+      echo "  FAIL: $1 = '$2' (expected '$3')" >&2; fails=$((fails+1))
+    fi
+  }
+  # stable, N=1
+  compute_versions 2026.06.27 false 1
+  assert_eq "N1 stable APP"    "$APP_VERSION"    "2026.06.27"
+  assert_eq "N1 stable BUILD"  "$BUILD_INT"      "2026062701"
+  assert_eq "N1 stable ENGINE" "$ENGINE_VERSION" "2026.6.27"
+  # stable, N=2
+  compute_versions 2026.06.27 false 2
+  assert_eq "N2 stable APP"    "$APP_VERSION"    "2026.06.27.2"
+  assert_eq "N2 stable BUILD"  "$BUILD_INT"      "2026062702"
+  assert_eq "N2 stable ENGINE" "$ENGINE_VERSION" "2026.6.27.2"
+  # beta, N=1
+  compute_versions 2026.06.27 true 1
+  assert_eq "N1 beta APP"      "$APP_VERSION"    "2026.06.27-beta"
+  assert_eq "N1 beta BUILD"    "$BUILD_INT"      "2026062701"
+  assert_eq "N1 beta ENGINE"   "$ENGINE_VERSION" "2026.6.27b1"
+  # beta, N=2
+  compute_versions 2026.06.27 true 2
+  assert_eq "N2 beta APP"      "$APP_VERSION"    "2026.06.27.2-beta"
+  assert_eq "N2 beta BUILD"    "$BUILD_INT"      "2026062702"
+  assert_eq "N2 beta ENGINE"   "$ENGINE_VERSION" "2026.6.27b2"
+  # next-day rollover: build int must exceed today's and the old 8-digit scheme
+  compute_versions 2026.06.28 true 1
+  assert_eq "next-day BUILD"   "$BUILD_INT"      "2026062801"
+  [ "$BUILD_INT" -gt 2026062702 ] && echo "  ok: monotonic across days" || { echo "  FAIL: build int not monotonic" >&2; fails=$((fails+1)); }
+  [ "$BUILD_INT" -gt 20260627 ]   && echo "  ok: new 10-digit > old 8-digit scheme" || { echo "  FAIL: not > old scheme" >&2; fails=$((fails+1)); }
+  echo
+  if [ "$fails" -eq 0 ]; then echo "self-check: PASS"; exit 0; else echo "self-check: $fails FAILED" >&2; exit 1; fi
+fi
+
+# ── compute for the real run ─────────────────────────────────────────────────
+N="$(seq_for_date "$DATE")"
+compute_versions "$DATE" "$BETA" "$N"
+
+echo "date   : $DATE  (same-day build #$N)"
 echo "app    : MARKETING_VERSION=$APP_VERSION  CURRENT_PROJECT_VERSION=$BUILD_INT"
 echo "engine : version=$ENGINE_VERSION"
 
-# --- frontend: CURRENT_PROJECT_VERSION via agvtool (sanctioned tool, works) ---
+if [ "$DRY_RUN" = true ]; then
+  echo
+  echo "dry-run: no files modified."
+  echo "pep440:"; pep440_check "$ENGINE_VERSION"
+  exit 0
+fi
+
+# ── frontend: CURRENT_PROJECT_VERSION via agvtool (sanctioned tool, works) ───
 ( cd "$ROOT/fichero" && xcrun agvtool new-version -all "$BUILD_INT" >/dev/null )
 
-# --- frontend: MARKETING_VERSION via value-only sed (sanctioned-tool-blocked fallback) ---
+# ── frontend: MARKETING_VERSION via value-only sed (sanctioned-tool-blocked) ─
 # agvtool new-marketing-version is broken on this project (it looks for a
 # literal "YES" path) and the xcodeproj gem 1.27.0 can't parse the project (a
 # PBXShellScriptBuildPhase stores shellScript as an Array). Value-only flat
@@ -50,17 +187,14 @@ echo "engine : version=$ENGINE_VERSION"
 # Project rule #10 sanctions agvtool/xcodeproj; this is the documented fallback.
 sed -i '' -E "s/^([[:space:]]*)MARKETING_VERSION = .*;/\1MARKETING_VERSION = $APP_VERSION;/" "$PBX"
 
-# --- backend: both [tool.briefcase] and [project] version lines ---
+# ── backend: both [tool.briefcase] and [project] version lines ───────────────
 # Anchored to a digit so a hypothetical `version = "<string>"` dep key is untouched.
 sed -i '' -E "s/^version = \"[0-9].*\"/version = \"$ENGINE_VERSION\"/" "$PY"
 
-# --- verify ---
+# ── verify ───────────────────────────────────────────────────────────────────
 echo
 echo "verify:"
 echo -n "  MARKETING_VERSION configs: "; grep -cE "MARKETING_VERSION = $APP_VERSION;" "$PBX"
 echo -n "  CURRENT_PROJECT_VERSION:   "; ( cd "$ROOT/fichero" && xcrun agvtool what-version -terse )
 echo "  engine version:"; grep -nE '^version = ' "$PY" | sed 's/^/    /'
-
-# sanity: PEP 440 parses
-"$ROOT/.venv/bin/python" -c "from packaging.version import Version; v=Version('$ENGINE_VERSION'); print('  PEP 440 OK:', v, '| prerelease:', v.is_prerelease)" 2>/dev/null \
-  || echo "  (packaging lib not available — $ENGINE_VERSION is canonical PEP 440 regardless)"
+pep440_check "$ENGINE_VERSION"


### PR DESCRIPTION
Release versioning now auto-stamps today's date (no manual arg); a second release the same day bumps a sub-number (2026.06.27.2). 10-digit monotonic build int (YYYYMMDDNN) preserves Sparkle ordering. Wired into build-release-dmg.sh + release-all.sh (opt-out via FICHERO_RELEASE_VERSION). --self-check passes. Daniel asked for this.