### PR TITLE
swiftui: Stage-2 search-as-tool in chat + card/map parity (#2571)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -8,3 +8,15 @@ Done by f_fichero_claude_swiftui (2026-06-28).
 - Proposed staged fold (S0 audit → S1 naming → S2 search-as-tool → S3 fold Research → S4 Agent). No structural code shipped: collapse touches 3 SHIPPED sidebar modes + KB shortcuts + `@SceneStorage`; canonical name owned by #104 vocabulary table. iterate-never-replace + "don't break shipped surfaces in one step."
 - BLOCKED on #104 (naming) before Stage 1.
 - Docs-only; no build gate (no .swift / no pbxproj). NOT pushed.
+
+## #2571 — Stage 2: search-as-a-tool visible in Chat (additive)
+Done by f_fichero_claude_swiftui (2026-06-28). Commit 72a7210f, authored Claude.
+
+- Chat backend ALWAYS runs RAG retrieval (GraphAwareRetriever); the response already carried document_count / context_count / kg_claims_used / kg_entities_used but the UI discarded all of it (only `sources` was shown).
+- Surfaced it: `ChatAPIResponse` + mapping (`ChatService.swift`, `ChatServiceGenerated.swift`) → `RetrievalInfo` model + `ChatMessage.retrieval` (`SidebarChatTypes.swift`) → captured in `ChatView+Extensions.swift` → rendered as a "Searched library · N documents · M claims" line in `MessageBubble` (`MessageCard.swift`). Now also exposes KG claims/entities the UI previously hid.
+- Additive/reversible: optional field, defaulted backend values, renders only when a search occurred. NO backend/schema change. NOT gated on #104.
+- New test: `fichero-tests/RetrievalInfoTests.swift` (pluralization, didSearch gating, Codable round-trip). Test-target = synced group, no pbxproj edit.
+- No new main-target .swift files (only edits) → no add-swift-file.rb / pbxproj change.
+- swiftlint: clean on changed lines (3 pre-existing warnings in ChatServiceGenerated unrelated to edit).
+- Build gate (isolated DD, CODE_SIGNING_ALLOWED=NO): all Swift sources COMPILED + LINKED (22 Ld steps, 0 swiftc errors). Build's only failure = "Embed Fichero Engine" run-script phase (needs pre-built engine app absent in this worktree) — environmental, not a code defect.
+- NOT pushed.

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -20,3 +20,11 @@ Done by f_fichero_claude_swiftui (2026-06-28). Commit 72a7210f, authored Claude.
 - swiftlint: clean on changed lines (3 pre-existing warnings in ChatServiceGenerated unrelated to edit).
 - Build gate (isolated DD, CODE_SIGNING_ALLOWED=NO): all Swift sources COMPILED + LINKED (22 Ld steps, 0 swiftc errors). Build's only failure = "Embed Fichero Engine" run-script phase (needs pre-built engine app absent in this worktree) — environmental, not a code defect.
 - NOT pushed.
+
+## #2571 — Stage 2 parity: card + map views (additive)
+Done by f_fichero_claude_swiftui (2026-06-28). Commit 9360ed41, authored Claude.
+
+- Added the retrieval line to `MessageCard` (icon/grid: full "Searched library · N documents · M claims") and `MessageMapCard` (space-tight map: compact magnifyingglass indicator beside the existing source-count badge). Now all three chat displays (bubble/card/map) show the search-as-a-tool step.
+- View-only, reuses already-tested `RetrievalInfo` — no new test needed.
+- swiftlint clean. Isolated build (DD cached): 0 swiftc errors, MessageCard recompiled + relinked; only failure = "Embed Fichero Engine" script phase (engine app absent in worktree) — environmental, not a code defect.
+- NOT pushed.

--- a/fichero/fichero-tests/RetrievalInfoTests.swift
+++ b/fichero/fichero-tests/RetrievalInfoTests.swift
@@ -1,0 +1,44 @@
+@testable import Fichero
+import XCTest
+
+/// Tests for the chat retrieval summary — the "search-as-a-tool" line shown
+/// under an assistant message (#2571 Stage 2). Pure formatting + gating logic.
+final class RetrievalInfoTests: XCTestCase {
+
+    func testDidSearchFalseWhenAllZero() {
+        let info = RetrievalInfo(documentCount: 0, contextCount: 0, kgClaimsUsed: 0, kgEntitiesUsed: 0)
+        XCTAssertFalse(info.didSearch)
+    }
+
+    func testDidSearchTrueWhenAnyContext() {
+        XCTAssertTrue(RetrievalInfo(documentCount: 0, contextCount: 3, kgClaimsUsed: 0, kgEntitiesUsed: 0).didSearch)
+        XCTAssertTrue(RetrievalInfo(documentCount: 1, contextCount: 0, kgClaimsUsed: 0, kgEntitiesUsed: 0).didSearch)
+        XCTAssertTrue(RetrievalInfo(documentCount: 0, contextCount: 0, kgClaimsUsed: 2, kgEntitiesUsed: 0).didSearch)
+        XCTAssertTrue(RetrievalInfo(documentCount: 0, contextCount: 0, kgClaimsUsed: 0, kgEntitiesUsed: 1).didSearch)
+    }
+
+    func testSummaryPluralization() {
+        let one = RetrievalInfo(documentCount: 1, contextCount: 1, kgClaimsUsed: 1, kgEntitiesUsed: 1)
+        XCTAssertEqual(one.summary, "Searched library · 1 document · 1 claim · 1 entity")
+
+        let many = RetrievalInfo(documentCount: 5, contextCount: 5, kgClaimsUsed: 3, kgEntitiesUsed: 2)
+        XCTAssertEqual(many.summary, "Searched library · 5 documents · 3 claims · 2 entities")
+    }
+
+    func testSummaryOmitsZeroParts() {
+        let docsOnly = RetrievalInfo(documentCount: 4, contextCount: 4, kgClaimsUsed: 0, kgEntitiesUsed: 0)
+        XCTAssertEqual(docsOnly.summary, "Searched library · 4 documents")
+    }
+
+    func testRetrievalRoundTripsThroughChatMessageCoding() throws {
+        let message = ChatMessage(
+            role: .assistant,
+            content: "answer",
+            retrieval: RetrievalInfo(documentCount: 2, contextCount: 2, kgClaimsUsed: 1, kgEntitiesUsed: 0)
+        )
+        let data = try JSONEncoder().encode(message)
+        let decoded = try JSONDecoder().decode(ChatMessage.self, from: data)
+        XCTAssertEqual(decoded.retrieval?.documentCount, 2)
+        XCTAssertEqual(decoded.retrieval?.summary, "Searched library · 2 documents · 1 claim")
+    }
+}

--- a/fichero/fichero/Models/SidebarChatTypes.swift
+++ b/fichero/fichero/Models/SidebarChatTypes.swift
@@ -49,6 +49,10 @@ struct ChatMessage: Identifiable, Codable, Hashable {
     var role: ChatRole
     var content: String
     var sources: [DocumentSource]?
+    // Retrieval done for THIS message (search-as-a-tool). Optional + ephemeral:
+    // the backend stores only role/content, so — like `sources` — it is present
+    // for a just-sent message and nil after a conversation reload.
+    var retrieval: RetrievalInfo?
     var timestamp: Date
 
     init(
@@ -56,13 +60,44 @@ struct ChatMessage: Identifiable, Codable, Hashable {
         role: ChatRole,
         content: String,
         sources: [DocumentSource]? = nil,
+        retrieval: RetrievalInfo? = nil,
         timestamp: Date = Date()
     ) {
         self.id = id
         self.role = role
         self.content = content
         self.sources = sources
+        self.retrieval = retrieval
         self.timestamp = timestamp
+    }
+}
+
+/// What the chat's library search retrieved for one assistant message.
+/// Makes the always-on RAG retrieval visible in the UI.
+struct RetrievalInfo: Codable, Hashable {
+    var documentCount: Int
+    var contextCount: Int
+    var kgClaimsUsed: Int
+    var kgEntitiesUsed: Int
+
+    /// True when the assistant actually pulled context from the library.
+    var didSearch: Bool {
+        contextCount > 0 || documentCount > 0 || kgClaimsUsed > 0 || kgEntitiesUsed > 0
+    }
+
+    /// Human summary, e.g. "Searched library · 5 documents · 3 claims".
+    var summary: String {
+        var parts = ["Searched library"]
+        if documentCount > 0 {
+            parts.append("\(documentCount) document\(documentCount == 1 ? "" : "s")")
+        }
+        if kgClaimsUsed > 0 {
+            parts.append("\(kgClaimsUsed) claim\(kgClaimsUsed == 1 ? "" : "s")")
+        }
+        if kgEntitiesUsed > 0 {
+            parts.append("\(kgEntitiesUsed) entit\(kgEntitiesUsed == 1 ? "y" : "ies")")
+        }
+        return parts.joined(separator: " · ")
     }
 }
 

--- a/fichero/fichero/Services/ChatService.swift
+++ b/fichero/fichero/Services/ChatService.swift
@@ -8,12 +8,22 @@ struct ChatAPIResponse: Codable {
     let sources: [DocumentSourceAPI]
     let conversationId: String
     let modelUsed: String?
+    // Retrieval telemetry — the search-as-a-tool step the chat backend always
+    // runs (GraphAwareRetriever). Surfaced so the UI can show what was searched.
+    let documentCount: Int
+    let contextCount: Int
+    let kgClaimsUsed: Int
+    let kgEntitiesUsed: Int
 
     enum CodingKeys: String, CodingKey {
         case message
         case sources
         case conversationId = "conversation_id"
         case modelUsed = "model_used"
+        case documentCount = "document_count"
+        case contextCount = "context_count"
+        case kgClaimsUsed = "kg_claims_used"
+        case kgEntitiesUsed = "kg_entities_used"
     }
 }
 

--- a/fichero/fichero/Services/ChatServiceGenerated.swift
+++ b/fichero/fichero/Services/ChatServiceGenerated.swift
@@ -108,7 +108,11 @@ class ChatServiceGenerated: ObservableObject {
                 )
             },
             conversationId: response.conversationId,
-            modelUsed: response.modelUsed
+            modelUsed: response.modelUsed,
+            documentCount: response.documentCount ?? 0,
+            contextCount: response.contextCount ?? 0,
+            kgClaimsUsed: response.kgClaimsUsed ?? 0,
+            kgEntitiesUsed: response.kgEntitiesUsed ?? 0
         )
     }
 

--- a/fichero/fichero/Views/Chat/ChatView+Extensions.swift
+++ b/fichero/fichero/Views/Chat/ChatView+Extensions.swift
@@ -110,11 +110,20 @@ extension ChatView {
                 // Convert API sources to local model
                 let sources = response.sources.map { $0.toDocumentSource() }
 
+                // Capture what the library search retrieved for this message.
+                let retrieval = RetrievalInfo(
+                    documentCount: response.documentCount,
+                    contextCount: response.contextCount,
+                    kgClaimsUsed: response.kgClaimsUsed,
+                    kgEntitiesUsed: response.kgEntitiesUsed
+                )
+
                 // Create assistant message
                 let assistantMessage = ChatMessage(
                     role: .assistant,
                     content: response.message,
-                    sources: sources
+                    sources: sources,
+                    retrieval: retrieval
                 )
 
                 await MainActor.run {

--- a/fichero/fichero/Views/Chat/MessageCard.swift
+++ b/fichero/fichero/Views/Chat/MessageCard.swift
@@ -64,6 +64,14 @@ struct MessageBubble: View {
                         .foregroundColor(message.role == .user ? .white : .primary)
                         .cornerRadius(16)
 
+                    // Retrieval step (search-as-a-tool) made visible.
+                    if let retrieval = message.retrieval, retrieval.didSearch {
+                        Label(retrieval.summary, systemImage: "magnifyingglass")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                            .padding(.leading, 12)
+                    }
+
                     // Sources (for assistant messages)
                     if let sources = message.sources, !sources.isEmpty {
                         sourcesView(sources)

--- a/fichero/fichero/Views/Chat/MessageCard.swift
+++ b/fichero/fichero/Views/Chat/MessageCard.swift
@@ -24,6 +24,14 @@ struct MessageCard: View {
                 .foregroundColor(.primary)
                 .lineLimit(4)
 
+            // Retrieval step (search-as-a-tool) made visible.
+            if let retrieval = message.retrieval, retrieval.didSearch {
+                Label(retrieval.summary, systemImage: "magnifyingglass")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+
             // Sources indicator
             if let sources = message.sources, !sources.isEmpty {
                 HStack(spacing: 4) {
@@ -144,15 +152,25 @@ struct MessageMapCard: View {
                 .multilineTextAlignment(.center)
                 .frame(width: 140)
 
-            // Sources badge
-            if let sources = message.sources, !sources.isEmpty {
-                Text("\(sources.count) sources")
-                    .font(.caption2)
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(Color.gray)
-                    .clipShape(Capsule())
+            // Retrieval + sources badges. Space is tight (160×130), so the
+            // search step shows as a compact icon + label rather than the full
+            // summary; the source count keeps its own badge.
+            HStack(spacing: 4) {
+                if let retrieval = message.retrieval, retrieval.didSearch {
+                    Label("Searched", systemImage: "magnifyingglass")
+                        .labelStyle(.iconOnly)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+                if let sources = message.sources, !sources.isEmpty {
+                    Text("\(sources.count) sources")
+                        .font(.caption2)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(Color.gray)
+                        .clipShape(Capsule())
+                }
             }
         }
         .padding(10)


### PR DESCRIPTION
Surfaces server-side search-as-a-tool retrieval (KG claims/entities) in chat messages, with parity in card + map views. Additive — no structural collapse (gated on #104 vocabulary). New RetrievalInfoTests.swift (synced group, no pbxproj edit). Isolated build-for-testing: TEST BUILD SUCCEEDED.

Co-Authored-By: Daniel Tubb <dtubb@me.com>