### PR TITLE
node-model F5 slice-1: bridge mind-palace rooms to room nodes + edge-case tests (#2591 #108)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,3 @@
+# WORKER-REPORT
+
+- 2026-06-28: added node-model edge-case unit coverage only, no source changes. Covered alias hop chains/re-parenting/dangling second-hop raises in `test_node_aliases.py`; deeper prototype inheritance/unknown mid-chain parents/cycle cases in `test_node_prototypes.py`; and saved-search/workspace/plan/task/step plus room round-trip/malformed-payload/parent-edge cases in `test_db.py`. Focused run passed: `102 passed` across the touched unit files. Manager still owns the full suite gate.

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,1 @@
+2026-06-28 Codex: F5 slice 1 shipped on this worktree — `SpatialRoom` now round-trips through room-prototype `Document` nodes with inherited folder attrs, compatibility routes unchanged, and full unit+contracts passed locally.

--- a/fichero-engine/src/fichero/db.py
+++ b/fichero-engine/src/fichero/db.py
@@ -170,6 +170,7 @@ _RESEARCH_TASK_NODE_KIND = "task"
 _RESEARCH_TASK_PROTOTYPE_KEY = "research_task"
 _RESEARCH_STEP_NODE_KIND = "step"
 _RESEARCH_STEP_PROTOTYPE_KEY = "research_step"
+_ROOM_NODE_KIND = "room"
 _FOLDER_PROTOTYPE_KEY = "folder"
 _ROOM_PROTOTYPE_KEY = "room"
 
@@ -535,6 +536,7 @@ class Database(DatabaseEmbeddingMixin):
         self._seed_builtin_node_classes()
         self._backfill_claim_links_to_library_links()
         self._backfill_saved_search_documents()
+        self._backfill_spatial_room_documents()
         self._backfill_research_workspace_documents()
         self._backfill_research_plan_task_step_documents()
 
@@ -785,6 +787,8 @@ class Database(DatabaseEmbeddingMixin):
 
         if type(obj).__name__ == "SavedSearch":
             self._save_saved_search_document(obj)
+        if type(obj).__name__ == "SpatialRoom":
+            self._save_spatial_room_document(obj)
         if type(obj).__name__ == "ResearchProject":
             self._save_research_workspace_document(obj)
         if type(obj).__name__ == "ResearchPlan":
@@ -926,6 +930,21 @@ class Database(DatabaseEmbeddingMixin):
             if (hydrated := self._hydrate_row(model_cls, columns, row)) is not None
         ]
 
+    def _legacy_all_spatial_room_rows(self) -> list[BaseModel]:
+        """Read legacy SpatialRoom rows without node folding."""
+        from fichero.spatial_models import SpatialRoom
+
+        sql_table = self._sql_table_name(SpatialRoom)
+        self._ensure_table(SpatialRoom)
+        with self._lock:
+            rows = self._execute(f"SELECT * FROM {sql_table}").fetchall()
+            columns = [desc[0] for desc in self.conn.description]
+        return [
+            hydrated
+            for row in rows
+            if (hydrated := self._hydrate_row(SpatialRoom, columns, row)) is not None
+        ]
+
     @staticmethod
     def _saved_search_from_document(doc: Any) -> BaseModel:
         """Hydrate a SavedSearch view-model from its folded document node."""
@@ -969,6 +988,50 @@ class Database(DatabaseEmbeddingMixin):
 
         docs = self.query(Document, node_kind=_SAVED_SEARCH_NODE_KIND)
         return [self._saved_search_from_document(doc) for doc in docs]
+
+    @staticmethod
+    def _spatial_room_from_document(db: "Database", doc: Any) -> BaseModel:
+        """Hydrate a SpatialRoom view-model from its folded room document."""
+        from fichero.spatial_models import RoomType, SpatialRoom
+
+        if doc.prototype_key != _ROOM_PROTOTYPE_KEY:
+            raise ValueError(f"Document {doc.id} is not a room node")
+
+        attrs = db._effective_prototype_attributes(doc)
+        description = attrs.get("description", "")
+        if not isinstance(description, str):
+            raise ValueError(f"Room {doc.id} has invalid description payload")
+        room_type_value = attrs.get("room_type", RoomType.research.value)
+        try:
+            room_type = RoomType(room_type_value)
+        except Exception as exc:
+            raise ValueError(
+                f"Room {doc.id} has invalid room_type payload: {room_type_value!r}"
+            ) from exc
+        owner_id = attrs.get("owner_id", "user")
+        if not isinstance(owner_id, str):
+            raise ValueError(f"Room {doc.id} has invalid owner_id payload")
+        metadata = attrs.get("metadata", {})
+        if not isinstance(metadata, dict):
+            raise ValueError(f"Room {doc.id} has invalid metadata payload")
+
+        return SpatialRoom(
+            id=doc.id,
+            name=doc.name,
+            description=description,
+            room_type=room_type,
+            owner_id=owner_id,
+            metadata=metadata,
+            created_at=doc.created_at,
+            updated_at=doc.updated_at,
+        )
+
+    def _all_folded_spatial_rooms(self) -> list[BaseModel]:
+        """Return all mind-palace rooms from their folded document nodes."""
+        from fichero.models import Document
+
+        docs = self.query(Document, node_kind=_ROOM_NODE_KIND)
+        return [self._spatial_room_from_document(self, doc) for doc in docs]
 
     def _seed_builtin_document_prototypes(self) -> None:
         """Ensure the fold's built-in folder/container prototypes exist."""
@@ -1299,6 +1362,19 @@ class Database(DatabaseEmbeddingMixin):
             if doc is None or doc.node_kind != _SAVED_SEARCH_NODE_KIND:
                 return None
             return cast(T, self._saved_search_from_document(doc))
+        if model.__name__ == "SpatialRoom":
+            from fichero.models import Document
+
+            doc = self.get(Document, id)
+            if doc is None:
+                return None
+            if doc.node_kind == _ROOM_NODE_KIND and doc.prototype_key != _ROOM_PROTOTYPE_KEY:
+                raise ValueError(
+                    f"Document {doc.id} is a room node but has prototype {doc.prototype_key!r}"
+                )
+            if doc.prototype_key != _ROOM_PROTOTYPE_KEY:
+                return None
+            return cast(T, self._spatial_room_from_document(self, doc))
         if model.__name__ == "ResearchProject":
             from fichero.models import Document
 
@@ -1346,6 +1422,8 @@ class Database(DatabaseEmbeddingMixin):
         """Get all objects of a type."""
         if model.__name__ == "SavedSearch":
             return cast(list[T], self._all_folded_saved_searches())
+        if model.__name__ == "SpatialRoom":
+            return cast(list[T], self._all_folded_spatial_rooms())
         if model.__name__ == "ResearchProject":
             return cast(list[T], self._all_folded_research_projects())
         if model.__name__ == "ResearchPlan":
@@ -1375,6 +1453,22 @@ class Database(DatabaseEmbeddingMixin):
         """Query with simple equality filters."""
         if model.__name__ == "SavedSearch":
             rows = self._all_folded_saved_searches()
+            if not filters:
+                return cast(list[T], rows)
+            out: list[BaseModel] = []
+            for row in rows:
+                matches = True
+                for key, value in filters.items():
+                    if not hasattr(row, key):
+                        raise ValueError(f"Invalid column name: {key}")
+                    if getattr(row, key) != value:
+                        matches = False
+                        break
+                if matches:
+                    out.append(row)
+            return cast(list[T], out)
+        if model.__name__ == "SpatialRoom":
+            rows = self._all_folded_spatial_rooms()
             if not filters:
                 return cast(list[T], rows)
             out: list[BaseModel] = []
@@ -1751,6 +1845,8 @@ class Database(DatabaseEmbeddingMixin):
         self._execute(f"DELETE FROM {sql_table} WHERE id = $id", {"id": obj.id})
         if type(obj).__name__ == "SavedSearch":
             self._delete_saved_search_document(obj.id)
+        if type(obj).__name__ == "SpatialRoom":
+            self._delete_spatial_room_document(obj.id)
         if type(obj).__name__ == "ResearchProject":
             self._delete_research_workspace_document(obj.id)
         if type(obj).__name__ in {"ResearchPlan", "ResearchTask", "ResearchStep"}:
@@ -1880,6 +1976,43 @@ class Database(DatabaseEmbeddingMixin):
         doc.updated_at = project.updated_at
         self.save(doc)
 
+    def _save_spatial_room_document(self, room: BaseModel) -> None:
+        """Mirror a SpatialRoom row into the document tree as a room node."""
+        from fichero.models import DocType, Document
+
+        existing = self.get(Document, room.id)
+        metadata = (
+            dict(existing.metadata)
+            if existing is not None and isinstance(existing.metadata, dict)
+            else {}
+        )
+        metadata.update({
+            "node_class": _ROOM_NODE_KIND,
+            "mind_palace_room_id": room.id,
+        })
+        attributes = (
+            dict(existing.attributes)
+            if existing is not None and isinstance(existing.attributes, dict)
+            else {}
+        )
+        attributes.update({
+            "description": room.description,
+            "room_type": room.room_type.value,
+            "owner_id": room.owner_id,
+            "metadata": room.metadata,
+        })
+
+        doc = existing or Document(id=room.id, name=room.name)
+        doc.name = room.name
+        doc.node_kind = _ROOM_NODE_KIND
+        doc.doc_type = DocType.folder
+        doc.prototype_key = _ROOM_PROTOTYPE_KEY
+        doc.metadata = metadata
+        doc.attributes = attributes
+        doc.created_at = room.created_at
+        doc.updated_at = room.updated_at
+        self.save(doc)
+
     def _save_research_plan_document(self, plan: BaseModel) -> None:
         """Mirror a ResearchPlan row into the document tree."""
         from fichero.models import DocType, Document
@@ -2000,6 +2133,15 @@ class Database(DatabaseEmbeddingMixin):
             return
         self._execute("DELETE FROM documents WHERE id = $id", {"id": project_id})
 
+    def _delete_spatial_room_document(self, room_id: str) -> None:
+        """Remove the mirrored document row for a room, if present."""
+        from fichero.models import Document
+
+        doc = self.get(Document, room_id)
+        if doc is None:
+            return
+        self._execute("DELETE FROM documents WHERE id = $id", {"id": room_id})
+
     def _delete_research_content_document(self, doc_id: str) -> None:
         """Remove the mirrored document row for a folded research content node."""
         from fichero.models import Document
@@ -2029,6 +2171,27 @@ class Database(DatabaseEmbeddingMixin):
 
         for project in self._legacy_all_research_project_rows():
             self._save_research_workspace_document(project)
+
+    def _backfill_spatial_room_documents(self) -> None:
+        """Backfill legacy mind-palace rooms into room document nodes."""
+        if not hasattr(self.conn, "execute"):
+            return
+
+        from fichero.spatial_models import SpatialRoom
+
+        table_name = self._table_name(SpatialRoom)
+        table_exists = self.execute_fetchone(
+            """
+            SELECT COUNT(*) FROM information_schema.tables
+            WHERE table_name = $table_name
+            """,
+            {"table_name": table_name},
+        )
+        if not table_exists or int(table_exists[0] or 0) == 0:
+            return
+
+        for room in self._legacy_all_spatial_room_rows():
+            self._save_spatial_room_document(room)
 
     def _backfill_research_plan_task_step_documents(self) -> None:
         """Backfill legacy research plan/task/step rows into document nodes."""

--- a/fichero-engine/tests/unit/test_db.py
+++ b/fichero-engine/tests/unit/test_db.py
@@ -33,6 +33,7 @@ from fichero.research_models import (
     ResearchTask,
     StepTool,
 )
+from fichero.spatial_models import SpatialRoom
 from fichero.knowledge_models import (
     ClaimRelationType,
     ClassificationDimension,
@@ -1243,6 +1244,39 @@ class TestSavedSearchCRUD:
         assert saved.sort_order == 4
         assert saved.filters == {"tag": "letters"}
 
+    def test_saved_search_round_trips_odd_but_valid_payloads(self, temp_db):
+        search = SavedSearch(
+            query="name:odd payload",
+            filters={},
+            folder_path="",
+            sort_order=9,
+        )
+        temp_db.save(search)
+
+        mirrored = temp_db.get(Document, search.id)
+        assert mirrored.attributes["folder_path"] == ""
+        assert mirrored.attributes["filters"] == {}
+
+        retrieved = temp_db.get(SavedSearch, search.id)
+        assert retrieved.folder_path == ""
+        assert retrieved.filters == {}
+        assert retrieved.sort_order == 9
+
+    def test_saved_search_missing_query_payload_raises(self, temp_db):
+        doc = Document(
+            id="saved-doc-bad",
+            name="Bad Saved Search",
+            node_kind="saved_search",
+            prototype_key="saved_search",
+            doc_type=DocType.folder,
+            attributes={"filters": {"tag": "letters"}},
+            curated_items=[],
+        )
+        temp_db.save(doc)
+
+        with pytest.raises(ValueError, match="missing its query payload"):
+            temp_db.get(SavedSearch, doc.id)
+
 
 class TestResearchWorkspaceFold:
     def test_workspace_prototype_inherits_folder_attributes(self, temp_db):
@@ -1353,6 +1387,26 @@ class TestResearchWorkspaceFold:
         assert project.status.value == "active"
         assert project.created_by == "human"
         assert project.metadata == {"topic": "archives"}
+
+    def test_research_project_invalid_created_by_payload_raises(self, temp_db):
+        doc = Document(
+            id="ws-doc-bad-created-by",
+            name="Broken Workspace",
+            node_kind="workspace",
+            prototype_key="research_workspace",
+            doc_type=DocType.folder,
+            is_workspace=True,
+            attributes={
+                "description": "broken",
+                "status": "active",
+                "created_by": ["not", "a", "string"],
+                "metadata": {},
+            },
+        )
+        temp_db.save(doc)
+
+        with pytest.raises(ValueError, match="invalid created_by payload"):
+            temp_db.get(ResearchProject, doc.id)
 
     def test_research_project_raises_when_workspace_prototype_definition_missing(self, temp_db):
         doc = Document(
@@ -1507,6 +1561,96 @@ class TestResearchContentFold:
         assert temp_db.get(ResearchPlan, "plan-doc").project_id == "ws-root"
         assert temp_db.get(ResearchTask, "task-doc").plan_id == "plan-doc"
         assert temp_db.get(ResearchStep, "step-doc").task_id == "task-doc"
+
+    def test_research_plan_round_trips_with_preserved_parent_edge(self, temp_db):
+        plan = ResearchPlan(
+            project_id="missing-workspace-parent",
+            name="Detached Plan",
+            description="still mirrored",
+            metadata={"odd": []},
+        )
+        temp_db.save(plan)
+
+        mirrored = temp_db.get(Document, plan.id)
+        assert mirrored.parent_id == "missing-workspace-parent"
+
+        retrieved = temp_db.get(ResearchPlan, plan.id)
+        assert retrieved.project_id == "missing-workspace-parent"
+        assert retrieved.metadata == {"odd": []}
+
+    def test_research_plan_missing_parent_id_raises(self, temp_db):
+        doc = Document(
+            id="plan-missing-parent",
+            name="Plan Node",
+            node_kind="plan",
+            prototype_key="research_plan",
+            doc_type=DocType.folder,
+            attributes={"description": "", "status": "draft", "order_index": 0, "metadata": {}},
+        )
+        temp_db.save(doc)
+
+        with pytest.raises(ValueError, match="missing project parent_id"):
+            temp_db.get(ResearchPlan, doc.id)
+
+    def test_research_task_invalid_completed_at_payload_raises(self, temp_db):
+        doc = Document(
+            id="task-bad-completed-at",
+            parent_id="plan-1",
+            name="Task Node",
+            node_kind="task",
+            prototype_key="research_task",
+            doc_type=DocType.folder,
+            attributes={
+                "description": "",
+                "status": "pending",
+                "priority": 0,
+                "assigned_to": None,
+                "metadata": {},
+                "completed_at": "2026-06-28T00:00:00",
+            },
+        )
+        temp_db.save(doc)
+
+        with pytest.raises(ValueError, match="invalid completed_at payload"):
+            temp_db.get(ResearchTask, doc.id)
+
+    def test_research_step_invalid_tool_payload_raises(self, temp_db):
+        doc = Document(
+            id="step-bad-tool",
+            parent_id="task-1",
+            name="Step Node",
+            node_kind="step",
+            prototype_key="research_step",
+            doc_type=DocType.file,
+            attributes={
+                "tool": "unknown_tool",
+                "description": "",
+                "config": {},
+                "status": "pending",
+                "result": {},
+                "error": None,
+                "order_index": 0,
+            },
+        )
+        temp_db.save(doc)
+
+        with pytest.raises(ValueError, match="invalid tool payload"):
+            temp_db.get(ResearchStep, doc.id)
+
+
+class TestRoomRoundTrips:
+    def test_spatial_room_round_trips_odd_metadata_payload(self, temp_db):
+        room = SpatialRoom(
+            name="Odd Room",
+            description="",
+            metadata={"nested": {"items": []}, "flag": False},
+        )
+        temp_db.save(room)
+
+        retrieved = temp_db.get(SpatialRoom, room.id)
+        assert retrieved is not None
+        assert retrieved.description == ""
+        assert retrieved.metadata == {"nested": {"items": []}, "flag": False}
 
 
 class TestLibraryLinkBackfill:

--- a/fichero-engine/tests/unit/test_db.py
+++ b/fichero-engine/tests/unit/test_db.py
@@ -33,6 +33,7 @@ from fichero.research_models import (
     ResearchTask,
     StepTool,
 )
+from fichero.spatial_models import RoomType, SpatialRoom
 from fichero.knowledge_models import (
     ClaimRelationType,
     ClassificationDimension,
@@ -1378,6 +1379,115 @@ class TestResearchWorkspaceFold:
 
         with pytest.raises(PrototypeResolutionError):
             temp_db.get(ResearchProject, doc.id)
+
+
+class TestSpatialRoomFold:
+    def test_save_and_get_spatial_room(self, temp_db):
+        room = SpatialRoom(
+            name="Archive Room",
+            description="A room for sources",
+            room_type=RoomType.synthesis,
+            owner_id="agent",
+            metadata={"theme": "blue"},
+        )
+        temp_db.save(room)
+
+        retrieved = temp_db.get(SpatialRoom, room.id)
+        assert retrieved is not None
+        assert retrieved.name == "Archive Room"
+        assert retrieved.room_type == RoomType.synthesis
+        assert retrieved.owner_id == "agent"
+        assert retrieved.metadata == {"theme": "blue"}
+
+        mirrored = temp_db.get(Document, room.id)
+        assert mirrored is not None
+        assert mirrored.node_kind == "room"
+        assert mirrored.doc_type == DocType.folder
+        assert mirrored.prototype_key == "room"
+        assert mirrored.attributes["description"] == "A room for sources"
+        assert mirrored.attributes["room_type"] == "synthesis"
+        assert mirrored.attributes["owner_id"] == "agent"
+
+    def test_spatial_room_reads_from_folded_document_node(self, temp_db):
+        doc = Document(
+            id="room-doc-1",
+            name="Room Node",
+            node_kind="room",
+            prototype_key="room",
+            doc_type=DocType.folder,
+            attributes={
+                "description": "Node-owned room",
+                "room_type": "presentation",
+                "owner_id": "human",
+                "metadata": {"theme": "gold"},
+            },
+        )
+        temp_db.save(doc)
+
+        room = temp_db.get(SpatialRoom, doc.id)
+        assert room is not None
+        assert room.description == "Node-owned room"
+        assert room.room_type == RoomType.presentation
+        assert room.owner_id == "human"
+        assert room.metadata == {"theme": "gold"}
+
+    def test_spatial_room_inherits_folder_prototype_attributes(self, temp_db):
+        room = SpatialRoom(name="Inherited Room")
+        temp_db.save(room)
+
+        effective = resolve_prototype_attributes(temp_db, "room")
+        assert effective["container_kind"] == "folder"
+        assert effective["supports_children"] is True
+        assert effective["workspace_kind"] == "room"
+
+        mirrored = temp_db.get(Document, room.id)
+        assert mirrored is not None
+        child = Document(
+            id="room-child",
+            name="Room Child",
+            doc_type=DocType.file,
+            parent_id=room.id,
+        )
+        temp_db.save(child)
+        children = temp_db.query(Document, parent_id=mirrored.id)
+        assert [item.id for item in children] == ["room-child"]
+
+    def test_spatial_room_raises_when_document_is_not_room_prototype(self, temp_db):
+        doc = Document(
+            id="bad-room",
+            name="Bad Room",
+            node_kind="room",
+            prototype_key="letter",
+            doc_type=DocType.folder,
+        )
+        temp_db.save(doc)
+
+        with pytest.raises(ValueError, match="room node"):
+            temp_db.get(SpatialRoom, doc.id)
+
+    def test_spatial_room_raises_when_room_prototype_definition_missing(self, temp_db):
+        doc = Document(
+            id="missing-room-proto",
+            name="Broken Room",
+            node_kind="room",
+            prototype_key="room",
+            doc_type=DocType.folder,
+            attributes={"description": "broken"},
+        )
+        temp_db.save(doc)
+
+        room_proto = next(
+            value
+            for value in temp_db.query(
+                ClassificationValue,
+                dimension=ClassificationDimension.document_prototype,
+            )
+            if value.key == "room"
+        )
+        temp_db.delete(room_proto)
+
+        with pytest.raises(PrototypeResolutionError):
+            temp_db.get(SpatialRoom, doc.id)
 
 
 class TestResearchContentFold:

--- a/fichero-engine/tests/unit/test_node_aliases.py
+++ b/fichero-engine/tests/unit/test_node_aliases.py
@@ -58,6 +58,73 @@ def test_alias_resolves_to_live_target(temp_db):
     assert resolved.name == "Target"
 
 
+def test_alias_to_alias_requires_multiple_hops(temp_db):
+    target = Document(name="Leaf", doc_type=DocType.file)
+    temp_db.save(target)
+    first = make_alias(target, parent_id="container-a")
+    temp_db.save(first)
+    second = make_alias(first, parent_id="container-b", name="Alias Of Alias")
+    temp_db.save(second)
+
+    resolved = resolve_alias(temp_db, temp_db.get(Document, second.id))
+    assert resolved.id == first.id
+    assert resolved.alias_target_id == target.id
+    assert resolved.parent_id == "container-a"
+
+    leaf = resolve_alias(temp_db, resolved)
+    assert leaf.id == target.id
+
+
+def test_deep_alias_chain_can_be_walked_hop_by_hop(temp_db):
+    target = Document(name="Leaf", doc_type=DocType.file)
+    temp_db.save(target)
+    hop1 = make_alias(target, parent_id="c1")
+    hop2 = make_alias(hop1, parent_id="c2")
+    hop3 = make_alias(hop2, parent_id="c3")
+    temp_db.save(hop1)
+    temp_db.save(hop2)
+    temp_db.save(hop3)
+
+    current = temp_db.get(Document, hop3.id)
+    for expected in (hop2.id, hop1.id, target.id):
+        current = resolve_alias(temp_db, current)
+        assert current.id == expected
+
+
+def test_alias_resolves_after_target_is_reparented(temp_db):
+    root = Document(name="Root", doc_type=DocType.folder)
+    new_parent = Document(name="New Parent", doc_type=DocType.folder)
+    target = Document(name="Target", doc_type=DocType.file, parent_id=root.id)
+    temp_db.save(root)
+    temp_db.save(new_parent)
+    temp_db.save(target)
+    alias = make_alias(target, parent_id="alias-container")
+    temp_db.save(alias)
+
+    target.parent_id = new_parent.id
+    temp_db.save(target)
+
+    resolved = resolve_alias(temp_db, temp_db.get(Document, alias.id))
+    assert resolved.id == target.id
+    assert resolved.parent_id == new_parent.id
+
+
+def test_alias_to_alias_second_hop_raises_when_leaf_target_is_deleted(temp_db):
+    target = Document(name="Leaf", doc_type=DocType.file)
+    temp_db.save(target)
+    first = make_alias(target, parent_id=None)
+    second = make_alias(first, parent_id=None)
+    temp_db.save(first)
+    temp_db.save(second)
+    temp_db.delete(target)
+
+    intermediate = resolve_alias(temp_db, temp_db.get(Document, second.id))
+    assert intermediate.id == first.id
+
+    with pytest.raises(DanglingAliasError):
+        resolve_alias(temp_db, intermediate)
+
+
 def test_resolving_dangling_alias_raises(temp_db):
     """Deleting the target must surface loudly, not silently substitute."""
     target = Document(name="Doomed", doc_type=DocType.file)

--- a/fichero-engine/tests/unit/test_node_prototypes.py
+++ b/fichero-engine/tests/unit/test_node_prototypes.py
@@ -62,6 +62,16 @@ def test_three_level_chain_merges_root_to_leaf(temp_db):
     assert effective == {"a": 99, "b": 2, "c": 3}
 
 
+def test_four_level_chain_uses_leaf_override_precedence(temp_db):
+    _proto(temp_db, "root", attributes={"icon": "square", "theme": "plain", "locked": False})
+    _proto(temp_db, "mid_a", parent_key="root", attributes={"theme": "paper"})
+    _proto(temp_db, "mid_b", parent_key="mid_a", attributes={"icon": "tray"})
+    _proto(temp_db, "leaf", parent_key="mid_b", attributes={"theme": "canvas", "locked": True})
+
+    effective = resolve_prototype_attributes(temp_db, "leaf")
+    assert effective == {"icon": "tray", "theme": "canvas", "locked": True}
+
+
 def test_unknown_key_raises(temp_db):
     with pytest.raises(PrototypeResolutionError):
         resolve_prototype_attributes(temp_db, "does-not-exist")
@@ -73,8 +83,26 @@ def test_unknown_parent_raises(temp_db):
         resolve_prototype_attributes(temp_db, "child")
 
 
+def test_unknown_parent_mid_chain_raises(temp_db):
+    _proto(temp_db, "root", attributes={"a": 1})
+    _proto(temp_db, "middle", parent_key="ghost", attributes={"b": 2})
+    _proto(temp_db, "leaf", parent_key="middle", attributes={"c": 3})
+
+    with pytest.raises(PrototypeResolutionError, match="Unknown prototype key"):
+        resolve_prototype_attributes(temp_db, "leaf")
+
+
 def test_cyclic_chain_raises(temp_db):
     _proto(temp_db, "a", parent_key="b")
     _proto(temp_db, "b", parent_key="a")
     with pytest.raises(PrototypeResolutionError):
+        resolve_prototype_attributes(temp_db, "a")
+
+
+def test_three_node_cycle_raises_at_resolution_time(temp_db):
+    _proto(temp_db, "a", parent_key="b")
+    _proto(temp_db, "b", parent_key="c")
+    _proto(temp_db, "c", parent_key="a")
+
+    with pytest.raises(PrototypeResolutionError, match="Cyclic prototype parent chain"):
         resolve_prototype_attributes(temp_db, "a")

--- a/fichero-engine/tests/unit/test_routes_mind_palace.py
+++ b/fichero-engine/tests/unit/test_routes_mind_palace.py
@@ -13,6 +13,7 @@ from fichero.spatial_models import (
     SpatialRoom,
     SpatialNode,
 )
+from fichero.models import Document
 
 
 BASE = "/api/mind-palace"
@@ -55,6 +56,20 @@ class TestCreateRoom:
         data = r.json()
         assert data["name"] == "Archive Room"
         assert "id" in data
+
+    def test_create_room_creates_backing_room_document(self, client, db):
+        response = client.post(
+            f"{BASE}/rooms",
+            json={"name": "Node Backed Room", "room_type": "research"},
+        )
+        assert response.status_code == 200
+
+        room_id = response.json()["id"]
+        mirrored = db.get(Document, room_id)
+        assert mirrored is not None
+        assert mirrored.node_kind == "room"
+        assert mirrored.prototype_key == "room"
+        assert mirrored.doc_type == "folder"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two backend lanes:
- F5 slice-1 (#2591): mind-palace rooms now have a node-backed representation (room prototype inheriting folder from P5) + converter; /api/mind-palace/rooms/* endpoints unchanged (compatibility preserved — no /rooms/* retirement yet).
- node-model edge tests (#108): deeper coverage for node_aliases (looping/chained), node_prototypes (multi-level inheritance, cycles, unknown-parent), and db.py fold round-trips incl. prefer-raise paths.

Full unit+contracts suite: 6175 passed, 0 failed.

Co-Authored-By: Daniel Tubb <dtubb@me.com>