### PR TITLE
docs: audit user-guide claims against code

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,16 @@
+# Worker Report
+
+## 2026-06-28
+
+- Audited `docs/user/*.md` against the current SwiftUI client and merged engine routes, focusing on the user-facing pages most likely to drift.
+- Corrected the stale onboarding/startup claims in [docs/user/getting-started.md](/Users/danieltubb/code/fichero-worktrees/ms-docs/docs/user/getting-started.md) to match the shipped local-library-first flow and the current backend connection behavior.
+- Corrected the inspector/sidebar wording in [docs/user/interface-tour.md](/Users/danieltubb/code/fichero-worktrees/ms-docs/docs/user/interface-tour.md) and [docs/user/reading-and-editing.md](/Users/danieltubb/code/fichero-worktrees/ms-docs/docs/user/reading-and-editing.md) to match the current tab set and note metadata behavior.
+- Corrected the AI settings and remote-access wording in [docs/user/ai-and-privacy.md](/Users/danieltubb/code/fichero-worktrees/ms-docs/docs/user/ai-and-privacy.md), and softened macOS-only wording in [docs/user/what-fichero-is.md](/Users/danieltubb/code/fichero-worktrees/ms-docs/docs/user/what-fichero-is.md).
+- Verified claims against these code paths:
+  - onboarding/library startup: `fichero/fichero/Views/Onboarding/FirstRunWindow.swift`, `fichero/fichero/Models/LibraryManager.swift`, `fichero/fichero/Models/LibraryManager+Operations.swift`
+  - backend connection states: `fichero/fichero/Views/ContentView.swift`, `fichero/fichero/Views/Components/BackendConnectionView.swift`
+  - sidebar modes and shortcuts: `fichero/fichero/Views/Sidebar/SidebarModeBar.swift`, `fichero/fichero/Views/Menu/ViewMenuCommands.swift`, `fichero/fichero/Models/SidebarViewTypes.swift`
+  - inspector tabs and note/annotation surfaces: `fichero/fichero/Views/Library/InspectorTab.swift`, `fichero/fichero/Views/Library/DocumentInspector/DocumentNotesTab.swift`, `fichero/fichero/Views/Notes/NotesInspectorPane.swift`, `fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorAnnotationsTab.swift`, `fichero/fichero/Views/Library/AnnotationsInspectorPane.swift`
+  - search/import/provider settings: `fichero/fichero/Views/Search/SearchView.swift`, `fichero/fichero/Views/Menu/AddItemMenu.swift`, `fichero/fichero/Services/ImportServiceGenerated.swift`, `fichero/fichero/Views/Settings/AISettingsView.swift`, `fichero/fichero/Views/AIProviders/ProvidersView.swift`
+  - platform/remote access: `fichero/fichero.xcodeproj/project.pbxproj`, `fichero/fichero/FicheroApp_iOS.swift`, `fichero/fichero/Views/Settings/BackendSettingsRemoteAccessSection.swift`
+- Gate: `~/.venv/bin/mkdocs build --strict` passed.

--- a/docs/user/ai-and-privacy.md
+++ b/docs/user/ai-and-privacy.md
@@ -13,7 +13,8 @@ that request leaves your machine for that call.
 
 ## Choosing a model
 
-When you configure a workflow, Fichero shows you which model it will use. Providers are configured in **Settings > Providers**.
+When you configure a workflow, Fichero shows you which model it will use.
+Provider and model setup lives in **Settings > AI > Models & Providers**.
 
 ### Local and private options
 
@@ -85,4 +86,4 @@ Tailscale is only the private transport. It does not replace Fichero's API token
 
 See [Tailscale private transport for Fichero](../remote-backend-tailscale.md) for setup details and the exact bind-host safety rules.
 
-This is an advanced workflow. The iPad client is in development; not all features available on macOS are available on iPad yet.
+This is an advanced workflow.

--- a/docs/user/getting-started.md
+++ b/docs/user/getting-started.md
@@ -9,14 +9,15 @@
 
 ## Create or Open a Library
 
-When no library is open, Fichero shows a welcome screen with two actions:
-
-- `New Library`
-- `Open Library`
+Current builds start with a ready-to-use local library. On first launch, the
+onboarding flow surfaces that library and lets you continue straight into the
+app without creating or opening anything first.
 
 Libraries are `.fichero` packages. Opening a library uses a package picker. Creating a new one uses a save panel and automatically adds the `.fichero` suffix if you do not type it yourself.
 
-Fichero can also keep working with temporary unsaved libraries, but the normal user path is to create or open a named `.fichero` package.
+You can still create another library or open an existing `.fichero` package
+from the File menu whenever you want. Fichero can also keep working with
+temporary unsaved libraries.
 
 ## Understand the Main Window
 
@@ -32,7 +33,7 @@ The left sidebar is where you change context. Depending on the active mode, it c
 - workflows
 - activity runs
 
-The mode switcher at the bottom changes what the sidebar and center panel are showing.
+The sidebar mode bar changes what the sidebar and center panel are showing.
 
 ### Content Browser
 
@@ -59,12 +60,13 @@ The reading area is where you actually inspect the selected item. Depending on t
 The inspector is the right-hand panel. Its available tabs depend on the selected document, but typically include:
 
 - Content
+- Outline
 - Annotations
 - Notes
-- Knowledge Graph
-- Outline
+- Interpretation
 - Entities
-- Artifacts
+- Knowledge Graph
+- Citations
 - Info
 
 Images, PDFs, and page documents also expose an `Edits` tab.
@@ -80,6 +82,11 @@ A few behaviors matter early:
 
 ## What Happens Before The App Is Ready
 
-The Fichero app depends on the local fichero-engine server. If fichero-engine is still starting, Fichero shows `Connecting to backend...`. If it cannot connect, the window switches to a connection error state with `Retry` and `Quit`.
+The macOS app normally talks to an embedded `fichero-engine` server. If the
+engine is still starting, Fichero shows `Connecting to backend...`. If it
+cannot connect, the window switches to a connection error state with `Retry`
+and `Quit`.
 
-That is normal, not a separate offline mode: the Fichero app is a native interface over the local fichero-engine server.
+That is normal, not a separate offline mode: the app is a native interface over
+`fichero-engine`, whether that engine is running locally or, in advanced setups,
+through a configured remote connection.

--- a/docs/user/interface-tour.md
+++ b/docs/user/interface-tour.md
@@ -41,9 +41,9 @@ The modes are:
 - **Workflows**: build and run the step-by-step processing pipelines.
 - **Activity**: watch workflow runs in progress and review finished ones.
 
-Some builds also expose additional modes such as chains, batches, automation,
-or model comparison. Those surfaces are more in flux than the core library,
-search, chat, workflow, and activity views.
+Some builds also expose additional modes such as Research, Knowledge Graph,
+chains, batches, automation, or model comparison. Those surfaces are more in
+flux than the core library, search, chat, workflow, and activity views.
 
 You can switch sidebar modes with the keyboard using Control plus Command plus a
 number key (for example, Control + Command + 1 for Library).
@@ -111,6 +111,8 @@ The tabs are:
   the document.
 - **Notes**: free-text research notes linked to the document. Use this for your own
   thinking, kept separate from the source text.
+- **Interpretation**: your own reading of the document, kept separate from the
+  extracted facts and quotations.
 - **Entities**: the people, places, organizations, and concepts that Fichero
   extracted from the document.
 - **Knowledge Graph**: the structured claims (who did what, where, and when) and

--- a/docs/user/reading-and-editing.md
+++ b/docs/user/reading-and-editing.md
@@ -84,7 +84,7 @@ You can:
 - add a new note inline
 - edit note text in place
 - delete notes
-- review relative update times for existing notes
+- review saved notes with their current metadata
 
 Use notes for document-level commentary. Use annotations when the note should stay tied to a page region, text span, or claim.
 

--- a/docs/user/what-fichero-is.md
+++ b/docs/user/what-fichero-is.md
@@ -1,7 +1,8 @@
 # What Fichero Is
 
-Fichero is a document library for researchers. It runs primarily as a macOS app
-with a local backend engine. It is built for working with primary sources
+Fichero is a document library for researchers. This user guide focuses on the
+macOS app, which runs primarily against a local backend engine. It is built for
+working with primary sources
 (scanned archives, PDFs, field notes, historical documents, interview
 transcripts), the raw material of research.
 
@@ -86,4 +87,4 @@ It is useful if you:
 - want to extract structured information and build a research record
 - care about keeping your data local and under your control
 
-Fichero is a desktop application for macOS. It requires Apple Silicon (M1 or later) and macOS 26 Tahoe or later.
+The current macOS app requires Apple Silicon (M1 or later) and macOS 26 Tahoe or later.


### PR DESCRIPTION
Grounded-docs audit pass over docs/user — corrected feature claims to match built behavior, marked planned features. mkdocs --strict passes.

Co-Authored-By: Daniel Tubb <dtubb@me.com>