### PR TITLE
merge: UI smoke suite in full verify + app-delegate lifecycle coverage (#1939 #1988)

### DIFF
--- a/fichero-engine/tests/unit/scripts/test_verify_all_ui_suite.py
+++ b/fichero-engine/tests/unit/scripts/test_verify_all_ui_suite.py
@@ -1,0 +1,13 @@
+"""Regression tests for verify_all GUI smoke wiring (#1939)."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[4]
+
+
+def test_full_macos_gate_runs_fichero_ui_tests_scheme() -> None:
+    verify_all = (ROOT / "scripts" / "verify_all.sh").read_text(encoding="utf-8")
+
+    assert "xcodebuild macOS UI smoke tests" in verify_all
+    assert '-scheme "FicheroUITests"' in verify_all

--- a/fichero/fichero-tests/FicheroAppDelegateTests.swift
+++ b/fichero/fichero-tests/FicheroAppDelegateTests.swift
@@ -1,0 +1,26 @@
+#if canImport(AppKit)
+import AppKit
+import XCTest
+
+@testable import Fichero
+
+@MainActor
+final class FicheroAppDelegateTests: XCTestCase {
+    func testApplicationSupportsSecureRestorableState() {
+        let delegate = FicheroAppDelegate()
+
+        XCTAssertTrue(delegate.applicationSupportsSecureRestorableState(NSApplication.shared))
+    }
+
+    func testApplicationWillTerminateStopsBackendService() {
+        let delegate = FicheroAppDelegate()
+        let backendService = EmbeddedBackendService()
+        backendService.status = .running
+        delegate.backendService = backendService
+
+        delegate.applicationWillTerminate(Notification(name: NSApplication.willTerminateNotification))
+
+        XCTAssertEqual(backendService.status, .stopped)
+    }
+}
+#endif

--- a/scripts/verify_all.sh
+++ b/scripts/verify_all.sh
@@ -388,6 +388,12 @@ run_platform_checks() {
       -scheme "${XCODE_SCHEME}" \
       -destination 'platform=macOS' \
       -resultBundlePath "$(mktemp -d)/verify.xcresult"
+
+    run_xcode_test "xcodebuild macOS UI smoke tests" \
+      -project "${XCODE_PROJECT}" \
+      -scheme "FicheroUITests" \
+      -destination 'platform=macOS' \
+      -resultBundlePath "$(mktemp -d)/verify-ui.xcresult"
   fi
 
   if [[ "$run_ios" -eq 1 ]]; then


### PR DESCRIPTION
remote lane:
- **#1939:** run the UI smoke suite in full verify_all (verify_all.sh + test_verify_all_ui_suite guard).
- **#1988:** cover FicheroAppDelegate lifecycle hooks (Swift test).

Gate: ruff clean + verify_all guard test 1 passed + **TEST BUILD SUCCEEDED** (app + test targets compile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)