### PR TITLE
docs: audit contributor docs against code

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,3 @@
+# WORKER-REPORT
+
+- 2026-06-28: audited contributor docs against current code, corrected transport/LLM/action-registry/node-model drift in `docs/contributor/*.md` and `docs/how-its-built.md`, then ran `~/.venv/bin/mkdocs build --strict`.

--- a/docs/contributor/README.md
+++ b/docs/contributor/README.md
@@ -16,12 +16,12 @@ This section explains how the current Fichero codebase works for contributors. I
 
 ## Read This First
 
-Fichero is not a single-process desktop app. The macOS app is a native SwiftUI app over a local fichero-engine server (Python, FastAPI).
+Fichero is not a single-process desktop app. The default macOS path is a native SwiftUI app over a local `fichero-engine` server (Python, FastAPI), while other Apple clients connect to an explicitly configured remote engine host.
 
 The shortest accurate picture is:
 
 ```text
-SwiftUI app -> pinned HTTPS loopback -> FastAPI engine -> DuckDB + LanceDB
+SwiftUI app -> pinned HTTPS transport -> FastAPI engine -> DuckDB + LanceDB
                                                      -> LangGraph workflows
                                                      -> LLM providers via LangChain integrations
 ```
@@ -36,7 +36,7 @@ That architecture shapes almost every contributor task:
 
 For environment setup, build commands, and branch discipline, see [Setup and Contributing](./setup-and-contributing.md). The key mechanics: commit directly to the milestone branch, register new Swift files with `scripts/add-swift-file.rb`, use conventional commits with issue references, and never push to `main` without a PR.
 
-For all backend mutations, the starting point is the action registry. Every write goes through `registry.invoke` rather than directly to DuckDB. See [Action Registry](./action-registry.md) for how to define actions, write the required tests, and use the generic invocation endpoint. The [Security Model](./security-model.md) covers the shared-secret token, multi-user ACL, Tailscale transport, and audit attribution.
+For audited cross-surface mutations, the starting point is the action registry. The registry-backed routes are the shared path for surfaces such as chat tools, App Intents, and undoable action flows, but the backend still has direct `db.save(...)` routes outside that layer today. See [Action Registry](./action-registry.md) for the current architecture and [Security Model](./security-model.md) for the shared-secret token, multi-user ACL, transport, and audit attribution.
 
 ## Core Reference Material In This Repo
 

--- a/docs/contributor/architecture-overview.md
+++ b/docs/contributor/architecture-overview.md
@@ -16,8 +16,10 @@ Fichero is a two-part system:
 - `fichero-engine/src/fichero/`: the Python FastAPI engine
 
 The Swift app is not the source of truth for data or AI behavior. It is a UI
-layer that talks to the engine over pinned HTTPS on `127.0.0.1:8765` for the
-local macOS path.
+layer that talks to the engine over pinned HTTPS. On macOS, the embedded-engine
+path defaults to `https://127.0.0.1:8765`; `EngineConfig` also supports an
+explicit configured host, and iOS/iPadOS use that remote-host path rather than
+starting a local engine.
 
 ## Frontend Responsibilities
 
@@ -26,7 +28,7 @@ The frontend owns:
 - windows, panes, and navigation
 - document browsing and selection state
 - reading surfaces for images and PDFs
-- inspector tabs for content, notes, annotations, entities, KG, artifacts, and info
+- inspector tabs for content, outline, annotations, notes, interpretation, entities, knowledge graph, citations, edits, and info
 - workflow launch and activity display
 - hand-written service wrappers around the generated OpenAPI client
 
@@ -40,6 +42,7 @@ The backend owns:
 
 - file ingest
 - document and folder persistence
+- folded node-model persistence for saved searches, bookmark aliases, research workspaces, and research plan/task/step nodes
 - annotations and notes APIs
 - search and embedding logic
 - entity and claim storage
@@ -73,8 +76,8 @@ The desktop app is the main user-facing client, but the engine is shared across 
 The same backend is also consumed by:
 
 - the typed `python -m fichero` CLI
-- generated Swift service layers
-- `fichero-mcp`
-- additional Apple-client surfaces that are still in progress
+- the generated Swift OpenAPI client plus hand-written service wrappers
+- the `fichero.mcp_server` / `fichero-mcp` MCP server entrypoint
+- iOS/iPadOS clients that connect to a configured remote engine host
 
 That is why backend behavior should be explained in terms of routes and models, not in terms of one specific screen.

--- a/docs/contributor/setup-and-contributing.md
+++ b/docs/contributor/setup-and-contributing.md
@@ -33,14 +33,14 @@ swiftlint lint fichero/fichero/
 
 ## Backend First
 
-The frontend depends on the local engine being available. For normal app development:
+The frontend depends on the engine being available. For the default macOS development path:
 
 1. start the backend on port `8765`
    via `bash fichero-engine/scripts/start_backend.sh`
 2. open `fichero/fichero.xcodeproj`
 3. build and run the macOS app against that engine
 
-This is the default mental model for the project. The app is not designed as a separate disconnected client.
+This is the default mental model for embedded-macOS development. iOS/iPadOS do not start a local engine; they connect to an explicit remote host configured through `EngineConfig`.
 
 ## OpenAPI Sync Discipline
 
@@ -107,7 +107,7 @@ All work goes through a PR. Create it and merge it yourself once the build gate 
 
 Backend schema changes go into `db.py` `_ensure_table` via the Pydantic model field. Fresh databases pick up new columns automatically.
 
-Do not add `ALTER TABLE ADD COLUMN` migration functions for columns that are already declared in the model. Only structural historical changes (table renames, data backfills) belong in `db_migrations.py`. This rule applies for the entire 0.0.x series and will change when 0.1.0 ships to real users.
+Do not add `ALTER TABLE ADD COLUMN` migration functions for columns that are already declared in the model when you are only targeting fresh databases. Persisted libraries still need idempotent `ALTER` and backfill work in `db_migrations.py` when a new column or structural change must land against real existing data.
 
 ### Feature tier
 
@@ -115,16 +115,16 @@ Do not add `ALTER TABLE ADD COLUMN` migration functions for columns that are alr
 
 ## Expanding the Action Registry
 
-All backend mutations go through `registry.invoke`. Do not write to DuckDB directly from a route handler.
+Not every backend mutation goes through `registry.invoke` today. The action registry is the audited path for the domains that have been folded into it, especially the shared mutation path used by chat tools, App Intents, and undo/audit flows. Many route handlers still persist directly with `db.save(...)`.
 
-Route handlers should look like this:
+When you are extending an action-backed mutation surface, route handlers should look like this:
 
 ```python
 ctx = ActionContext(actor=request.state.user, origin_window=request.headers.get("X-Window-Id"))
-result = await registry.invoke("document.tag", {"doc_id": doc_id, "tag": tag}, ctx)
+result = registry.invoke(db, "document.tag", {"doc_id": doc_id, "tag": tag}, ctx)
 return result
 ```
 
-If you are adding a new mutation, define it as a named action in the registry. This gives it an automatic audit record, change-event emission, and an undo path at no extra cost.
+If you are adding a new shared, audited mutation, define it as a named action in the registry instead of inventing a parallel path. That gives it an audit record, change-event emission, and an undo hook where the action domain supports inversion.
 
 See [action-registry.md](./action-registry.md) for the full guide: how to define an action, implement invert, write the required tests, and use the generic invocation endpoint.

--- a/docs/how-its-built.md
+++ b/docs/how-its-built.md
@@ -4,7 +4,9 @@ Fichero is built openly with the help of AI coding agents. This page documents
 how that actually works, as the concrete process
 the project follows. It is grounded in the workflow files that live in the
 repository: `AGENTS.md` (the canonical agent constitution + operational manual),
-`CLAUDE.md`, `MEMORY.md`, and the skills under `agents/skills/` and `agent-work/agent-workflow/`.
+`CLAUDE.md`, `MEMORY.md`, `docs/ROADMAP.md`, and the skills under
+`agents/skills/`, with older background notes still preserved under
+`agent-work/agent-workflow/`.
 
 ## Why document this
 
@@ -62,10 +64,11 @@ collides:
 
 A few hard rules keep the machine usable while agents run:
 
-- **Workers write tests but do not run the heavy suites.** The fichero-engine `pytest`
-  suite loads the embedding model and several gigabytes of dependencies; the **manager**
-  runs the fichero-engine test suite serially, one lane at a time. Workers may run cheap
-  guards (`swiftlint`, stdlib `scripts/check_*` checks).
+- **Workers verify their own diff; integrators own the full gate.** Backend
+  workers run focused `ruff` and `pytest` on the area they changed. Swift
+  workers run `swiftlint` on the touched surface. The manager/integrator owns
+  the full Xcode build, the full `FicheroTests` run, and the cross-stack
+  verification gate before merge.
 - Build, lint, and test logs are pushed **off** the lead agent's context: the
   lead reads a pass/fail verdict, not the full log. This is the "the lead reads a
   verdict, not a log" rule from `agent-work/agent-workflow/parallel-execution.md`.
@@ -85,15 +88,9 @@ reference note for that pattern):
 ## The QA review gate
 
 Before a sweep of changes is committed, the project runs a **review gate** rather
-than self-certifying. A small review team inspects the staged diff through
-distinct, non-overlapping lenses, for example:
-
-- **backend-reviewer**: correctness and the recurring bug patterns recorded in
-  `MEMORY.md`;
-- **silent-failure-hunter**: catch blocks, fallbacks, and "success" returned on
-  systemic failure;
-- **code-reviewer**: style, conventions, and the standards in
-  `docs/architecture/`.
+than self-certifying. The current workflow files point the manager at distinct
+review passes before merge, including a code-review pass, a simplification
+pass, and then the build/test integration gate.
 
 The lead **synthesizes** the findings, applies fixes, and only then commits. In
 autonomous (unattended) runs, this review team *is* the gate, since there is no


### PR DESCRIPTION
Grounded-docs audit over docs/contributor — corrected architectural claims to match code (module layout, langchain LLM path, transport invariants, node model). mkdocs --strict passes.

Co-Authored-By: Daniel Tubb <dtubb@me.com>