### PR TITLE
docs: final grounded-audit sweep (release/qa/cli/archive)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,3 @@
+# WORKER-REPORT
+
+- 2026-06-28: audited `docs/release/*`, `docs/qa/*`, `docs/contributor/cli-test-harness.md`, and `docs/archive/*` against the current release scripts, CLI surface, and full-book QA test. Fixed stale CLI commands/flags, updated the QA pytest invocation to the shipped venv pattern, and marked the dated release checklist pages plus the old Sparkle setup note as historical where they no longer describe the evergreen process. Docs work is now largely drained; reassess before opening another docs-only sweep.

--- a/docs/contributor/cli-test-harness.md
+++ b/docs/contributor/cli-test-harness.md
@@ -19,21 +19,21 @@ fichero` against the running engine.
 Start the backend from the repo root:
 
 ```bash
-PYTHONPATH=fichero-engine/src .venv/bin/python -m fichero engine start --port 8765
+PYTHONPATH=fichero-engine/src ~/.venv/bin/python -m fichero engine start --port 8765
 ```
 
 Then run CLI commands in another shell. Prefer JSON output for bug reports and
 agent comparisons:
 
 ```bash
-PYTHONPATH=fichero-engine/src .venv/bin/python -m fichero --json health
+PYTHONPATH=fichero-engine/src ~/.venv/bin/python -m fichero --json health
 ```
 
 For library-scoped endpoints, pass the same library the app is using:
 
 ```bash
-PYTHONPATH=fichero-engine/src .venv/bin/python -m fichero \
-  --library-path /path/to/Library.fichero \
+PYTHONPATH=fichero-engine/src ~/.venv/bin/python -m fichero \
+  --library /path/to/Library.fichero \
   --json search "sample query"
 ```
 
@@ -59,7 +59,7 @@ These checks keep the CLI and app from drifting away from the backend contract:
 ```bash
 python3 scripts/check_endpoint_usage.py
 python3 scripts/check_endpoint_coverage_matrix.py
-PYTHONPATH=fichero-engine/src .venv/bin/python fichero-engine/scripts/validate_model_sync.py
+PYTHONPATH=fichero-engine/src ~/.venv/bin/python fichero-engine/scripts/validate_model_sync.py
 ```
 
 `scripts/verify_all.sh --fast` runs the endpoint and OpenAPI guardrails as part

--- a/docs/qa/full-book-catalogue-e2e.md
+++ b/docs/qa/full-book-catalogue-e2e.md
@@ -7,7 +7,8 @@ Run only when Daniel's local fixture is available:
 ```bash
 FICHERO_RUN_FULL_BOOK_E2E=1 \
 PYTHONPATH=fichero-engine/src \
-pytest fichero-engine/tests/integration/test_full_book_catalogue_e2e.py::test_tubb2020shift_catalogue_populates_kg -q
+~/.venv/bin/python -m pytest \
+  fichero-engine/tests/integration/test_full_book_catalogue_e2e.py::test_tubb2020shift_catalogue_populates_kg -q
 ```
 
 Override the fixture path with `FICHERO_FULL_BOOK_E2E_PDF=/path/to/book.pdf`.

--- a/docs/release/RELEASE_READINESS.md
+++ b/docs/release/RELEASE_READINESS.md
@@ -1,3 +1,8 @@
+> **HISTORICAL CHECKLIST — audited 2026-06-27.** This page is a point-in-time
+> release-prep snapshot with concrete versions, cert IDs, and blocking items
+> from that date. Use [release-lane.md](./release-lane.md) for the current
+> release runbook; keep this page for provenance.
+
 # Release Readiness Checklist
 
 Manager-executable checklist for cutting **both** outputs in one sitting:

--- a/docs/release/qa-signoff-0.1.0.md
+++ b/docs/release/qa-signoff-0.1.0.md
@@ -1,3 +1,7 @@
+> **HISTORICAL CHECKLIST — release-candidate artifact.** This page is a
+> point-in-time QA sign-off list for the `0.1.0` gate, not a general current
+> runbook. Keep it for provenance; adapt a fresh checklist for the next release.
+
 # 0.1.0 QA Sign-Off Checklist
 
 Use this checklist for the 0.1.0 release gate. Attach failures to GitHub issues

--- a/docs/release/sparkle-release.md
+++ b/docs/release/sparkle-release.md
@@ -1,4 +1,9 @@
-# Sparkle Release Setup (0.0.1)
+> **HISTORICAL SETUP NOTE.** This page describes an older Sparkle setup pass and
+> still contains the retired `fichero-releases` feed URL. Do not use it as the
+> current release procedure; use [release-lane.md](./release-lane.md) for the
+> shipped DMG/Sparkle path.
+
+# Sparkle Release Setup (historical 0.0.1-era note)
 
 This project uses Sparkle for app updates via the **Check for Updates...** menu item.
 


### PR DESCRIPTION
Final grounded-docs audit over release/qa/cli-harness/archive pages — claims verified against scripts/code, stale processes marked historical. mkdocs --strict passes.

Co-Authored-By: Daniel Tubb <dtubb@me.com>