### PR TITLE
node-model P6: chat scopes as node references (#2591)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,1 +1,0 @@
-2026-06-28 P6 bridged chat scopes to node references via Conversation.scope_document_id with alias-aware resolution, descendant containment, and missing-node 404 coverage.

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,1 @@
+2026-06-28 P6 bridged chat scopes to node references via Conversation.scope_document_id with alias-aware resolution, descendant containment, and missing-node 404 coverage.

--- a/fichero-engine/src/fichero/api/routes/chat.py
+++ b/fichero-engine/src/fichero/api/routes/chat.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, ConfigDict, Field
 
+from fichero.api.routes.claims import _descendant_doc_ids
 from fichero.db import Database
 from fichero.api.main import get_library_database, get_library_database_for_write
 from fichero.app_db import get_app_db, AppDatabase
@@ -25,6 +26,7 @@ from fichero.models import (
 )
 from fichero.keychain import has_api_key
 from fichero.llm import LLMConfig, get_langchain_model
+from fichero.node_aliases import DanglingAliasError, is_alias, resolve_alias
 from fichero.providers import get_provider_info
 from fichero.prompts import compose_system_prompt
 from fichero.retrieval.graph_rag import GraphAwareRetriever
@@ -261,6 +263,49 @@ def _build_chat_system_prompt(has_context: bool) -> str:
     return compose_system_prompt(role="chat", extra=extra)
 
 
+def _requested_scope_document_id(request: ChatRequest) -> str | None:
+    """Compatibility bridge for node-backed scope refs on chat requests."""
+    value = getattr(request, "scope_document_id", None)
+    return value if isinstance(value, str) and value else None
+
+
+def _resolve_scope_node(db: Database, scope_document_id: str) -> Document:
+    """Resolve a chat scope node, following aliases and raising on misses."""
+    scope = db.get(Document, scope_document_id)
+    if scope is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Chat scope node not found: {scope_document_id}",
+        )
+    if not is_alias(scope):
+        return scope
+    try:
+        return resolve_alias(db, scope)
+    except DanglingAliasError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+def _effective_scope(
+    db: Database,
+    request: ChatRequest,
+    conv: Conversation,
+) -> tuple[list[str] | None, str | None]:
+    """Resolve retrieval doc ids plus the stored scope node reference."""
+    requested_scope = _requested_scope_document_id(request)
+    if requested_scope:
+        resolved = _resolve_scope_node(db, requested_scope)
+        return sorted(_descendant_doc_ids(db, resolved.id)), requested_scope
+    if request.document_ids is not None:
+        scope_id = request.document_ids[0] if len(request.document_ids) == 1 else None
+        return request.document_ids, scope_id
+    if conv.scope_document_id:
+        resolved = _resolve_scope_node(db, conv.scope_document_id)
+        return sorted(_descendant_doc_ids(db, resolved.id)), conv.scope_document_id
+    if conv.document_ids:
+        return conv.document_ids, None
+    return None, None
+
+
 @router.post("")
 async def chat(
     request: ChatRequest,
@@ -296,6 +341,14 @@ async def chat(
             sort_order=0,
         )
 
+    effective_document_ids, scope_document_id = _effective_scope(db, request, conv)
+    conv.scope_document_id = scope_document_id
+    conv.document_ids = (
+        [scope_document_id]
+        if scope_document_id is not None
+        else list(effective_document_ids or [])
+    )
+
     # Add user message
     conv.messages.append({"role": "user", "content": request.message})
     conv.updated_at = datetime.now()
@@ -313,7 +366,7 @@ async def chat(
             query=request.message,
             max_sources=request.max_sources,
             include_sources=request.include_sources,
-            document_ids=request.document_ids,
+            document_ids=effective_document_ids,
             graph_hops=request.graph_hops,
             max_kg_claims=request.max_kg_claims,
         )
@@ -510,6 +563,7 @@ def duplicate_conversation_impl(db: Database, conversation_id: str) -> Conversat
         provider=original.provider,
         model=original.model,
         document_ids=original.document_ids[:],
+        scope_document_id=original.scope_document_id,
         folder_path=original.folder_path,
         sort_order=original.sort_order,
     )

--- a/fichero-engine/src/fichero/models.py
+++ b/fichero-engine/src/fichero/models.py
@@ -1232,6 +1232,7 @@ class Conversation(BaseModel):
     provider: str | None = None  # LLM provider used
     model: str | None = None  # LLM model used
     document_ids: list[str] = Field(default_factory=list)  # Documents used in RAG
+    scope_document_id: str | None = None  # Node-backed chat scope reference
     metadata: dict[str, Any] = Field(default_factory=dict)  # Additional metadata
 
     # Organization

--- a/fichero-engine/tests/unit/test_routes_chat.py
+++ b/fichero-engine/tests/unit/test_routes_chat.py
@@ -7,7 +7,8 @@ delete, reorder) and the providers list. Chat routes live at /api/chat/...
 
 from langchain_core.messages import HumanMessage, SystemMessage
 
-from fichero.models import Conversation, Document
+from fichero.models import Conversation, DocType, Document
+from fichero.node_aliases import make_alias
 
 
 # ---------------------------------------------------------------------------
@@ -15,8 +16,18 @@ from fichero.models import Conversation, Document
 # ---------------------------------------------------------------------------
 
 
-def _make_conv(conv_id: str = "conv-1", title: str = "My Chat") -> Conversation:
-    return Conversation(id=conv_id, title=title, messages=[])
+def _make_conv(
+    conv_id: str = "conv-1",
+    title: str = "My Chat",
+    *,
+    scope_document_id: str | None = None,
+) -> Conversation:
+    return Conversation(
+        id=conv_id,
+        title=title,
+        messages=[],
+        scope_document_id=scope_document_id,
+    )
 
 
 class _FakeLLM:
@@ -116,6 +127,101 @@ class TestChatWithSources:
         assert "transparent, local instrument" in fake_llm.messages[0].content
         assert "Never pretend to be human" in fake_llm.messages[0].content
         assert db.get(Conversation, data["conversation_id"]) is not None
+
+    def test_chat_scope_node_round_trips_and_includes_contained_docs(
+        self, client, db, monkeypatch
+    ):
+        folder = Document(id="chat-folder", name="Scope Folder", doc_type=DocType.folder)
+        child = Document(
+            id="chat-child",
+            name="Contained Doc",
+            parent_id=folder.id,
+            page_content="Contained archive evidence.",
+        )
+        db.save(folder)
+        db.save(child)
+
+        fake_llm = _FakeLLM()
+        monkeypatch.setattr(
+            "fichero.api.routes.chat._get_langchain_llm",
+            lambda *_args, **_kwargs: fake_llm,
+        )
+
+        response = client.post(
+            "/api/chat",
+            json={
+                "message": "What evidence is in scope?",
+                "scope_document_id": folder.id,
+                "include_sources": True,
+            },
+        )
+
+        assert response.status_code == 200
+        payload = response.json()
+        conv = db.get(Conversation, payload["conversation_id"])
+        assert conv is not None
+        assert conv.scope_document_id == folder.id
+        assert conv.document_ids == [folder.id]
+        assert payload["sources"] == [
+            {
+                "document_id": child.id,
+                "document_name": "Contained Doc",
+                "excerpt": "Contained archive evidence.",
+                "relevance_score": 1.0,
+            }
+        ]
+
+    def test_chat_conversation_scope_alias_resolves_to_target_node(
+        self, client, db, monkeypatch
+    ):
+        folder = Document(id="chat-folder-alias-target", name="Target", doc_type=DocType.folder)
+        child = Document(
+            id="chat-folder-alias-child",
+            name="Alias Child",
+            parent_id=folder.id,
+            page_content="Alias-routed evidence.",
+        )
+        alias = make_alias(folder, parent_id=None, name="Alias Scope")
+        conv = _make_conv("conv-alias-scope", scope_document_id=alias.id)
+        db.save(folder)
+        db.save(child)
+        db.save(alias)
+        db.save(conv)
+
+        fake_llm = _FakeLLM()
+        monkeypatch.setattr(
+            "fichero.api.routes.chat._get_langchain_llm",
+            lambda *_args, **_kwargs: fake_llm,
+        )
+
+        response = client.post(
+            "/api/chat",
+            json={"message": "Use alias scope", "conversation_id": conv.id},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["sources"][0]["document_id"] == child.id
+        assert db.get(Conversation, conv.id).scope_document_id == alias.id
+
+    def test_chat_conversation_scope_missing_node_prefers_raise(
+        self, client, db, monkeypatch
+    ):
+        conv = _make_conv("conv-missing-scope", scope_document_id="missing-node")
+        db.save(conv)
+
+        fake_llm = _FakeLLM()
+        monkeypatch.setattr(
+            "fichero.api.routes.chat._get_langchain_llm",
+            lambda *_args, **_kwargs: fake_llm,
+        )
+
+        response = client.post(
+            "/api/chat",
+            json={"message": "Use missing scope", "conversation_id": conv.id},
+        )
+
+        assert response.status_code == 404
+        assert "Chat scope node not found: missing-node" in response.json()["detail"]
 
     def test_chat_passes_graph_knobs_to_retriever(self, client, monkeypatch):
         captured: dict = {}

--- a/fichero-engine/tests/unit/test_routes_conversation_actions.py
+++ b/fichero-engine/tests/unit/test_routes_conversation_actions.py
@@ -64,7 +64,7 @@ def _undo(db, audit_id, ctx):
 
 
 def _mk_conversation(
-    db, title="Chat", folder_path="/", sort_order=0, messages=None
+    db, title="Chat", folder_path="/", sort_order=0, messages=None, scope_document_id=None
 ) -> Conversation:
     conv = Conversation(
         title=title,
@@ -73,6 +73,7 @@ def _mk_conversation(
         messages=messages if messages is not None else [],
         provider="openai",
         model="gpt-4o-mini",
+        scope_document_id=scope_document_id,
     )
     db.save(conv)
     return conv
@@ -213,6 +214,20 @@ class TestConversationDuplicateAction:
 
         reloaded_original = db.get(Conversation, original.id)
         assert reloaded_original.messages == [{"role": "user", "content": "a"}]
+
+    def test_duplicate_preserves_scope_document_id(self, db):
+        ctx = _ctx()
+        original = _mk_conversation(
+            db,
+            title="Scoped",
+            scope_document_id="folder-1",
+        )
+
+        result = registry.invoke(
+            db, "conversation.duplicate", {"conversation_id": original.id}, ctx
+        )
+
+        assert db.get(Conversation, result.result["id"]).scope_document_id == "folder-1"
 
     def test_duplicate_unknown_id_404(self, db):
         with pytest.raises(HTTPException) as exc:


### PR DESCRIPTION
Foundation P6 of EPIC #2591 (final foundation slice). A chat scope (docs/search/workspace/researcher context) is now a reference to a node rather than an ad-hoc enum/id; existing chat endpoints unchanged (compatibility). Prefer-raise on a scope pointing at a missing node. No library-DB migration, no contract change. Full unit+contracts suite: 6216 passed, 0 failed.

With P6, the node-model foundation (P1-P6) + content folds F1-F4 + F5 slice-1 are complete. Remaining: F5 /rooms/* endpoint retirement.

Co-Authored-By: Daniel Tubb <dtubb@me.com>