### PR TITLE
merge: lazy bootstrap-token + observer baseline + AppKit audit (#2388 #2378 #2101)

### DIFF
--- a/docs/architecture/swiftui/appkit_import_audit_2101.md
+++ b/docs/architecture/swiftui/appkit_import_audit_2101.md
@@ -1,0 +1,57 @@
+# AppKit / UIKit Import Audit (#2101)
+
+Status: captured for the iOS/iPad remote-client port.
+
+Rule: SwiftUI first. AppKit/UIKit imports are allowed only as macOS-only code, a platform shim, or a real UI capability gap that needs an iOS alternative.
+
+The machine guardrail is `scripts/check_appkit_imports.py`. This document explains every current allowlisted importer.
+
+## Buckets
+
+| File | Bucket | Next move |
+|---|---|---|
+| `App/AppInstaller.swift` | macOS-only | Keep behind `#if canImport(AppKit)`; no iOS installer path. |
+| `App/LibraryWindow.swift` | macOS-only shell | Keep Mac window behavior isolated; iOS uses scene/navigation shell. |
+| `App/SparkleUpdater.swift` | macOS-only | Keep Sparkle out of iOS. |
+| `FicheroApp.swift` | macOS-only app entry | Keep Mac app delegate/window wiring isolated. |
+| `FicheroApp_iOS.swift` | iOS app entry | UIKit entry point for the remote-only client. |
+| `Models/Platform/PlatformAliases.swift` | platform shim | Canonical `PlatformImage`, `PlatformColor`, `PlatformFont`, and split-view aliases. |
+| `Models/Platform/PlatformPasteboard.swift` | platform shim | Pasteboard bridge; keep as the single copy/paste crossing. |
+| `Models/SpatialTheme.swift` | platform shim | Uses `PlatformColor`; keep platform color math centralized. |
+| `Models/WorkflowExporter.swift` | file picker bridge | Replace panel-specific paths with SwiftUI file exporter/importer when porting. |
+| `Services/ImageEditingServiceGenerated.swift` | platform shim | Uses `PlatformImage`; keep image decode/preview platform-neutral. |
+| `Services/RemoteClientPairing.swift` | platform shim | Uses UIKit device name where available; keep pairing logic shared. |
+| `Views/Capture/MobileCaptureQueueView.swift` | iOS surface | UIKit-only capture queue UI for mobile. |
+| `Views/Components/BackendConnectionView.swift` | platform shim | Uses `PlatformImage`; iOS branch is remote-only connection copy. |
+| `Views/Components/MacPlainTextEditor.swift` | needs iOS alternative | Keep Mac text editor bridge; iOS should use SwiftUI/UITextView. |
+| `Views/KnowledgeGraph/OntologyBrowser/ClaimSummaryCardView.swift` | macOS interaction gap | Cmd-click/open-window behavior needs touch/edit-mode alternative. |
+| `Views/Library/ArtifactRichTextCodec.swift` | rich text bridge | Keep concrete AppKit attributes for RTF round-trip; iOS alternative must preserve formatting. |
+| `Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift` | macOS interaction gap | Multi-select/open behavior needs iOS edit-mode alternative. |
+| `Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift` | macOS interaction gap | Multi-select/open behavior needs iOS edit-mode alternative. |
+| `Views/Library/DocumentKGWebPane.swift` | WebKit bridge | Keep platform WebView/pinning boundary isolated. |
+| `Views/Library/FolderAccessManager.swift` | file picker/bookmark bridge | Swap panels to SwiftUI file importer/exporter for iOS. |
+| `Views/Library/ImageEditor/ImageEditorModel.swift` | platform shim | Uses platform image type for editor previews. |
+| `Views/Library/ImageEditor/ImageEditorView.swift` | platform shim | Uses platform image views; keep editor logic shared. |
+| `Views/Library/ImageViewer/ImageWithCursorTracking.swift` | needs iOS alternative | Mac uses `NSScrollView`/tracking; iOS needs `UIScrollView`/gesture path. |
+| `Views/Library/ImageViewer/TrackingImageView.swift` | needs iOS alternative | Mac cursor/loupe bridge; iOS needs touch/loupe implementation. |
+| `Views/Library/ImageViewerComponents.swift` | image viewer host | Keep shared host; platform-specific viewer remains behind child bridge. |
+| `Views/Library/LibraryWorkspaceRoot.swift` | iOS scene support | Uses UIKit scene capability checks. |
+| `Views/Library/MagnifierPanel.swift` | needs iOS alternative | Mac AppKit magnifier; iOS touch magnifier can be SwiftUI/UIKit. |
+| `Views/Library/PDFPageView.swift` | PDFKit bridge | PDFKit is cross-platform; keep bridge split by platform. |
+| `Views/Library/PDFThumbnailView.swift` | PDFKit/platform image shim | Keep shared thumbnail rendering through `PlatformImage`. |
+| `Views/Library/QuickLookComponents.swift` | Quick Look bridge | Mac inline Quick Look; iOS should present `QLPreviewController`. |
+| `Views/Library/QuickLookPreviewViews.swift` | Quick Look bridge | Mac `QLPreviewView`; iOS presenter needed. |
+| `Views/Library/ScrollWheelZoom.swift` | macOS interaction gap | Mac scroll-wheel zoom only; iOS uses pinch. |
+| `Views/Menu/FileMenuCommands.swift` | macOS menu/file panels | Keep Mac menu commands; iOS uses toolbar/share/file exporters. |
+| `Views/Onboarding/FirstRunWindow.swift` | macOS onboarding window | iOS needs remote-host onboarding, not Mac package picker. |
+| `Views/OpenAffordances.swift` | macOS windowing | Keep NSWindow tab/window affordances Mac-only. |
+| `Views/Sidebar/SidebarView+ActivityRows.swift` | macOS interaction gap | Cmd-click/multi-select needs touch/edit-mode alternative. |
+
+## Near-Term Slice
+
+Do not add new AppKit/UIKit imports. For incremental work, prefer:
+
+- Moving platform types into `Models/Platform/PlatformAliases.swift`.
+- Keeping Mac-only app/window/updater code behind compile guards.
+- Replacing file panels with SwiftUI `fileImporter` / `fileExporter` where practical.
+- Leaving image viewer, rich text, Quick Look, and command-click behavior as explicit iOS-alternative work rather than pretending they are mechanical.

--- a/fichero-engine/src/fichero/api/auth.py
+++ b/fichero-engine/src/fichero/api/auth.py
@@ -21,6 +21,7 @@ isn't 127.0.0.1.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timedelta
 import logging
 import os
@@ -265,12 +266,38 @@ def action_context(
     )
 
 
-def attach_auth_middleware(app: FastAPI, token: str) -> None:
+def attach_auth_middleware(
+    app: FastAPI,
+    token: str | None = None,
+    *,
+    token_provider: Callable[[], str] | None = None,
+) -> None:
     """Add a middleware that requires `Authorization: Bearer <token>` on
     every request not in `_UNAUTHENTICATED_PATHS`, and that the request
     came from 127.0.0.1.
+
+    Pass a literal ``token`` (tests, embedded launch) to pin the expected
+    secret eagerly. Pass ``token_provider`` instead to resolve the secret
+    lazily on the FIRST authenticated request — this keeps merely importing
+    the app (e.g. the CLI pulling route response models out of
+    ``fichero.api``) from running ``initialize_token()`` and grabbing the
+    ``app.duckdb`` lock at import time (#2388).
     """
-    expected_header = f"Bearer {token}"
+    if token is None and token_provider is None:
+        raise ValueError("attach_auth_middleware needs token or token_provider")
+
+    # ponytail: single-slot cache; initialize_token() is idempotent so a
+    # concurrent first-request race just resolves the same file twice.
+    resolved: dict[str, str] = {}
+    if token is not None:
+        resolved["header"] = f"Bearer {token}"
+
+    def _expected_header() -> str:
+        header = resolved.get("header")
+        if header is None:
+            header = f"Bearer {token_provider()}"  # type: ignore[misc]
+            resolved["header"] = header
+        return header
 
     @app.middleware("http")
     async def _enforce_auth(request: Request, call_next):
@@ -280,6 +307,7 @@ def attach_auth_middleware(app: FastAPI, token: str) -> None:
         ):
             return await call_next(request)
 
+        expected_header = _expected_header()
         is_loopback = _is_loopback_request(request)
         if not _use_multiuser_auth():
             provided = request.headers.get("authorization", "")

--- a/fichero-engine/src/fichero/api/main.py
+++ b/fichero-engine/src/fichero/api/main.py
@@ -633,10 +633,48 @@ async def _watch_parent_process() -> None:
             return
 
 
+def _auth_enabled() -> bool:
+    """True when the shared-secret middleware is active (auth not disabled)."""
+    return os.environ.get("FICHERO_DISABLE_AUTH", "").lower() not in {
+        "1",
+        "true",
+        "yes",
+    }
+
+
+# Bootstrap secret, populated at server startup (NOT at import — #2388). Used by
+# _with_server_proof to HMAC the health nonce so a client can verify it reached
+# the genuine engine during pairing. Stays None on a bare import (e.g. the CLI).
+_api_token: str | None = None
+
+
+def _ensure_bootstrap_token_written() -> None:
+    """Write/rotate the bootstrap auth token at server startup.
+
+    The middleware resolves the token lazily so bare imports stay DB-free
+    (the CLI's `fichero --help`, #2388). The server, however, must persist the
+    token file before it serves, or the Swift app would wait forever for a
+    `.api-key` that is never written. Called from the lifespan, which only runs
+    when the engine truly serves — never on a plain import. Also caches the
+    secret in the module global so the health server-proof keeps working.
+    """
+    global _api_token
+    if not _auth_enabled():
+        return
+    from fichero.api.auth import initialize_token
+
+    _api_token = initialize_token()
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Startup and shutdown events."""
     import asyncio
+
+    # Write/rotate the bootstrap auth token NOW that the server is actually
+    # starting, so the Swift app can read ~/Library/Application Support/Fichero/
+    # .api-key before its first authenticated request (#2388).
+    _ensure_bootstrap_token_written()
 
     # Startup: optionally validate model sync
     if os.environ.get("FICHERO_VALIDATE_MODELS") == "1":
@@ -744,15 +782,18 @@ app = FastAPI(
 )
 
 
-# Local-host shared-secret authentication (#742). Initialized once at module
-# import; the token is also written to ~/Library/Application Support/Fichero/.api-key
-# (mode 0600) so the Swift app can read it. Tests can disable by setting
+# Local-host shared-secret authentication (#742). The middleware is attached at
+# import, but the token is resolved LAZILY on the first authenticated request —
+# the token file (~/Library/Application Support/Fichero/.api-key, mode 0600) is
+# written/rotated then, not at import. This keeps a second process that imports
+# this module only for its route response models (the CLI — `fichero --help`)
+# from calling initialize_token() and fighting the running engine for the
+# app.duckdb lock (#2388). Tests can disable auth entirely with
 # FICHERO_DISABLE_AUTH=1 before importing this module.
 if os.environ.get("FICHERO_DISABLE_AUTH", "").lower() not in {"1", "true", "yes"}:
     from fichero.api.auth import attach_auth_middleware, initialize_token
 
-    _api_token = initialize_token()
-    attach_auth_middleware(app, _api_token)
+    attach_auth_middleware(app, token_provider=initialize_token)
 
 
 # CORS configuration

--- a/fichero-engine/tests/unit/test_auth_lazy_token.py
+++ b/fichero-engine/tests/unit/test_auth_lazy_token.py
@@ -1,0 +1,170 @@
+"""Lazy bootstrap-token resolution in the auth middleware (#2388).
+
+`attach_auth_middleware(app, token_provider=...)` must NOT resolve the token
+until the first authenticated request. Importing the app only for its route
+response models (the CLI does this for `fichero --help`) therefore never calls
+`initialize_token()` and never grabs the `app.duckdb` lock from a second
+process.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from fichero.api.auth import attach_auth_middleware
+
+
+def _app_with_provider(provider) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/api/health")
+    async def health():
+        return {"ok": True}
+
+    @app.get("/api/private")
+    async def private():
+        return {"private": True}
+
+    attach_auth_middleware(app, token_provider=provider)
+    return app
+
+
+def test_attach_requires_token_or_provider():
+    with pytest.raises(ValueError):
+        attach_auth_middleware(FastAPI())
+
+
+def test_provider_not_called_until_first_authenticated_request():
+    calls = {"n": 0}
+
+    def provider() -> str:
+        calls["n"] += 1
+        return "lazy-secret"
+
+    client = TestClient(_app_with_provider(provider))
+    # Attaching the middleware (and constructing the client) must not resolve.
+    assert calls["n"] == 0
+
+    # An unauthenticated path is allowed through WITHOUT resolving the token.
+    assert client.get("/api/health").status_code == 200
+    assert calls["n"] == 0
+
+    # First authenticated request resolves exactly once.
+    ok = client.get("/api/private", headers={"Authorization": "Bearer lazy-secret"})
+    assert ok.status_code == 200
+    assert calls["n"] == 1
+
+    # Subsequent requests reuse the cached header — no re-resolution.
+    client.get("/api/private", headers={"Authorization": "Bearer lazy-secret"})
+    assert calls["n"] == 1
+
+
+def test_lazy_provider_secret_is_enforced():
+    client = TestClient(_app_with_provider(lambda: "lazy-secret"))
+
+    assert client.get("/api/private").status_code == 401
+    assert (
+        client.get(
+            "/api/private", headers={"Authorization": "Bearer wrong"}
+        ).status_code
+        == 401
+    )
+    assert (
+        client.get(
+            "/api/private", headers={"Authorization": "Bearer lazy-secret"}
+        ).status_code
+        == 200
+    )
+
+
+def test_app_main_attaches_middleware_without_resolving_token(monkeypatch):
+    """Importing fichero.api.main must not eagerly resolve the bootstrap token.
+
+    The module attaches the middleware with token_provider=initialize_token; if
+    it ever reverts to calling initialize_token() at import, a second process
+    (the CLI) would fight the engine for the app.duckdb lock again (#2388).
+    """
+    import fichero.api.auth as auth_module
+
+    calls = {"n": 0}
+    real = auth_module.initialize_token
+
+    def counting_initialize_token(*args, **kwargs):
+        calls["n"] += 1
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(auth_module, "initialize_token", counting_initialize_token)
+
+    # Re-attach the way main.py does; provider must stay unevaluated.
+    app = FastAPI()
+    attach_auth_middleware(app, token_provider=auth_module.initialize_token)
+    assert calls["n"] == 0
+
+
+def test_startup_writes_token_file_so_client_is_not_deadlocked(monkeypatch, tmp_path):
+    """Server startup must persist .api-key (#2388 deadlock guard).
+
+    The middleware resolves lazily, but if the file were only written on the
+    first authenticated request the Swift app could never read the token to
+    MAKE that request. The lifespan helper writes it proactively at serve time.
+    """
+    import fichero.api.auth as auth_module
+    from fichero.api.main import _ensure_bootstrap_token_written
+
+    token_path = tmp_path / ".api-key"
+    monkeypatch.setattr(auth_module, "_token_file_path", lambda: token_path)
+    monkeypatch.delenv("FICHERO_DISABLE_AUTH", raising=False)
+
+    assert not token_path.exists()
+    _ensure_bootstrap_token_written()
+    assert token_path.exists()
+    assert token_path.read_text().strip()
+
+
+def test_startup_skips_token_when_auth_disabled(monkeypatch, tmp_path):
+    import fichero.api.auth as auth_module
+    from fichero.api.main import _ensure_bootstrap_token_written
+
+    token_path = tmp_path / ".api-key"
+    monkeypatch.setattr(auth_module, "_token_file_path", lambda: token_path)
+    monkeypatch.setenv("FICHERO_DISABLE_AUTH", "1")
+
+    _ensure_bootstrap_token_written()
+    assert not token_path.exists()
+
+
+def test_cli_help_does_not_open_app_duckdb(tmp_path):
+    """`fichero --help` must not create/open app.duckdb (#2388 acceptance).
+
+    Runs the CLI in a subprocess with app storage redirected to an empty dir,
+    asserts a clean exit, and asserts no app.duckdb appeared — proving help
+    never reached the backend DB even though it imports route response models.
+    """
+    src = Path(__file__).resolve().parents[2] / "src"
+    base = tmp_path / "fichero-base"
+    base.mkdir()
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(src), env.get("PYTHONPATH", "")])
+    env["FICHERO_BASE_PATH"] = str(base)
+    env.pop("FICHERO_DISABLE_AUTH", None)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "fichero", "--help"],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Usage:" in result.stdout
+    db_files = list(base.rglob("app.duckdb"))
+    assert not db_files, f"CLI --help opened the app DB: {db_files}"

--- a/fichero-engine/tests/unit/test_check_appkit_imports.py
+++ b/fichero-engine/tests/unit/test_check_appkit_imports.py
@@ -71,6 +71,15 @@ def test_preview_named_file_still_scanned(tmp_path):
     assert "QuickLookPreviewViews.swift" in found
 
 
+def test_appkit_audit_doc_covers_every_known_importer():
+    audit = (_SCRIPT.parents[1] / _mod.RULE_DOC).read_text(encoding="utf-8")
+    missing = [
+        path for path in _mod.KNOWN_VIOLATIONS
+        if f"`{path}`" not in audit
+    ]
+    assert not missing
+
+
 # ---------------------------------------------------------------------------
 # Real repo gate
 # ---------------------------------------------------------------------------

--- a/scripts/check_appkit_imports.py
+++ b/scripts/check_appkit_imports.py
@@ -35,7 +35,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 SWIFT_DIR = ROOT / "fichero" / "fichero"
-RULE_DOC = "docs/architecture/swiftui/reform_masterplan_2026-06.md"
+RULE_DOC = "docs/architecture/swiftui/appkit_import_audit_2101.md"
 
 # Current cross-platform migration backlog: files that import AppKit/UIKit.
 # Keys are paths relative to SWIFT_DIR (posix). Value documents why it is a

--- a/scripts/check_observer_pattern.py
+++ b/scripts/check_observer_pattern.py
@@ -146,6 +146,15 @@ KNOWN_VIOLATIONS: dict[str, str] = dict.fromkeys(
         "fichero/fichero/Views/Settings/BackendSettingsView.swift",
         "fichero/fichero/Views/Settings/LocalModelsSettingsView.swift",
         "fichero/fichero/Views/Settings/SettingsView.swift",
+        # Settings sections exposed by the QR-pairing / sharing work — staged
+        # @EnvironmentObject → @Environment(@Observable) migration (#2378).
+        "fichero/fichero/Views/Settings/AISettingsView+Tabs.swift",
+        "fichero/fichero/Views/Settings/AuditHistoryView.swift",
+        "fichero/fichero/Views/Settings/BackupsView.swift",
+        "fichero/fichero/Views/Settings/CaptureSettingsView.swift",
+        "fichero/fichero/Views/Settings/EngineSettingsView.swift",
+        "fichero/fichero/Views/Settings/ShareSettingsView.swift",
+        "fichero/fichero/Views/Settings/UsersSettingsView.swift",
         "fichero/fichero/Views/Sheets/DocumentPickerSheet.swift",
         "fichero/fichero/Views/Sheets/WorkflowPickerSheet.swift",
         "fichero/fichero/Views/Sidebar/Components/SidebarObservers.swift",


### PR DESCRIPTION
Two backend lanes:
- **connect #2388:** resolve CLI/engine bootstrap token lazily so `fichero --help` can't grab app.duckdb (auth.py/main.py + test_auth_lazy_token). **#2378:** baseline pairing/settings observer-pattern offenders.
- **remote #2101:** AppKit import audit doc + check_appkit_imports guardrail tweak + test.

Gate: ruff clean + **full unit suite 5981 passed, 0 failed** (auth.py change → full suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)