### PR TITLE
docs: chat retrieval cues in interface tour (#2758)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,12 @@
+# Worker Report
+
+## 2026-06-28
+
+- Documented the shipped chat retrieval UI from `#2758` in [docs/user/interface-tour.md](/Users/danieltubb/code/fichero-worktrees/ms-docs/docs/user/interface-tour.md).
+- Verified the behavior against `ChatView+Extensions.swift`, `MessageCard.swift`, `SidebarChatTypes.swift`, `RetrievalInfoTests.swift`, and the backend retrieval path in `fichero-engine/src/fichero/api/routes/chat.py` plus `fichero-engine/src/fichero/retrieval/graph_rag.py`.
+- Captured current behavior only:
+  - assistant replies can show a retrieval summary when library search ran
+  - citations can list source documents with relevance percentages
+  - card and map chat layouts expose the same retrieval/source state in compact forms
+  - retrieval/source metadata is not yet restored after conversation reload
+- Gate: `~/.venv/bin/mkdocs build --strict` passed.

--- a/docs/user/interface-tour.md
+++ b/docs/user/interface-tour.md
@@ -143,12 +143,28 @@ For a fuller walkthrough, see
 
 ## Chat
 
-Chat mode lets you ask questions about your documents in plain language and get
-answers grounded in the sources, with links back to the passages the answer drew
-from. It is a way to interrogate your material, and it always shows you where an
-answer came from so you can check it.
+Chat mode lets you ask questions about your documents in plain language. When the
+assistant pulls context from your library, the reply can show that retrieval step
+directly in the message so you can tell the answer was grounded in library search.
 
 *[Screenshot: a chat conversation with source links beside the answer.]*
+
+### When chat cites sources
+
+When a reply uses library retrieval, Fichero can show a line such as
+`Searched library · 5 documents · 3 claims · 2 entities` beneath the assistant's
+answer. That summary tells you, at a glance, whether the response drew on document
+matches only or also on knowledge-graph material connected to those documents.
+
+If source citations are available, the same message can also list the source
+documents used for the answer and show a relevance percentage for each one. In the
+more visual chat layouts, Fichero keeps the same cues in compact form: card-style
+messages show the retrieval summary plus a source count, while map-style messages
+show compact search and source badges.
+
+This metadata is currently attached to the reply that just came back from the
+server. If you reload an older conversation, the saved transcript keeps the message
+text, but the retrieval summary and source list are not yet restored.
 
 ## Search
 


### PR DESCRIPTION
Documents what users see when chat answers cite sources (retrieval cues, KG claims/entities). Grounded in merged code. mkdocs --strict passes.

Co-Authored-By: Daniel Tubb <dtubb@me.com>