### PR TITLE
node-model P3: notes & milestones as node types (#2591)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,1 +1,0 @@
-2026-06-28 P3 folded knowledge notes and net-new milestones into node-backed document children with parent validation/backfill; full unit + contracts passed locally.

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,1 @@
+2026-06-28 P3 folded knowledge notes and net-new milestones into node-backed document children with parent validation/backfill; full unit + contracts passed locally.

--- a/fichero-engine/src/fichero/db.py
+++ b/fichero-engine/src/fichero/db.py
@@ -170,6 +170,10 @@ _RESEARCH_TASK_NODE_KIND = "task"
 _RESEARCH_TASK_PROTOTYPE_KEY = "research_task"
 _RESEARCH_STEP_NODE_KIND = "step"
 _RESEARCH_STEP_PROTOTYPE_KEY = "research_step"
+_NOTE_NODE_KIND = "note"
+_NOTE_PROTOTYPE_KEY = "note"
+_MILESTONE_NODE_KIND = "milestone"
+_MILESTONE_PROTOTYPE_KEY = "milestone"
 _ENTITY_NODE_KIND = "entity"
 _ROOM_NODE_KIND = "room"
 _FOLDER_PROTOTYPE_KEY = "folder"
@@ -242,6 +246,18 @@ _BUILTIN_DOCUMENT_PROTOTYPE_SEEDS: tuple[dict[str, Any], ...] = (
         "key": "map",
         "label": "Map",
         "color": "#64D2FF",
+        "attributes": {},
+    },
+    {
+        "key": _MILESTONE_PROTOTYPE_KEY,
+        "label": "Milestone",
+        "color": "#FF375F",
+        "attributes": {},
+    },
+    {
+        "key": _NOTE_PROTOTYPE_KEY,
+        "label": "Note",
+        "color": "#FF9500",
         "attributes": {},
     },
     {
@@ -537,6 +553,8 @@ class Database(DatabaseEmbeddingMixin):
         self._seed_builtin_node_classes()
         self._backfill_claim_links_to_library_links()
         self._backfill_filed_entity_documents()
+        self._backfill_note_documents()
+        self._backfill_milestone_documents()
         self._backfill_saved_search_documents()
         self._backfill_spatial_room_documents()
         self._backfill_research_workspace_documents()
@@ -748,6 +766,10 @@ class Database(DatabaseEmbeddingMixin):
         """
         if type(obj).__name__ == "KnowledgeEntity":
             self._validate_entity_parent(obj)
+        if type(obj).__name__ == "Note" and hasattr(obj, "body"):
+            self._validate_note_parent(obj)
+        if type(obj).__name__ == "Milestone":
+            self._validate_milestone_parent(obj)
 
         sql_table = self._sql_table_name(obj)
         self._ensure_table(type(obj))
@@ -804,6 +826,10 @@ class Database(DatabaseEmbeddingMixin):
             self._save_research_task_document(obj)
         if type(obj).__name__ == "ResearchStep":
             self._save_research_step_document(obj)
+        if type(obj).__name__ == "Note" and hasattr(obj, "body"):
+            self._save_note_document(obj)
+        if type(obj).__name__ == "Milestone":
+            self._save_milestone_document(obj)
 
         # Auto-embed if requested and has content
         # ponytail: bulk callers (importers / reindex loops) that save many
@@ -967,6 +993,36 @@ class Database(DatabaseEmbeddingMixin):
             if (hydrated := self._hydrate_row(KnowledgeEntity, columns, row)) is not None
         ]
 
+    def _legacy_all_note_rows(self) -> list[BaseModel]:
+        """Read Note rows without any node-tree bridge logic."""
+        from fichero.knowledge_models import Note
+
+        sql_table = self._sql_table_name(Note)
+        self._ensure_table(Note)
+        with self._lock:
+            rows = self._execute(f"SELECT * FROM {sql_table}").fetchall()
+            columns = [desc[0] for desc in self.conn.description]
+        return [
+            hydrated
+            for row in rows
+            if (hydrated := self._hydrate_row(Note, columns, row)) is not None
+        ]
+
+    def _legacy_all_milestone_rows(self) -> list[BaseModel]:
+        """Read Milestone rows without any node-tree bridge logic."""
+        from fichero.knowledge_models import Milestone
+
+        sql_table = self._sql_table_name(Milestone)
+        self._ensure_table(Milestone)
+        with self._lock:
+            rows = self._execute(f"SELECT * FROM {sql_table}").fetchall()
+            columns = [desc[0] for desc in self.conn.description]
+        return [
+            hydrated
+            for row in rows
+            if (hydrated := self._hydrate_row(Milestone, columns, row)) is not None
+        ]
+
     @staticmethod
     def _saved_search_from_document(doc: Any) -> BaseModel:
         """Hydrate a SavedSearch view-model from its folded document node."""
@@ -1068,6 +1124,60 @@ class Database(DatabaseEmbeddingMixin):
             raise ValueError(f"Parent not found: {parent_id}")
         if parent.doc_type != DocType.folder:
             raise ValueError(f"Parent is not a folder: {parent_id}")
+
+    def _validate_document_parent(
+        self,
+        parent_id: str,
+        *,
+        allowed_doc_types: set[Any] | None = None,
+        expected_kind: str,
+    ) -> Any:
+        """Resolve and validate a live document parent."""
+        from fichero.models import Document
+
+        parent = self.get(Document, parent_id)
+        if parent is None or getattr(parent, "deleted_at", None) is not None:
+            raise ValueError(f"{expected_kind} parent not found: {parent_id}")
+        if allowed_doc_types is not None and parent.doc_type not in allowed_doc_types:
+            raise ValueError(f"{expected_kind} parent has invalid doc_type: {parent_id}")
+        return parent
+
+    def _note_parent_id(self, note: BaseModel) -> str | None:
+        """Resolve a note's containment parent without changing the route schema."""
+        folder_id = getattr(note, "folder_id", None)
+        page_id = getattr(note, "page_id", None)
+        if folder_id and page_id and folder_id != page_id:
+            raise ValueError(
+                f"Note {note.id} cannot target both folder_id={folder_id} and page_id={page_id}"
+            )
+        return folder_id or page_id
+
+    def _validate_note_parent(self, note: BaseModel) -> None:
+        """Folded notes may target a folder or page, and must resolve cleanly."""
+        from fichero.models import DocType
+
+        parent_id = self._note_parent_id(note)
+        if parent_id is None:
+            return
+        parent = self._validate_document_parent(
+            parent_id,
+            allowed_doc_types={DocType.folder, DocType.page},
+            expected_kind="Note",
+        )
+        if getattr(note, "folder_id", None) is not None and parent.doc_type != DocType.folder:
+            raise ValueError(f"Note folder parent is not a folder: {parent_id}")
+        if getattr(note, "page_id", None) is not None and parent.doc_type != DocType.page:
+            raise ValueError(f"Note page parent is not a page: {parent_id}")
+
+    def _validate_milestone_parent(self, milestone: BaseModel) -> None:
+        """Milestones are folder-contained content nodes."""
+        from fichero.models import DocType
+
+        self._validate_document_parent(
+            milestone.parent_id,
+            allowed_doc_types={DocType.folder},
+            expected_kind="Milestone",
+        )
 
     def _seed_builtin_document_prototypes(self) -> None:
         """Ensure the fold's built-in folder/container prototypes exist."""
@@ -1889,6 +1999,10 @@ class Database(DatabaseEmbeddingMixin):
             self._delete_research_workspace_document(obj.id)
         if type(obj).__name__ in {"ResearchPlan", "ResearchTask", "ResearchStep"}:
             self._delete_research_content_document(obj.id)
+        if type(obj).__name__ == "Note" and hasattr(obj, "body"):
+            self._delete_note_document(obj.id)
+        if type(obj).__name__ == "Milestone":
+            self._delete_milestone_document(obj.id)
 
     def _save_saved_search_document(self, saved: BaseModel) -> None:
         """Mirror a SavedSearch row into the document tree as a smart folder."""
@@ -1942,6 +2056,89 @@ class Database(DatabaseEmbeddingMixin):
         }]
         doc.created_at = saved.created_at
         doc.updated_at = saved.updated_at
+        self.save(doc)
+
+    def _save_note_document(self, note: BaseModel) -> None:
+        """Mirror a note row into the document tree."""
+        from fichero.models import DocType, Document
+
+        existing = self.get(Document, note.id)
+        metadata = (
+            dict(existing.metadata)
+            if existing is not None and isinstance(existing.metadata, dict)
+            else {}
+        )
+        metadata.update({"node_class": _NOTE_NODE_KIND, "note_id": note.id})
+        attributes = (
+            dict(existing.attributes)
+            if existing is not None and isinstance(existing.attributes, dict)
+            else {}
+        )
+        attributes.update({
+            "body": note.body,
+            "kind": note.kind.value,
+            "tags": note.tags,
+            "linked_note_ids": note.linked_note_ids,
+            "linked_entity_ids": note.linked_entity_ids,
+            "linked_claim_ids": note.linked_claim_ids,
+            "linked_document_ids": note.linked_document_ids,
+            "page_id": note.page_id,
+            "folder_id": note.folder_id,
+            "linked_structure_node_id": note.linked_structure_node_id,
+            "address": note.address,
+            "parent_address": note.parent_address,
+            "author_type": note.author_type,
+            "created_by": note.created_by,
+        })
+
+        doc = existing or Document(id=note.id, name=note.title or "Untitled note")
+        doc.parent_id = self._note_parent_id(note)
+        doc.name = note.title or note.address or "Untitled note"
+        doc.node_kind = _NOTE_NODE_KIND
+        doc.doc_type = DocType.file
+        doc.prototype_key = _NOTE_PROTOTYPE_KEY
+        doc.metadata = metadata
+        doc.attributes = attributes
+        doc.created_at = note.created_at
+        doc.updated_at = note.updated_at
+        self.save(doc)
+
+    def _save_milestone_document(self, milestone: BaseModel) -> None:
+        """Mirror a milestone row into the document tree."""
+        from fichero.models import DocType, Document
+
+        existing = self.get(Document, milestone.id)
+        metadata = (
+            dict(existing.metadata)
+            if existing is not None and isinstance(existing.metadata, dict)
+            else {}
+        )
+        metadata.update({
+            "node_class": _MILESTONE_NODE_KIND,
+            "milestone_id": milestone.id,
+        })
+        attributes = (
+            dict(existing.attributes)
+            if existing is not None and isinstance(existing.attributes, dict)
+            else {}
+        )
+        attributes.update({
+            "description": milestone.description,
+            "status": milestone.status,
+            "metadata": milestone.metadata,
+            "created_by": milestone.created_by,
+        })
+
+        doc = existing or Document(id=milestone.id, name=milestone.title)
+        doc.parent_id = milestone.parent_id
+        doc.name = milestone.title
+        doc.node_kind = _MILESTONE_NODE_KIND
+        doc.doc_type = DocType.file
+        doc.prototype_key = _MILESTONE_PROTOTYPE_KEY
+        doc.metadata = metadata
+        doc.attributes = attributes
+        doc.created_at = milestone.created_at
+        doc.updated_at = milestone.updated_at
         self.save(doc)
 
     def _save_filed_entity_document(self, entity: BaseModel) -> None:
@@ -2008,6 +2205,24 @@ class Database(DatabaseEmbeddingMixin):
             return
         self._execute("DELETE FROM documents WHERE id = $id", {"id": entity_id})
 
+    def _delete_note_document(self, note_id: str) -> None:
+        """Remove the mirrored document row for a note, if present."""
+        from fichero.models import Document
+
+        doc = self.get(Document, note_id)
+        if doc is None:
+            return
+        self._execute("DELETE FROM documents WHERE id = $id", {"id": note_id})
+
+    def _delete_milestone_document(self, milestone_id: str) -> None:
+        """Remove the mirrored document row for a milestone, if present."""
+        from fichero.models import Document
+
+        doc = self.get(Document, milestone_id)
+        if doc is None:
+            return
+        self._execute("DELETE FROM documents WHERE id = $id", {"id": milestone_id})
+
     def _backfill_saved_search_documents(self) -> None:
         """Backfill existing saved_searches rows into same-id document nodes."""
         # ponytail: mocked connections in unit tests may only support close().
@@ -2050,6 +2265,48 @@ class Database(DatabaseEmbeddingMixin):
 
         for entity in self._legacy_all_knowledge_entity_rows():
             self._save_filed_entity_document(entity)
+
+    def _backfill_note_documents(self) -> None:
+        """Backfill legacy notes into same-id document nodes."""
+        if not hasattr(self.conn, "execute"):
+            return
+
+        from fichero.knowledge_models import Note
+
+        table_name = self._table_name(Note)
+        table_exists = self.execute_fetchone(
+            """
+            SELECT COUNT(*) FROM information_schema.tables
+            WHERE table_name = $table_name
+            """,
+            {"table_name": table_name},
+        )
+        if not table_exists or int(table_exists[0] or 0) == 0:
+            return
+
+        for note in self._legacy_all_note_rows():
+            self._save_note_document(note)
+
+    def _backfill_milestone_documents(self) -> None:
+        """Backfill legacy milestones into same-id document nodes."""
+        if not hasattr(self.conn, "execute"):
+            return
+
+        from fichero.knowledge_models import Milestone
+
+        table_name = self._table_name(Milestone)
+        table_exists = self.execute_fetchone(
+            """
+            SELECT COUNT(*) FROM information_schema.tables
+            WHERE table_name = $table_name
+            """,
+            {"table_name": table_name},
+        )
+        if not table_exists or int(table_exists[0] or 0) == 0:
+            return
+
+        for milestone in self._legacy_all_milestone_rows():
+            self._save_milestone_document(milestone)
 
     def _save_research_workspace_document(self, project: BaseModel) -> None:
         """Mirror a ResearchProject row into the document tree as a workspace."""

--- a/fichero-engine/src/fichero/knowledge/knowledge_models.py
+++ b/fichero-engine/src/fichero/knowledge/knowledge_models.py
@@ -1297,6 +1297,22 @@ class Note(BaseModel):
     updated_at: datetime = Field(default_factory=datetime.now)
 
 
+class Milestone(BaseModel):
+    """User-authored milestone content that can be filed into the node tree."""
+
+    model_config = ConfigDict(from_attributes=True, extra="allow")
+
+    id: str = Field(default_factory=_new_id)
+    title: str
+    description: str = ""
+    parent_id: str
+    status: str = "planned"
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_by: str = "human"
+    created_at: datetime = Field(default_factory=datetime.now)
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
 class NoteLink(BaseModel):
     """Bidirectional link between two Notes — the Zettelkasten edge (#917).
 

--- a/fichero-engine/tests/unit/test_db.py
+++ b/fichero-engine/tests/unit/test_db.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, Field
 
 from fichero import db as db_module
 from fichero.models import (
-    Document, Artifact, Workflow, Run, Trace, Note, Event,
+    Document, Artifact, Workflow, Run, Trace, Note as LegacyNote, Event,
     DocType, FileType, Status, RunStatus, SavedSearch
 )
 from fichero.db import Database
@@ -43,6 +43,9 @@ from fichero.knowledge_models import (
     KnowledgeClaimLink,
     KnowledgeEntity,
     LibraryItemLink,
+    Milestone,
+    Note,
+    NoteKind,
 )
 from fichero.node_prototypes import (
     PrototypeResolutionError,
@@ -741,7 +744,7 @@ class TestNoteCRUD:
         doc = Document(name="test.jpg", path="/test.jpg")
         temp_db.save(doc)
 
-        note = Note(
+        note = LegacyNote(
             target_type="Document",
             target_id=doc.id,
             content="This handwriting is hard to read",
@@ -749,7 +752,7 @@ class TestNoteCRUD:
         )
         temp_db.save(note)
 
-        retrieved = temp_db.get(Note, note.id)
+        retrieved = temp_db.get(LegacyNote, note.id)
         assert retrieved.content == "This handwriting is hard to read"
         assert retrieved.note_type == "comment"
 
@@ -758,7 +761,7 @@ class TestNoteCRUD:
         doc = Document(name="test.jpg", path="/test.jpg")
         temp_db.save(doc)
 
-        note = Note(
+        note = LegacyNote(
             target_type="Document",
             target_id=doc.id,
             content="Check this signature",
@@ -767,7 +770,7 @@ class TestNoteCRUD:
         )
         temp_db.save(note)
 
-        retrieved = temp_db.get(Note, note.id)
+        retrieved = temp_db.get(LegacyNote, note.id)
         assert retrieved.bbox == (600, 850, 300, 100)
 
 
@@ -1276,6 +1279,109 @@ class TestSavedSearchCRUD:
 
         with pytest.raises(ValueError, match="missing its query payload"):
             temp_db.get(SavedSearch, doc.id)
+
+
+class TestNoteAndMilestoneFold:
+    def test_note_round_trip_mirrors_to_document_node(self, temp_db):
+        folder = Document(name="Notes", doc_type=DocType.folder)
+        temp_db.save(folder)
+        note = Note(
+            title="Bridge note",
+            body="Atomic thought",
+            kind=NoteKind.hub,
+            tags=["zettel"],
+            folder_id=folder.id,
+        )
+
+        temp_db.save(note)
+
+        retrieved = temp_db.get(Note, note.id)
+        assert retrieved is not None
+        assert retrieved.title == "Bridge note"
+        assert retrieved.folder_id == folder.id
+
+        mirrored = temp_db.get(Document, note.id)
+        assert mirrored is not None
+        assert mirrored.parent_id == folder.id
+        assert mirrored.node_kind == "note"
+        assert mirrored.prototype_key == "note"
+        assert mirrored.attributes["body"] == "Atomic thought"
+        assert mirrored.attributes["kind"] == "hub"
+        assert mirrored.attributes["tags"] == ["zettel"]
+
+    def test_page_scoped_note_is_contained_under_page_node(self, temp_db):
+        page = Document(name="Page 1", doc_type=DocType.page)
+        temp_db.save(page)
+        note = Note(title="Margin note", body="Page scoped", page_id=page.id)
+
+        temp_db.save(note)
+
+        mirrored = temp_db.get(Document, note.id)
+        assert mirrored is not None
+        assert mirrored.parent_id == page.id
+        children = temp_db.query(Document, parent_id=page.id)
+        assert [child.id for child in children if child.id == note.id] == [note.id]
+
+    def test_note_parent_validation_prefers_raise(self, temp_db):
+        bad_parent = Document(name="Not a folder", doc_type=DocType.file)
+        temp_db.save(bad_parent)
+
+        with pytest.raises(ValueError, match="invalid doc_type"):
+            temp_db.save(Note(title="Bad note", body="broken", folder_id=bad_parent.id))
+
+        with pytest.raises(ValueError, match="cannot target both"):
+            temp_db.save(
+                Note(
+                    title="Conflicted note",
+                    body="broken",
+                    folder_id="folder-a",
+                    page_id="page-b",
+                )
+            )
+
+    def test_milestone_round_trip_and_move_updates_containment(self, temp_db):
+        backlog = Document(name="Backlog", doc_type=DocType.folder)
+        archive = Document(name="Archive", doc_type=DocType.folder)
+        temp_db.save(backlog)
+        temp_db.save(archive)
+        milestone = Milestone(
+            title="Milestone A",
+            description="Ship the bridge",
+            parent_id=backlog.id,
+            status="active",
+            metadata={"lane": "engine"},
+        )
+
+        temp_db.save(milestone)
+        milestone.parent_id = archive.id
+        milestone.status = "done"
+        temp_db.save(milestone)
+
+        retrieved = temp_db.get(Milestone, milestone.id)
+        assert retrieved is not None
+        assert retrieved.parent_id == archive.id
+        assert retrieved.status == "done"
+
+        mirrored = temp_db.get(Document, milestone.id)
+        assert mirrored is not None
+        assert mirrored.parent_id == archive.id
+        assert mirrored.node_kind == "milestone"
+        assert mirrored.prototype_key == "milestone"
+        assert mirrored.attributes["description"] == "Ship the bridge"
+        assert mirrored.attributes["status"] == "done"
+
+        effective = temp_db._effective_prototype_attributes(mirrored)
+        assert effective["description"] == "Ship the bridge"
+
+    def test_milestone_missing_or_non_folder_parent_raises(self, temp_db):
+        with pytest.raises(ValueError, match="parent not found"):
+            temp_db.save(Milestone(title="Broken", parent_id="missing-parent"))
+
+        bad_parent = Document(name="Plain file", doc_type=DocType.file)
+        temp_db.save(bad_parent)
+
+        with pytest.raises(ValueError, match="invalid doc_type"):
+            temp_db.save(Milestone(title="Broken Again", parent_id=bad_parent.id))
 
 
 class TestResearchWorkspaceFold:

--- a/fichero-engine/tests/unit/test_routes_documents.py
+++ b/fichero-engine/tests/unit/test_routes_documents.py
@@ -21,7 +21,9 @@ from fichero.knowledge_models import (
     ClassificationValue,
     KnowledgeClaim,
     KnowledgeEntity,
+    Milestone,
     MutationLog,
+    Note,
 )
 from fichero.models import Document, DocType
 from fichero.node_prototypes import resolve_prototype_attributes
@@ -369,6 +371,23 @@ class TestGetChildren:
         assert entity.id in items
         assert items[entity.id]["node_kind"] == "entity"
         assert items[entity.id]["name"] == "Eldorado"
+
+    def test_returns_folded_notes_and_milestones_as_children(self, client, db):
+        parent = Document(name="Parent", doc_type=DocType.folder)
+        db.save(parent)
+        note = Note(title="Folder note", body="Node-backed", folder_id=parent.id)
+        milestone = Milestone(title="Phase 1", parent_id=parent.id, status="active")
+        db.save(note)
+        db.save(milestone)
+
+        response = client.get(f"/api/documents/{parent.id}/children")
+
+        assert response.status_code == 200
+        items = {item["id"]: item for item in response.json()["items"]}
+        assert items[note.id]["node_kind"] == "note"
+        assert items[note.id]["prototype_key"] == "note"
+        assert items[milestone.id]["node_kind"] == "milestone"
+        assert items[milestone.id]["prototype_key"] == "milestone"
 
     def test_returns_empty_for_leaf(self, client, db):
         doc = _make_doc(db)


### PR DESCRIPTION
Foundation P3 of EPIC #2591. Notes and milestones become document nodes (note/milestone prototypes) with parent_id containment, reusing the fold pattern. tasks.py BackgroundTask is INFRA and untouched (research plan/task/step content already folded in F3). No library-DB migration, no contract change. Full unit+contracts suite: 6206 passed, 0 failed.

Co-Authored-By: Daniel Tubb <dtubb@me.com>