### PR TITLE
node-model fold F3: research plans/tasks/steps into document nodes (#2591)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,1 @@
+2026-06-28 F3 research-content fold: ResearchPlan/Task/Step now hydrate from research_plan/research_task/research_step document nodes with parent-child hierarchy, targeted ruff + pytest green.

--- a/fichero-engine/src/fichero/db.py
+++ b/fichero-engine/src/fichero/db.py
@@ -164,6 +164,12 @@ _SAVED_SEARCH_PROTOTYPE_KEY = "saved_search"
 _SAVED_SEARCH_QUERY_ITEM_ID = "saved-search-query"
 _RESEARCH_WORKSPACE_NODE_KIND = "workspace"
 _RESEARCH_WORKSPACE_PROTOTYPE_KEY = "research_workspace"
+_RESEARCH_PLAN_NODE_KIND = "plan"
+_RESEARCH_PLAN_PROTOTYPE_KEY = "research_plan"
+_RESEARCH_TASK_NODE_KIND = "task"
+_RESEARCH_TASK_PROTOTYPE_KEY = "research_task"
+_RESEARCH_STEP_NODE_KIND = "step"
+_RESEARCH_STEP_PROTOTYPE_KEY = "research_step"
 
 
 def _is_content_marker_only(text: str) -> bool:
@@ -443,6 +449,7 @@ class Database(DatabaseEmbeddingMixin):
         self._backfill_claim_links_to_library_links()
         self._backfill_saved_search_documents()
         self._backfill_research_workspace_documents()
+        self._backfill_research_plan_task_step_documents()
 
     def _connect(self) -> duckdb.DuckDBPyConnection:
         """Open a DuckDB connection for this library path."""
@@ -693,6 +700,12 @@ class Database(DatabaseEmbeddingMixin):
             self._save_saved_search_document(obj)
         if type(obj).__name__ == "ResearchProject":
             self._save_research_workspace_document(obj)
+        if type(obj).__name__ == "ResearchPlan":
+            self._save_research_plan_document(obj)
+        if type(obj).__name__ == "ResearchTask":
+            self._save_research_task_document(obj)
+        if type(obj).__name__ == "ResearchStep":
+            self._save_research_step_document(obj)
 
         # Auto-embed if requested and has content
         # ponytail: bulk callers (importers / reindex loops) that save many
@@ -813,6 +826,19 @@ class Database(DatabaseEmbeddingMixin):
             if (hydrated := self._hydrate_row(ResearchProject, columns, row)) is not None
         ]
 
+    def _legacy_all_research_rows(self, model_cls: type[BaseModel]) -> list[BaseModel]:
+        """Read legacy research rows without node folding."""
+        sql_table = self._sql_table_name(model_cls)
+        self._ensure_table(model_cls)
+        with self._lock:
+            rows = self._execute(f"SELECT * FROM {sql_table}").fetchall()
+            columns = [desc[0] for desc in self.conn.description]
+        return [
+            hydrated
+            for row in rows
+            if (hydrated := self._hydrate_row(model_cls, columns, row)) is not None
+        ]
+
     @staticmethod
     def _saved_search_from_document(doc: Any) -> BaseModel:
         """Hydrate a SavedSearch view-model from its folded document node."""
@@ -911,6 +937,173 @@ class Database(DatabaseEmbeddingMixin):
         docs = self.query(Document, prototype_key=_RESEARCH_WORKSPACE_PROTOTYPE_KEY)
         return [self._research_project_from_document(doc) for doc in docs]
 
+    @staticmethod
+    def _research_plan_from_document(doc: Any) -> BaseModel:
+        """Hydrate a ResearchPlan view-model from its document node."""
+        from fichero.research_models import PlanStatus, ResearchPlan
+
+        if doc.prototype_key != _RESEARCH_PLAN_PROTOTYPE_KEY:
+            raise ValueError(f"Document {doc.id} is not a research plan node")
+        if not doc.parent_id:
+            raise ValueError(f"Research plan {doc.id} is missing project parent_id")
+
+        attrs = doc.attributes if isinstance(doc.attributes, dict) else {}
+        description = attrs.get("description", "")
+        if not isinstance(description, str):
+            raise ValueError(f"Research plan {doc.id} has invalid description payload")
+        status_value = attrs.get("status", PlanStatus.draft.value)
+        try:
+            status = PlanStatus(status_value)
+        except Exception as exc:
+            raise ValueError(
+                f"Research plan {doc.id} has invalid status payload: {status_value!r}"
+            ) from exc
+        order_index = attrs.get("order_index", 0)
+        if not isinstance(order_index, int):
+            raise ValueError(f"Research plan {doc.id} has invalid order_index payload")
+        metadata = attrs.get("metadata", {})
+        if not isinstance(metadata, dict):
+            raise ValueError(f"Research plan {doc.id} has invalid metadata payload")
+
+        return ResearchPlan(
+            id=doc.id,
+            project_id=doc.parent_id,
+            name=doc.name,
+            description=description,
+            status=status,
+            order_index=order_index,
+            metadata=metadata,
+            created_at=doc.created_at,
+            updated_at=doc.updated_at,
+        )
+
+    @staticmethod
+    def _research_task_from_document(doc: Any) -> BaseModel:
+        """Hydrate a ResearchTask view-model from its document node."""
+        from fichero.research_models import ResearchTask, TaskStatus
+
+        if doc.prototype_key != _RESEARCH_TASK_PROTOTYPE_KEY:
+            raise ValueError(f"Document {doc.id} is not a research task node")
+        if not doc.parent_id:
+            raise ValueError(f"Research task {doc.id} is missing plan parent_id")
+
+        attrs = doc.attributes if isinstance(doc.attributes, dict) else {}
+        description = attrs.get("description", "")
+        if not isinstance(description, str):
+            raise ValueError(f"Research task {doc.id} has invalid description payload")
+        status_value = attrs.get("status", TaskStatus.pending.value)
+        try:
+            status = TaskStatus(status_value)
+        except Exception as exc:
+            raise ValueError(
+                f"Research task {doc.id} has invalid status payload: {status_value!r}"
+            ) from exc
+        priority = attrs.get("priority", 0)
+        if not isinstance(priority, int):
+            raise ValueError(f"Research task {doc.id} has invalid priority payload")
+        assigned_to = attrs.get("assigned_to")
+        if assigned_to is not None and not isinstance(assigned_to, str):
+            raise ValueError(f"Research task {doc.id} has invalid assigned_to payload")
+        metadata = attrs.get("metadata", {})
+        if not isinstance(metadata, dict):
+            raise ValueError(f"Research task {doc.id} has invalid metadata payload")
+        completed_at = attrs.get("completed_at")
+        if completed_at is not None and not hasattr(completed_at, "isoformat"):
+            # Parsed DB datetimes arrive as datetimes; raw malformed payloads fail loud.
+            raise ValueError(f"Research task {doc.id} has invalid completed_at payload")
+
+        return ResearchTask(
+            id=doc.id,
+            plan_id=doc.parent_id,
+            name=doc.name,
+            description=description,
+            status=status,
+            priority=priority,
+            assigned_to=assigned_to,
+            metadata=metadata,
+            created_at=doc.created_at,
+            updated_at=doc.updated_at,
+            completed_at=completed_at,
+        )
+
+    @staticmethod
+    def _research_step_from_document(doc: Any) -> BaseModel:
+        """Hydrate a ResearchStep view-model from its document node."""
+        from fichero.research_models import ResearchStep, StepStatus, StepTool
+
+        if doc.prototype_key != _RESEARCH_STEP_PROTOTYPE_KEY:
+            raise ValueError(f"Document {doc.id} is not a research step node")
+        if not doc.parent_id:
+            raise ValueError(f"Research step {doc.id} is missing task parent_id")
+
+        attrs = doc.attributes if isinstance(doc.attributes, dict) else {}
+        tool_value = attrs.get("tool")
+        try:
+            tool = StepTool(tool_value)
+        except Exception as exc:
+            raise ValueError(
+                f"Research step {doc.id} has invalid tool payload: {tool_value!r}"
+            ) from exc
+        description = attrs.get("description", "")
+        if not isinstance(description, str):
+            raise ValueError(f"Research step {doc.id} has invalid description payload")
+        config = attrs.get("config", {})
+        if not isinstance(config, dict):
+            raise ValueError(f"Research step {doc.id} has invalid config payload")
+        status_value = attrs.get("status", StepStatus.pending.value)
+        try:
+            status = StepStatus(status_value)
+        except Exception as exc:
+            raise ValueError(
+                f"Research step {doc.id} has invalid status payload: {status_value!r}"
+            ) from exc
+        result = attrs.get("result", {})
+        if not isinstance(result, dict):
+            raise ValueError(f"Research step {doc.id} has invalid result payload")
+        error = attrs.get("error")
+        if error is not None and not isinstance(error, str):
+            raise ValueError(f"Research step {doc.id} has invalid error payload")
+        order_index = attrs.get("order_index", 0)
+        if not isinstance(order_index, int):
+            raise ValueError(f"Research step {doc.id} has invalid order_index payload")
+        completed_at = attrs.get("completed_at")
+        if completed_at is not None and not hasattr(completed_at, "isoformat"):
+            raise ValueError(f"Research step {doc.id} has invalid completed_at payload")
+
+        return ResearchStep(
+            id=doc.id,
+            task_id=doc.parent_id,
+            tool=tool,
+            label=doc.name,
+            description=description,
+            config=config,
+            status=status,
+            result=result,
+            error=error,
+            order_index=order_index,
+            created_at=doc.created_at,
+            updated_at=doc.updated_at,
+            completed_at=completed_at,
+        )
+
+    def _all_folded_research_plans(self) -> list[BaseModel]:
+        from fichero.models import Document
+
+        docs = self.query(Document, prototype_key=_RESEARCH_PLAN_PROTOTYPE_KEY)
+        return [self._research_plan_from_document(doc) for doc in docs]
+
+    def _all_folded_research_tasks(self) -> list[BaseModel]:
+        from fichero.models import Document
+
+        docs = self.query(Document, prototype_key=_RESEARCH_TASK_PROTOTYPE_KEY)
+        return [self._research_task_from_document(doc) for doc in docs]
+
+    def _all_folded_research_steps(self) -> list[BaseModel]:
+        from fichero.models import Document
+
+        docs = self.query(Document, prototype_key=_RESEARCH_STEP_PROTOTYPE_KEY)
+        return [self._research_step_from_document(doc) for doc in docs]
+
     def get(self, model: Type[T], id: str) -> T | None:
         """Get a single object by ID."""
         if model.__name__ == "SavedSearch":
@@ -927,6 +1120,27 @@ class Database(DatabaseEmbeddingMixin):
             if doc is None or doc.prototype_key != _RESEARCH_WORKSPACE_PROTOTYPE_KEY:
                 return None
             return cast(T, self._research_project_from_document(doc))
+        if model.__name__ == "ResearchPlan":
+            from fichero.models import Document
+
+            doc = self.get(Document, id)
+            if doc is None or doc.prototype_key != _RESEARCH_PLAN_PROTOTYPE_KEY:
+                return None
+            return cast(T, self._research_plan_from_document(doc))
+        if model.__name__ == "ResearchTask":
+            from fichero.models import Document
+
+            doc = self.get(Document, id)
+            if doc is None or doc.prototype_key != _RESEARCH_TASK_PROTOTYPE_KEY:
+                return None
+            return cast(T, self._research_task_from_document(doc))
+        if model.__name__ == "ResearchStep":
+            from fichero.models import Document
+
+            doc = self.get(Document, id)
+            if doc is None or doc.prototype_key != _RESEARCH_STEP_PROTOTYPE_KEY:
+                return None
+            return cast(T, self._research_step_from_document(doc))
 
         sql_table = self._sql_table_name(model)
         self._ensure_table(model)
@@ -948,6 +1162,12 @@ class Database(DatabaseEmbeddingMixin):
             return cast(list[T], self._all_folded_saved_searches())
         if model.__name__ == "ResearchProject":
             return cast(list[T], self._all_folded_research_projects())
+        if model.__name__ == "ResearchPlan":
+            return cast(list[T], self._all_folded_research_plans())
+        if model.__name__ == "ResearchTask":
+            return cast(list[T], self._all_folded_research_tasks())
+        if model.__name__ == "ResearchStep":
+            return cast(list[T], self._all_folded_research_steps())
 
         sql_table = self._sql_table_name(model)
         self._ensure_table(model)
@@ -985,6 +1205,27 @@ class Database(DatabaseEmbeddingMixin):
             return cast(list[T], out)
         if model.__name__ == "ResearchProject":
             rows = self._all_folded_research_projects()
+            if not filters:
+                return cast(list[T], rows)
+            out: list[BaseModel] = []
+            for row in rows:
+                matches = True
+                for key, value in filters.items():
+                    if not hasattr(row, key):
+                        raise ValueError(f"Invalid column name: {key}")
+                    if getattr(row, key) != value:
+                        matches = False
+                        break
+                if matches:
+                    out.append(row)
+            return cast(list[T], out)
+        if model.__name__ in {"ResearchPlan", "ResearchTask", "ResearchStep"}:
+            folded_lookup = {
+                "ResearchPlan": self._all_folded_research_plans,
+                "ResearchTask": self._all_folded_research_tasks,
+                "ResearchStep": self._all_folded_research_steps,
+            }
+            rows = folded_lookup[model.__name__]()
             if not filters:
                 return cast(list[T], rows)
             out: list[BaseModel] = []
@@ -1326,6 +1567,8 @@ class Database(DatabaseEmbeddingMixin):
             self._delete_saved_search_document(obj.id)
         if type(obj).__name__ == "ResearchProject":
             self._delete_research_workspace_document(obj.id)
+        if type(obj).__name__ in {"ResearchPlan", "ResearchTask", "ResearchStep"}:
+            self._delete_research_content_document(obj.id)
 
     def _save_saved_search_document(self, saved: BaseModel) -> None:
         """Mirror a SavedSearch row into the document tree as a smart folder."""
@@ -1451,6 +1694,117 @@ class Database(DatabaseEmbeddingMixin):
         doc.updated_at = project.updated_at
         self.save(doc)
 
+    def _save_research_plan_document(self, plan: BaseModel) -> None:
+        """Mirror a ResearchPlan row into the document tree."""
+        from fichero.models import DocType, Document
+
+        existing = self.get(Document, plan.id)
+        metadata = (
+            dict(existing.metadata)
+            if existing is not None and isinstance(existing.metadata, dict)
+            else {}
+        )
+        metadata.update({"node_class": "research_plan", "research_plan_id": plan.id})
+        attributes = (
+            dict(existing.attributes)
+            if existing is not None and isinstance(existing.attributes, dict)
+            else {}
+        )
+        attributes.update({
+            "description": plan.description,
+            "status": plan.status.value,
+            "order_index": plan.order_index,
+            "metadata": plan.metadata,
+        })
+
+        doc = existing or Document(id=plan.id, name=plan.name)
+        doc.parent_id = plan.project_id
+        doc.name = plan.name
+        doc.node_kind = _RESEARCH_PLAN_NODE_KIND
+        doc.doc_type = DocType.folder
+        doc.prototype_key = _RESEARCH_PLAN_PROTOTYPE_KEY
+        doc.metadata = metadata
+        doc.attributes = attributes
+        doc.created_at = plan.created_at
+        doc.updated_at = plan.updated_at
+        self.save(doc)
+
+    def _save_research_task_document(self, task: BaseModel) -> None:
+        """Mirror a ResearchTask row into the document tree."""
+        from fichero.models import DocType, Document
+
+        existing = self.get(Document, task.id)
+        metadata = (
+            dict(existing.metadata)
+            if existing is not None and isinstance(existing.metadata, dict)
+            else {}
+        )
+        metadata.update({"node_class": "research_task", "research_task_id": task.id})
+        attributes = (
+            dict(existing.attributes)
+            if existing is not None and isinstance(existing.attributes, dict)
+            else {}
+        )
+        attributes.update({
+            "description": task.description,
+            "status": task.status.value,
+            "priority": task.priority,
+            "assigned_to": task.assigned_to,
+            "metadata": task.metadata,
+            "completed_at": task.completed_at,
+        })
+
+        doc = existing or Document(id=task.id, name=task.name)
+        doc.parent_id = task.plan_id
+        doc.name = task.name
+        doc.node_kind = _RESEARCH_TASK_NODE_KIND
+        doc.doc_type = DocType.folder
+        doc.prototype_key = _RESEARCH_TASK_PROTOTYPE_KEY
+        doc.metadata = metadata
+        doc.attributes = attributes
+        doc.created_at = task.created_at
+        doc.updated_at = task.updated_at
+        self.save(doc)
+
+    def _save_research_step_document(self, step: BaseModel) -> None:
+        """Mirror a ResearchStep row into the document tree."""
+        from fichero.models import DocType, Document
+
+        existing = self.get(Document, step.id)
+        metadata = (
+            dict(existing.metadata)
+            if existing is not None and isinstance(existing.metadata, dict)
+            else {}
+        )
+        metadata.update({"node_class": "research_step", "research_step_id": step.id})
+        attributes = (
+            dict(existing.attributes)
+            if existing is not None and isinstance(existing.attributes, dict)
+            else {}
+        )
+        attributes.update({
+            "tool": step.tool.value,
+            "description": step.description,
+            "config": step.config,
+            "status": step.status.value,
+            "result": step.result,
+            "error": step.error,
+            "order_index": step.order_index,
+            "completed_at": step.completed_at,
+        })
+
+        doc = existing or Document(id=step.id, name=step.label)
+        doc.parent_id = step.task_id
+        doc.name = step.label
+        doc.node_kind = _RESEARCH_STEP_NODE_KIND
+        doc.doc_type = DocType.file
+        doc.prototype_key = _RESEARCH_STEP_PROTOTYPE_KEY
+        doc.metadata = metadata
+        doc.attributes = attributes
+        doc.created_at = step.created_at
+        doc.updated_at = step.updated_at
+        self.save(doc)
+
     def _delete_research_workspace_document(self, project_id: str) -> None:
         """Remove the mirrored document row for a research workspace, if present."""
         from fichero.models import Document
@@ -1459,6 +1813,15 @@ class Database(DatabaseEmbeddingMixin):
         if doc is None:
             return
         self._execute("DELETE FROM documents WHERE id = $id", {"id": project_id})
+
+    def _delete_research_content_document(self, doc_id: str) -> None:
+        """Remove the mirrored document row for a folded research content node."""
+        from fichero.models import Document
+
+        doc = self.get(Document, doc_id)
+        if doc is None:
+            return
+        self._execute("DELETE FROM documents WHERE id = $id", {"id": doc_id})
 
     def _backfill_research_workspace_documents(self) -> None:
         """Backfill legacy research projects into workspace documents."""
@@ -1480,6 +1843,31 @@ class Database(DatabaseEmbeddingMixin):
 
         for project in self._legacy_all_research_project_rows():
             self._save_research_workspace_document(project)
+
+    def _backfill_research_plan_task_step_documents(self) -> None:
+        """Backfill legacy research plan/task/step rows into document nodes."""
+        if not hasattr(self.conn, "execute"):
+            return
+
+        from fichero.research_models import ResearchPlan, ResearchStep, ResearchTask
+
+        for model_cls, saver in (
+            (ResearchPlan, self._save_research_plan_document),
+            (ResearchTask, self._save_research_task_document),
+            (ResearchStep, self._save_research_step_document),
+        ):
+            table_name = self._table_name(model_cls)
+            table_exists = self.execute_fetchone(
+                """
+                SELECT COUNT(*) FROM information_schema.tables
+                WHERE table_name = $table_name
+                """,
+                {"table_name": table_name},
+            )
+            if not table_exists or int(table_exists[0] or 0) == 0:
+                continue
+            for row in self._legacy_all_research_rows(model_cls):
+                saver(row)
 
     def _backfill_claim_links_to_library_links(self) -> None:
         """Mirror legacy claim-link rows into generic library-link rows."""

--- a/fichero-engine/tests/unit/test_db.py
+++ b/fichero-engine/tests/unit/test_db.py
@@ -26,7 +26,13 @@ from fichero.models import (
     DocType, FileType, Status, RunStatus, SavedSearch
 )
 from fichero.db import Database
-from fichero.research_models import ResearchProject
+from fichero.research_models import (
+    ResearchPlan,
+    ResearchProject,
+    ResearchStep,
+    ResearchTask,
+    StepTool,
+)
 from fichero.knowledge_models import (
     ClaimRelationType,
     EntityType,
@@ -1286,6 +1292,135 @@ class TestResearchWorkspaceFold:
         assert project.metadata == {"topic": "archives"}
 
 
+class TestResearchContentFold:
+    def test_save_and_get_plan_task_step(self, temp_db):
+        project = ResearchProject(name="Workspace Root")
+        temp_db.save(project)
+        plan = ResearchPlan(
+            project_id=project.id,
+            name="Plan A",
+            description="Outline",
+            order_index=2,
+            metadata={"term": "gold"},
+        )
+        temp_db.save(plan)
+        task = ResearchTask(
+            plan_id=plan.id,
+            name="Task A",
+            description="Search archive",
+            priority=3,
+            assigned_to="agent",
+            metadata={"lane": "research"},
+        )
+        temp_db.save(task)
+        step = ResearchStep(
+            task_id=task.id,
+            tool=StepTool.web_search,
+            label="Search Web",
+            description="Do search",
+            config={"query": "gold archive"},
+            result={"hits": 3},
+            order_index=1,
+        )
+        temp_db.save(step)
+
+        assert temp_db.get(ResearchPlan, plan.id).project_id == project.id
+        assert temp_db.get(ResearchTask, task.id).plan_id == plan.id
+        assert temp_db.get(ResearchStep, step.id).task_id == task.id
+
+        plan_doc = temp_db.get(Document, plan.id)
+        assert plan_doc is not None
+        assert plan_doc.parent_id == project.id
+        assert plan_doc.prototype_key == "research_plan"
+        assert plan_doc.node_kind == "plan"
+
+        task_doc = temp_db.get(Document, task.id)
+        assert task_doc is not None
+        assert task_doc.parent_id == plan.id
+        assert task_doc.prototype_key == "research_task"
+        assert task_doc.node_kind == "task"
+
+        step_doc = temp_db.get(Document, step.id)
+        assert step_doc is not None
+        assert step_doc.parent_id == task.id
+        assert step_doc.prototype_key == "research_step"
+        assert step_doc.node_kind == "step"
+        assert step_doc.attributes["tool"] == "web_search"
+
+    def test_research_content_reads_from_folded_document_nodes(self, temp_db):
+        project_doc = Document(
+            id="ws-root",
+            name="Workspace Root",
+            node_kind="workspace",
+            prototype_key="research_workspace",
+            doc_type=DocType.folder,
+            is_workspace=True,
+            attributes={
+                "description": "",
+                "status": "active",
+                "created_by": "human",
+                "library_destination_folder_id": None,
+                "metadata": {},
+            },
+        )
+        plan_doc = Document(
+            id="plan-doc",
+            parent_id="ws-root",
+            name="Plan Node",
+            node_kind="plan",
+            prototype_key="research_plan",
+            doc_type=DocType.folder,
+            attributes={
+                "description": "node plan",
+                "status": "active",
+                "order_index": 7,
+                "metadata": {"topic": "letters"},
+            },
+        )
+        task_doc = Document(
+            id="task-doc",
+            parent_id="plan-doc",
+            name="Task Node",
+            node_kind="task",
+            prototype_key="research_task",
+            doc_type=DocType.folder,
+            attributes={
+                "description": "node task",
+                "status": "in_progress",
+                "priority": 4,
+                "assigned_to": "agent",
+                "metadata": {"role": "search"},
+                "completed_at": None,
+            },
+        )
+        step_doc = Document(
+            id="step-doc",
+            parent_id="task-doc",
+            name="Step Node",
+            node_kind="step",
+            prototype_key="research_step",
+            doc_type=DocType.file,
+            attributes={
+                "tool": "web_search",
+                "description": "node step",
+                "config": {"query": "letters"},
+                "status": "completed",
+                "result": {"hits": 2},
+                "error": None,
+                "order_index": 1,
+                "completed_at": None,
+            },
+        )
+        temp_db.save(project_doc)
+        temp_db.save(plan_doc)
+        temp_db.save(task_doc)
+        temp_db.save(step_doc)
+
+        assert temp_db.get(ResearchPlan, "plan-doc").project_id == "ws-root"
+        assert temp_db.get(ResearchTask, "task-doc").plan_id == "plan-doc"
+        assert temp_db.get(ResearchStep, "step-doc").task_id == "task-doc"
+
+
 class TestLibraryLinkBackfill:
     def test_reopen_backfills_claim_links_into_library_links(self):
         """Legacy claim-link rows should appear in the generic library-link table."""
@@ -1377,6 +1512,44 @@ class TestLibraryLinkBackfill:
                 assert mirrored.prototype_key == "research_workspace"
                 assert mirrored.is_workspace is True
                 assert mirrored.attributes["description"] == ""
+            finally:
+                reopened.close()
+        finally:
+            shutil.rmtree(tmpdir)
+
+    def test_reopen_backfills_research_content_documents(self):
+        """Existing research plan/task/step rows are backfilled into document nodes on open."""
+        tmpdir = tempfile.mkdtemp()
+        db_path = Path(tmpdir) / "test.duckdb"
+        db = Database(db_path)
+        try:
+            project = ResearchProject(name="Workspace Root")
+            db.save(project)
+            plan = ResearchPlan(project_id=project.id, name="Plan Backfill")
+            task = ResearchTask(plan_id=plan.id, name="Task Backfill")
+            step = ResearchStep(
+                task_id=task.id,
+                tool=StepTool.web_search,
+                label="Step Backfill",
+            )
+            db.save(plan)
+            db.save(task)
+            db.save(step)
+            db._execute(
+                "DELETE FROM documents WHERE id IN ($plan_id, $task_id, $step_id)",
+                {
+                    "plan_id": plan.id,
+                    "task_id": task.id,
+                    "step_id": step.id,
+                },
+            )
+            db.close()
+
+            reopened = Database(db_path)
+            try:
+                assert reopened.get(Document, plan.id).prototype_key == "research_plan"
+                assert reopened.get(Document, task.id).prototype_key == "research_task"
+                assert reopened.get(Document, step.id).prototype_key == "research_step"
             finally:
                 reopened.close()
         finally:

--- a/fichero-engine/tests/unit/test_routes_research_agents.py
+++ b/fichero-engine/tests/unit/test_routes_research_agents.py
@@ -12,7 +12,9 @@ from fichero.models import DocType, Document
 from fichero.research_models import (
     ResearchPlan,
     ResearchProject,
+    ResearchStep,
     ResearchTask,
+    StepTool,
 )
 
 
@@ -34,6 +36,10 @@ def _make_plan(plan_id: str = "plan-1", project_id: str = "proj-1") -> ResearchP
 
 def _make_task(task_id: str = "task-1", plan_id: str = "plan-1") -> ResearchTask:
     return ResearchTask(id=task_id, plan_id=plan_id, name="Search literature")
+
+
+def _make_step(step_id: str = "step-1", task_id: str = "task-1") -> ResearchStep:
+    return ResearchStep(id=step_id, task_id=task_id, tool=StepTool.web_search, label="Search")
 
 
 # ---------------------------------------------------------------------------
@@ -371,3 +377,172 @@ class TestListProjectTasksHandler:
         assert result.count == 3
         plan_ids = {t.plan_id for t in result.items}
         assert plan_ids == {"plan-a", "plan-b"}
+
+
+class TestResearchContentHandlers:
+    async def test_list_plans_tasks_steps_read_folded_document_nodes(self, db):
+        from fichero.api.routes.research_crud import list_plans, list_tasks, list_steps
+
+        db.save(
+            Document(
+                id="ws-folded",
+                name="Workspace",
+                doc_type=DocType.folder,
+                node_kind="workspace",
+                prototype_key="research_workspace",
+                is_workspace=True,
+                attributes={
+                    "description": "",
+                    "status": "active",
+                    "created_by": "human",
+                    "library_destination_folder_id": None,
+                    "metadata": {},
+                },
+            )
+        )
+        db.save(
+            Document(
+                id="plan-folded",
+                parent_id="ws-folded",
+                name="Plan Folded",
+                doc_type=DocType.folder,
+                node_kind="plan",
+                prototype_key="research_plan",
+                attributes={
+                    "description": "plan",
+                    "status": "active",
+                    "order_index": 1,
+                    "metadata": {"topic": "letters"},
+                },
+            )
+        )
+        db.save(
+            Document(
+                id="task-folded",
+                parent_id="plan-folded",
+                name="Task Folded",
+                doc_type=DocType.folder,
+                node_kind="task",
+                prototype_key="research_task",
+                attributes={
+                    "description": "task",
+                    "status": "pending",
+                    "priority": 2,
+                    "assigned_to": "agent",
+                    "metadata": {},
+                    "completed_at": None,
+                },
+            )
+        )
+        db.save(
+            Document(
+                id="step-folded",
+                parent_id="task-folded",
+                name="Step Folded",
+                doc_type=DocType.file,
+                node_kind="step",
+                prototype_key="research_step",
+                attributes={
+                    "tool": "web_search",
+                    "description": "step",
+                    "config": {"query": "letters"},
+                    "status": "pending",
+                    "result": {},
+                    "error": None,
+                    "order_index": 0,
+                    "completed_at": None,
+                },
+            )
+        )
+
+        plans = await list_plans("ws-folded", db=db)
+        assert plans.count == 1
+        assert plans.items[0].id == "plan-folded"
+
+        tasks = await list_tasks("plan-folded", db=db)
+        assert tasks.count == 1
+        assert tasks.items[0].id == "task-folded"
+
+        steps = await list_steps("task-folded", db=db)
+        assert steps.count == 1
+        assert steps.items[0].id == "step-folded"
+
+    def test_plan_task_step_appear_in_document_children_hierarchy(self, client, db):
+        workspace = Document(
+            id="ws-tree",
+            name="Workspace Tree",
+            doc_type=DocType.folder,
+            node_kind="workspace",
+            prototype_key="research_workspace",
+            is_workspace=True,
+        )
+        plan = Document(
+            id="plan-tree",
+            parent_id="ws-tree",
+            name="Plan Tree",
+            doc_type=DocType.folder,
+            node_kind="plan",
+            prototype_key="research_plan",
+            attributes={"description": "", "status": "draft", "order_index": 0, "metadata": {}},
+        )
+        task = Document(
+            id="task-tree",
+            parent_id="plan-tree",
+            name="Task Tree",
+            doc_type=DocType.folder,
+            node_kind="task",
+            prototype_key="research_task",
+            attributes={
+                "description": "",
+                "status": "pending",
+                "priority": 0,
+                "assigned_to": None,
+                "metadata": {},
+                "completed_at": None,
+            },
+        )
+        step = Document(
+            id="step-tree",
+            parent_id="task-tree",
+            name="Step Tree",
+            doc_type=DocType.file,
+            node_kind="step",
+            prototype_key="research_step",
+            attributes={
+                "tool": "web_search",
+                "description": "",
+                "config": {},
+                "status": "pending",
+                "result": {},
+                "error": None,
+                "order_index": 0,
+                "completed_at": None,
+            },
+        )
+        db.save(workspace)
+        db.save(plan)
+        db.save(task)
+        db.save(step)
+
+        plan_children = client.get("/api/documents/ws-tree/children")
+        assert plan_children.status_code == 200
+        assert [item["id"] for item in plan_children.json()["items"]] == ["plan-tree"]
+
+        task_children = client.get("/api/documents/plan-tree/children")
+        assert task_children.status_code == 200
+        assert [item["id"] for item in task_children.json()["items"]] == ["task-tree"]
+
+        step_children = client.get("/api/documents/task-tree/children")
+        assert step_children.status_code == 200
+        assert [item["id"] for item in step_children.json()["items"]] == ["step-tree"]
+
+    async def test_missing_folded_plan_raises_not_found(self, db):
+        from fichero.api.routes.research_crud import get_plan
+
+        db.save(_make_plan("legacy-plan", "proj-1"))
+        db._execute("DELETE FROM documents WHERE id = $id", {"id": "legacy-plan"})
+
+        with pytest.raises(HTTPException) as exc:
+            await get_plan("legacy-plan", db=db)
+
+        assert exc.value.status_code == 404


### PR DESCRIPTION
Fold F3 of EPIC #2591. Research plans/tasks/steps become document nodes (research_plan prototype; task/step child nodes via parent_id). tasks.py BackgroundTask is INFRA, NOT folded. No new endpoints, no contract change, no library-DB migration. Full unit+contracts suite: 6147 passed, 0 failed.

Co-Authored-By: Daniel Tubb <dtubb@me.com>