### PR TITLE
docs review: developer docs + API reference grounded in code (#2690 #2691)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,3 @@
+# WORKER REPORT
+
+- 2026-06-28 `#2690`: corrected contributor docs and `how-its-built` to match the current transport, route-tiering, canonical skill locations, and worktree rules. Gate: `~/.venv/bin/mkdocs build --strict` passed.

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,3 +1,4 @@
 # WORKER REPORT
 
 - 2026-06-28 `#2690`: corrected contributor docs and `how-its-built` to match the current transport, route-tiering, canonical skill locations, and worktree rules. Gate: `~/.venv/bin/mkdocs build --strict` passed.
+- 2026-06-28 `#2691`: tightened `docs/api-reference/index.md` to describe the real committed OpenAPI surface and removed the incorrect claim that the schema version tracks dated releases. Gate: `~/.venv/bin/mkdocs build --strict` passed.

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -8,12 +8,16 @@ hide:
 !!! warning "Work in progress, unstable"
     The Fichero API is still in progress. Endpoints and response shapes will
     change before 1.0, and this is not yet a stable contract. Do not build
-    against it expecting backward compatibility. The API version tracks the
-    dated release.
+    against it expecting backward compatibility.
 
 The Fichero engine is a FastAPI application that exposes an OpenAPI 3 schema.
 The interactive reference below is rendered from the committed schema
 (`openapi.json`, copied from `fichero-engine/tests/contracts/openapi.json`).
+
+That committed schema is the real backend surface used to generate the Swift
+client and document the engine routes. In the current contract it includes route
+families for documents, search, workflows, workflow execution, annotations,
+providers, knowledge-graph endpoints, mind-palace endpoints, and more.
 
 !!! note
     This is a static render of the committed contract schema. For live,

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -20,9 +20,9 @@ Fichero is not a single-process desktop app. The macOS app is a native SwiftUI a
 The shortest accurate picture is:
 
 ```text
-SwiftUI app -> localhost HTTP API -> FastAPI engine -> DuckDB + LanceDB
-                                               -> LangGraph workflows
-                                               -> LLM providers via LangChain integrations
+SwiftUI app -> pinned HTTPS loopback -> FastAPI engine -> DuckDB + LanceDB
+                                                     -> LangGraph workflows
+                                                     -> LLM providers via LangChain integrations
 ```
 
 That architecture shapes almost every contributor task:
@@ -39,7 +39,7 @@ For all backend mutations, the starting point is the action registry. Every writ
 
 ## Core Reference Material In This Repo
 
-- Root guidance: [../CLAUDE.md](../CLAUDE.md)
+- Detailed architecture + dev guide: [../CLAUDE.md](../CLAUDE.md)
 - Operational rules: [../../AGENTS.md](../../AGENTS.md)
 - Backend overview: [../architecture/api/overview.md](../architecture/api/overview.md)
 - SwiftUI overview: [../architecture/swiftui/overview.md](../architecture/swiftui/overview.md)

--- a/docs/contributor/architecture-overview.md
+++ b/docs/contributor/architecture-overview.md
@@ -12,10 +12,12 @@
 
 Fichero is a two-part system:
 
-- `fichero/fichero/`: the native macOS SwiftUI app
+- `fichero/fichero/`: the native Apple SwiftUI app, with macOS as the primary surface today
 - `fichero-engine/src/fichero/`: the Python FastAPI engine
 
-The Swift app is not the source of truth for data or AI behavior. It is a UI layer that talks to the engine over HTTP on `localhost:8765`.
+The Swift app is not the source of truth for data or AI behavior. It is a UI
+layer that talks to the engine over pinned HTTPS on `127.0.0.1:8765` for the
+local macOS path.
 
 ## Frontend Responsibilities
 
@@ -44,18 +46,25 @@ The backend owns:
 - workflow execution, tasking, and activity logs
 - provider and model configuration
 
-`fichero.api.main` is the application entry point. `db.py` is the main storage abstraction over DuckDB and LanceDB. Business features are exposed through route modules under `fichero/api/routes/`.
+`fichero.api.main` is the application entry point. `db.py` is the main storage
+abstraction over DuckDB and LanceDB. Business features are exposed through
+route modules under `fichero/api/routes/`.
 
 ## Route Registration and Feature Tiers
 
-The engine does not always register the same route set. `register_tiered_routes` in `api/main.py` chooses routers based on `FICHERO_FEATURE_TIER`.
+The engine does not always register the same route set. `register_tiered_routes`
+in `api/main.py` chooses routers based on `FICHERO_FEATURE_TIER`.
 
 Two practical tiers matter:
 
-- `release`: stable core routes
-- `dev`: adds staged KG, research, graph, and other experimental or not-yet-promoted surfaces
+- `release`: the default route set used by the app and normal builds
+- `dev`: `release` plus the currently dev-tier extras
 
-Core routes include activity, annotations, documents, entities, folders, ingest, providers, search, tasks, workflow execution, and workflows. Dev-tier routes add the `/api/kg/*` family plus related graph and research surfaces.
+As of the current `api/main.py`, most knowledge-graph, research, action,
+chains, model-comparison, and automation-related surfaces are already in the
+core route list. The remaining dev-tier surface is small; contributors should
+check `get_route_specs_for_tier` in `fichero.api.main` rather than assuming KG
+or research routes are dev-only.
 
 ## One Engine, Many Surfaces
 
@@ -65,6 +74,7 @@ The same backend is also consumed by:
 
 - the typed `python -m fichero` CLI
 - generated Swift service layers
-- web-oriented or research-oriented surfaces in development
+- `fichero-mcp`
+- additional Apple-client surfaces that are still in progress
 
 That is why backend behavior should be explained in terms of routes and models, not in terms of one specific screen.

--- a/docs/contributor/setup-and-contributing.md
+++ b/docs/contributor/setup-and-contributing.md
@@ -14,7 +14,7 @@ The commands below are the current repo-standard ones from `AGENTS.md`.
 ### Backend
 
 ```bash
-PYTHONPATH=fichero-engine/src .venv/bin/uvicorn fichero.api.main:app --port 8765
+bash fichero-engine/scripts/start_backend.sh
 PYTHONPATH=fichero-engine/src .venv/bin/ruff check fichero-engine/src/
 PYTHONPATH=fichero-engine/src .venv/bin/pytest fichero-engine/tests/unit/ --ignore=fichero-engine/tests/unit/_archived
 ```
@@ -36,6 +36,7 @@ swiftlint lint fichero/fichero/
 The frontend depends on the local engine being available. For normal app development:
 
 1. start the backend on port `8765`
+   via `bash fichero-engine/scripts/start_backend.sh`
 2. open `fichero/fichero.xcodeproj`
 3. build and run the macOS app against that engine
 
@@ -84,7 +85,9 @@ ruby scripts/add-swift-file.rb fichero/fichero/Views/MyFolder/MyView.swift
 
 ### No per-task branches
 
-Commit work directly to the milestone branch. Do not create a branch per issue or per task. For a large or risky slice an isolated agent worktree under `.claude/worktrees/` is fine, but it is keyed to the work, not to a version.
+Commit work directly to the milestone branch. Do not create a branch per issue
+or per task. Isolated worktrees live under `~/code/fichero-worktrees/<name>`,
+not ad hoc sibling directories.
 
 ### Conventional commits with issue references
 

--- a/docs/how-its-built.md
+++ b/docs/how-its-built.md
@@ -16,8 +16,9 @@ unreviewed code.
 
 ## The two core roles
 
-Work is organized around a **manager / worker** split, defined as session-start
-skills in `agent-work/agent-workflow/skills/`:
+Work is organized around a **manager / worker** split. In the current repo, the
+canonical reusable skills live under `agents/skills/`, with older workflow
+notes and templates still preserved under `agent-work/agent-workflow/`:
 
 - **Manager** (`session-start-manager`): the control lane. It reads project
   state and the roadmap, triages GitHub issues, decides what to do next, and
@@ -72,7 +73,8 @@ A few hard rules keep the machine usable while agents run:
 ## Three execution modes
 
 The workflow picks the lightest tool that fits the task
-(`agent-work/agent-workflow/parallel-execution.md`):
+(`agent-work/agent-workflow/parallel-execution.md` remains the detailed
+reference note for that pattern):
 
 | Mode | What it is | Use when |
 |---|---|---|
@@ -118,6 +120,7 @@ those lessons down at the end of a working session.
 
 ---
 
-*This page describes the development workflow, not a feature of the app. For the
-full operational detail, see `agent-work/agent-workflow/parallel-execution.md` and the
-skills in `agent-work/agent-workflow/skills/`.*
+*This page describes the development workflow, not a feature of the app. For
+the detailed operating rules, see `AGENTS.md`, the current skills under
+`agents/skills/`, and the longer background notes in
+`agent-work/agent-workflow/`.*


### PR DESCRIPTION
Docs Review (#108). Developer/'How It's Built' docs grounded in current repo state; API Reference derived from committed OpenAPI schema. mkdocs build --strict passes.

Co-Authored-By: Daniel Tubb <dtubb@me.com>