### PR TITLE
merge: gate IIIF server mode to dev tier (#378)

### DIFF
--- a/fichero-engine/src/fichero/api/main.py
+++ b/fichero-engine/src/fichero/api/main.py
@@ -1374,7 +1374,6 @@ _CORE_ROUTE_SPECS: list[RouteSpec] = [
     (mind_palace.router, "/api/mind-palace", ["mind-palace"]),
     (mindpalace_render.router, "/api", ["mind-palace"]),
     (research_agents.router, "/api/research", ["research"]),
-    (iiif.router, "/api/iiif", ["iiif"]),
     # Action layer registry (EPIC #1848 keystone #2013). Registered BEFORE
     # actions.router so its static /actions/{invoke,registry,audit/...} paths win
     # over the Action Library's /actions/{action_id} dynamic segment.
@@ -1393,7 +1392,9 @@ _CORE_ROUTE_SPECS: list[RouteSpec] = [
 # (Daniel 2026-05-28). Kept as an empty list so the tier plumbing
 # (get_route_specs_for_tier) stays intact; re-add a spec here to demote a
 # feature back to dev-only.
-_DEV_ROUTE_SPECS: list[RouteSpec] = []
+_DEV_ROUTE_SPECS: list[RouteSpec] = [
+    (iiif.router, "/api/iiif", ["iiif"]),
+]
 
 
 def resolve_feature_tier() -> str:

--- a/fichero-engine/tests/unit/test_feature_tier_routing.py
+++ b/fichero-engine/tests/unit/test_feature_tier_routing.py
@@ -75,6 +75,17 @@ def test_release_tier_promotes_mind_palace_and_research_agents():
     )
 
 
+def test_iiif_server_mode_is_dev_tier_only():
+    assert not any(
+        prefix == "/api/iiif" and "iiif" in tags
+        for _, prefix, tags in get_route_specs_for_tier("release")
+    )
+    assert any(
+        prefix == "/api/iiif" and "iiif" in tags
+        for _, prefix, tags in get_route_specs_for_tier("dev")
+    )
+
+
 def test_invalid_tier_defaults_to_release(monkeypatch):
     monkeypatch.setenv("FICHERO_FEATURE_TIER", "invalid-tier")
     assert resolve_feature_tier() == "release"


### PR DESCRIPTION
Codex remote lane: gate IIIF image-server mode behind the dev feature tier in api/main.py (#378). Adds test_feature_tier_routing coverage.

Gate: ruff clean + tier-routing tests 5 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)