### PR TITLE
fix(P0): single-user local auth by default + workflow preset typing (#2721 #2720)

### DIFF
--- a/fichero-engine/src/fichero/multiuser.py
+++ b/fichero-engine/src/fichero/multiuser.py
@@ -24,12 +24,21 @@ def _truthy(value: str | None) -> bool:
 def multiuser_enabled(env: Mapping[str, str] | None = None) -> bool:
     """Return True when per-user auth/pairing should be active.
 
-    Multi-user auth is enabled by default. Explicit `FICHERO_MULTIUSER=0` is
-    the off switch for development/tests that need the legacy single-user
-    behavior. Remote-facing deployment signals also force it on:
+    Multi-user auth is **opt-in**. A fresh single-user local launch has no
+    account/ACL rows, so turning the per-user authorizer on by default denied
+    the Mac owner read/write to its own library (401 on app-wide routes, 403
+    on library routes — #2721). Single-user local therefore defaults OFF and
+    keeps the loopback + bootstrap-token trust model (#742); the ACL layer
+    only matters once real accounts exist.
+
+    It turns ON when explicitly requested (`FICHERO_MULTIUSER=1`) or when a
+    genuinely network-facing deployment signal is present:
     - Bonjour advertisement
     - a configured public/private reachable URL for clients
     - a deliberate non-loopback bind host
+
+    Explicit `FICHERO_MULTIUSER=0` forces it off even under those signals
+    (development/tests).
     """
 
     source = env if env is not None else os.environ
@@ -48,4 +57,4 @@ def multiuser_enabled(env: Mapping[str, str] | None = None) -> bool:
         if host and not _is_loopback_host(host):
             return True
 
-    return True
+    return False

--- a/fichero-engine/tests/unit/test_authz_management_adversarial.py
+++ b/fichero-engine/tests/unit/test_authz_management_adversarial.py
@@ -61,10 +61,10 @@ def _grant(app_db, user: AccountUser, library_path: str, role: str) -> None:
         ("YES", True),
         ("off", False),
         ("0", False),
-        # Empty/unset is NOT an off-signal: multiuser is enabled by default
-        # (fichero/multiuser.py). An empty string falls through to the
-        # default-on path, so the expectation is True, not False.
-        ("", True),
+        # Empty/unset falls through to the default: multiuser is OPT-IN, so a
+        # single-user local launch with no explicit flag and no remote signal
+        # stays OFF (fichero/multiuser.py, #2721).
+        ("", False),
     ],
 )
 def test_multiuser_enabled_parses_truthy_and_falsey_values(monkeypatch, raw, expected):

--- a/fichero-engine/tests/unit/test_fresh_launch_authz.py
+++ b/fichero-engine/tests/unit/test_fresh_launch_authz.py
@@ -1,0 +1,63 @@
+"""Regression: a fresh single-user local launch is fully authorized (#2721).
+
+Daniel hit 401 on app-wide routes (registry/providers) and 403 on library
+routes (documents/workflows/chat/search) at first launch: the per-user ACL
+layer was on by default but a fresh install has no account/role rows, so the
+authorizer denied the Mac owner access to its own library.
+
+These tests assert that, under the DEFAULT environment (no FICHERO_MULTIUSER,
+no remote signals), the loopback bootstrap token authorizes every route.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from fichero.multiuser import multiuser_enabled
+
+
+_APP_WIDE_ROUTES = ["/api/registry", "/api/providers"]
+_LIBRARY_ROUTES = [
+    "/api/documents",
+    "/api/workflows",
+    "/api/chat/conversations",
+    "/api/search/saved",
+]
+
+
+@pytest.fixture
+def fresh_launch(client, test_package):
+    # Shared `client` fixture already attaches the bootstrap-token middleware
+    # and authenticates over loopback; single-user is the default (#2721).
+    client.headers["X-Fichero-Library-Path"] = str(test_package)
+    return client
+
+
+def test_fresh_launch_defaults_to_single_user(monkeypatch):
+    for name in (
+        "FICHERO_MULTIUSER",
+        "FICHERO_PUBLIC_BASE_URL",
+        "FICHERO_ENABLE_BONJOUR",
+        "FICHERO_BIND_HOST",
+        "FICHERO_REMOTE_BACKEND_BIND_HOST",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    assert multiuser_enabled() is False
+
+
+def test_fresh_launch_app_wide_routes_not_401(fresh_launch):
+    for path in _APP_WIDE_ROUTES:
+        response = fresh_launch.get(path)
+        assert response.status_code != 401, f"401 on {path}: {response.text}"
+
+
+def test_fresh_launch_library_routes_not_403(fresh_launch):
+    for path in _LIBRARY_ROUTES:
+        response = fresh_launch.get(path)
+        assert response.status_code != 403, f"403 on {path}: {response.text}"
+
+
+def test_fresh_launch_all_routes_authorized(fresh_launch):
+    for path in _APP_WIDE_ROUTES + _LIBRARY_ROUTES:
+        response = fresh_launch.get(path)
+        assert response.status_code == 200, f"{response.status_code} on {path}: {response.text}"

--- a/fichero-engine/tests/unit/test_multiuser.py
+++ b/fichero-engine/tests/unit/test_multiuser.py
@@ -13,16 +13,17 @@ def test_multiuser_enabled_explicit_flag(monkeypatch):
     assert authz.multiuser_enabled() is True
 
 
-def test_multiuser_enabled_by_default(monkeypatch):
+def test_multiuser_disabled_by_default(monkeypatch):
+    """Single-user local launch is opt-in: multiuser OFF unless signalled (#2721)."""
     monkeypatch.delenv("FICHERO_MULTIUSER", raising=False)
     monkeypatch.delenv("FICHERO_PUBLIC_BASE_URL", raising=False)
     monkeypatch.delenv("FICHERO_ENABLE_BONJOUR", raising=False)
     monkeypatch.delenv("FICHERO_BIND_HOST", raising=False)
     monkeypatch.delenv("FICHERO_REMOTE_BACKEND_BIND_HOST", raising=False)
 
-    assert multiuser_enabled() is True
-    assert _use_multiuser_auth() is True
-    assert authz.multiuser_enabled() is True
+    assert multiuser_enabled() is False
+    assert _use_multiuser_auth() is False
+    assert authz.multiuser_enabled() is False
 
 
 def test_multiuser_enabled_by_public_base_url(monkeypatch):

--- a/fichero-engine/tests/unit/workflows/test_workflow_persistence_typing.py
+++ b/fichero-engine/tests/unit/workflows/test_workflow_persistence_typing.py
@@ -231,3 +231,34 @@ def test_all_shipped_presets_load_and_validate():
             # every edge has the canonical endpoint key after normalization
             assert "source" in edge
             assert "source_port" in edge
+
+
+def test_all_shipped_presets_compile_to_runtime_graph():
+    """Every bundled preset must also survive the runtime EdgeDef graph build.
+
+    The seed/storage boundary above validates edges, but the executable path
+    (`to_workflow_def` -> `EdgeDef`) is where a route-style edge with a missing
+    `target`/`route_map` blows up with
+    'EdgeDef.target is required for non-route_map edges' (#2720). Sweep every
+    preset through that path so a malformed route edge can never ship again.
+    """
+    from fichero.workflows.runtime import to_workflow_def
+
+    files = _preset_files()
+    assert files, "expected packaged preset JSON to exist"
+    for path in files:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not data.get("name"):
+            continue
+        wf = Workflow(
+            name=data["name"],
+            nodes=data.get("nodes", []),
+            edges=data.get("edges", []),
+            format=data.get("format", "nodes"),
+        )
+        wd = to_workflow_def(wf)
+        for edge in wd.edges:
+            # A route edge declares route_map; a plain edge must name a target.
+            assert edge.route_map is not None or edge.target, (
+                f"{path.name}: edge {edge.id!r} has neither target nor route_map"
+            )


### PR DESCRIPTION
**P0 — fixes the 401/403 errors Daniel hit launching the app.**

#2721: `multiuser_enabled()` now defaults **OFF** for single-user local launches. A fresh local install has no account/ACL rows, so defaulting the per-user authorizer ON denied the Mac owner read/write to its own library (401 app-wide, 403 library routes). Local loopback keeps the bootstrap-token trust model (#742).

**Network perimeter preserved:** the remote-facing forcing branches are UNCHANGED — Bonjour advertisement, a configured reachable URL, or a non-loopback bind host all still force multiuser ON. `FICHERO_MULTIUSER=1` opts in explicitly; `=0` forces off. Matches the documented opt-in model (loopback + tailscale-serve perimeter). The adversarial authz test was updated only for the empty-string default expectation; the explicit-on and remote-signal assertions are intact.

#2720: sweep every bundled preset through the runtime EdgeDef graph (catches the workflow-seed validation error) + workflow-persistence typing test.

Gate: ruff clean + **full unit suite 5823 passed, 0 failed** (21 skipped, 26 xfailed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)