### PR TITLE
fix(chat): render markdown in sidebar chat bubbles (#2639)

### DIFF
--- a/fichero/fichero-tests/MarkdownBlockTests.swift
+++ b/fichero/fichero-tests/MarkdownBlockTests.swift
@@ -1,0 +1,70 @@
+@testable import Fichero
+import XCTest
+
+/// Tests for the line-based Markdown block parser behind chat message rendering
+/// (#2639). Covers the block types the issue lists.
+final class MarkdownBlockTests: XCTestCase {
+
+    func testHeadingLevels() {
+        guard case .heading(let level, let content)? = MarkdownBlock.parse("## Title").first else {
+            return XCTFail("expected heading")
+        }
+        XCTAssertEqual(level, 2)
+        XCTAssertEqual(content, "Title")
+    }
+
+    func testHashWithoutSpaceIsParagraph() {
+        guard case .paragraph(let text)? = MarkdownBlock.parse("#nospace").first else {
+            return XCTFail("expected paragraph")
+        }
+        XCTAssertEqual(text, "#nospace")
+    }
+
+    func testUnorderedList() {
+        guard case .list(let items)? = MarkdownBlock.parse("- one\n- two").first else {
+            return XCTFail("expected list")
+        }
+        XCTAssertEqual(items.map(\.content), ["one", "two"])
+        XCTAssertEqual(items.first?.marker, "•")
+    }
+
+    func testOrderedList() {
+        guard case .list(let items)? = MarkdownBlock.parse("1. first\n2. second").first else {
+            return XCTFail("expected list")
+        }
+        XCTAssertEqual(items.map(\.marker), ["1.", "2."])
+        XCTAssertEqual(items.map(\.content), ["first", "second"])
+    }
+
+    func testFencedCodeBlockPreservesContentAndDoesNotParseInside() {
+        let markdown = "```\n- not a list\n# not a heading\n```"
+        guard case .codeBlock(let code)? = MarkdownBlock.parse(markdown).first else {
+            return XCTFail("expected code block")
+        }
+        XCTAssertEqual(code, "- not a list\n# not a heading")
+    }
+
+    func testBlockquote() {
+        guard case .blockquote(let text)? = MarkdownBlock.parse("> quoted").first else {
+            return XCTFail("expected blockquote")
+        }
+        XCTAssertEqual(text, "quoted")
+    }
+
+    func testParagraphJoinsConsecutiveLines() {
+        guard case .paragraph(let text)? = MarkdownBlock.parse("hello\nworld").first else {
+            return XCTFail("expected paragraph")
+        }
+        XCTAssertEqual(text, "hello world")
+    }
+
+    func testMixedDocumentBlockOrder() {
+        let markdown = "# Heading\n\nintro text\n\n- a\n- b\n\n```\ncode\n```"
+        let blocks = MarkdownBlock.parse(markdown)
+        XCTAssertEqual(blocks.count, 4)
+        if case .heading = blocks[0] {} else { XCTFail("0 should be heading") }
+        if case .paragraph = blocks[1] {} else { XCTFail("1 should be paragraph") }
+        if case .list = blocks[2] {} else { XCTFail("2 should be list") }
+        if case .codeBlock = blocks[3] {} else { XCTFail("3 should be code block") }
+    }
+}

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		20ED240D4093078C1DD920D5 /* Spatial2DCanvasItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C09E634BBFD5CA7C83DBCC4 /* Spatial2DCanvasItems.swift */; };
 		21B8070BD02B0087A8B83D04 /* SpatialTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55DF06231EA1679E067896E3 /* SpatialTheme.swift */; };
 		230EB3E3E820CFEC092A3C49 /* ResearchTasksPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5287875D44BA51CD93CA12F8 /* ResearchTasksPane.swift */; };
+		235BB484E009F2DC1E3B149D /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA362DBBB6387D0FEB6A7626 /* MarkdownText.swift */; };
 		23CB922EB4868B4EF1C20215 /* PDFReadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74515FA0260E31DB7F74A1D3 /* PDFReadingView.swift */; };
 		24D8496D37D6F2973BD2E825 /* AnnotationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABB27CA283069DA160FB5AA /* AnnotationStore.swift */; };
 		25B9458F0E27EB2BCD55B439 /* ClaimSummaryCard+Details.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA39991F769A1DD42BB17F01 /* ClaimSummaryCard+Details.swift */; };
@@ -981,6 +982,7 @@
 		AA112233001122BB /* LibraryView+Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibraryView+Sorting.swift"; sourceTree = "<group>"; };
 		AA112233001122DD /* LibraryView+ColumnConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibraryView+ColumnConfig.swift"; sourceTree = "<group>"; };
 		AA112233001122FF /* LibraryView+FilterAndBatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibraryView+FilterAndBatch.swift"; sourceTree = "<group>"; };
+		AA362DBBB6387D0FEB6A7626 /* MarkdownText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MarkdownText.swift; sourceTree = "<group>"; };
 		AB59736A9E632D7997FA8412 /* CitationDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CitationDetailView.swift; sourceTree = "<group>"; };
 		AB786740043A3DAB4CDBFD6F /* DocumentInspectorAnnotationsTab.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DocumentInspectorAnnotationsTab.swift; sourceTree = "<group>"; };
 		ACE504DAF1BA303DE7043D34 /* CitationListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CitationListView.swift; sourceTree = "<group>"; };
@@ -1782,6 +1784,7 @@
 				20D8ED542F48E2CC006950A3 /* WorkflowExecutionRow+Helpers.swift */,
 				7AA64CFDF3C633C03CCE24A6 /* FicheroWebView.swift */,
 				5D0B24DE95228CEA6B853324 /* SplittablePane.swift */,
+				AA362DBBB6387D0FEB6A7626 /* MarkdownText.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2795,6 +2798,7 @@
 				3781E7E2FCBF08F37B93599C /* RepresentationPicker.swift in Sources */,
 				32994A78CFC2F20F3A656E27 /* RepresentationView.swift in Sources */,
 				02C3632FB97086976DD89BBE /* DocumentInterpretationsTab.swift in Sources */,
+				235BB484E009F2DC1E3B149D /* MarkdownText.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero/Views/Chat/MessageCard.swift
+++ b/fichero/fichero/Views/Chat/MessageCard.swift
@@ -66,7 +66,7 @@ struct MessageBubble: View {
                 if message.role == .user { Spacer() }
 
                 VStack(alignment: .leading, spacing: 8) {
-                    Text(message.content)
+                    MarkdownText(message.content)
                         .padding(12)
                         .background(bubbleBackground)
                         .foregroundColor(message.role == .user ? .white : .primary)

--- a/fichero/fichero/Views/Components/MarkdownText.swift
+++ b/fichero/fichero/Views/Components/MarkdownText.swift
@@ -1,0 +1,216 @@
+import SwiftUI
+
+/// Renders Markdown as native SwiftUI views — headings, lists, blockquotes,
+/// fenced code blocks, and inline syntax (bold/italic/inline code/links).
+///
+/// SwiftUI's `Text(AttributedString(markdown:))` only renders *inline* syntax;
+/// block structure collapses. This view splits the source into blocks and gives
+/// each the right semantic treatment, using `AttributedString` for inline runs
+/// within a block. Dependency-free; heavier Markdown (tables, images) is left as
+/// raw inline text for now, matching `MarkdownCanvas` (#2264).
+///
+/// Reused by the chat bubbles (#2639). Semantic system fonts throughout so it
+/// scales with the system text size.
+struct MarkdownText: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(Array(MarkdownBlock.parse(text).enumerated()), id: \.offset) { _, block in
+                blockView(block)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func blockView(_ block: MarkdownBlock) -> some View {
+        switch block {
+        case .heading(let level, let content):
+            inlineText(content)
+                .font(headingFont(level))
+                .fontWeight(.semibold)
+        case .paragraph(let content):
+            inlineText(content)
+        case .blockquote(let content):
+            HStack(alignment: .top, spacing: 8) {
+                Rectangle()
+                    .fill(.secondary)
+                    .frame(width: 3)
+                inlineText(content)
+                    .foregroundStyle(.secondary)
+            }
+        case .codeBlock(let code):
+            Text(code)
+                .font(.callout.monospaced())
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
+                .background(Color(.textBackgroundColor).opacity(0.5))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+        case .list(let items):
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+                    HStack(alignment: .top, spacing: 6) {
+                        Text(item.marker)
+                            .font(.body)
+                            .monospacedDigit()
+                        inlineText(item.content)
+                    }
+                }
+            }
+        }
+    }
+
+    /// Inline Markdown (bold/italic/code/links) → `Text`, falling back to the
+    /// raw line if it doesn't parse.
+    private func inlineText(_ line: String) -> Text {
+        if let attributed = try? AttributedString(
+            markdown: line,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        ) {
+            return Text(attributed)
+        }
+        return Text(line)
+    }
+
+    private func headingFont(_ level: Int) -> Font {
+        switch level {
+        case 1: .title
+        case 2: .title2
+        case 3: .title3
+        default: .headline
+        }
+    }
+}
+
+/// One parsed Markdown block. Parsing is line-based and intentionally small —
+/// it covers the elements #2639 lists, not the full CommonMark grammar.
+enum MarkdownBlock {
+    case heading(level: Int, content: String)
+    case paragraph(String)
+    case blockquote(String)
+    case codeBlock(String)
+    case list([ListItem])
+
+    struct ListItem {
+        let marker: String
+        let content: String
+    }
+
+    static func parse(_ text: String) -> [MarkdownBlock] {
+        var blocks: [MarkdownBlock] = []
+        let lines = text.components(separatedBy: "\n")
+        var index = 0
+
+        while index < lines.count {
+            let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
+
+            if trimmed.isEmpty {
+                index += 1
+            } else if trimmed.hasPrefix("```") {
+                (blocks, index) = consumeCodeBlock(lines, from: index, into: blocks)
+            } else if let heading = headingBlock(trimmed) {
+                blocks.append(heading)
+                index += 1
+            } else if trimmed.hasPrefix(">") {
+                (blocks, index) = consumeBlockquote(lines, from: index, into: blocks)
+            } else if listMarker(trimmed) != nil {
+                (blocks, index) = consumeList(lines, from: index, into: blocks)
+            } else {
+                (blocks, index) = consumeParagraph(lines, from: index, into: blocks)
+            }
+        }
+
+        return blocks
+    }
+
+    /// True for any line that starts a new block (ends an open paragraph).
+    private static func isStructural(_ trimmed: String) -> Bool {
+        trimmed.isEmpty || trimmed.hasPrefix("```") || trimmed.hasPrefix(">")
+            || headingBlock(trimmed) != nil || listMarker(trimmed) != nil
+    }
+
+    private static func consumeCodeBlock(
+        _ lines: [String], from start: Int, into blocks: [MarkdownBlock]
+    ) -> ([MarkdownBlock], Int) {
+        var code: [String] = []
+        var index = start + 1
+        while index < lines.count,
+              !lines[index].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+            code.append(lines[index])
+            index += 1
+        }
+        return (blocks + [.codeBlock(code.joined(separator: "\n"))], index + 1)
+    }
+
+    private static func consumeBlockquote(
+        _ lines: [String], from start: Int, into blocks: [MarkdownBlock]
+    ) -> ([MarkdownBlock], Int) {
+        var quote: [String] = []
+        var index = start
+        while index < lines.count {
+            let line = lines[index].trimmingCharacters(in: .whitespaces)
+            guard line.hasPrefix(">") else { break }
+            quote.append(String(line.dropFirst()).trimmingCharacters(in: .whitespaces))
+            index += 1
+        }
+        return (blocks + [.blockquote(quote.joined(separator: "\n"))], index)
+    }
+
+    private static func consumeList(
+        _ lines: [String], from start: Int, into blocks: [MarkdownBlock]
+    ) -> ([MarkdownBlock], Int) {
+        var items: [ListItem] = []
+        var index = start
+        while index < lines.count,
+              let item = listMarker(lines[index].trimmingCharacters(in: .whitespaces)) {
+            items.append(item)
+            index += 1
+        }
+        return (blocks + [.list(items)], index)
+    }
+
+    private static func consumeParagraph(
+        _ lines: [String], from start: Int, into blocks: [MarkdownBlock]
+    ) -> ([MarkdownBlock], Int) {
+        var para: [String] = []
+        var index = start
+        while index < lines.count {
+            let line = lines[index].trimmingCharacters(in: .whitespaces)
+            if isStructural(line) { break }
+            para.append(line)
+            index += 1
+        }
+        return (blocks + [.paragraph(para.joined(separator: " "))], index)
+    }
+
+    private static func headingBlock(_ trimmed: String) -> MarkdownBlock? {
+        guard trimmed.hasPrefix("#") else { return nil }
+        let hashes = trimmed.prefix { $0 == "#" }
+        let level = hashes.count
+        guard level <= 6 else { return nil }
+        let rest = trimmed.dropFirst(level)
+        guard rest.hasPrefix(" ") else { return nil }
+        return .heading(level: level, content: rest.trimmingCharacters(in: .whitespaces))
+    }
+
+    private static func listMarker(_ trimmed: String) -> ListItem? {
+        // Unordered: -, *, +
+        for bullet in ["- ", "* ", "+ "] where trimmed.hasPrefix(bullet) {
+            return ListItem(marker: "•", content: String(trimmed.dropFirst(2)))
+        }
+        // Ordered: digits followed by ". "
+        let digits = trimmed.prefix { $0.isNumber }
+        if !digits.isEmpty {
+            let rest = trimmed.dropFirst(digits.count)
+            if rest.hasPrefix(". ") {
+                return ListItem(marker: "\(digits).", content: String(rest.dropFirst(2)))
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Closes #2639. Sidebar chat now renders markdown via a new MarkdownText component (MarkdownBlockTests.swift). Registered via add-swift-file.rb (pbxproj updated). Isolated build-for-testing on the merged tree: TEST BUILD SUCCEEDED.

Closes #2639

Co-Authored-By: Daniel Tubb <dtubb@me.com>