### PR TITLE
docs: macOS 26 (Tahoe) requirement, not Sequoia

### DIFF
--- a/site/docs/faq.md
+++ b/site/docs/faq.md
@@ -22,7 +22,7 @@ Yes. Fichero is designed for offline-first use. Your documents are stored locall
 
 ### What macOS version is required?
 
-Fichero requires macOS 15.0 (Sequoia) or later.
+Fichero requires macOS 26 (Tahoe) or later.
 
 ### Is my data secure?
 

--- a/site/docs/index.md
+++ b/site/docs/index.md
@@ -131,7 +131,7 @@ Fichero is a work in progress. Iterative. It is, I hope, something useful.
 
 ## System requirements
 
-- macOS 15.0 Sequoia or later
+- macOS 26 Tahoe or later
 - Apple Silicon (M1 or later)
 
 ---

--- a/site/docs/user/install.md
+++ b/site/docs/user/install.md
@@ -2,7 +2,7 @@
 
 ## System requirements
 
-- macOS 15 Sequoia or later
+- macOS 26 Tahoe or later
 - Apple Silicon (M1 or later)
 
 Fichero does not run on Intel Macs or on macOS 14 or earlier.

--- a/site/docs/user/what-fichero-is.md
+++ b/site/docs/user/what-fichero-is.md
@@ -78,4 +78,4 @@ It is useful if you:
 - want to extract structured information and build a research record
 - care about keeping your data local and under your control
 
-Fichero is a desktop application for macOS. It requires Apple Silicon (M1 or later) and macOS 15 Sequoia or later.
+Fichero is a desktop application for macOS. It requires Apple Silicon (M1 or later) and macOS 26 Tahoe or later.


### PR DESCRIPTION
System requirements said macOS 15 Sequoia; the target is macOS 26 (Tahoe / Golden Gate). Fixed in faq/index/install/what-fichero-is.