### PR TITLE
backend: AI Backend Hardening + Workflows (#2507/#2538/#2528/#2529/#2535/#2615/#2545)

### DIFF
--- a/fichero-engine/scripts/start_backend.py
+++ b/fichero-engine/scripts/start_backend.py
@@ -19,6 +19,30 @@ from fichero.bind_host import resolve_bind_host
 
 logger = logging.getLogger(__name__)
 
+# The Swift app pins https://127.0.0.1:8765 fail-closed (#2376/#2370), so a
+# plain-HTTP engine on that port is silently unreachable — the Activity SSE
+# stream and every loopback call die with no error (#2538).
+APP_LOOPBACK_PORT = 8765
+
+
+def _warn_if_app_unreachable(scheme: str, port: int) -> None:
+    """Loudly flag the HTTP-vs-pinned-HTTPS mismatch instead of a dead stream.
+
+    Plain HTTP is a legitimate CLI-only dev choice, so we warn rather than
+    raise — but we make the mismatch impossible to miss (Daniel's rule:
+    log loudly, never fail silently).
+    """
+    if scheme == "http" and port == APP_LOOPBACK_PORT:
+        logger.warning(
+            "Engine is serving PLAIN HTTP on :%d but the Swift app pins "
+            "https://127.0.0.1:%d fail-closed (#2538) — the Activity stream "
+            "and all loopback calls from the app will silently fail. "
+            "Launch via scripts/start_backend.sh (prepares loopback TLS), or "
+            "set FICHERO_TLS_CERTFILE/FICHERO_TLS_KEYFILE, to serve HTTPS.",
+            port,
+            port,
+        )
+
 
 def main(argv: list[str] | None = None) -> None:
     """Start the backend or prepare remote-access TLS material."""
@@ -85,6 +109,7 @@ def main(argv: list[str] | None = None) -> None:
     scheme = "https" if "ssl_certfile" in config else "http"
     logger.info("Starting Fichero backend on %s://%s:%d", scheme, bind_host, config["port"])
     logger.info("Hot-reload: %s", config["reload"])
+    _warn_if_app_unreachable(scheme, int(config["port"]))
 
     uvicorn.run(**config)
 

--- a/fichero-engine/src/fichero/api/routes/export.py
+++ b/fichero-engine/src/fichero/api/routes/export.py
@@ -9,6 +9,7 @@ from fichero.api.library_header import optional_library_path
 from fichero.api.main import get_library_database_for_write
 from fichero.db import Database
 from fichero.export_service import (
+    export_eleventy_site,
     export_excel_xlsx,
     export_markdown_folder,
     export_word_docx,
@@ -91,6 +92,66 @@ class ExcelExportResponse(BaseModel):
     entity_count: int
     claim_count: int
     bytes_written: int
+
+
+class EleventySiteExportRequest(BaseModel):
+    """Request body for 11ty/Netlify static-site export."""
+
+    model_config = ConfigDict(extra="allow")
+
+    output_path: str = Field(..., description="Destination folder for the site project")
+    target_id: str | None = Field(
+        default=None,
+        description="Optional folder id to publish; omitted exports the library",
+    )
+    recursive: bool = Field(default=True, description="Include descendants of folders")
+    overwrite: bool = Field(
+        default=False, description="Allow writing into a non-empty folder"
+    )
+    site_title: str | None = Field(
+        default=None, description="Site title (defaults to the root folder name)"
+    )
+
+
+class EleventySiteExportResponse(BaseModel):
+    output_path: str
+    document_count: int
+    collection_count: int
+    files: list[ExportedFileResponse]
+    assets: list[ExportedFileResponse]
+
+
+@router.post("/eleventy-site", response_model=EleventySiteExportResponse)
+async def export_eleventy_site_route(
+    request: EleventySiteExportRequest,
+    db: Database = Depends(get_library_database_for_write),
+    x_fichero_library_path: str | None = Depends(optional_library_path),
+) -> EleventySiteExportResponse:
+    """Publish a library, folder, or subfolder as an 11ty/Netlify static site."""
+    try:
+        result = export_eleventy_site(
+            db=db,
+            output_path=Path(request.output_path),
+            target_id=request.target_id,
+            recursive=request.recursive,
+            overwrite=request.overwrite,
+            package_path=x_fichero_library_path,
+            site_title=request.site_title,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except FileExistsError as e:
+        raise HTTPException(status_code=409, detail=str(e))
+    except OSError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return EleventySiteExportResponse(
+        output_path=result.output_path,
+        document_count=result.document_count,
+        collection_count=result.collection_count,
+        files=[ExportedFileResponse(**file.__dict__) for file in result.files],
+        assets=[ExportedFileResponse(**asset.__dict__) for asset in result.assets],
+    )
 
 
 @router.post("/markdown-folder", response_model=MarkdownFolderExportResponse)

--- a/fichero-engine/src/fichero/api/routes/workflows.py
+++ b/fichero-engine/src/fichero/api/routes/workflows.py
@@ -569,14 +569,52 @@ def import_workflow_impl(
 ) -> "Workflow":  # noqa: F821
     """Validate + persist a workflow from imported JSON (extracted from the
     ``POST /api/workflows/import`` route so the route and the
-    ``workflow.import`` action share one implementation). Raises
-    ``HTTPException(400)`` when the payload lacks ``nodes``/``edges``."""
+    ``workflow.import`` action share one implementation).
+
+    Parity with export (#2528): every node/edge is validated against the typed
+    NodeDef/EdgeDef models *before* anything is persisted, so a malformed file
+    fails loud (HTTP 400) with the offending element — never a silent partial
+    import. Export emits the raw stored dicts, so we persist those same dicts
+    once they validate (export→import round-trips to an identical graph)."""
     from fichero.models import Workflow
 
     if "nodes" not in workflow_data or "edges" not in workflow_data:
         raise HTTPException(
             status_code=400, detail="Invalid workflow data: missing nodes or edges"
         )
+
+    nodes = workflow_data.get("nodes", [])
+    edges = workflow_data.get("edges", [])
+    if not isinstance(nodes, list) or not isinstance(edges, list):
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid workflow data: 'nodes' and 'edges' must be lists",
+        )
+
+    # Validate against the typed models up front — fail loud, persist nothing
+    # on a bad element (no silent partial import). enrich_ports=False keeps
+    # validation to structure, independent of the live tool registry so a
+    # round-tripped export validates regardless of registry state.
+    for i, node in enumerate(nodes):
+        try:
+            _dict_to_node_def(node, enrich_ports=False)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid workflow data: node[{i}] failed validation: {exc}",
+            )
+    for i, edge in enumerate(edges):
+        try:
+            _dict_to_edge_def(edge)
+        except HTTPException:
+            raise
+        except Exception as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid workflow data: edge[{i}] failed validation: {exc}",
+            )
 
     workflow_name = name or workflow_data.get("name", "Imported Workflow")
     workflow_description = description or workflow_data.get("description", "")
@@ -589,8 +627,8 @@ def import_workflow_impl(
         format="nodes",
         provider=workflow_provider,
         model=workflow_model,
-        nodes=workflow_data.get("nodes", []),
-        edges=workflow_data.get("edges", []),
+        nodes=nodes,
+        edges=edges,
     )
     db.save(db_workflow)
     return db_workflow

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -2787,6 +2787,20 @@ def register_generated_openapi_commands(
         target_app = typer.Typer(help='Generated OpenAPI commands for export endpoints.', no_args_is_help=True)
         root_app.add_typer(target_app, name='export')
 
+    @target_app.command("eleventy-site-route")
+    def export_eleventy_site_route_post(
+        ctx: typer.Context,
+        body: Optional[str] = typer.Option(None, "--body", help="Inline JSON request body."),
+        body_file: Optional[Path] = typer.Option(None, "--body-file", exists=True, dir_okay=False, readable=True, help="Path to a JSON request body file."),
+    ) -> None:
+        """Export Eleventy Site Route (POST /api/export/eleventy-site)."""
+        def op_call(client: FicheroClient) -> Any:
+            path = "/api/export/eleventy-site"
+            params = None
+            payload = _load_json_payload(body, body_file, required=True)
+            return client.request("POST", path, params=params, json=payload)
+        invoke(ctx, op_call)
+
     @target_app.command("excel-route")
     def export_excel_route_post(
         ctx: typer.Context,

--- a/fichero-engine/src/fichero/export_service.py
+++ b/fichero-engine/src/fichero/export_service.py
@@ -76,6 +76,232 @@ class ExcelExportResult:
     bytes_written: int
 
 
+@dataclass
+class EleventySiteExportResult:
+    """Result metadata for an 11ty/Netlify static-site export."""
+
+    output_path: str
+    document_count: int
+    collection_count: int
+    files: list[ExportedFile] = field(default_factory=list)
+    assets: list[ExportedFile] = field(default_factory=list)
+
+
+def export_eleventy_site(
+    db: Database,
+    output_path: str | Path,
+    target_id: str | None = None,
+    recursive: bool = True,
+    overwrite: bool = False,
+    package_path: str | Path | None = None,
+    site_title: str | None = None,
+) -> EleventySiteExportResult:
+    """Export a folder (or subfolder) as a buildable 11ty/Netlify static site.
+
+    The third export target alongside Markdown and Excel (#2535), reusing the
+    same document-collection + asset-copy plumbing. Folder structure maps to
+    11ty collections: each top-level folder under the export root becomes a
+    collection, nested folders become subcollections, and each document is an
+    item page (Markdown + YAML front matter with metadata, image copied in).
+
+    Produces a self-contained project that builds with ``npx @11ty/eleventy``
+    and deploys to Netlify (``netlify.toml`` publishes ``_site``). Assets are
+    copied into the site so it is portable/publishable — a static bundle, not
+    the running app (which renders via storage endpoints, not local paths).
+    """
+    output_dir = Path(output_path).expanduser()
+    if output_dir.exists() and any(output_dir.iterdir()) and not overwrite:
+        raise FileExistsError(
+            f"Export folder already exists and is not empty: {output_dir}"
+        )
+    output_dir.mkdir(parents=True, exist_ok=True)
+    src_dir = output_dir / "src"
+    src_dir.mkdir(exist_ok=True)
+
+    root, documents = _collect_documents(db, target_id=target_id, recursive=recursive)
+    package = Path(package_path).expanduser() if package_path else None
+    # by_id powers the ancestor walk that reconstructs each doc's collection
+    # path. ponytail: db.all() is O(library); fine for a deliberate batch
+    # export, swap to a parent-chain query if it ever needs to stream.
+    by_id = {d.id: d for d in db.all(Document)}
+    root_id = root.id if root else None
+
+    title = site_title or (root.name if root else "Fichero Export")
+    result = EleventySiteExportResult(
+        output_path=str(output_dir),
+        document_count=len(documents),
+        collection_count=0,
+    )
+
+    collections: set[str] = set()
+    used_per_dir: dict[str, set[str]] = {}
+    for doc in documents:
+        rel_parts = _collection_path_for(doc, by_id, root_id)
+        if rel_parts:
+            collections.add(rel_parts[0])
+        doc_dir = src_dir.joinpath(*rel_parts) if rel_parts else src_dir
+        doc_dir.mkdir(parents=True, exist_ok=True)
+
+        assets_dir = doc_dir / "assets"
+        asset_refs: list[_AssetRef] = []
+        if _is_image_document(doc):
+            assets_dir.mkdir(exist_ok=True)
+            asset_refs = _copy_document_assets(doc, assets_dir, package)
+
+        used = used_per_dir.setdefault(str(doc_dir), set())
+        filename = _unique_filename(_slugify(doc.name), used, ".md")
+        page_path = doc_dir / filename
+        page_path.write_text(
+            _render_eleventy_item(db, doc, asset_refs, rel_parts),
+            encoding="utf-8",
+        )
+        result.files.append(
+            ExportedFile(path=str(page_path), kind="page", document_id=doc.id)
+        )
+        result.assets.extend(
+            ExportedFile(path=str(a.path), kind="asset", document_id=doc.id)
+            for a in asset_refs
+        )
+
+    result.collection_count = len(collections)
+
+    # Site scaffolding — a minimal but real, buildable 11ty + Netlify project.
+    (src_dir / "index.md").write_text(
+        _render_eleventy_index(title, sorted(collections), documents),
+        encoding="utf-8",
+    )
+    for name, content in _eleventy_scaffold(title).items():
+        (output_dir / name).write_text(content, encoding="utf-8")
+        result.files.append(ExportedFile(path=str(output_dir / name), kind="scaffold"))
+
+    return result
+
+
+def _collection_path_for(
+    doc: Document,
+    by_id: dict[str, Document],
+    root_id: str | None,
+) -> list[str]:
+    """Slugged folder names from the export root down to ``doc``'s parent."""
+    parts: list[str] = []
+    cur = by_id.get(doc.parent_id) if doc.parent_id else None
+    seen: set[str] = set()
+    while cur is not None and cur.id != root_id and cur.id not in seen:
+        seen.add(cur.id)
+        if cur.doc_type == DocType.folder:
+            parts.append(_slugify(cur.name))
+        cur = by_id.get(cur.parent_id) if cur.parent_id else None
+    return list(reversed(parts))
+
+
+def _render_eleventy_item(
+    db: Database,
+    doc: Document,
+    assets: Iterable[_AssetRef],
+    collection_path: list[str],
+) -> str:
+    lines = [
+        "---",
+        f"title: {_escape_frontmatter(doc.name)}",
+        f"id: {doc.id}",
+        f"doc_type: {doc.doc_type.value}",
+        f"file_type: {doc.file_type.value if doc.file_type else ''}",
+    ]
+    if collection_path:
+        # 11ty groups pages by tag → the top-level folder is the collection.
+        lines.append(f"tags:\n  - {_escape_frontmatter(collection_path[0])}")
+        lines.append(f"collection_path: {_escape_frontmatter('/'.join(collection_path))}")
+    lines.extend(["---", "", f"# {doc.name}", ""])
+
+    for asset in assets:
+        lines.extend([f"![{doc.name}]({asset.markdown_path})", ""])
+
+    content = (doc.page_content or "").strip()
+    if content:
+        lines.extend([content, ""])
+    artifacts = _text_artifacts(db, doc.id)
+    if artifacts:
+        lines.extend(["## Artifacts", ""])
+        for artifact in artifacts:
+            lines.extend(
+                [f"### {artifact.artifact_type}", "", artifact.content.strip(), ""]
+            )
+    if not content and not artifacts and not list(assets):
+        lines.extend(["_No text content available._", ""])
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_eleventy_index(
+    title: str,
+    collections: list[str],
+    documents: list[Document],
+) -> str:
+    lines = [
+        "---",
+        f"title: {_escape_frontmatter(title)}",
+        "---",
+        "",
+        f"# {title}",
+        "",
+        f"Exported: {datetime.now().isoformat(timespec='seconds')}",
+        "",
+        f"{len(documents)} item(s) across {len(collections)} collection(s).",
+        "",
+    ]
+    if collections:
+        lines.extend(["## Collections", ""])
+        lines.extend(f"- {name}" for name in collections)
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _eleventy_scaffold(title: str) -> dict[str, str]:
+    """The static-site project files that make the export buildable + deployable."""
+    package_json = json.dumps(
+        {
+            "name": _slugify(title).lower() or "fichero-site",
+            "version": "1.0.0",
+            "private": True,
+            "scripts": {"build": "eleventy", "serve": "eleventy --serve"},
+            "devDependencies": {"@11ty/eleventy": "^3.0.0"},
+        },
+        indent=2,
+    )
+    eleventy_config = (
+        "module.exports = function (eleventyConfig) {\n"
+        '  eleventyConfig.addPassthroughCopy("src/**/assets");\n'
+        "  return {\n"
+        '    dir: { input: "src", output: "_site" },\n'
+        '    markdownTemplateEngine: "njk",\n'
+        "  };\n"
+        "};\n"
+    )
+    netlify_toml = (
+        "[build]\n"
+        '  command = "npx @11ty/eleventy"\n'
+        '  publish = "_site"\n'
+    )
+    readme = (
+        f"# {title}\n\n"
+        "Static site exported from Fichero (11ty + Netlify).\n\n"
+        "## Build\n\n"
+        "```sh\n"
+        "npm install\n"
+        "npm run build   # outputs _site/\n"
+        "npm run serve   # local preview\n"
+        "```\n\n"
+        "Deploy `_site/` to Netlify (or run `netlify deploy`). "
+        "Collections map to folders, item pages carry metadata front matter, "
+        "and images are bundled under each folder's `assets/`.\n"
+    )
+    return {
+        "package.json": package_json,
+        ".eleventy.js": eleventy_config,
+        "netlify.toml": netlify_toml,
+        "README.md": readme,
+    }
+
+
 def export_markdown_folder(
     db: Database,
     output_path: str | Path,

--- a/fichero-engine/src/fichero/llm.py
+++ b/fichero-engine/src/fichero/llm.py
@@ -145,6 +145,13 @@ def clear_api_key_cache(provider: str | None = None) -> None:
         else:
             _API_KEY_CACHE.pop(provider, None)
 
+    # A rotated key must also drop cached embedding clients built with the old
+    # key (#2545 N1). Cheap and rare; clear all (the client cache isn't keyed
+    # by provider). Lazy import avoids a circular dependency at module load.
+    from fichero.llm_embeddings import clear_embeddings_client_cache
+
+    clear_embeddings_client_cache()
+
 # Content-addressed result cache for vision (and future LLM) calls (#2224).
 # Keyed by SHA-256 of (provider, model, prompt, per-image content hashes).
 # Caps at 1 000 entries with FIFO eviction. Thread-safe via a lock.

--- a/fichero-engine/src/fichero/llm_embeddings.py
+++ b/fichero-engine/src/fichero/llm_embeddings.py
@@ -8,8 +8,30 @@ Included by llm.py via re-exports in __all__.
 from __future__ import annotations
 
 import logging
+from functools import lru_cache
+from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=32)
+def _build_embeddings_client(model: str, api_key: str | None) -> Any:
+    """Construct (and cache) one OpenAIEmbeddings client per (model, key).
+
+    ponytail: at 100k images the embed path was rebuilding a fresh
+    OpenAIEmbeddings client — and its httpx connection pool — on every call
+    (#2545 N1). Cache keyed by (model, api_key) so a key rotation lands on a
+    new entry; ``clear_embeddings_client_cache()`` drops stale clients when a
+    credential changes. maxsize bounds the rare multi-model/multi-key case.
+    """
+    from langchain_openai import OpenAIEmbeddings
+
+    return OpenAIEmbeddings(model=model, api_key=api_key)
+
+
+def clear_embeddings_client_cache() -> None:
+    """Drop cached embedding clients (call on credential change)."""
+    _build_embeddings_client.cache_clear()
 
 
 def _embedding_provider(model: str) -> str:
@@ -58,8 +80,6 @@ def _get_langchain_embeddings(
     Returns:
         LangChain embeddings instance
     """
-    from langchain_openai import OpenAIEmbeddings
-
     # Resolve API key
     if not api_key:
         # Extract provider from model name
@@ -70,12 +90,9 @@ def _get_langchain_embeddings(
         from fichero.llm import get_api_key  # lazy import avoids circular dependency
         api_key = get_api_key(provider)
 
-    # Currently we primarily use OpenAI embeddings
-    # Could be extended for other providers
-    return OpenAIEmbeddings(
-        model=model,
-        api_key=api_key,
-    )
+    # Currently we primarily use OpenAI embeddings; the cached builder reuses
+    # one client per (model, key) instead of rebuilding per call (#2545 N1).
+    return _build_embeddings_client(model, api_key)
 
 
 def embed(

--- a/fichero-engine/src/fichero/workflows/human_review.py
+++ b/fichero-engine/src/fichero/workflows/human_review.py
@@ -1,0 +1,78 @@
+"""Typed human-in-the-loop contract for workflows (#2529).
+
+A workflow node can pause and ask the user a question (disambiguate a reading,
+confirm an entity, choose a branch). LangGraph's ``interrupt()`` is the pause
+primitive — the checkpointer persists state and the run suspends until it is
+resumed with the user's answer.
+
+The *payload* that crosses that boundary needs to be a single typed shape, not
+an ad-hoc dict per call site: the SSE/Activity surface and the eventual resume
+endpoint both have to render and round-trip it without data loss. This module
+owns that contract + a thin ``ask_human()`` wrapper so every node (the catalogue
+grouping confirmation today; a general "Ask / Human Review" node next) speaks
+the same language.
+
+Resume wiring (a /threads/{id}/resume endpoint that feeds the answer back via
+``Command(resume=...)``) is intentionally NOT here yet — see the design notes on
+issue #2529. This is the typed foundation it will build on.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class HumanReviewRequest(BaseModel):
+    """The question a paused workflow surfaces to the user.
+
+    Serialized into the LangGraph interrupt value, so it must be plain-JSON
+    safe (no engine objects) — that is what the frontend receives and what the
+    resume endpoint will echo back alongside the answer.
+    """
+
+    # Stable discriminator so the UI can pick a renderer (free-text vs.
+    # the catalogue grouping editor vs. a bbox HTR confirmation, etc.).
+    kind: str = "human_review"
+    # The human-readable question the AI is asking.
+    question: str
+    # Optional context to help the human answer: an image region (bbox),
+    # a draft transcription, the proposed groupings, etc. Free-form but typed
+    # as a dict so it round-trips as JSON.
+    context: dict[str, Any] = Field(default_factory=dict)
+    # Optional discrete choices — when present, the UI can render buttons.
+    options: list[str] | None = None
+    # The node that asked, for attribution in Activity (filled by callers
+    # that know their node id).
+    node_id: str | None = None
+
+
+def ask_human(
+    question: str,
+    *,
+    kind: str = "human_review",
+    context: dict[str, Any] | None = None,
+    options: list[str] | None = None,
+    node_id: str | None = None,
+) -> Any:
+    """Suspend the workflow and ask the user ``question``; return their answer.
+
+    Thin wrapper over LangGraph ``interrupt()`` that enforces the typed
+    :class:`HumanReviewRequest` payload. The return value is whatever the
+    resume call feeds back (``Command(resume=<answer>)``) — typically the
+    user's typed answer or a structured edit.
+
+    Imported lazily so this module stays importable without langgraph (e.g.
+    for contract tests / schema export).
+    """
+    from langgraph.types import interrupt
+
+    payload = HumanReviewRequest(
+        kind=kind,
+        question=question,
+        context=context or {},
+        options=options,
+        node_id=node_id,
+    )
+    return interrupt(payload.model_dump())

--- a/fichero-engine/src/fichero/workflows/tools/_entity_writer.py
+++ b/fichero-engine/src/fichero/workflows/tools/_entity_writer.py
@@ -1421,8 +1421,16 @@ def upsert_entity(
                 canonical_name=matched.canonical_name,
                 description=matched.description,
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            # #2507: don't swallow silently — a stale alias-merge vector
+            # degrades future fuzzy matches. Log loudly like the new-entity
+            # index path below; the catalogue stays up either way.
+            logger.warning(
+                "upsert_entity: failed to refresh merged entity vector "
+                "(id=%s): %s",
+                matched.id,
+                exc,
+            )
         _record_source_page(db, matched, source_document_id)  # #1562
         return matched.id
 

--- a/fichero-engine/src/fichero/workflows/tools/catalogue.py
+++ b/fichero-engine/src/fichero/workflows/tools/catalogue.py
@@ -39,7 +39,6 @@ from fichero.llm import LLMConfig, chat_with_fallback
 from fichero.db import db_manager
 from fichero.models import Document, DocType, Artifact
 from fichero.workflows.tools._workflow_change_emit import emit_workflow_artifact_changes
-from langgraph.types import interrupt
 
 logger = logging.getLogger(__name__)
 
@@ -536,17 +535,22 @@ async def catalogue(
         groups = _group_documents_by_case(container, library_path)
         min_items = int(inputs.get("ambiguous_min_items", 25) or 25)
         if _grouping_is_ambiguous(groups, min_items=min_items):
-            interrupt(
-                {
-                    "type": "catalogue_grouping_confirmation",
+            # Typed human-in-the-loop contract (#2529) — one Pydantic payload
+            # shared with any future "Ask / Human Review" node, instead of an
+            # ad-hoc dict the frontend has to parse blind.
+            from fichero.workflows.human_review import ask_human
+
+            ask_human(
+                question=(
+                    "Catalogue grouping appears ambiguous. Confirm, split, "
+                    "or merge groups, then resume."
+                ),
+                kind="catalogue_grouping_confirmation",
+                context={
                     "container_id": container.id,
                     "container_name": container.name,
                     "proposed_groupings": _proposed_groupings(groups),
-                    "message": (
-                        "Catalogue grouping appears ambiguous. Confirm, split, "
-                        "or merge groups, then resume."
-                    ),
-                }
+                },
             )
 
     # Bubbleable LLM-error messages from any of the catalogue's nested

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -2889,6 +2889,16 @@
     "export": [
       {
         "method": "POST",
+        "path": "/export/eleventy-site",
+        "operation_id": "export_eleventy_site_route_api_export_eleventy_site_post",
+        "summary": "Export Eleventy Site Route",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "EleventySiteExportRequest",
+        "response_model": "EleventySiteExportResponse"
+      },
+      {
+        "method": "POST",
         "path": "/export/excel",
         "operation_id": "export_excel_route_api_export_excel_post",
         "summary": "Export Excel Route",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -9221,6 +9221,49 @@
         }
       }
     },
+    "/api/export/eleventy-site": {
+      "post": {
+        "tags": [
+          "export",
+          "export"
+        ],
+        "summary": "Export Eleventy Site Route",
+        "description": "Publish a library, folder, or subfolder as an 11ty/Netlify static site.",
+        "operationId": "export_eleventy_site_route_api_export_eleventy_site_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EleventySiteExportRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EleventySiteExportResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/export/markdown-folder": {
       "post": {
         "tags": [
@@ -40308,6 +40351,85 @@
         ],
         "title": "EdgeDef",
         "description": "Definition of an edge connecting two nodes via their ports.\n\nEdges define data flow between nodes. Each edge connects\nan output port on the source node to an input port on the target node."
+      },
+      "EleventySiteExportRequest": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path",
+            "description": "Destination folder for the site project"
+          },
+          "target_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Target Id",
+            "description": "Optional folder id to publish; omitted exports the library"
+          },
+          "recursive": {
+            "type": "boolean",
+            "title": "Recursive",
+            "description": "Include descendants of folders",
+            "default": true
+          },
+          "overwrite": {
+            "type": "boolean",
+            "title": "Overwrite",
+            "description": "Allow writing into a non-empty folder",
+            "default": false
+          },
+          "site_title": {
+            "type": "string",
+            "nullable": true,
+            "title": "Site Title",
+            "description": "Site title (defaults to the root folder name)"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "output_path"
+        ],
+        "title": "EleventySiteExportRequest",
+        "description": "Request body for 11ty/Netlify static-site export."
+      },
+      "EleventySiteExportResponse": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path"
+          },
+          "document_count": {
+            "type": "integer",
+            "title": "Document Count"
+          },
+          "collection_count": {
+            "type": "integer",
+            "title": "Collection Count"
+          },
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/ExportedFileResponse"
+            },
+            "type": "array",
+            "title": "Files"
+          },
+          "assets": {
+            "items": {
+              "$ref": "#/components/schemas/ExportedFileResponse"
+            },
+            "type": "array",
+            "title": "Assets"
+          }
+        },
+        "type": "object",
+        "required": [
+          "output_path",
+          "document_count",
+          "collection_count",
+          "files",
+          "assets"
+        ],
+        "title": "EleventySiteExportResponse"
       },
       "EmbedClaimsResponse": {
         "properties": {

--- a/fichero-engine/tests/unit/test_embedded_models_lean_deps.py
+++ b/fichero-engine/tests/unit/test_embedded_models_lean_deps.py
@@ -1,0 +1,102 @@
+"""Guard: embedded local models (Apple FM + MLX) stay lean (#2615).
+
+Daniel 2026-06-25: ship BOTH on-device backends — Apple Foundation Models
+(subprocess to the Swift fm-bridge) and MLX (a separate mlx-lm server spoken
+to over HTTP via langchain-openai) — *without* dragging torch/transformers
+into the shipped engine.
+
+The "without heavy deps" half was previously enforced only by comments in
+pyproject.toml. These tests make it executable: if a future change adds a
+torch-class dependency to a *shipped* list, this fails loudly instead of
+silently bloating the bundle by hundreds of MB.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+
+# Heavy ML stacks that must never enter the shipped engine. MLX is the light
+# Apple-Silicon path and runs as its own mlx-lm *server* process (HTTP), so
+# even mlx-lm/mlx-vlm must not be imported into the engine.
+_FORBIDDEN_SHIPPED = {
+    "torch",
+    "torchvision",
+    "transformers",
+    "sentence-transformers",
+    "accelerate",
+    "pykeen",
+    "spacy",
+    "mlx",
+    "mlx-lm",
+    "mlx-vlm",
+    "opencv-python",
+    "opencv-python-headless",
+}
+
+
+def _pyproject() -> dict:
+    root = Path(__file__).resolve().parents[2]  # fichero-engine/
+    with open(root / "pyproject.toml", "rb") as fh:
+        return tomllib.load(fh)
+
+
+def _base_name(requirement: str) -> str:
+    """Strip version/extras: 'uvicorn[standard]>=1' -> 'uvicorn'."""
+    name = requirement.strip()
+    for sep in ("[", ">", "<", "=", "!", "~", ";", " "):
+        name = name.split(sep, 1)[0]
+    return name.strip().lower()
+
+
+def _shipped_lists() -> dict[str, list[str]]:
+    """The dependency lists that actually ship in the bundle.
+
+    Deliberately EXCLUDES [project.optional-dependencies] (kg/image/dev) —
+    those are local-dev extras where torch-class deps are allowed.
+    """
+    data = _pyproject()
+    briefcase = data["tool"]["briefcase"]["app"]["engine"]
+    return {
+        "briefcase.requires": briefcase.get("requires", []),
+        "project.dependencies": data["project"]["dependencies"],
+    }
+
+
+@pytest.mark.parametrize("list_name", ["briefcase.requires", "project.dependencies"])
+def test_shipped_deps_have_no_heavy_ml(list_name):
+    names = {_base_name(r) for r in _shipped_lists()[list_name]}
+    leaked = names & _FORBIDDEN_SHIPPED
+    assert not leaked, (
+        f"{list_name} ships heavy ML deps {sorted(leaked)} — #2615 requires "
+        "Apple FM (subprocess) and MLX (separate mlx-lm server over HTTP) to "
+        "stay out of the engine bundle. Move it to optional-dependencies."
+    )
+
+
+def test_apple_and_mlx_providers_are_registered_local():
+    """Both on-device backends are selectable and marked local/private."""
+    from fichero.providers import PROVIDERS, ProviderType
+
+    apple = PROVIDERS[ProviderType.apple]
+    assert apple.is_local, "Apple FM must be marked local (zero cloud calls)"
+
+    # MLX ships as the OpenAI-compatible 'omlx' provider (a local mlx-lm server).
+    omlx = PROVIDERS[ProviderType.omlx]
+    assert omlx.is_local, "MLX (omlx) must be marked local (on-device server)"
+
+
+def test_mlx_provider_uses_local_openai_compatible_base_url():
+    """omlx (MLX) talks to a localhost OpenAI-compatible server, keyless."""
+    from fichero.llm import _KEYLESS_OPENAI_COMPATIBLE, _OPENAI_COMPATIBLE_BASE_URLS
+
+    assert "omlx" in _OPENAI_COMPATIBLE_BASE_URLS
+    base = _OPENAI_COMPATIBLE_BASE_URLS["omlx"]
+    assert "localhost" in base or "127.0.0.1" in base, base
+    assert "omlx" in _KEYLESS_OPENAI_COMPATIBLE
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/fichero-engine/tests/unit/test_llm_embeddings.py
+++ b/fichero-engine/tests/unit/test_llm_embeddings.py
@@ -53,3 +53,39 @@ def test_remote_embeddings_run_when_paid_fallbacks_enabled(monkeypatch) -> None:
             result = llm_embeddings.embed(["hola"], model="text-embedding-3-small")
 
     assert result == [[0.1, 0.2]]
+
+
+class TestEmbeddingsClientCache:
+    """#2545 N1: the embed path reuses one client per (model, key) instead of
+    rebuilding per call, and credential changes drop stale clients."""
+
+    def setup_method(self):
+        llm_embeddings.clear_embeddings_client_cache()
+
+    def teardown_method(self):
+        llm_embeddings.clear_embeddings_client_cache()
+
+    def test_same_model_and_key_returns_cached_instance(self):
+        c1 = llm_embeddings._get_langchain_embeddings("text-embedding-3-small", "k1")
+        c2 = llm_embeddings._get_langchain_embeddings("text-embedding-3-small", "k1")
+        assert c1 is c2  # cached, not rebuilt
+
+    def test_different_key_returns_new_instance(self):
+        c1 = llm_embeddings._get_langchain_embeddings("text-embedding-3-small", "k1")
+        c2 = llm_embeddings._get_langchain_embeddings("text-embedding-3-small", "k2")
+        assert c1 is not c2
+
+    def test_clear_cache_forces_rebuild(self):
+        c1 = llm_embeddings._get_langchain_embeddings("text-embedding-3-small", "k1")
+        llm_embeddings.clear_embeddings_client_cache()
+        c2 = llm_embeddings._get_langchain_embeddings("text-embedding-3-small", "k1")
+        assert c1 is not c2
+
+    def test_clear_api_key_cache_invalidates_embedding_clients(self):
+        """A credential rotation (clear_api_key_cache) must also drop clients."""
+        from fichero.llm import clear_api_key_cache
+
+        c1 = llm_embeddings._get_langchain_embeddings("text-embedding-3-small", "k1")
+        clear_api_key_cache()
+        c2 = llm_embeddings._get_langchain_embeddings("text-embedding-3-small", "k1")
+        assert c1 is not c2

--- a/fichero-engine/tests/unit/test_routes_export.py
+++ b/fichero-engine/tests/unit/test_routes_export.py
@@ -316,3 +316,70 @@ class TestExcelExport:
         )
 
         assert r.status_code == 409
+
+
+class TestEleventySiteExport:
+    def test_publishes_collections_subcollections_and_scaffold(
+        self, client, db, tmp_path
+    ):
+        # root/ → Coleccion A/ (collection) → Subseccion/ (subcollection) → doc
+        root = Document(id="site-root", name="Archivo", doc_type=DocType.folder)
+        coll = Document(
+            id="coll-a", name="Coleccion A", parent_id=root.id,
+            doc_type=DocType.folder,
+        )
+        sub = Document(
+            id="sub-1", name="Subseccion", parent_id=coll.id,
+            doc_type=DocType.folder,
+        )
+        doc = Document(
+            id="doc-1", name="Carta Uno", parent_id=sub.id,
+            doc_type=DocType.file, file_type=FileType.text,
+            page_content="El contenido de la carta.",
+        )
+        for d in (root, coll, sub, doc):
+            db.save(d)
+
+        output_path = tmp_path / "site"
+        r = client.post(
+            "/api/export/eleventy-site",
+            json={"target_id": root.id, "output_path": str(output_path)},
+        )
+
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert data["document_count"] == 1
+        assert data["collection_count"] == 1  # "Coleccion A"
+
+        # Buildable + deployable scaffolding exists.
+        assert (output_path / "package.json").exists()
+        assert (output_path / ".eleventy.js").exists()
+        assert (output_path / "netlify.toml").exists()
+        assert (output_path / "src" / "index.md").exists()
+
+        # Folder hierarchy → collection/subcollection directories.
+        page = output_path / "src" / "Coleccion-A" / "Subseccion" / "Carta-Uno.md"
+        assert page.exists()
+        body = page.read_text()
+        assert "# Carta Uno" in body
+        assert "El contenido de la carta." in body
+        # Top-level folder is the 11ty collection tag.
+        assert "Coleccion-A" in body
+
+    def test_rejects_non_empty_output_without_overwrite(self, client, tmp_path):
+        output_path = tmp_path / "site"
+        output_path.mkdir()
+        (output_path / "existing.txt").write_text("x")
+
+        r = client.post(
+            "/api/export/eleventy-site",
+            json={"output_path": str(output_path)},
+        )
+        assert r.status_code == 409
+
+    def test_missing_target_returns_404(self, client, tmp_path):
+        r = client.post(
+            "/api/export/eleventy-site",
+            json={"target_id": "nope", "output_path": str(tmp_path / "site")},
+        )
+        assert r.status_code == 404

--- a/fichero-engine/tests/unit/test_start_backend_scheme_warning.py
+++ b/fichero-engine/tests/unit/test_start_backend_scheme_warning.py
@@ -1,0 +1,50 @@
+"""#2538: the launcher must loudly flag a plain-HTTP engine on the app's
+pinned port, instead of leaving the app with a silently dead Activity stream.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+from pathlib import Path
+
+import pytest
+
+_LAUNCHER = (
+    Path(__file__).resolve().parents[2] / "scripts" / "start_backend.py"
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("start_backend", _LAUNCHER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_warns_on_plain_http_on_app_port(caplog):
+    mod = _load()
+    with caplog.at_level(logging.WARNING):
+        mod._warn_if_app_unreachable("http", mod.APP_LOOPBACK_PORT)
+    assert any(
+        "silently fail" in r.message and "#2538" in r.message
+        for r in caplog.records
+    ), "plain HTTP on the pinned app port must warn loudly"
+
+
+@pytest.mark.parametrize(
+    "scheme,port",
+    [
+        ("https", 8765),  # correct: TLS on the app port
+        ("http", 9000),  # plain HTTP on some other (non-app) port is fine
+    ],
+)
+def test_no_warning_when_scheme_matches_or_other_port(scheme, port, caplog):
+    mod = _load()
+    with caplog.at_level(logging.WARNING):
+        mod._warn_if_app_unreachable(scheme, port)
+    assert not caplog.records, f"unexpected warning for {scheme}:{port}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/fichero-engine/tests/unit/test_workflow_import_parity.py
+++ b/fichero-engine/tests/unit/test_workflow_import_parity.py
@@ -1,0 +1,93 @@
+"""#2528: workflow import has parity with export — it validates against the
+typed NodeDef/EdgeDef models, fails loud on a bad file (no silent partial
+import), and round-trips with export to an identical graph.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+
+def _make_workflow(db):
+    """Create a stored workflow and return (workflow, export_payload dict)."""
+    from fichero.api.routes.workflows import create_workflow_impl
+    from fichero.workflows.types import WorkflowDef, NodeDef, EdgeDef
+
+    wf = create_workflow_impl(
+        db,
+        WorkflowDef(
+            id="wf-imp",
+            name="Round Trip",
+            description="export→import identical",
+            nodes=[
+                NodeDef(id="n1", tool="transcribe"),
+                NodeDef(id="n2", tool="describe"),
+            ],
+            edges=[EdgeDef(source="n1", target="n2")],
+        ),
+    )
+    # The export endpoint emits the raw stored node/edge dicts verbatim.
+    export_payload = {
+        "name": wf.name,
+        "description": wf.description,
+        "provider": wf.provider,
+        "model": wf.model,
+        "nodes": wf.nodes,
+        "edges": wf.edges,
+    }
+    return wf, export_payload
+
+
+class TestImportParity:
+    def test_export_import_round_trips_identical(self, db):
+        from fichero.api.routes.workflows import import_workflow_impl
+
+        _, payload = _make_workflow(db)
+        imported = import_workflow_impl(db, name="", description="", workflow_data=payload)
+
+        assert imported.nodes == payload["nodes"]
+        assert imported.edges == payload["edges"]
+        assert imported.name == "Round Trip"
+
+    def test_missing_nodes_or_edges_fails_loud(self, db):
+        from fichero.api.routes.workflows import import_workflow_impl
+
+        with pytest.raises(HTTPException) as exc:
+            import_workflow_impl(db, name="", description="", workflow_data={"nodes": []})
+        assert exc.value.status_code == 400
+
+    def test_malformed_node_fails_loud_and_persists_nothing(self, db):
+        from fichero.api.routes.workflows import import_workflow_impl
+        from fichero.models import Workflow
+
+        before = len(db.query(Workflow))
+        bad = {"nodes": ["not-a-node-dict"], "edges": []}
+        with pytest.raises(HTTPException) as exc:
+            import_workflow_impl(db, name="", description="", workflow_data=bad)
+        assert exc.value.status_code == 400
+        assert "node[0]" in exc.value.detail
+        # No silent partial import — nothing was saved.
+        assert len(db.query(Workflow)) == before
+
+    def test_malformed_edge_fails_loud(self, db):
+        from fichero.api.routes.workflows import import_workflow_impl
+
+        bad = {"nodes": [{"id": "n1", "tool": "transcribe"}], "edges": ["bad-edge"]}
+        with pytest.raises(HTTPException) as exc:
+            import_workflow_impl(db, name="", description="", workflow_data=bad)
+        assert exc.value.status_code == 400
+        assert "edge[0]" in exc.value.detail
+
+    def test_nodes_not_a_list_fails_loud(self, db):
+        from fichero.api.routes.workflows import import_workflow_impl
+
+        with pytest.raises(HTTPException) as exc:
+            import_workflow_impl(
+                db, name="", description="", workflow_data={"nodes": {}, "edges": []}
+            )
+        assert exc.value.status_code == 400
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/fichero-engine/tests/unit/workflows/test_entity_writer.py
+++ b/fichero-engine/tests/unit/workflows/test_entity_writer.py
@@ -1756,3 +1756,49 @@ class TestEmbeddingPrecisionGate:
         )
         rows = db.query(KnowledgeEntity, entity_type=EntityType.location)
         assert len(rows) == 1
+
+
+class TestMergeVectorFailureIsLoud:
+    """#2507: a failed vector refresh on the alias-merge path must be logged
+    loudly (like the new-entity index path), never silently swallowed — a
+    stale vector quietly degrades future fuzzy matches.
+    """
+
+    def test_merge_vector_failure_logs_and_still_merges(
+        self, db, monkeypatch, caplog
+    ):
+        import logging
+
+        from fichero.kg import entity_vectors
+        from fichero.workflows.tools._entity_writer import upsert_entity
+
+        # Force the SequenceMatcher (Stage 3) fuzzy-merge path: no embedding
+        # decision, and a fuzzy variant (not an exact name) so we land in the
+        # alias-refresh block that re-indexes the vector — not the Stage 1
+        # exact-match early return.
+        monkeypatch.setattr(entity_vectors, "find_similar", lambda **_: [])
+
+        first = upsert_entity(
+            db, canonical_name="San Pablo", entity_type=EntityType.location
+        )
+
+        # The merge-path vector refresh blows up; the catalogue must stay up.
+        def _boom(**_):
+            raise RuntimeError("vector backend down")
+
+        monkeypatch.setattr(entity_vectors, "index_entity", _boom)
+
+        with caplog.at_level(logging.WARNING):
+            # Typo-suffix variant → Stage 3 SequenceMatcher merge, which
+            # re-indexes the vector (the path that used to swallow failures).
+            second = upsert_entity(
+                db, canonical_name="San Pabloo", entity_type=EntityType.location
+            )
+
+        # Merge still happened (same id, catalogue not taken down)...
+        assert first == second
+        # ...and the failure was surfaced loudly, not swallowed.
+        assert any(
+            "failed to refresh merged entity vector" in r.message
+            for r in caplog.records
+        ), "merge-path vector failure must be logged, not silently passed"

--- a/fichero-engine/tests/unit/workflows/test_human_review_contract.py
+++ b/fichero-engine/tests/unit/workflows/test_human_review_contract.py
@@ -1,0 +1,77 @@
+"""#2529: typed human-in-the-loop contract.
+
+The payload a paused workflow surfaces must be one stable JSON-safe Pydantic
+shape (the SSE/Activity surface and the resume endpoint both depend on it),
+and ask_human() must round-trip whatever the resume call feeds back.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from fichero.workflows.human_review import HumanReviewRequest, ask_human
+
+
+def test_request_is_json_safe_and_has_defaults():
+    req = HumanReviewRequest(question="Which reading is correct?")
+    dumped = req.model_dump()
+    # JSON-safe primitives only — survives the interrupt boundary + SSE.
+    assert dumped["kind"] == "human_review"
+    assert dumped["question"] == "Which reading is correct?"
+    assert dumped["context"] == {}
+    assert dumped["options"] is None
+    assert dumped["node_id"] is None
+
+
+def test_request_carries_context_and_options():
+    req = HumanReviewRequest(
+        kind="bbox_htr",
+        question="What does this region say?",
+        context={"bbox": [1, 2, 3, 4], "draft": "ilegible"},
+        options=["accept", "edit"],
+        node_id="n-7",
+    )
+    d = req.model_dump()
+    assert d["kind"] == "bbox_htr"
+    assert d["context"]["bbox"] == [1, 2, 3, 4]
+    assert d["options"] == ["accept", "edit"]
+    assert d["node_id"] == "n-7"
+
+
+def test_ask_human_passes_typed_payload_and_returns_answer(monkeypatch):
+    """ask_human wraps interrupt() with the typed payload and returns its value."""
+    captured = {}
+
+    def _fake_interrupt(value):
+        captured["value"] = value
+        return "user typed answer"  # what Command(resume=...) would feed back
+
+    # langgraph.types.interrupt is imported lazily inside ask_human.
+    fake_mod = types.ModuleType("langgraph.types")
+    fake_mod.interrupt = _fake_interrupt
+    monkeypatch.setitem(sys.modules, "langgraph.types", fake_mod)
+
+    answer = ask_human(
+        "Confirm this entity?",
+        kind="entity_confirm",
+        context={"entity": "Bogotá"},
+        options=["yes", "no"],
+        node_id="n1",
+    )
+
+    assert answer == "user typed answer"
+    # The payload that crossed the boundary is the typed contract, as a dict.
+    assert captured["value"] == {
+        "kind": "entity_confirm",
+        "question": "Confirm this entity?",
+        "context": {"entity": "Bogotá"},
+        "options": ["yes", "no"],
+        "node_id": "n1",
+    }
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -9221,6 +9221,49 @@
         }
       }
     },
+    "/api/export/eleventy-site": {
+      "post": {
+        "tags": [
+          "export",
+          "export"
+        ],
+        "summary": "Export Eleventy Site Route",
+        "description": "Publish a library, folder, or subfolder as an 11ty/Netlify static site.",
+        "operationId": "export_eleventy_site_route_api_export_eleventy_site_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EleventySiteExportRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EleventySiteExportResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/export/markdown-folder": {
       "post": {
         "tags": [
@@ -40308,6 +40351,85 @@
         ],
         "title": "EdgeDef",
         "description": "Definition of an edge connecting two nodes via their ports.\n\nEdges define data flow between nodes. Each edge connects\nan output port on the source node to an input port on the target node."
+      },
+      "EleventySiteExportRequest": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path",
+            "description": "Destination folder for the site project"
+          },
+          "target_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Target Id",
+            "description": "Optional folder id to publish; omitted exports the library"
+          },
+          "recursive": {
+            "type": "boolean",
+            "title": "Recursive",
+            "description": "Include descendants of folders",
+            "default": true
+          },
+          "overwrite": {
+            "type": "boolean",
+            "title": "Overwrite",
+            "description": "Allow writing into a non-empty folder",
+            "default": false
+          },
+          "site_title": {
+            "type": "string",
+            "nullable": true,
+            "title": "Site Title",
+            "description": "Site title (defaults to the root folder name)"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "output_path"
+        ],
+        "title": "EleventySiteExportRequest",
+        "description": "Request body for 11ty/Netlify static-site export."
+      },
+      "EleventySiteExportResponse": {
+        "properties": {
+          "output_path": {
+            "type": "string",
+            "title": "Output Path"
+          },
+          "document_count": {
+            "type": "integer",
+            "title": "Document Count"
+          },
+          "collection_count": {
+            "type": "integer",
+            "title": "Collection Count"
+          },
+          "files": {
+            "items": {
+              "$ref": "#/components/schemas/ExportedFileResponse"
+            },
+            "type": "array",
+            "title": "Files"
+          },
+          "assets": {
+            "items": {
+              "$ref": "#/components/schemas/ExportedFileResponse"
+            },
+            "type": "array",
+            "title": "Assets"
+          }
+        },
+        "type": "object",
+        "required": [
+          "output_path",
+          "document_count",
+          "collection_count",
+          "files",
+          "assets"
+        ],
+        "title": "EleventySiteExportResponse"
       },
       "EmbedClaimsResponse": {
         "properties": {


### PR DESCRIPTION
Backend lane batch. ruff clean + 112 focused tests pass.
- #2507 log loudly on entity vector refresh failure (no silent fallback)
- #2538 warn loudly when engine serves plain HTTP on the pinned port
- #2528 validate workflow import against typed models, fail loud
- #2529 typed human-in-the-loop contract + ask_human()
- #2535 11ty/Netlify static-site export target
- #2615 test enforcing lean shipped deps (Apple FM + MLX)
- #2545 cache OpenAIEmbeddings client (N+1)
Authored by Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)