### PR TITLE
backend: fix #2545 embedding managed-cache-dir regression + cli formatter tests (#1982)

### DIFF
--- a/fichero-engine/src/fichero/db_embeddings.py
+++ b/fichero-engine/src/fichero/db_embeddings.py
@@ -720,10 +720,13 @@ class DatabaseEmbeddingMixin:
                 self._embedder = _get_shared_embedder(
                     space.fastembed_model_name, str(cache_dir)
                 )
-            except ImportError:
+            except ImportError as exc:
+                # Chain the real cause (#2507): a non-fastembed ImportError
+                # (e.g. a bad submodule import) used to be masked as the
+                # generic "fastembed not installed", hiding the actual failure.
                 raise ImportError(
                     "fastembed not installed. Install with: pip install fastembed"
-                )
+                ) from exc
 
     def _embed_text(self, text: str, *, role: EmbeddingRole = "query") -> list[float]:
         """Generate embedding vector for text.

--- a/fichero-engine/tests/unit/test_cli_client.py
+++ b/fichero-engine/tests/unit/test_cli_client.py
@@ -624,3 +624,50 @@ def test_context_manager_closes(monkeypatch):
     with _client(handler) as c:
         c.health()
     assert c._client.is_closed
+
+
+# -- Mind Palace + KG wrappers (#1982 coverage) -----------------------------
+class TestMindPalaceWrappers:
+    """Thin HTTP passthroughs — verify method, path, and JSON body shape."""
+
+    def test_mp_get_room_builds_get(self):
+        handler, seen = _capture()
+        _client(handler).mp_get_room("room-1")
+        assert seen[0].method == "GET"
+        assert seen[0].url.path == "/api/mind-palace/rooms/room-1"
+
+    def test_mp_create_stack_posts_body(self):
+        handler, seen = _capture()
+        _client(handler).mp_create_stack(
+            "room-1", name="Group", node_ids=["n1", "n2"], position_x=3.0
+        )
+        assert seen[0].method == "POST"
+        assert seen[0].url.path == "/api/mind-palace/stacks"
+        body = json.loads(seen[0].content)
+        assert body["room_id"] == "room-1"
+        assert body["name"] == "Group"
+        assert body["node_ids"] == ["n1", "n2"]
+        assert body["position_x"] == 3.0
+
+    def test_mp_create_stack_defaults_node_ids_to_empty_list(self):
+        handler, seen = _capture()
+        _client(handler).mp_create_stack("room-1")
+        assert json.loads(seen[0].content)["node_ids"] == []
+
+    def test_mp_add_to_stack_builds_post_path(self):
+        handler, seen = _capture()
+        _client(handler).mp_add_to_stack("stack-9", "node-4")
+        assert seen[0].method == "POST"
+        assert seen[0].url.path == "/api/mind-palace/stacks/stack-9/nodes/node-4"
+
+    def test_mp_remove_from_stack_builds_delete_path(self):
+        handler, seen = _capture()
+        _client(handler).mp_remove_from_stack("stack-9", "node-4")
+        assert seen[0].method == "DELETE"
+        assert seen[0].url.path == "/api/mind-palace/stacks/stack-9/nodes/node-4"
+
+    def test_mp_get_viewport_uses_user_id(self):
+        handler, seen = _capture()
+        _client(handler).mp_get_viewport("room-1", user_id="alice")
+        assert seen[0].method == "GET"
+        assert seen[0].url.path == "/api/mind-palace/rooms/room-1/viewport/alice"

--- a/fichero-engine/tests/unit/test_cli_formatters.py
+++ b/fichero-engine/tests/unit/test_cli_formatters.py
@@ -1,0 +1,130 @@
+"""Unit tests for fichero.cli.formatters (#1982 — python/cli coverage).
+
+The render_* helpers are pure functions over dicts / Pydantic models — no HTTP,
+no backend. They drive every `fichero` CLI line, so their human + --json output
+and missing-field handling are worth pinning.
+"""
+
+from __future__ import annotations
+
+import json
+
+from fichero.cli.formatters import (
+    render,
+    render_claim,
+    render_document,
+    render_entity,
+    render_top_entity,
+)
+
+
+class TestRenderEntity:
+    def test_human_aligns_name_type_description(self):
+        out = render_entity(
+            {
+                "canonical_name": "Bogotá",
+                "entity_type": "location",
+                "description": "Capital city",
+            }
+        )
+        assert "Bogotá" in out
+        assert "location" in out
+        assert "Capital city" in out
+
+    def test_missing_fields_show_placeholder(self):
+        out = render_entity({})
+        assert "(missing)" in out
+
+    def test_long_description_truncated_with_ellipsis(self):
+        out = render_entity(
+            {"canonical_name": "X", "entity_type": "t", "description": "d" * 80}
+        )
+        assert "..." in out
+        # 50-char cap + ellipsis, never the full 80.
+        assert "d" * 80 not in out
+
+    def test_json_mode_is_valid_json_roundtrip(self):
+        data = {"canonical_name": "Lima", "entity_type": "location"}
+        out = render_entity(data, as_json=True)
+        assert json.loads(out)["canonical_name"] == "Lima"
+
+
+class TestRenderClaim:
+    def test_human_renders_subject_predicate_object_and_source(self):
+        out = render_claim(
+            {
+                "subject_canonical": "Alfonso",
+                "predicate_verb": "owned",
+                "object_phrase": "the mill",
+                "source_document_id": "doc-7",
+            }
+        )
+        assert "Alfonso" in out
+        assert "→" in out
+        assert "owned" in out
+        assert "the mill" in out
+        assert "doc-7" in out
+
+    def test_missing_fields_placeholder(self):
+        out = render_claim({})
+        assert "(missing)" in out
+
+    def test_json_mode(self):
+        out = render_claim({"subject_canonical": "A"}, as_json=True)
+        assert json.loads(out)["subject_canonical"] == "A"
+
+
+class TestRenderDocument:
+    def test_human_prefers_filename_then_name(self):
+        assert "letter.txt" in render_document(
+            {"filename": "letter.txt", "doc_type": "file"}
+        )
+        # Falls back to name when filename absent.
+        assert "Folder One" in render_document(
+            {"name": "Folder One", "doc_type": "folder"}
+        )
+
+    def test_doc_type_and_truncated_description(self):
+        out = render_document(
+            {"filename": "f", "doc_type": "file", "description": "z" * 80}
+        )
+        assert "[file]" in out
+        assert "..." in out
+
+    def test_json_mode(self):
+        out = render_document({"filename": "f.txt"}, as_json=True)
+        assert json.loads(out)["filename"] == "f.txt"
+
+
+class TestRenderDispatch:
+    """render() routes to the specialized formatter by key signature."""
+
+    def test_entity_dispatch(self):
+        out = render({"canonical_name": "Cali", "entity_type": "location"})
+        assert "Cali" in out
+
+    def test_claim_dispatch(self):
+        out = render({"subject_canonical": "A", "predicate_verb": "is"})
+        assert "→" in out
+
+    def test_document_dispatch(self):
+        out = render({"filename": "a.txt", "doc_type": "file"})
+        assert "a.txt" in out
+
+    def test_envelope_list_unwrapped(self):
+        out = render({"entities": [{"id": "e1", "canonical_name": "Uno"}]})
+        assert "entities (1)" in out
+        assert "Uno" in out
+
+    def test_empty_list_is_marked(self):
+        assert render([]) == "(empty)"
+
+    def test_none_is_no_data(self):
+        assert render(None) == "(no data)"
+
+
+def test_render_top_entity_columns():
+    out = render_top_entity({"name": "Marshall", "kind": "person", "claim_count": 12})
+    assert "Marshall" in out
+    assert "person" in out
+    assert "12" in out

--- a/fichero-engine/tests/unit/test_db.py
+++ b/fichero-engine/tests/unit/test_db.py
@@ -1388,10 +1388,15 @@ class TestEmbeddingsModelLoading:
 
         fake_fastembed = types.SimpleNamespace(TextEmbedding=FakeTextEmbedding)
         monkeypatch.setitem(sys.modules, "fastembed", fake_fastembed)
+        # _ensure_embedder registers the model via _register_fastembed_model_for_space
+        # (the embedding-space refactor, #2542); stub THAT — the previously-patched
+        # _register_pinned_fastembed_model is no longer on the call path, so the real
+        # `from fastembed.common.model_description import ...` ran against the fake
+        # fastembed namespace and raised (masked as "fastembed not installed").
         monkeypatch.setattr(
             db_embeddings_module,
-            "_register_pinned_fastembed_model",
-            lambda: None,
+            "_register_fastembed_model_for_space",
+            lambda _space: None,
         )
         monkeypatch.delenv("FICHERO_EMBED_MODEL", raising=False)
         db_embeddings_module._EMBEDDER_CACHE.clear()


### PR DESCRIPTION
Un-reds main: the #2545 embedding-client caching regressed test_embedder_uses_managed_cache_dir; repaired after the embedding-space refactor. + #1982 cli formatter + mind-palace client wrapper tests. ruff clean, target tests green. Authored as Claude.