### PR TITLE
merge: folder-org + ui-smoke guards + 0.1.0 QA checklist (#1704 #1230 #258)

### DIFF
--- a/docs/release/qa-signoff-0.1.0.md
+++ b/docs/release/qa-signoff-0.1.0.md
@@ -1,0 +1,62 @@
+# 0.1.0 QA Sign-Off Checklist
+
+Use this checklist for the 0.1.0 release gate. Attach failures to GitHub issues
+with repro steps, expected behavior, actual behavior, logs/screenshots, and the
+tested commit.
+
+## Preconditions
+
+- [ ] App version and build number match the release candidate.
+- [ ] Fresh install launches without using a developer checkout.
+- [ ] Existing library opens after upgrade.
+- [ ] New empty library can be created.
+- [ ] Backend health indicator reaches ready.
+
+## Core Library
+
+- [ ] Import a PDF, image, text file, and folder.
+- [ ] Link mode preserves original file paths.
+- [ ] Copy mode stores files inside the `.fichero` package.
+- [ ] Sidebar selection, grid/list selection, and inspector selection stay in sync.
+- [ ] Rename, move, duplicate, and delete show expected undoable behavior.
+
+## Reading Surface
+
+- [ ] PDF preview renders a multi-page PDF.
+- [ ] Image preview renders without stretching or clipping controls.
+- [ ] Text/content pane displays extracted text.
+- [ ] Inspector tabs switch without blanking the selected document.
+- [ ] Knowledge surface opens for a document with claims.
+
+## Search And KG
+
+- [ ] Text search returns expected imported documents.
+- [ ] Saved search persists after relaunch.
+- [ ] KG entity browser opens and can navigate to a source document.
+- [ ] Related claims panel shows claims for the selected document.
+
+## Workflows And Activity
+
+- [ ] Catalogue workflow can be started on a small fixture library.
+- [ ] Activity view shows the running workflow.
+- [ ] Completed run shows status, log, and artifacts.
+- [ ] Failed run surfaces a readable error.
+
+## Release Outputs
+
+- [ ] DMG is Developer ID signed, notarized, stapled, and opens on a clean Mac.
+- [ ] Sparkle update feed points at the GitHub appcast and validates.
+- [ ] TestFlight build uploads and installs for internal testing.
+- [ ] Release notes mention known limitations and upgrade notes.
+
+## Sign-Off
+
+- [ ] No open P0/P1 bugs remain.
+- [ ] Deferred issues are explicitly moved to later milestones.
+- [ ] Daniel approved this release candidate.
+
+Sign-off commit:
+
+Sign-off date:
+
+Tester:

--- a/fichero-engine/tests/unit/scripts/test_check_folder_organization.py
+++ b/fichero-engine/tests/unit/scripts/test_check_folder_organization.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+_SCRIPT = Path(__file__).resolve().parents[4] / "scripts" / "check_folder_organization.py"
+_SPEC = importlib.util.spec_from_file_location("check_folder_organization", _SCRIPT)
+assert _SPEC and _SPEC.loader
+check_folder_organization = importlib.util.module_from_spec(_SPEC)
+sys.modules[_SPEC.name] = check_folder_organization
+_SPEC.loader.exec_module(check_folder_organization)  # type: ignore[attr-defined]
+
+
+def test_scan_flags_known_mixed_library_directory(monkeypatch, tmp_path) -> None:
+    swift_root = tmp_path / "fichero" / "fichero"
+    library = swift_root / "Views" / "Library"
+    library.mkdir(parents=True)
+    (library / "LibraryView.swift").write_text("struct LibraryView {}\n", encoding="utf-8")
+
+    monkeypatch.setattr(check_folder_organization, "SWIFT_ROOT", swift_root)
+
+    found = check_folder_organization.scan()
+
+    assert "Views/Library" in found
+    assert any("mixes browser" in reason for reason in found["Views/Library"])
+
+
+def test_scan_flags_new_directory_over_direct_file_limit(monkeypatch, tmp_path) -> None:
+    swift_root = tmp_path / "fichero" / "fichero"
+    crowded = swift_root / "Views" / "Crowded"
+    crowded.mkdir(parents=True)
+    for index in range(check_folder_organization.MAX_DIRECT_SWIFT_FILES + 1):
+        (crowded / f"View{index}.swift").write_text("struct View {}\n", encoding="utf-8")
+
+    monkeypatch.setattr(check_folder_organization, "SWIFT_ROOT", swift_root)
+
+    found = check_folder_organization.scan()
+
+    assert found == {
+        "Views/Crowded": [
+            "19 Swift files directly in one directory (limit: 18)"
+        ]
+    }

--- a/fichero-engine/tests/unit/scripts/test_check_folder_organization.py
+++ b/fichero-engine/tests/unit/scripts/test_check_folder_organization.py
@@ -43,3 +43,17 @@ def test_scan_flags_new_directory_over_direct_file_limit(monkeypatch, tmp_path) 
             "19 Swift files directly in one directory (limit: 18)"
         ]
     }
+
+
+def test_list_output_includes_library_reorg_targets(monkeypatch, tmp_path, capsys) -> None:
+    swift_root = tmp_path / "fichero" / "fichero"
+    library = swift_root / "Views" / "Library"
+    library.mkdir(parents=True)
+    (library / "LibraryView.swift").write_text("struct LibraryView {}\n", encoding="utf-8")
+
+    monkeypatch.setattr(check_folder_organization, "SWIFT_ROOT", swift_root)
+
+    check_folder_organization.print_list(check_folder_organization.scan())
+
+    output = capsys.readouterr().out
+    assert "suggested subfolders: Artifacts/, PDFReading/, QuickLook/" in output

--- a/fichero-engine/tests/unit/test_uitest_launch_contract.py
+++ b/fichero-engine/tests/unit/test_uitest_launch_contract.py
@@ -18,3 +18,18 @@ def test_ui_test_launch_uses_isolated_library_hooks() -> None:
     assert "--fichero-library" in support_text
     assert "FICHERO_UITEST_LIBRARY" in support_text
     assert "openUITestLibraryOverrideIfNeeded()" in app_text
+
+
+def test_reading_surface_has_stable_accessibility_hooks() -> None:
+    files = [
+        ROOT / "fichero" / "fichero" / "Views" / "Library" / "DocumentInspector.swift",
+        ROOT / "fichero" / "fichero" / "Views" / "Library" / "DocumentKGSurface.swift",
+        ROOT / "fichero" / "fichero" / "Views" / "Toolbars" / "ReaderToolbar.swift",
+    ]
+    text = "\n".join(path.read_text(encoding="utf-8") for path in files)
+
+    assert '"inspectorTabBar"' in text
+    assert '"inspectorTab-\\(tab.rawValue)"' in text
+    assert '"knowledgeSurfaceContent"' in text
+    assert '"pdfPreviousPage"' in text
+    assert '"pdfNextPage"' in text

--- a/fichero-engine/tests/unit/test_uitest_launch_contract.py
+++ b/fichero-engine/tests/unit/test_uitest_launch_contract.py
@@ -1,0 +1,20 @@
+"""Source-contract guard for the future XCUITest target (#1230)."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_ui_test_launch_uses_isolated_library_hooks() -> None:
+    support = ROOT / "fichero" / "fichero" / "Services" / "UITestSupport.swift"
+    app = ROOT / "fichero" / "fichero" / "FicheroApp.swift"
+
+    support_text = support.read_text(encoding="utf-8")
+    app_text = app.read_text(encoding="utf-8")
+
+    assert "--uitesting" in support_text
+    assert "FICHERO_UITEST_HOME" in support_text
+    assert "--fichero-library" in support_text
+    assert "FICHERO_UITEST_LIBRARY" in support_text
+    assert "openUITestLibraryOverrideIfNeeded()" in app_text

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,5 +125,6 @@ nav:
           - Backend API Overview: architecture/api/overview.md
           - SwiftUI Overview: architecture/swiftui/overview.md
           - Release Process: architecture/release-process.md
+          - 0.1.0 QA Sign-Off: release/qa-signoff-0.1.0.md
   - API Reference: api-reference/index.md
   - How It's Built: how-its-built.md

--- a/scripts/check_folder_organization.py
+++ b/scripts/check_folder_organization.py
@@ -34,6 +34,10 @@ MIXED_CONCERN_DIRS: dict[str, str] = {
     "Views/Sidebar": "mixes sidebar state, rows, drag/drop, modes, and commands",
 }
 
+SUGGESTED_SUBFOLDERS: dict[str, str] = {
+    "Views/Library": "Artifacts/, PDFReading/, QuickLook/, KnowledgeGraph/, Pickers/, Tools/, Thumbnails/",
+}
+
 # Current folder-organization backlog. Drop entries as directories are split.
 KNOWN_VIOLATIONS: dict[str, str] = {
     "Models": "#1944 — 53 Swift files directly in Models",
@@ -75,6 +79,8 @@ def print_list(found: dict[str, list[str]]) -> None:
         print(f"  [{tag}] {rel}")
         for reason in reasons:
             print(f"          - {reason}")
+        if rel in SUGGESTED_SUBFOLDERS:
+            print(f"          - suggested subfolders: {SUGGESTED_SUBFOLDERS[rel]}")
         print(f"          - move new files into a specific subfolder under {rel}")
 
 


### PR DESCRIPTION
devex lane (codex), Python guards + docs:
- **#1704:** library folder-organization guard (check_folder_organization + tests, surfaces reorg targets).
- **#1230:** UI-smoke accessibility-hooks + test-launch-isolation guards (uitest_launch_contract).
- **#258:** 0.1.0 QA signoff checklist + surface it in docs nav.

Gate: ruff clean + mkdocs --strict clean + **full unit suite 6027 passed, 0 failed** (full suite because #1704 adds a codebase-scanning guardrail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)