### PR TITLE
feat(node-model): alias node kind — P2 keystone (#2591)

### DIFF
--- a/fichero-engine/src/fichero/models.py
+++ b/fichero-engine/src/fichero/models.py
@@ -189,6 +189,14 @@ class Document(BaseModel):
     bbox: tuple[int, int, int, int] | None = None  # x, y, width, height
     prototype_key: str | None = None  # user-assigned document prototype/class key
 
+    # Alias / reference node (#2591 P2, node-model fold). When set, this node is
+    # a *reference* to another node (Tinderbox-style alias): it appears inside a
+    # container via ``parent_id`` but never duplicates the target's content. The
+    # convention is ``node_kind == "alias"`` together with ``alias_target_id``
+    # pointing at the referenced node. Resolution lives in ``node_aliases.py`` and
+    # *raises* on a dangling target rather than silently substituting (prefer-raise).
+    alias_target_id: str | None = None
+
     # Content (LangChain compatible)
     page_content: str | None = None
 

--- a/fichero-engine/src/fichero/node_aliases.py
+++ b/fichero-engine/src/fichero/node_aliases.py
@@ -1,0 +1,66 @@
+"""Alias (reference) nodes — node-model fold P2 (#2591 / EPIC #2081).
+
+A Tinderbox-style *alias* is a node that references another node. It lives inside
+a container (via ``parent_id``) and resolves to its target, but never duplicates
+the target's content. This is the keystone relation #2591 calls out
+("Aliases = reference relation"); bookmarks (Fold-D) and Mind-Palace connections
+(Fold-E) both build on it.
+
+Convention: an alias is a :class:`~fichero.models.Document` with
+``node_kind == "alias"`` and ``alias_target_id`` pointing at the referenced node.
+
+Design rules honoured here:
+- **No copy.** The alias carries no ``page_content``; reads go through the target.
+- **Prefer raise over silent fallback.** Resolving a dangling alias (missing
+  ``alias_target_id`` or a target that no longer exists) raises
+  :class:`DanglingAliasError` rather than returning ``None`` or a stand-in node.
+"""
+
+from __future__ import annotations
+
+from .models import Document
+
+ALIAS_NODE_KIND = "alias"
+
+
+class DanglingAliasError(Exception):
+    """Raised when an alias cannot be resolved to a live target node."""
+
+
+def is_alias(doc: Document) -> bool:
+    """True when ``doc`` is an alias (reference) node."""
+    return doc.node_kind == ALIAS_NODE_KIND and bool(doc.alias_target_id)
+
+
+def make_alias(target: Document, parent_id: str | None, name: str | None = None) -> Document:
+    """Build an alias node that references ``target`` inside ``parent_id``.
+
+    The alias mirrors the target's structural ``doc_type`` (so a folder alias
+    still reads as a container) but carries no content of its own.
+    """
+    return Document(
+        parent_id=parent_id,
+        node_kind=ALIAS_NODE_KIND,
+        doc_type=target.doc_type,
+        alias_target_id=target.id,
+        name=name if name is not None else target.name,
+    )
+
+
+def resolve_alias(db, alias: Document) -> Document:
+    """Return the live target node an alias references.
+
+    Raises:
+        ValueError: ``alias`` is not an alias node.
+        DanglingAliasError: the alias has no target, or the target is gone.
+    """
+    if alias.node_kind != ALIAS_NODE_KIND:
+        raise ValueError(f"Not an alias node: {alias.id} (node_kind={alias.node_kind!r})")
+    if not alias.alias_target_id:
+        raise DanglingAliasError(f"Alias {alias.id} has no target")
+    target = db.get(Document, alias.alias_target_id)
+    if target is None:
+        raise DanglingAliasError(
+            f"Alias {alias.id} references missing node {alias.alias_target_id}"
+        )
+    return target

--- a/fichero-engine/tests/unit/test_node_aliases.py
+++ b/fichero-engine/tests/unit/test_node_aliases.py
@@ -1,0 +1,83 @@
+"""Tests for alias (reference) nodes — node-model fold P2 (#2591)."""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from fichero.db import Database
+from fichero.models import Document, DocType
+from fichero.node_aliases import (
+    ALIAS_NODE_KIND,
+    DanglingAliasError,
+    is_alias,
+    make_alias,
+    resolve_alias,
+)
+
+
+@pytest.fixture
+def temp_db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.duckdb")
+    yield db
+    db.close()
+    shutil.rmtree(tmpdir)
+
+
+def test_make_alias_references_target_without_copying():
+    target = Document(name="Real Folder", doc_type=DocType.folder, page_content="body")
+    alias = make_alias(target, parent_id="container-1")
+
+    assert is_alias(alias)
+    assert alias.node_kind == ALIAS_NODE_KIND
+    assert alias.alias_target_id == target.id
+    assert alias.parent_id == "container-1"
+    # Mirrors the target's structural kind, but carries no content of its own.
+    assert alias.doc_type == DocType.folder
+    assert alias.name == "Real Folder"
+    assert alias.page_content is None
+    # The alias is its own node — not the target.
+    assert alias.id != target.id
+
+
+def test_alias_resolves_to_live_target(temp_db):
+    target = Document(name="Target", doc_type=DocType.file)
+    temp_db.save(target)
+    alias = make_alias(target, parent_id=None)
+    temp_db.save(alias)
+
+    # Reload the alias from the DB to prove alias_target_id round-trips.
+    reloaded = temp_db.get(Document, alias.id)
+    assert reloaded is not None
+    assert reloaded.alias_target_id == target.id
+
+    resolved = resolve_alias(temp_db, reloaded)
+    assert resolved.id == target.id
+    assert resolved.name == "Target"
+
+
+def test_resolving_dangling_alias_raises(temp_db):
+    """Deleting the target must surface loudly, not silently substitute."""
+    target = Document(name="Doomed", doc_type=DocType.file)
+    temp_db.save(target)
+    alias = make_alias(target, parent_id=None)
+    temp_db.save(alias)
+
+    temp_db.delete(target)
+
+    with pytest.raises(DanglingAliasError):
+        resolve_alias(temp_db, temp_db.get(Document, alias.id))
+
+
+def test_alias_with_no_target_id_raises(temp_db):
+    bare = Document(name="bare", node_kind=ALIAS_NODE_KIND)
+    with pytest.raises(DanglingAliasError):
+        resolve_alias(temp_db, bare)
+
+
+def test_resolving_non_alias_raises_value_error(temp_db):
+    plain = Document(name="plain", doc_type=DocType.file)
+    with pytest.raises(ValueError):
+        resolve_alias(temp_db, plain)


### PR DESCRIPTION
First slice of the Node Model & Endpoint Unification milestone (EPIC #2081), implemented per docs/architecture/node_model_fold_staging.md.

**P2 — Alias (reference) node kind** (the keystone the fold's #2591 explicitly calls out):
- `Document.alias_target_id` reference field (no migration — auto-derived column on the library DB per the staging-doc rule).
- `node_aliases.py`: `make_alias` / `resolve_alias` / `is_alias`. An alias is `node_kind='alias'` + `alias_target_id`; it appears in a container without copying the target's content.
- Resolution **raises** `DanglingAliasError` on a missing target rather than silently substituting (prefer-raise).

Unblocks Fold-D (bookmarks) and Fold-E (mind-palace connection→reference).

Gate: ruff clean + 5 alias unit tests + **full unit suite 6117 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)