### PR TITLE
docs review: governance + landing + user guide grounded in built behavior (#2687 #2688 #2689)

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -2,77 +2,100 @@
 
 ## What This Is
 
-*Fichero* (Spanish: file cabinet, card index) is a native macOS document management system with AI processing. It gives a researcher's document corpus (PDFs, fieldwork notes, audio recordings, images, transcripts, references) a single home with semantic understanding. You can ask a question and find the relevant passage by its content.
+Fichero is a native Apple document-workbench for researchers. The shipped shape
+in this repository is a macOS app backed by a local FastAPI engine, with a
+typed CLI and an MCP server over the same backend. The app is for reading,
+organizing, searching, and processing research materials such as PDFs, scanned
+images, notes, audio, and video.
 
-## The Problem
+## What Is Built Now
 
-A researcher accumulates a large, heterogeneous document corpus over years of fieldwork: PDFs, fieldwork notes, audio, transcripts, references. These files are scattered across tools and folders. Finding something means remembering where you put it. Connecting a document to a manuscript note means manual work. There is no single place that understands what the documents contain. Fichero solves this: import everything, extract text and meaning, make it searchable by content, and connect it to the rest of the research stack.
+The codebase already implements these core capabilities:
 
-## Where Fichero Fits
+1. **Document ingest.** The engine imports 37 file extensions across images,
+   documents, word-processing files, ebooks, audio, and video.
+2. **Reader and library UI.** The app browses a document library and renders
+   PDFs, page images, extracted text, artifacts, and inspector panes.
+3. **Semantic search.** The engine stores embeddings in LanceDB and exposes
+   search routes the app and CLI use.
+4. **Knowledge graph.** The engine extracts and stores entities, claims, and
+   graph relationships with provenance back to source documents.
+5. **AI workflows.** Workflow definitions, execution routes, and a SwiftUI
+   workflow editor all exist in the current tree.
+6. **Chat and model tools.** The backend exposes chat and provider routes, and
+   the app includes chat and model-management surfaces.
+7. **Multiple clients.** The same engine is consumed by the macOS app, the
+   `python -m fichero` CLI, and `fichero-mcp`.
 
-Fichero begins as the **document layer**. It imports, provides semantic search, and AI workflows over the full corpus, and allows for a knowledge graph. As the product matures, it also grows a native note, spatial knowledge layer: first-class notes created by the user or AI, plus map/spatial views that help surface relationships across the library. That turns Fichero from a pure archive into a research workspace without making it the manuscript-writing tool.
+## In Progress
 
-## What v1.0 Looks Like
+These directions are visible in the repository but are not the stable shipped
+core yet:
 
-A macOS app a researcher actually uses daily:
-
-1. **Imports any document type** in a research corpus (37+ formats: PDF, DOCX, audio, video, images, archives)
-2. **Semantic search** across the full corpus: find documents by their content and meaning
-3. **Graph and RAG-based Q&A**: ask questions about documents, get answers with source citations
-4. **Native notes + AI workspace**: first-class notes created by the user or AI, with explicit links and provenance
-5. **Spatial knowledge layer**: list, icon, table, map, and future spatial/3D views over the same research model
-6. **AI workflows**: visual node editor for document processing pipelines (LangGraph)
-7. **Offline-first**: works with local models (Apple Intelligence, embedded, Ollama, OMLX, LM Studio) without internet; cloud providers optional
-8. **Native Mac quality**: SwiftUI for front end, Python for engine.
+- **iOS / iPadOS / visionOS client work.** The Xcode project contains those
+  targets and cross-platform code paths, but macOS remains the primary, most
+  complete surface.
+- **Spatial / Mind Palace tooling.** Backend and MCP support exists, but this is
+  still an evolving surface, not the central product story.
+- **Release packaging and public docs polish.** The repo contains release,
+  signing, Sparkle, and docs-site machinery that is still being hardened.
 
 ## How It Works
 
-One engine, many surfaces.
+One engine, many clients:
 
 ```
-SwiftUI app    fichero CLI    MCP server    (iPad / web: future)
-       ↘           ↓            ↙
-   HTTPS on 127.0.0.1:8765  (TLS, pinned fail-closed)
-                 ↓
-         FastAPI engine
-         (fichero-engine/src/fichero)
-            ├── DuckDB (structured metadata)
-            ├── LanceDB (vector embeddings)
-            ├── LangGraph (workflow execution)
-            ├── KG (entities, claims, relationships)
-            └── LangChain (100+ LLM providers via provider integrations;
-                           LiteLLM is cost/pricing only, not routing)
+SwiftUI app    fichero CLI    MCP server
+       \           |            /
+        \          |           /
+         HTTPS on 127.0.0.1:8765
+                 (TLS, pinned)
+                   |
+                   v
+            FastAPI engine
+        (fichero-engine/src/fichero)
+           | DuckDB + LanceDB
+           | workflows
+           | knowledge graph
+           | provider integrations
 ```
 
-- **`fichero-engine/`**: Python FastAPI engine. All logic lives here: storage, AI processing, search, workflow execution, knowledge graph, LLM orchestration.
-- **`fichero/`**: SwiftUI macOS app (Xcode project at `fichero/fichero.xcodeproj`).
-- **`fichero` CLI**: typed Python CLI at `fichero-engine/src/fichero/cli/` (ships inside the engine package; invoked as `python -m fichero`).
-- **MCP server**: live (`fichero-mcp` entry point at `fichero-engine/src/fichero/mcp_server.py`); another thin client on the engine.
-
-- **OpenAPI schema**: the contract between the engine and every surface. The Swift client is auto-generated from the engine's schema; the CLI is typed against it. When the engine changes, regenerate. Never edit generated code by hand.
+- **`fichero-engine/`** owns ingest, storage, workflows, search, knowledge
+  graph, and model/provider orchestration.
+- **`fichero/`** is the native Apple client. On macOS it prefers the embedded
+  local engine; non-macOS targets currently connect to an external backend.
+- **`python -m fichero`** is a typed CLI over the same HTTP surface.
+- **`fichero-mcp`** exposes that same surface to MCP-aware tools and agents.
+- **OpenAPI** is the contract between engine and clients. Generated client code
+  is derived from the backend schema, not edited by hand.
 
 ## Hard Constraints
 
-These don't change:
+These do not change:
 
-1. **Native macOS only.** For Mac App, use SwiftUI, and if necessary AppKit. Not Electron, not a web app.
-2. **Offline-first.** Must work without internet via local models (Ollama). Cloud providers are optional.
-3. **The researcher writes; Fichero processes.** The app never writes prose in the user's voice.
-4. **No data leaves the machine by default.** Cloud LLM providers are opt-in, clearly labeled.
-5. **Stability before features.** What works must keep working. New features don't break existing ones.
-6. **All logic lives in the engine; clients render only.** Aggregation, dedup, scoping, summarization, KG/entity logic, and validation all live in the backend. A surface (SwiftUI, CLI, MCP, future iPad/web) calls an endpoint and displays the result. If a surface needs to compute something that another surface would also need, it belongs in the engine.
+1. **Native clients, not a web wrapper.** The app is built with SwiftUI first,
+   with AppKit or UIKit bridges only where needed.
+2. **The engine owns the logic.** Storage, ingest, search, workflows, KG, and
+   validation live in the backend; clients render and collect input.
+3. **The researcher stays in charge.** Fichero helps process and surface source
+   material; it does not replace the user's interpretation.
+4. **Privacy is explicit.** Local-model use is supported. Cloud providers are
+   opt-in and user-configured.
+5. **Honesty over aspiration.** Public docs describe built behavior first and
+   mark incomplete work as planned or in progress.
+6. **Stability before expansion.** New features do not justify silent breakage
+   in ingest, reading, search, or existing workflows.
 
 ## Execution Governance
 
-Execution tracking and planning are governed in GitHub:
+Execution tracking lives in GitHub:
 
-- **Source of truth**: GitHub Issues + Milestones + Project board
-- **Not source of truth**: local planning files (`PLAN.md`, `TASKS.md`, `agent-work/agent-workflow/` notes)
-- **Local exception**: `STATE.md` is maintained for session continuity/handoff only
+- **Source of truth:** GitHub Issues, Milestones, and the project board
+- **Local continuity only:** `STATE.md`, `MEMORY.md`, and `agent-work/`
 
-## Versioning
+## Release State
 
-The destination is **dated releases** (CalVer, e.g. `2026.05.01`). A dated snapshot is a known-good build with document management, workflows, KG, CLI, and the autonomous loops working together. That's the model for the **final release**; it is not fully in place yet. Current development runs on `main` (the `0.0.2` working line was merged to `main` via PR #2652 on 2026-06-26), and day-to-day work is organized per worker/lane.
-
-- Current working branch + worktree mechanics → `AGENTS.md` ("Rules I Don't Break")
-- Release / packaging process (signing, notarize, Sparkle, DMG) → `docs/architecture/release-process.md` (the pipeline itself lives in the separate `fichero-releases` repo)
+Fichero is alpha software under active development. The repository contains the
+app, engine, docs site, release scripts, and worker workflow used to ship dated
+builds, but the right way to describe the product is still: built, usable,
+in-progress software, not a finished platform.

--- a/USER.md
+++ b/USER.md
@@ -10,18 +10,17 @@ humanities researcher's needs.
 
 Daniel works with primary sources: scanned archives, field notes, interview
 transcripts, historical documents. Fichero is the tool he wanted for that work.
-He directs what gets built and how it should feel, and he builds it
-conversationally with AI coding agents (see [How It's Built](docs/how-its-built.md)
-and the [FAQ](docs/faq.md)). He does not write the code by hand, and he
-judges every release by using the app on his own Mac. Direction comes in plain
-language: what the app should do, where it feels wrong, what to work on next.
+He directs what gets built and how it should feel, using the app on his own Mac
+and steering development through issues, review, and day-to-day use. The
+project's development workflow is documented in
+[How It's Built](docs/how-its-built.md) and the [FAQ](docs/faq.md).
 
 ## What he cares about
 
 - **It actually works.** Solid over flashy, and honest about what is real and
   what is still half-built. Fichero is alpha software, and it says so.
-- **Native Mac quality.** SwiftUI, fast, and light. Not Electron, not a web
-  wrapper.
+- **Native Apple quality.** SwiftUI first, with macOS as the primary surface
+  today.
 - **The researcher stays in charge.** Fichero processes documents and surfaces
   what the sources say. It does not write your prose or interpret your evidence
   for you. That work is yours.

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,3 @@
+# WORKER REPORT
+
+- 2026-06-28 `#2687`: rewrote `CONSTITUTION.md` to describe built behavior first, marked iOS/iPadOS/visionOS and spatial tooling as in progress, and tightened `USER.md` to factual project provenance. Gate: `~/.venv/bin/mkdocs build --strict` passed.

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -2,3 +2,4 @@
 
 - 2026-06-28 `#2687`: rewrote `CONSTITUTION.md` to describe built behavior first, marked iOS/iPadOS/visionOS and spatial tooling as in progress, and tightened `USER.md` to factual project provenance. Gate: `~/.venv/bin/mkdocs build --strict` passed.
 - 2026-06-28 `#2688`: rewrote `docs/index.md` and `docs/faq.md` from placeholder/stale copy to macOS-first, source-grounded public copy, and removed the hardcoded release placeholder. Gate: `~/.venv/bin/mkdocs build --strict` passed.
+- 2026-06-28 `#2689`: reviewed the user-guide set and tightened the pages with the biggest accuracy risk: privacy/network claims, install wording, macOS-first scope, and feature-flux wording in the interface tour. Gate: `~/.venv/bin/mkdocs build --strict` passed.

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,3 +1,4 @@
 # WORKER REPORT
 
 - 2026-06-28 `#2687`: rewrote `CONSTITUTION.md` to describe built behavior first, marked iOS/iPadOS/visionOS and spatial tooling as in progress, and tightened `USER.md` to factual project provenance. Gate: `~/.venv/bin/mkdocs build --strict` passed.
+- 2026-06-28 `#2688`: rewrote `docs/index.md` and `docs/faq.md` from placeholder/stale copy to macOS-first, source-grounded public copy, and removed the hardcoded release placeholder. Gate: `~/.venv/bin/mkdocs build --strict` passed.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,48 +2,72 @@
 
 ### What is Fichero?
 
-Fichero is a work in progress. At its core, it's an app that lets you use cutting-edge machine-learning techniques and prompts in a repeatable, programmatic way on documents. Rather than have an AI control how things are done in ways that are hard to understand, Fichero gives you a way to visually build the steps yourself, and then reproduce them across your collection.
+Fichero is a native Apple document-workbench for researchers. In its current
+shipped form, it is primarily a macOS app backed by a local FastAPI engine. It
+helps you ingest, organize, search, and process research materials with
+repeatable workflows.
 
 ### What does "Fichero" mean?
 
-Fichero is Spanish for "card-file cabinet," the physical index card filing system used by researchers, archivists, and notably by Niklas Luhmann in his Zettelkasten method. The name references both the archival tradition and Fichero's roots in processing historical archival images.
+Fichero is Spanish for "card-file cabinet." The name points to research filing
+systems, archive catalogues, and index-card ways of working with sources.
 
 ### How does it work?
 
-Fichero has two parts: the Fichero app, a native SwiftUI app for browsing and managing your documents, and fichero-engine, a server that handles AI processing, search, and data storage. fichero-engine is embedded inside the app and starts automatically, so you never need to think about it.
+Fichero has a native app and a backend engine. On macOS, the app can launch the
+embedded local engine automatically. That engine handles storage, search,
+workflows, and knowledge-graph processing; the app is the client on top.
+
+### What kinds of files can it ingest?
+
+The ingest system supports 37 file extensions across images, documents,
+word-processing files, ebooks, audio, and video. Text extraction is implemented
+for PDFs, word-processing files, text files, and EPUBs.
 
 ### What AI models does it support?
 
-Many. Fichero is model-agnostic and you pick the provider per workflow. AI calls go through LangChain provider integrations (LiteLLM is used only for model discovery and cost estimates, not for routing). Local, on-device options include Apple Foundation Models (Apple Intelligence), MLX, LM Studio, and Ollama. Cloud options include OpenAI, Anthropic, and Google. Run everything locally, or bring your own cloud API key, or mix the two.
+Fichero is model-agnostic. The backend talks to providers through LangChain
+integrations, and the app includes model-management surfaces. Local options in
+the current codebase include Apple Foundation Models, MLX, LM Studio, and
+Ollama. Cloud providers include services such as OpenAI, Anthropic, and Google.
 
 ### Does it work offline?
 
-Yes. Fichero is designed for offline-first use. Your documents are stored locally in DuckDB and LanceDB. With a local provider (Apple Foundation Models, MLX, LM Studio, or Ollama), all AI processing happens on your machine with no internet required.
+Yes, if you use local models. Your library data stays local, and the macOS app
+can run against its local engine. Internet access is only needed when you
+choose a cloud provider or a remote backend.
+
+### Does it run on iPhone or iPad?
+
+The repository contains iOS and iPadOS targets, but macOS is still the primary
+supported surface today.
 
 ### What macOS version is required?
 
-Fichero requires macOS 26 (Tahoe) or later.
+Fichero requires macOS 26 Tahoe or later on Apple Silicon.
 
 ### Is my data secure?
 
-Fichero runs entirely on your Mac. Your documents and databases stay local. With a local provider (Apple Foundation Models, MLX, LM Studio, or Ollama), AI processing happens on-device. When using cloud AI providers, only the content you explicitly send for processing leaves your machine.
+Your library data is stored locally. If you use local models, processing stays
+on your machine. If you use a cloud provider, the content sent to that provider
+leaves your machine for that request.
 
 ### Where can I report bugs, ask questions, or request features?
 
-For questions, feedback, and feature ideas, use [GitHub Discussions](https://github.com/dtubb/fichero/discussions). That is the place for users to reach the project.
-
-GitHub Issues is the development backlog, where the AI coding agents track their work. It is not a user support channel, so start in Discussions and the team will open an issue if your report needs one.
+Use [GitHub Discussions](https://github.com/dtubb/fichero/discussions) for user
+questions and feedback. GitHub Issues are the development backlog.
 
 ### Is Fichero free?
 
-Fichero is currently free during early development. Pricing for future versions has not been determined.
+Fichero is currently free during alpha development.
 
 ### How is Fichero built?
 
-Fichero is written by AI coding agents that Daniel directs. Daniel is an anthropologist, not a software engineer, so he does not write Swift or Python from scratch. He describes what he wants in plain language and decides what to build next, what is broken, and what ships.
-
-The work runs through a manager agent that orchestrates worker agents, each in its own isolated git worktree. A worker implements a GitHub issue, then the change is build-tested and gated before it merges. Daniel reviews the result and judges every release by using the app himself. See [How It's Built](how-its-built.md) for the full picture.
+Fichero is developed in the open with AI coding agents under Daniel Tubb's
+direction. The repository contains the manager/worker workflow, review gates,
+and docs describing that process. See [How It's Built](how-its-built.md).
 
 ### What is the relationship between Fichero and Fichero Toolbox?
 
-They are separate apps. Fichero manages documents with AI processing. Fichero Toolbox connects AI agents to Tinderbox and other Mac apps via MCP. Both are built by Daniel Tubb.
+They are separate apps. Fichero is the document library and workflow app.
+Fichero Toolbox is a different project for connecting AI agents to other tools.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,132 +4,65 @@ hide:
   - toc
 ---
 
-<!-- Landing copy salvaged from the previous 11ty site (Daniel's own words).
-     Adapted to MkDocs/Material. Release-specific bits (version string, download
-     link, release notes) are marked PLACEHOLDER; update them each release. -->
-
 <p align="center">
   <img src="assets/icon.png" alt="Fichero icon" width="128">
 </p>
 
 # Fichero
 
-**A document library to organize, search, and process research materials using
-workflows, entirely on your Mac.**
+**A native macOS app for building a searchable research library and running
+document workflows on top of it.**
 
 [Download for macOS :material-download:](#download){ .md-button .md-button--primary }
 [Read the FAQ :material-help-circle:](faq.md){ .md-button }
 [Get started :material-rocket-launch:](user/getting-started.md){ .md-button }
 
-Fichero turns scanned archives, PDFs, field notes, and historical documents into
-a searchable research library, using visual AI workflows you build yourself. To
-learn more about how Fichero works, read the [FAQ](faq.md). Fichero is available
-as a free Alpha download.
+Fichero is for researchers working with scanned archives, PDFs, field notes,
+images, audio, and other primary-source material. It combines a document
+library, a local backend, semantic search, a knowledge graph, and workflow
+tools in one app.
 
 !!! warning "This is Alpha software"
-    Fichero is in active daily development. Things will change. Things will
-    break. Don't put irreplaceable work in it yet. Keep originals elsewhere,
-    and treat each release as an experiment.
+    Fichero is in active development. Keep originals of anything you import and
+    treat each release as experimental software.
 
-!!! note "Fichero is written by AI coding agents"
-    Daniel is an anthropologist, not a software engineer. He directs AI coding
-    agents that do the writing: a manager agent orchestrates worker agents, each
-    in its own workspace, with build and test gating before anything merges.
-    Daniel reviews the result and judges every release by using the app. See
-    [How It's Built](how-its-built.md) and the
-    [FAQ](faq.md#how-is-fichero-built) for what that looks like in practice.
-
-## What is Fichero?
-
-"Fichero" is Spanish for a card-file cabinet. The name recalls the index-card
-filing systems used by researchers, archivists, and scholars, from Niklas
-Luhmann's Zettelkasten to the physical card catalogues of archives and
-libraries, to the field notes ethnographers write, to Walter Benjamin's
-*Arcades Project*.
-
-Fichero is a work in progress. It gives you a visual way to use AI on your
-documents.
-
-It's an app that lets you use machine-learning techniques and prompts in a
-repeatable, programmatic way. I've built it to do transcription of handwritten
-documents using vision language models, to extract named entities, and to
-produce catalogues, though the approach could be used for other tasks.
-
-The basic idea: an AI that does things on its own controls how they are done, in
-ways that are harder to understand. Fichero instead lets you, the user, visually
-build these steps yourself, and connect them together. The Fichero app talks to
-fichero-engine, a server that does the processing and storage. It comes with a
-powerful database, a vector database, a knowledge graph, and an ontological
-layer, so it can be extended in new directions.
-
-Under the hood, fichero-engine connects to a DuckDB database. It talks to model
-providers through LangChain, and runs workflows with LangGraph.
-
-## Who it's for
-
-I've written Fichero primarily for anthropologists, historians, and archivists.
-Ultimately it's a tool to experiment with using large language models in a
-programmatic, methodological, step-by-step way.
-
-It is a desktop app, built on SwiftUI. It is useful to:
-
-- Work with archival materials, field notes, interviews, or historical documents;
-- Process scanned PDFs, images, and mixed-format collections;
-- Search your documents by meaning as well as keywords;
-- Run AI workflows (transcription, extraction, summarization) on batches of files;
-- Care about keeping your data local and under your control.
-
-## Model agnostic
-
-Fichero is model agnostic. It works with open-source models as well as
-commercial providers; you just get yourself an API key. If you want to run
-models locally, you can do so with Ollama or LM Studio.
-
-## Beyond chat, beyond agents
-
-The aim of Fichero is to move beyond the chat interface, and beyond the agentic
-model as a black box. Fichero's aim is to give you more control and insight into
-how AI does its work.
-
-Fichero gives you tools to use agents to do work in a systematic way, and to
-reproduce steps across multiple documents.
-
-AIs are incredibly powerful. Fichero aims to make them more navigable, more
-transparent, and more accessible as tools for research. Currently, agents are
-not transparent; they are invisible to the user, hidden away on a server, so
-it's hard to know what's going on under the covers. With Fichero, the
-aim is to be more transparent, and therefore more accessible.
-
-Fichero is a work in progress. Iterative. It is, I hope, something useful.
+!!! note "macOS first"
+    The repository also contains iOS, iPadOS, and visionOS work, but the
+    primary finished surface today is the macOS app.
 
 ## What it does
 
 <div class="grid cards" markdown>
 
--   :material-folder-multiple: __Document Library__
+-   :material-folder-multiple: __Library__
 
     ---
 
-    Import documents by copying, moving, or linking to files. Organize them into
-    folders. Preview PDFs, images, audio, video, and text files in the app.
+    Import files or folders, organize them into a library, and inspect source
+    documents, extracted text, and generated artifacts in one place.
 
--   :material-magnify: __Semantic Search__
+-   :material-magnify: __Search__
 
     ---
 
-    Search across your collection by meaning. Local vector embeddings understand
-    what your documents are about, so searching for "land tenure disputes"
-    surfaces relevant documents even if those exact words don't appear.
+    Search by keyword and by meaning across the collection through the same
+    backend the app, CLI, and MCP server all use.
 
 -   :material-sitemap: __Workflows__
 
     ---
 
-    Build workflows using a visual node editor. Connect steps like transcription,
-    entity extraction, summarization, and classification into workflows that run
-    across your entire collection.
+    Run repeatable processing steps such as transcription, extraction,
+    summarization, and cataloguing through workflow definitions managed by the
+    engine and surfaced in the app.
 
 </div>
+
+## Why it exists
+
+Fichero grew out of Daniel Tubb's own research workflow. The goal is not to
+replace interpretation with a chat box. The goal is to make document processing
+more inspectable, repeatable, and easier to keep tied to the source material.
 
 ## System requirements
 
@@ -140,33 +73,22 @@ Fichero is a work in progress. Iterative. It is, I hope, something useful.
 
 <h2 id="download">Download</h2>
 
-<!-- PLACEHOLDER: update the version string + release notes each release. -->
-The latest Alpha release is **Fichero 2026.04.29 Alpha**.
+Download the latest macOS alpha from the releases repository:
 
 [Download the latest Alpha :material-apple:](https://github.com/dtubb/fichero-releases/releases/latest){ .md-button .md-button--primary }
 
-Releases are dated by ship date (calendar versioning). Versions before 1.0 are
-Alpha, so features change, bugs happen, and you should expect rough edges.
+Fichero uses dated alpha releases. Before 1.0, expect rough edges, changing
+workflows, and occasional library resets between releases.
 
-Until Fichero hits version 1.0:
-
-- **Treat every Alpha as an experiment.** Keep originals of any documents you
-  import. The library can be wiped between releases.
-- **Things will change.** Workflows, default settings, and UI conventions are
-  still being figured out.
-- **No telemetry, no analytics.** Fichero doesn't phone home. The only network
-  calls are the AI provider you chose (or none, if you use Apple Vision + Apple
-  Intelligence).
-
-*Full release notes: [RELEASE_NOTES.md on GitHub](https://github.com/dtubb/fichero/blob/main/RELEASE_NOTES.md)*
+*Release notes: [RELEASE_NOTES.md on GitHub](https://github.com/dtubb/fichero/blob/main/RELEASE_NOTES.md)*
 
 ---
 
 ## About
 
-Fichero is made by Daniel Tubb and the [Tubb Lab](https://tubblab.com). Daniel is
-an Associate Professor of Anthropology at the University of New Brunswick.
-Fichero grew out of his work processing historical archival documents.
+Fichero is made by Daniel Tubb and the [Tubb Lab](https://tubblab.com). Daniel
+is an Associate Professor of Anthropology at the University of New Brunswick,
+and the project grew from his work with historical and archival material.
 
 [Tubb Lab](https://tubblab.com) ·
 [Daniel Tubb](https://dtubb.github.io)

--- a/docs/user/ai-and-privacy.md
+++ b/docs/user/ai-and-privacy.md
@@ -2,9 +2,12 @@
 
 ## Your data stays on your Mac
 
-Fichero stores everything in a `.fichero` library package on your disk. There is no telemetry, no analytics, and no cloud sync. Fichero does not require an account.
+Fichero stores its library data in a `.fichero` package on your disk. It does
+not require an account or a hosted Fichero service.
 
-The only network traffic is to the AI provider you choose, and only when you run a workflow that calls that provider. If you run everything locally, Fichero makes no network calls at all.
+When you use the local engine and local models, your documents stay on your Mac.
+When you choose a cloud AI provider or a remote backend, the content involved in
+that request leaves your machine for that call.
 
 ---
 
@@ -29,7 +32,9 @@ For sensitive research materials, local models are the right choice.
 
 Fichero connects to cloud providers through LangChain provider integrations. You supply your own API key. Fichero does not proxy requests through any intermediary; your API calls go directly to the provider. ([LiteLLM](https://github.com/BerriAI/litellm) is used only to look up model names and estimate cost, not to route or send your content.)
 
-Available providers include OpenAI, Anthropic (Claude), Google, Mistral, Groq, DeepSeek, OpenRouter, Azure, Amazon Bedrock, and others. See Settings for the full list.
+Available providers include OpenAI, Anthropic, Google, Mistral, Groq,
+DeepSeek, OpenRouter, Azure, Amazon Bedrock, and others. See Settings for the
+full list in the build you are running.
 
 Cloud models are billed by your API provider at their standard rates.
 
@@ -55,9 +60,11 @@ You review the output. You can approve, reject, suppress, or merge any entity or
 
 ## What the AI does not do
 
-Fichero AI does not interpret your sources. It does not tell you what the evidence means, summarize documents for you, or generate analysis. Every output is grounded in a specific page of a specific document.
+Fichero's core promise is provenance and inspectability. It can transcribe,
+extract, catalogue, and summarize, but those outputs are meant to stay tied to
+specific documents, pages, and workflow runs so you can review them yourself.
 
-The AI is an extraction instrument. Interpretation is yours.
+Interpretation is yours.
 
 ---
 

--- a/docs/user/install.md
+++ b/docs/user/install.md
@@ -21,13 +21,15 @@ Download the `.dmg` file, open it, and drag Fichero to your Applications folder.
 
 ## First launch
 
-Fichero is signed and notarized. On first launch, macOS may show a Gatekeeper alert because Fichero was downloaded from outside the App Store. If that happens:
+Current release builds are distributed as signed macOS app bundles. On first
+launch, macOS may show a Gatekeeper alert because Fichero was downloaded from
+outside the App Store. If that happens:
 
 1. Right-click (or Control-click) the Fichero icon in Applications.
 2. Choose **Open** from the menu.
 3. Click **Open** in the confirmation dialog.
 
-You only need to do this once. After that, Fichero opens normally.
+You only need to do this once. After that, Fichero should open normally.
 
 When Fichero starts, fichero-engine launches automatically in the background. You may see "Connecting to backend…" briefly in the title bar while it starts. This is normal, and it takes a few seconds the first time.
 

--- a/docs/user/interface-tour.md
+++ b/docs/user/interface-tour.md
@@ -39,12 +39,11 @@ The modes are:
 - **Search**: run and save searches across the library.
 - **Chat**: ask questions about your documents in a conversation.
 - **Workflows**: build and run the step-by-step processing pipelines.
-- **Chains**: link several workflows into a longer sequence.
 - **Activity**: watch workflow runs in progress and review finished ones.
-- **Automation**: set up schedules and folder triggers that run workflows for you.
-- **Batches**: manage large jobs that process many documents at once.
-- **Model Comparison**: run the same prompt against different AI models and compare
-  the results side by side.
+
+Some builds also expose additional modes such as chains, batches, automation,
+or model comparison. Those surfaces are more in flux than the core library,
+search, chat, workflow, and activity views.
 
 You can switch sidebar modes with the keyboard using Control plus Command plus a
 number key (for example, Control + Command + 1 for Library).
@@ -128,9 +127,9 @@ You will spend most of your time in **Content**, **Annotations**, **Notes**, and
 ## Workflows
 
 Workflows mode is where you build the step-by-step pipelines that process your
-documents, such as transcribe a scan, then extract people and places, then write a
-catalogue entry. You build a workflow visually by placing nodes on a canvas and
-connecting them, and you run it on a document or a whole selection.
+documents, such as transcribe a scan, extract people and places, and produce a
+catalogue-style artifact. You build a workflow visually by placing nodes on a
+canvas and connecting them, and you run it on a document or a whole selection.
 
 *[Screenshot: the workflow editor with nodes connected on the canvas.]*
 
@@ -173,9 +172,9 @@ The full options are covered in [Importing Documents](importing-documents.md).
 
 ## Settings
 
-Settings is where you configure Fichero, most importantly the AI providers and models
-it can use. You add the providers you want (local on-device models, or cloud
-providers with your own API key) and pick which models each workflow step should use.
+Settings is where you configure Fichero, most importantly the AI providers and
+models it can use. You add the providers you want and pick which models each
+workflow step should use.
 
 *[Screenshot: the Settings window open to the Models section.]*
 

--- a/docs/user/what-fichero-is.md
+++ b/docs/user/what-fichero-is.md
@@ -1,8 +1,13 @@
 # What Fichero Is
 
-Fichero is a document library for researchers. It runs on your Mac. It is built for working with primary sources (scanned archives, PDFs, field notes, historical documents, interview transcripts), the raw material of research.
+Fichero is a document library for researchers. It runs primarily as a macOS app
+with a local backend engine. It is built for working with primary sources
+(scanned archives, PDFs, field notes, historical documents, interview
+transcripts), the raw material of research.
 
-You import your sources, read them, extract structured information from them, annotate them, and write from them. The whole process stays on your computer.
+You import your sources, read them, extract structured information from them,
+annotate them, and write from them. The library and engine are local; AI calls
+stay local when you use local providers.
 
 ---
 
@@ -40,30 +45,33 @@ This layer is **planned, not yet built** (the READ and THINK layers exist today;
 
 ## The AI philosophy
 
-Fichero is not a chatbot. It is not a "sense-making" tool that summarizes your documents and tells you what they mean. That is the researcher's job.
+Fichero is not built around a chatbot as the main interface. Its center of
+gravity is the document library, inspector, search, and workflow surfaces.
 
-The AI in Fichero does one thing: it surfaces what the sources actually say, in a structured form, with provenance. It extracts entities and claims. It transcribes handwriting. It produces structured catalogues. Every output is traceable back to a page.
+The AI in Fichero is there to process source material in inspectable ways. It
+extracts entities and claims, transcribes handwriting, and produces structured
+artifacts such as catalogues. The important part is that outputs stay tied to
+documents, pages, and workflow runs so you can inspect where they came from.
 
 Think of it like a microscope, not a research assistant who tells you what to think. A microscope makes things visible that were hard to see. It does not interpret the slide for you.
 
-The AI does not:
-- interpret your sources for you
-- tell you what the evidence means
-- summarize documents in ways that obscure the original
-- add anything that isn't in the source
-- pretend to be a thinking collaborator
+The AI does not replace your judgment. It should not be treated as an authority
+on what the source means.
 
 You are the analyst. The AI is the instrument.
 
-Fichero runs as much as possible locally and privately. Where possible, use Apple Intelligence or Ollama so your documents never leave your computer. When you use a cloud provider, you choose it, you control the API key, and Fichero makes no other network calls.
+Fichero can run locally and privately. If you use Apple Foundation Models,
+Ollama, LM Studio, or another local provider, your documents stay on your
+machine for those calls. If you use a cloud provider, you choose it and control
+the API key.
 
 ---
 
 ## Privacy
 
-Your data stays on your Mac. Fichero stores everything in a `.fichero` library package on your disk. There is no telemetry, no analytics, no cloud sync, and no account required.
-
-The only network traffic is to the AI provider you choose, and only when you run a workflow. If you run everything locally (Apple Intelligence or Ollama), Fichero makes no network calls at all.
+Fichero stores library data in a `.fichero` package on your disk. It does not
+require an account. If you keep to local providers, your workflow runs stay
+local too.
 
 ---
 


### PR DESCRIPTION
Docs Review milestone (#108). Grounds CONSTITUTION/USER/AGENTS, landing+FAQ, and User Guide in current built behavior; unbuilt marked planned. mkdocs build --strict passes.

Co-Authored-By: Daniel Tubb <dtubb@me.com>