### PR TITLE
feat(node-model): prototype attribute inheritance — P1 keystone (#2591)

### DIFF
--- a/fichero-engine/src/fichero/knowledge/knowledge_models.py
+++ b/fichero-engine/src/fichero/knowledge/knowledge_models.py
@@ -837,6 +837,16 @@ class ClassificationValue(BaseModel):
         default=None,
         description="Optional hierarchy: 'binding' parent of 'constitutional'.",
     )
+    attributes: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Prototype definition attributes (node-model P1, #2591). For "
+            "dimension=document_prototype these are inheritable defaults a node "
+            "of this prototype carries; resolved via node_prototypes.py, where a "
+            "child prototype's attributes override its parent_key chain. Other "
+            "dimensions leave this empty."
+        ),
+    )
     color: str | None = Field(
         default=None, description="Hex tint for badge rendering, e.g. '#FF8800'."
     )

--- a/fichero-engine/src/fichero/node_prototypes.py
+++ b/fichero-engine/src/fichero/node_prototypes.py
@@ -1,0 +1,65 @@
+"""Prototype/class resolution — node-model fold P1 (#2591 / EPIC #2081).
+
+A node's ``prototype_key`` names a prototype *definition* — a
+:class:`~fichero.knowledge.knowledge_models.ClassificationValue` row with
+``dimension == document_prototype``. Prototypes form a class hierarchy via
+``parent_key`` and carry inheritable ``attributes``. This module resolves a
+prototype key to its **effective** attributes: the parent chain merged
+root → leaf, so a child prototype overrides its ancestors (Tinderbox-style
+inheritance — the P1 keystone the folds build on).
+
+Prefer-raise: an unknown key or a cyclic ``parent_key`` chain raises rather
+than silently returning partial/empty attributes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .knowledge.knowledge_models import ClassificationDimension, ClassificationValue
+
+
+class PrototypeResolutionError(Exception):
+    """Raised when a prototype key cannot be resolved (unknown key or a cycle)."""
+
+
+def _prototype_by_key(db, key: str) -> ClassificationValue | None:
+    matches = db.query(
+        ClassificationValue,
+        dimension=ClassificationDimension.document_prototype,
+        key=key,
+    )
+    return matches[0] if matches else None
+
+
+def resolve_prototype_attributes(db, key: str) -> dict[str, Any]:
+    """Return a prototype's effective attributes (parent chain merged root→leaf).
+
+    A child prototype's own ``attributes`` override values inherited from its
+    ``parent_key`` ancestors.
+
+    Raises:
+        PrototypeResolutionError: ``key`` (or an ancestor it points at) is
+            unknown, or the ``parent_key`` chain contains a cycle.
+    """
+    # Walk to the root collecting the chain leaf → root, detecting cycles.
+    chain: list[ClassificationValue] = []
+    seen: set[str] = set()
+    cursor: str | None = key
+    while cursor is not None:
+        if cursor in seen:
+            raise PrototypeResolutionError(
+                f"Cyclic prototype parent chain at {cursor!r}"
+            )
+        seen.add(cursor)
+        proto = _prototype_by_key(db, cursor)
+        if proto is None:
+            raise PrototypeResolutionError(f"Unknown prototype key: {cursor!r}")
+        chain.append(proto)
+        cursor = proto.parent_key
+
+    # Merge root → leaf so the leaf (the requested key) wins.
+    merged: dict[str, Any] = {}
+    for proto in reversed(chain):
+        merged.update(proto.attributes)
+    return merged

--- a/fichero-engine/tests/unit/test_node_prototypes.py
+++ b/fichero-engine/tests/unit/test_node_prototypes.py
@@ -1,0 +1,80 @@
+"""Tests for prototype/class resolution — node-model fold P1 (#2591)."""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from fichero.db import Database
+from fichero.knowledge.knowledge_models import (
+    ClassificationDimension,
+    ClassificationValue,
+)
+from fichero.node_prototypes import (
+    PrototypeResolutionError,
+    resolve_prototype_attributes,
+)
+
+
+@pytest.fixture
+def temp_db():
+    tmpdir = tempfile.mkdtemp()
+    db = Database(Path(tmpdir) / "test.duckdb")
+    yield db
+    db.close()
+    shutil.rmtree(tmpdir)
+
+
+def _proto(db, key, *, parent_key=None, attributes=None):
+    db.save(
+        ClassificationValue(
+            dimension=ClassificationDimension.document_prototype,
+            key=key,
+            label=key.title(),
+            parent_key=parent_key,
+            attributes=attributes or {},
+        )
+    )
+
+
+def test_child_inherits_and_overrides_parent_attributes(temp_db):
+    _proto(temp_db, "container", attributes={"chat_enabled": True, "icon": "folder"})
+    _proto(
+        temp_db,
+        "workspace",
+        parent_key="container",
+        attributes={"icon": "rectangle.3.group", "carries_tasks": True},
+    )
+
+    effective = resolve_prototype_attributes(temp_db, "workspace")
+    assert effective["chat_enabled"] is True  # inherited from container
+    assert effective["carries_tasks"] is True  # own
+    assert effective["icon"] == "rectangle.3.group"  # child overrides parent
+
+
+def test_three_level_chain_merges_root_to_leaf(temp_db):
+    _proto(temp_db, "node", attributes={"a": 1})
+    _proto(temp_db, "container", parent_key="node", attributes={"b": 2})
+    _proto(temp_db, "room", parent_key="container", attributes={"a": 99, "c": 3})
+
+    effective = resolve_prototype_attributes(temp_db, "room")
+    assert effective == {"a": 99, "b": 2, "c": 3}
+
+
+def test_unknown_key_raises(temp_db):
+    with pytest.raises(PrototypeResolutionError):
+        resolve_prototype_attributes(temp_db, "does-not-exist")
+
+
+def test_unknown_parent_raises(temp_db):
+    _proto(temp_db, "child", parent_key="ghost", attributes={"x": 1})
+    with pytest.raises(PrototypeResolutionError):
+        resolve_prototype_attributes(temp_db, "child")
+
+
+def test_cyclic_chain_raises(temp_db):
+    _proto(temp_db, "a", parent_key="b")
+    _proto(temp_db, "b", parent_key="a")
+    with pytest.raises(PrototypeResolutionError):
+        resolve_prototype_attributes(temp_db, "a")


### PR DESCRIPTION
Second foundation keystone for Node Model & Endpoint Unification (#2591).

**P1 — Prototype/class system (attribute inheritance):**
- `ClassificationValue` (the `document_prototype` store, which already carried `parent_key`) gains an `attributes` dict.
- `node_prototypes.resolve_prototype_attributes(db, key)` merges the `parent_key` chain root→leaf so a child prototype overrides its ancestors.
- Unknown key / unknown parent / cyclic chain all raise `PrototypeResolutionError` (prefer-raise).

P1 + P2 (alias, #2750) are the two keystones the staging doc requires before any fold (F1 saved-searches, F2 workspace, F3 tasks, F5 mind-palace all block on P1).

Gate: ruff clean + 5 prototype unit tests + **full unit suite 6122 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)