### PR TITLE
merge: annotation anchors + ephemeral crop endpoint (#2256)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/annotations.py
+++ b/fichero-engine/src/fichero/api/routes/annotations.py
@@ -345,20 +345,14 @@ async def delete_annotation(
     )
 
 
-@router.get(
-    "/{annotation_id}/crop",
-    summary="Cropped content for this annotation (text body or image bytes)",
-    description=(
-        "Returns the annotation's underlying content cropped to its "
-        "anchor: substring for text, PNG bytes for image / PDF region. "
-        "Workflow tools call this to feed only the highlighted region "
-        "to vision / LLM providers instead of the whole document. (#914)"
-    ),
-)
-async def get_crop(
-    annotation_id: str,
-    db: Database = Depends(get_library_database),
-):
+def _crop_response(db: Database, ann: Annotation):
+    """Resolve an annotation's cropped content to an HTTP response.
+
+    Shared by ``GET /{id}/crop`` (a persisted annotation) and the ephemeral
+    ``POST /crop`` (an unsaved region) so both drive identical crop logic
+    (iterate-not-replace, #2256). Works on any in-memory ``Annotation`` — it
+    never touches the annotation table, only the source ``Document``.
+    """
     from fastapi.responses import PlainTextResponse, Response
 
     from fichero.workflows.tools._annotation_input import (
@@ -367,9 +361,6 @@ async def get_crop(
         crop_text,
     )
 
-    ann = db.get(Annotation, annotation_id)
-    if ann is None:
-        raise HTTPException(404, f"Annotation not found: {annotation_id}")
     if ann.document_id is None:
         raise HTTPException(400, "Folder-scoped annotations do not have crop content")
     doc = db.get(Document, ann.document_id)
@@ -392,6 +383,70 @@ async def get_crop(
     if text is None:
         raise HTTPException(404, "No crop available for this annotation")
     return PlainTextResponse(text)
+
+
+@router.get(
+    "/{annotation_id}/crop",
+    summary="Cropped content for this annotation (text body or image bytes)",
+    description=(
+        "Returns the annotation's underlying content cropped to its "
+        "anchor: substring for text, PNG bytes for image / PDF region. "
+        "Workflow tools call this to feed only the highlighted region "
+        "to vision / LLM providers instead of the whole document. (#914)"
+    ),
+)
+async def get_crop(
+    annotation_id: str,
+    db: Database = Depends(get_library_database),
+):
+    ann = db.get(Annotation, annotation_id)
+    if ann is None:
+        raise HTTPException(404, f"Annotation not found: {annotation_id}")
+    return _crop_response(db, ann)
+
+
+class EphemeralCropRequest(BaseModel):
+    """A region to crop WITHOUT persisting an annotation (#2256).
+
+    Lets the reader send the LLM/vision provider just the marked region of a
+    document on the fly — the user is still deciding, so nothing is saved.
+    """
+
+    document_id: str
+    kind: AnnotationKind = AnnotationKind.highlight
+    bbox: list[float] | None = None
+    char_start: int | None = None
+    char_end: int | None = None
+    page_index: int | None = None
+    page_label: str | None = None
+    text: str | None = None
+
+
+@router.post(
+    "/crop",
+    summary="Ephemeral crop for an unsaved region (no annotation persisted)",
+    description=(
+        "Crops a document to a transient region (bbox / char range) and returns "
+        "the content — substring for text, PNG bytes for image / PDF — WITHOUT "
+        "creating an annotation. The reader uses this to feed only the region "
+        "under consideration to a provider before the user commits. (#2256)"
+    ),
+)
+async def crop_ephemeral(
+    request: EphemeralCropRequest,
+    db: Database = Depends(get_library_database),
+):
+    ann = Annotation(
+        document_id=request.document_id,
+        kind=request.kind,
+        bbox=request.bbox,
+        char_start=request.char_start,
+        char_end=request.char_end,
+        page_index=request.page_index,
+        page_label=request.page_label,
+        text=request.text,
+    )
+    return _crop_response(db, ann)
 
 
 class PromoteResponse(BaseModel):

--- a/fichero-engine/src/fichero/api/routes/annotations.py
+++ b/fichero-engine/src/fichero/api/routes/annotations.py
@@ -42,6 +42,8 @@ class AnnotationCreateRequest(BaseModel):
     char_start: int | None = None
     char_end: int | None = None
     bbox: list[float] | None = None
+    anchor_kind: str | None = None
+    paragraph_index: int | None = None
     text: str | None = None
     rating: int | None = None
     color: str | None = None
@@ -234,6 +236,8 @@ class AnnotationPatchRequest(BaseModel):
     char_start: int | None = None
     char_end: int | None = None
     bbox: list[float] | None = None
+    anchor_kind: str | None = None
+    paragraph_index: int | None = None
     metadata: dict[str, Any] | None = None
 
 

--- a/fichero-engine/src/fichero/knowledge/knowledge_models.py
+++ b/fichero-engine/src/fichero/knowledge/knowledge_models.py
@@ -1354,6 +1354,15 @@ class Annotation(BaseModel):
         default=None,
         description="Bounding box [x, y, width, height] as fractions of source dimensions in [0, 1].",
     )
+    # How this annotation is anchored to its source — lets the reader render the
+    # right control (text highlight vs image box vs a paragraph checkmark) and
+    # lets workflows pick the right crop mode (#2256). Free-form string rather
+    # than an enum so the additive UI vocabulary can grow without a model bump;
+    # expected values today: "char_range", "bbox", "paragraph", "ink".
+    anchor_kind: str | None = None
+    # 0-indexed paragraph within the page, set when anchor_kind == "paragraph"
+    # (paragraph checkmarks). Resolved against page_content paragraph offsets.
+    paragraph_index: int | None = None
 
     kind: AnnotationKind
     text: str | None = None  # note body / comment text / bookmark label

--- a/fichero-engine/tests/unit/test_annotations.py
+++ b/fichero-engine/tests/unit/test_annotations.py
@@ -426,3 +426,57 @@ class TestAnnotationAnchorFields:
         data = resp.json()
         assert data["anchor_kind"] is None
         assert data["paragraph_index"] is None
+
+
+# ---------------------------------------------------------------------------
+# Ephemeral crop — POST /annotations/crop (#2256)
+# ---------------------------------------------------------------------------
+
+
+class TestEphemeralCrop:
+    """POST /annotations/crop returns cropped content WITHOUT persisting."""
+
+    def test_text_crop_by_char_offsets(self, client, doc):
+        # doc.page_content == "Hello world. This is the document body."
+        resp = client.post(
+            "/api/annotations/crop",
+            json={"document_id": doc.id, "char_start": 0, "char_end": 5},
+        )
+        assert resp.status_code == 200
+        assert resp.text == "Hello"
+
+    def test_text_crop_falls_back_to_request_text(self, client, doc):
+        resp = client.post(
+            "/api/annotations/crop",
+            json={"document_id": doc.id, "kind": "note", "text": "free note"},
+        )
+        assert resp.status_code == 200
+        assert resp.text == "free note"
+
+    def test_unknown_document_returns_404(self, client):
+        resp = client.post(
+            "/api/annotations/crop",
+            json={"document_id": "does-not-exist", "char_start": 0, "char_end": 3},
+        )
+        assert resp.status_code == 404
+
+    def test_missing_document_id_is_422(self, client):
+        resp = client.post("/api/annotations/crop", json={"char_start": 0, "char_end": 3})
+        assert resp.status_code == 422
+
+    def test_no_crop_available_returns_404(self, client, doc):
+        # bookmark with neither offsets nor text → nothing to crop.
+        resp = client.post(
+            "/api/annotations/crop",
+            json={"document_id": doc.id, "kind": "bookmark"},
+        )
+        assert resp.status_code == 404
+
+    def test_crop_persists_nothing(self, client, doc):
+        before = client.get("/api/annotations", params={"document_id": doc.id}).json()["count"]
+        client.post(
+            "/api/annotations/crop",
+            json={"document_id": doc.id, "char_start": 0, "char_end": 5},
+        )
+        after = client.get("/api/annotations", params={"document_id": doc.id}).json()["count"]
+        assert before == after == 0

--- a/fichero-engine/tests/unit/test_annotations.py
+++ b/fichero-engine/tests/unit/test_annotations.py
@@ -331,3 +331,98 @@ class TestCropText:
         )
         ann = Annotation(document_id="d3", kind=AnnotationKind.bookmark)
         assert crop_text(doc, ann) is None
+
+
+# ---------------------------------------------------------------------------
+# Additive anchor fields + ink metadata (#2256)
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotationAnchorFields:
+    """anchor_kind / paragraph_index / ink metadata are additive (#2256).
+
+    Pre-existing libraries created before these fields existed must keep
+    working: the DB column reconcile (ALTER TABLE ADD COLUMN) is what makes
+    the no-migration rule hold, so a persistence round-trip is the regression
+    that proves a new field doesn't break save()/get() on the annotation table.
+    """
+
+    def test_create_with_anchor_kind_and_paragraph_index(self, client, doc):
+        resp = client.post(
+            "/api/annotations",
+            json={
+                "document_id": doc.id,
+                "kind": "highlight",
+                "anchor_kind": "paragraph",
+                "paragraph_index": 3,
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["anchor_kind"] == "paragraph"
+        assert data["paragraph_index"] == 3
+
+    def test_anchor_fields_persist_round_trip(self, client, db, doc):
+        resp = client.post(
+            "/api/annotations",
+            json={
+                "document_id": doc.id,
+                "kind": "highlight",
+                "anchor_kind": "bbox",
+                "paragraph_index": 0,
+            },
+        )
+        ann_id = resp.json()["id"]
+        # Read back through the DB layer (not just the response echo) to prove
+        # the columns were actually persisted, not silently dropped.
+        stored = db.get(Annotation, ann_id)
+        assert stored is not None
+        assert stored.anchor_kind == "bbox"
+        assert stored.paragraph_index == 0
+
+    def test_create_with_ink_metadata(self, client, doc):
+        # The ink fields live in the free `metadata` dict (extra="allow"), so
+        # they need no schema column — but they must round-trip intact.
+        resp = client.post(
+            "/api/annotations",
+            json={
+                "document_id": doc.id,
+                "kind": "note",
+                "anchor_kind": "ink",
+                "text": "transcribed ink",
+                "metadata": {
+                    "ink_data": "base64-pencilkit-stroke-data",
+                    "ocr_provider": "apple_vision",
+                },
+            },
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["anchor_kind"] == "ink"
+        assert data["metadata"]["ink_data"] == "base64-pencilkit-stroke-data"
+        assert data["metadata"]["ocr_provider"] == "apple_vision"
+
+    def test_patch_sets_anchor_fields(self, client, db, doc):
+        ann = Annotation(document_id=doc.id, kind=AnnotationKind.highlight)
+        db.save(ann)
+        resp = client.patch(
+            f"/api/annotations/{ann.id}",
+            json={"anchor_kind": "paragraph", "paragraph_index": 7},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["anchor_kind"] == "paragraph"
+        assert data["paragraph_index"] == 7
+        assert db.get(Annotation, ann.id).paragraph_index == 7
+
+    def test_defaults_none_when_omitted(self, client, doc):
+        # Backward compatibility: a client that never sends the new fields gets
+        # nulls, exactly as before they existed.
+        resp = client.post(
+            "/api/annotations",
+            json={"document_id": doc.id, "kind": "note", "text": "plain"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["anchor_kind"] is None
+        assert data["paragraph_index"] is None

--- a/fichero-engine/tests/unit/test_route_write_authz_guardrail.py
+++ b/fichero-engine/tests/unit/test_route_write_authz_guardrail.py
@@ -17,6 +17,7 @@ MUTATING_METHODS = {"post", "put", "patch", "delete"}
 # Mutating HTTP verbs are sometimes used for read-only compute/export operations.
 # They may keep the read dependency only when listed here with a reason.
 READ_ONLY_MUTATING_VERB_ALLOWLIST: dict[str, str] = {
+    "annotations.py:crop_ephemeral:POST": "POST body selects a transient region; handler builds an in-memory Annotation, reads only the source document, and returns a crop — persists nothing (#2256).",
     "bibliography.py:export_bibtex:POST": "POST body selects document IDs; handler only reads metadata and returns BibTeX.",
     "hermeneutics.py:suggest_interpretations:POST": "POST body contains suggestion parameters; handler only reads active frameworks.",
     "kg_predictions.py:generate_heuristic_predictions:POST": "POST body contains prediction parameters; handler only reads claims and vector index.",


### PR DESCRIPTION
onboarding lane (Claude), #2256:
- additive Annotation anchor fields (anchor_kind, paragraph_index) on knowledge_models
- ephemeral POST /annotations/crop — returns a cropped image, persists NO annotation

**Security note:** the crop route is added to the write-authz guardrail allowlist (test_route_write_authz_guardrail.py) because it is genuinely ephemeral and writes nothing to the library DB — it does not need the write-authorized DB dependency. First gate run correctly CAUGHT the missing dependency; worker fixed via the justified allowlist. Flagging for your awareness.

Gate: ruff clean + **full unit suite 5973 passed, 0 failed** (incl. the write-authz guardrail, now green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)