### PR TITLE
refactor(chat): native bubbles only — drop icon/table/map transcript modes (#1891)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,21 @@
+
+## Chat & Agent milestone (#102) — 2026-06-28, f_fichero_claude_swiftui
+
+### #2639 — render markdown + Xcode-style bubbles in sidebar chat — DONE
+Commit c04b58f2, authored Claude.
+- New native, dependency-free `Views/Components/MarkdownText.swift` (headings, lists, blockquotes, fenced code blocks, inline bold/italic/code/links via AttributedString). Registered via add-swift-file.rb.
+- Wired into `MessageBubble` (the sidebar `.list` view = the bug's site); MessageBubble already had the Xcode-style role-coloured bubble layout, only the content Text was swapped. MessageCard preview Text left as-is (clamped preview).
+- Reusable in Components/ so MarkdownCanvas (#2264) can adopt later — reuse, not a parallel chat component.
+- Test: `fichero-tests/MarkdownBlockTests.swift` (heading levels, hash-without-space, ordered/unordered lists, fenced code doesn't parse inside, blockquote, paragraph join, mixed-doc order).
+- swiftlint clean (refactored parser into helpers for complexity/length; renamed short vars). Isolated build: 0 swiftc errors, both files compiled + linked; only failure = environmental engine-embed phase. NOT pushed.
+
+### #2034 — left toolbar one sidebar + one chat toggle — HELD (design)
+- Audit: NO duplicate sidebar toggle in the rendered toolbar. Live left zone = back/forward; sidebar toggle = NavigationSplitView system; inspector toggle = right. Only second `sidebar.left` is in `MainToolbar.swift` = DEAD CODE (only its own #Preview).
+- No chat toggle/rail exists. Chat toggle target = Xcode-style chat that REPLACES the left sidebar (per Daniel 2026-06-16), still converging in master-plan §7.10. Parent EPIC #2030 = needs-design; needs running-app visual verification (unavailable in this worktree).
+- Held per Daniel's call. Findings posted to issue #2034.
+
+### #1846 — chat first-party right-rail — HELD (shelved by owner)
+- #1846's own latest comment (Daniel) SHELVES the right-of-inspector placement: "Superseded by EPIC #2253; master plan §6d/§7.10 resolves chat placement to the left/top … this right-rail placement is shelved." Building it would contradict documented direction.
+- No code written. Held per Daniel's call. Findings posted to issue #1846.
+
+Net: 1 of 3 shipped (#2639); #2034 + #1846 held on the unresolved §7.10 chat-placement decision. Awaiting Daniel.

--- a/fichero/fichero/Views/Chat/ChatMessagesList.swift
+++ b/fichero/fichero/Views/Chat/ChatMessagesList.swift
@@ -1,70 +1,26 @@
 import SwiftUI
 
-/// Messages list display supporting four view modes
+/// The chat transcript: native bubble layout, scrolled to the latest message.
+///
+/// Chat used to switch its transcript across the universal icon/table/map view
+/// modes (#1891) — a non-standard oddity for a conversation. The transcript now
+/// always renders as the native bubble list; the toolbar view modes stay where
+/// they belong, on the library/search content.
 struct ChatMessagesList: View {
     let conversation: Conversation
-    let displayMode: ViewDisplayMode
     let isLoading: Bool
     let errorMessage: String?
     @Binding var inputText: String
 
     var body: some View {
-        Group {
-            if conversation.messages.isEmpty {
-                ChatEmptyStateView(inputText: $inputText)
-            } else {
-                switch displayMode {
-                case .icon:
-                    iconView
-                case .list:
-                    bubbleView
-                case .table:
-                    tableView
-                case .map, .realitykit, .spatial, .workspace:
-                    mapView
-                }
-            }
+        if conversation.messages.isEmpty {
+            ChatEmptyStateView(inputText: $inputText)
+        } else {
+            transcript
         }
     }
 
-    // MARK: - Icon View
-
-    private var iconView: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                LazyVGrid(
-                    columns: [GridItem(.adaptive(minimum: 200, maximum: 280))],
-                    spacing: 16
-                ) {
-                    ForEach(conversation.messages) { message in
-                        MessageCard(message: message)
-                            .id(message.id)
-                    }
-                }
-                .padding()
-
-                if isLoading {
-                    ChatLoadingIndicator()
-                }
-
-                if let error = errorMessage {
-                    ChatErrorView(message: error)
-                }
-            }
-            .onChange(of: conversation.messages.count) { _, _ in
-                if let lastMessage = conversation.messages.last {
-                    withAnimation {
-                        proxy.scrollTo(lastMessage.id, anchor: .bottom)
-                    }
-                }
-            }
-        }
-        .background(Color(.textBackgroundColor))
-    }
-
-    // MARK: - Bubble View
-
-    private var bubbleView: some View {
+    private var transcript: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 16) {
@@ -92,85 +48,5 @@ struct ChatMessagesList: View {
             }
         }
         .background(Color(.textBackgroundColor))
-    }
-
-    // MARK: - Table View
-
-    private var tableView: some View {
-        VStack(spacing: 0) {
-            Table(conversation.messages) {
-                TableColumn("Role") { message in
-                    Text(message.role == .user ? "User" : "Assistant")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                .width(min: 60, ideal: 80)
-
-                TableColumn("Content") { message in
-                    Text(message.content)
-                        .lineLimit(3)
-                }
-
-                TableColumn("Sources") { message in
-                    if let sources = message.sources, !sources.isEmpty {
-                        Text("\(sources.count) source(s)")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                    } else {
-                        Text("—")
-                            .foregroundColor(.secondary)
-                    }
-                }
-                .width(min: 80, ideal: 100)
-            }
-
-            if isLoading {
-                Divider()
-                ChatLoadingIndicator()
-                    .padding()
-            }
-
-            if let error = errorMessage {
-                Divider()
-                ChatErrorView(message: error)
-                    .padding()
-            }
-        }
-        .background(Color(.textBackgroundColor))
-    }
-
-    // MARK: - Map View
-
-    private var mapView: some View {
-        GeometryReader { geometry in
-            ScrollView([.horizontal, .vertical]) {
-                ZStack {
-                    // Grid background
-                    ChatMapGrid()
-                        .stroke(Color.gray.opacity(0.2), lineWidth: 0.5)
-                        .allowsHitTesting(false)
-
-                    // Message cards positioned on canvas
-                    ForEach(Array(conversation.messages.enumerated()), id: \.element.id) { index, message in
-                        MessageMapCard(message: message)
-                            .position(messagePosition(for: index, role: message.role, in: geometry.size))
-                    }
-
-                    if isLoading {
-                        ChatLoadingIndicator()
-                            .position(x: geometry.size.width / 2, y: geometry.size.height - 50)
-                    }
-                }
-                .frame(width: max(geometry.size.width, 1000), height: max(geometry.size.height, 600))
-            }
-        }
-        .background(Color(.textBackgroundColor))
-    }
-
-    /// Position messages in a flowing conversation layout
-    private func messagePosition(for index: Int, role: ChatRole, in size: CGSize) -> CGPoint {
-        let ySpacing: CGFloat = 120
-        let xOffset: CGFloat = role == .user ? size.width * 0.7 : size.width * 0.3
-        return CGPoint(x: min(max(xOffset, 150), size.width - 150), y: CGFloat(index) * ySpacing + 80)
     }
 }

--- a/fichero/fichero/Views/Chat/ChatView.swift
+++ b/fichero/fichero/Views/Chat/ChatView.swift
@@ -5,7 +5,6 @@ struct ChatView: View {
     let conversation: Conversation?
     @Binding var selectedDocuments: Set<String>
     var onConversationUpdated: (() -> Void)?
-    let displayMode: ViewDisplayMode  // Universal view mode from toolbar
 
     @State var currentConversation: Conversation
     // Tracks the backend-confirmed conversation ID. Nil until the first
@@ -29,13 +28,11 @@ struct ChatView: View {
     init(
         conversation: Conversation?,
         selectedDocuments: Binding<Set<String>>,
-        onConversationUpdated: (() -> Void)? = nil,
-        displayMode: ViewDisplayMode = .icon
+        onConversationUpdated: (() -> Void)? = nil
     ) {
         self.conversation = conversation
         self._selectedDocuments = selectedDocuments
         self.onConversationUpdated = onConversationUpdated
-        self.displayMode = displayMode
         self._currentConversation = State(initialValue: conversation ?? Conversation())
     }
 
@@ -56,7 +53,6 @@ struct ChatView: View {
             // Messages list
             ChatMessagesList(
                 conversation: currentConversation,
-                displayMode: displayMode,
                 isLoading: isLoading,
                 errorMessage: errorMessage,
                 inputText: $inputText
@@ -95,8 +91,7 @@ struct ChatView: View {
 #Preview {
     ChatView(
         conversation: nil,
-        selectedDocuments: .constant([]),
-        displayMode: .icon
+        selectedDocuments: .constant([])
     )
     .frame(width: 600, height: 500)
 }

--- a/fichero/fichero/Views/Chat/MessageCard.swift
+++ b/fichero/fichero/Views/Chat/MessageCard.swift
@@ -1,62 +1,10 @@
 import SwiftUI
 
-// MARK: - Message Card (for Icon view)
-
-/// Card representation of a chat message for Icon/Grid view
-struct MessageCard: View {
-    let message: ChatMessage
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            // Role badge
-            HStack {
-                Image(systemName: message.role == .user ? "person.fill" : "brain.head.profile")
-                    .foregroundColor(message.role == .user ? .accentColor : .purple)
-                Text(message.role == .user ? "You" : "Assistant")
-                    .font(.caption)
-                    .fontWeight(.medium)
-                Spacer()
-            }
-
-            // Content preview
-            Text(message.content)
-                .font(.subheadline)
-                .foregroundColor(.primary)
-                .lineLimit(4)
-
-            // Retrieval step (search-as-a-tool) made visible.
-            if let retrieval = message.retrieval, retrieval.didSearch {
-                Label(retrieval.summary, systemImage: "magnifyingglass")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-            }
-
-            // Sources indicator
-            if let sources = message.sources, !sources.isEmpty {
-                HStack(spacing: 4) {
-                    Image(systemName: "doc.text")
-                        .font(.caption2)
-                    Text("\(sources.count) source(s)")
-                        .font(.caption2)
-                }
-                .foregroundColor(.secondary)
-            }
-        }
-        .padding(12)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(message.role == .user ? Color.accentColor.opacity(0.1) : Color(.controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(Color(.separatorColor), lineWidth: 1)
-        )
-    }
-}
-
 // MARK: - Message Bubble
 
-/// Displays a single chat message in a bubble format
+/// Displays a single chat message in a bubble format — the one chat transcript
+/// row (#1891 dropped the icon/table/map card variants in favour of this native
+/// bubble layout).
 struct MessageBubble: View {
     let message: ChatMessage
 
@@ -126,61 +74,5 @@ struct MessageBubble: View {
             }
         }
         .padding(.leading, 12)
-    }
-}
-
-// MARK: - Message Map Card (for Map view)
-
-/// Card representation for spatial map view
-struct MessageMapCard: View {
-    let message: ChatMessage
-
-    var body: some View {
-        VStack(spacing: 6) {
-            // Role icon
-            Image(systemName: message.role == .user ? "person.fill" : "brain.head.profile")
-                .font(.title2)
-                .foregroundColor(message.role == .user ? .accentColor : .purple)
-                .frame(width: 40, height: 40)
-                .background((message.role == .user ? Color.accentColor : Color.purple).opacity(0.15))
-                .clipShape(Circle())
-
-            // Content preview
-            Text(message.content)
-                .font(.caption)
-                .lineLimit(3)
-                .multilineTextAlignment(.center)
-                .frame(width: 140)
-
-            // Retrieval + sources badges. Space is tight (160×130), so the
-            // search step shows as a compact icon + label rather than the full
-            // summary; the source count keeps its own badge.
-            HStack(spacing: 4) {
-                if let retrieval = message.retrieval, retrieval.didSearch {
-                    Label("Searched", systemImage: "magnifyingglass")
-                        .labelStyle(.iconOnly)
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-                if let sources = message.sources, !sources.isEmpty {
-                    Text("\(sources.count) sources")
-                        .font(.caption2)
-                        .foregroundColor(.white)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(Color.gray)
-                        .clipShape(Capsule())
-                }
-            }
-        }
-        .padding(10)
-        .frame(width: 160, height: 130)
-        .background(Color(.controlBackgroundColor))
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(message.role == .user ? Color.accentColor : Color.purple, lineWidth: 2)
-        )
-        .shadow(color: .black.opacity(0.1), radius: 2, x: 0, y: 1)
     }
 }

--- a/fichero/fichero/Views/ContentView+Navigation.swift
+++ b/fichero/fichero/Views/ContentView+Navigation.swift
@@ -156,8 +156,7 @@ extension ContentView {
             ChatView(
                 conversation: conversation,
                 selectedDocuments: $chatSelectedDocuments,
-                onConversationUpdated: { refreshConversations() },
-                displayMode: viewDisplayMode
+                onConversationUpdated: { refreshConversations() }
             )
 
         case .comparison(let comparison):

--- a/fichero/fichero/Views/Research/ResearchChatPane.swift
+++ b/fichero/fichero/Views/Research/ResearchChatPane.swift
@@ -13,8 +13,7 @@ struct ResearchChatPane: View {
         ChatView(
             conversation: nil,
             selectedDocuments: $chatSelectedDocuments,
-            onConversationUpdated: {},
-            displayMode: .list
+            onConversationUpdated: {}
         )
     }
 }


### PR DESCRIPTION
Closes #1891. ComparisonDetailView+Actions already used the typed generated client (no raw URLSession in chat). Removes the chat transcript's icon/table/map view-mode switching (those belong on library/search content) so chat always renders native bubbles; deletes the dead displayMode threading. ChatMapGrid.swift left unreferenced for a follow-up file-removal sweep (avoids a hand pbxproj edit). Isolated build-for-testing: TEST BUILD SUCCEEDED.

Closes #1891

Co-Authored-By: Daniel Tubb <dtubb@me.com>