### PR TITLE
feat(reader): image bounding-box annotations (#2458 slice 2)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -19,3 +19,18 @@ Commit c7a3a893, authored Claude.
 - REMAINING pre-existing break beyond scope: SpatialScene3DTests reads fileprivate `persistedDragEndPosition` (test/source access mismatch). Recommend a dedicated test-suite-repair task; stopped the whack-a-mole there.
 
 Verification: each issue app-build green (isolated xcodebuild, scratch DD, CODE_SIGNING_ALLOWED=NO); my source + test files compile with ZERO diagnostics. Suite not RUN (no-test-on-this-machine rule); build-for-testing used to compile-verify. NOT pushed.
+
+## UI Reform — Inspector & Annotation (#94): #2458 annotation controls — SLICE 1 DONE
+2026-06-28, f_fichero_claude_swiftui. Commit b50f3984, authored Claude.
+
+#2458 is broad; did Slice 1 well and stopped (per dispatch). Slice 1 = shared annotation control (highlight + note) + render saved annotations, wired into the text/markdown reader (PageContentPane), page-scoped (#2396).
+- NEW: AnnotationToolbar (shared bottom bar, reusable across readers), AnnotatableTextView (AppKit NSViewRepresentable: renders highlights at char spans + reports UTF-16 selection; iOS render-only fallback; #if-guarded), AnnotationHighlight (pure range calc).
+- EXTENDED (additive): AnnotationService.addNote + AnnotationStore.addNote gain charStart/charEnd → AnnotationCreateRequest (backend already supported char_start/char_end). No new store, no hand-rolled URLSession; typed client only.
+- PageContentPane: loads page annotations via AnnotationStore, renders saved highlights, creates highlight (from selection) + note (popover composer) annotations. Claim-source highlight path preserved. Annotation methods in same-file extension to stay under type-body limit.
+- Tests: AnnotationHighlightTests (7 cases). swiftlint clean.
+- Verification: app build green (isolated xcodebuild, scratch DD, CODE_SIGNING_ALLOWED=NO); my source + test compile with ZERO diagnostics. Suite not RUN (no-test-on-this-machine); only test-target blocker is the PRE-EXISTING SpatialScene3DTests fileprivate break (still unfixed on main — recommend dedicated test-suite-repair task). NOT pushed.
+
+### STOPPED HERE. Remaining:
+- Slice 2: PDF (PDFKit highlight/note — PDFPageView already makes PDFAnnotation highlights, extend) + image bounding-box overlay editor (bbox normalized rect + page id) + render saved boxes. Reuse AnnotationToolbar.
+- Slice 3: docx reader text-range highlight/note (reuse AnnotatableTextView).
+- Plumbing (AnnotationToolbar, AnnotationHighlight, addNote charStart/charEnd/bbox) already in place for both.

--- a/fichero/fichero-tests/BoundingBoxGeometryTests.swift
+++ b/fichero/fichero-tests/BoundingBoxGeometryTests.swift
@@ -1,0 +1,77 @@
+import CoreGraphics
+@testable import Fichero
+import XCTest
+
+/// Tests for the normalized-bbox ↔ view-rect mapping behind image annotations
+/// (#2458). These prove the coordinate math independent of the live viewport.
+final class BoundingBoxGeometryTests: XCTestCase {
+
+    private let unitVisible = CGRect(x: 0, y: 0, width: 1, height: 1)
+    private let size = CGSize(width: 200, height: 100)
+
+    // MARK: - viewRect (render)
+
+    func testViewRectAtFitScalesNormalizedToView() {
+        let rect = BoundingBoxGeometry.viewRect(
+            normalized: [0.25, 0.5, 0.5, 0.25], in: size, visible: unitVisible
+        )
+        XCTAssertEqual(rect, CGRect(x: 50, y: 50, width: 100, height: 25))
+    }
+
+    func testViewRectUnderZoomUsesVisibleWindow() {
+        // Visible window = right half, bottom half of the image.
+        let visible = CGRect(x: 0.5, y: 0.5, width: 0.5, height: 0.5)
+        // A box at the very centre of the image (0.5,0.5) sits at the view origin.
+        let rect = BoundingBoxGeometry.viewRect(
+            normalized: [0.5, 0.5, 0.25, 0.25], in: size, visible: visible
+        )
+        XCTAssertEqual(rect?.minX ?? -1, 0, accuracy: 0.001)
+        XCTAssertEqual(rect?.minY ?? -1, 0, accuracy: 0.001)
+        // 0.25 of image / 0.5 visible = half the view.
+        XCTAssertEqual(rect?.width ?? -1, 100, accuracy: 0.001)
+        XCTAssertEqual(rect?.height ?? -1, 50, accuracy: 0.001)
+    }
+
+    func testViewRectRejectsMalformedBox() {
+        XCTAssertNil(BoundingBoxGeometry.viewRect(normalized: [0.1, 0.2], in: size, visible: unitVisible))
+        XCTAssertNil(BoundingBoxGeometry.viewRect(normalized: [0, 0, 1, 1], in: .zero, visible: unitVisible))
+    }
+
+    // MARK: - normalizedBox (create)
+
+    func testNormalizedBoxFromDragAtFit() {
+        let box = BoundingBoxGeometry.normalizedBox(
+            from: CGPoint(x: 50, y: 25), to: CGPoint(x: 150, y: 75),
+            in: size, visible: unitVisible
+        )
+        XCTAssertEqual(box?[0] ?? -1, 0.25, accuracy: 0.001)
+        XCTAssertEqual(box?[1] ?? -1, 0.25, accuracy: 0.001)
+        XCTAssertEqual(box?[2] ?? -1, 0.5, accuracy: 0.001)
+        XCTAssertEqual(box?[3] ?? -1, 0.5, accuracy: 0.001)
+    }
+
+    func testNormalizedBoxNormalizesCornerOrder() {
+        // Drag bottom-right → top-left still yields a positive-size rect.
+        let box = BoundingBoxGeometry.normalizedBox(
+            from: CGPoint(x: 150, y: 75), to: CGPoint(x: 50, y: 25),
+            in: size, visible: unitVisible
+        )
+        XCTAssertEqual(box?[0] ?? -1, 0.25, accuracy: 0.001)
+        XCTAssertEqual(box?[1] ?? -1, 0.25, accuracy: 0.001)
+    }
+
+    func testNormalizedBoxClampsOutOfBoundsDrag() {
+        let box = BoundingBoxGeometry.normalizedBox(
+            from: CGPoint(x: -40, y: -40), to: CGPoint(x: 400, y: 400),
+            in: size, visible: unitVisible
+        )
+        XCTAssertEqual(box, [0, 0, 1, 1])
+    }
+
+    func testDegenerateTapReturnsNil() {
+        XCTAssertNil(BoundingBoxGeometry.normalizedBox(
+            from: CGPoint(x: 50, y: 50), to: CGPoint(x: 51, y: 51),
+            in: size, visible: unitVisible
+        ))
+    }
+}

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -212,6 +212,7 @@
 		56B06FF519C1F4B9CD4E6214 /* ActionInvokeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6175F28D959ABB4DB0C2F4CD /* ActionInvokeService.swift */; };
 		56DCD53ACD6483561CF542B3 /* KGTemporalSpatial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43EAB861267206E7A929830F /* KGTemporalSpatial.swift */; };
 		57EFBE5436C18075ECE90EFC /* ClaimStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C527476477074D83F628468 /* ClaimStore.swift */; };
+		58D2706E3737EB46CA0979B9 /* BoundingBoxOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382D17DD3ECD79ED5E9AAE08 /* BoundingBoxOverlay.swift */; };
 		5D064ECAAD353BDB778B8580 /* AnnotationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D7DC57117008EBCFE607A9 /* AnnotationService.swift */; };
 		5D621E99ED66F859FD195491 /* AnnotatableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032AA7721B1C054A6CD89D4C /* AnnotatableTextView.swift */; };
 		5E8 /* SidebarItemBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9 /* SidebarItemBuilder.swift */; };
@@ -279,6 +280,7 @@
 		9C60CF320CB5560D66695318 /* ArtifactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 935EF9A7E6549E855A80EA21 /* ArtifactListView.swift */; };
 		9D71A811170D438B938FC1DA /* LibraryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377DA5DA45FB4CE09C7F76FF /* LibraryManager.swift */; };
 		9F50071471DB4B1EA1618E6E /* ActivityMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C939F2EE06FF349761CA2F /* ActivityMonitorView.swift */; };
+		9F8F3883E8324E76A746FAF8 /* BoundingBoxGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D870DB81D42B1614D58CE3F /* BoundingBoxGeometry.swift */; };
 		9FB2B2B858EA25B4757ECFEC /* EntitySourceGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B0073490980740B06C80D7 /* EntitySourceGroupsView.swift */; };
 		A0DB690A7FF2BA11F0D05AE7 /* DocumentInspectorArtifactsTab+KGSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7EC6F2955D032D3FA13E30 /* DocumentInspectorArtifactsTab+KGSection.swift */; };
 		A13E7C1F2F27E01E00EC9EE1 /* ActivityRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C122F27E01E00EC9EE1 /* ActivityRun.swift */; };
@@ -749,6 +751,7 @@
 		375F58443D6F498C1FEDD3E3 /* ResearchStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResearchStore.swift; sourceTree = "<group>"; };
 		376E2EE5F22D7B7127D9CB2A /* OntologyBrowser+List.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "OntologyBrowser+List.swift"; sourceTree = "<group>"; };
 		377DA5DA45FB4CE09C7F76FF /* LibraryManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryManager.swift; sourceTree = "<group>"; };
+		382D17DD3ECD79ED5E9AAE08 /* BoundingBoxOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BoundingBoxOverlay.swift; sourceTree = "<group>"; };
 		38753C6C4C3EECE670188B92 /* ComparisonDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComparisonDetailView.swift; sourceTree = "<group>"; };
 		38E23447A5C31CE397D337CC /* ResearchChatPane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResearchChatPane.swift; sourceTree = "<group>"; };
 		397DBEE7CB99C18C680AB85E /* UITestSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UITestSupport.swift; sourceTree = "<group>"; };
@@ -793,6 +796,7 @@
 		5BAA47F1959AD79AA6C2E3EF /* TriggerEditorPreviewPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TriggerEditorPreviewPanel.swift; path = fichero/Views/Automation/TriggerEditorView/TriggerEditorPreviewPanel.swift; sourceTree = SOURCE_ROOT; };
 		5C8EFF7D9BC634BAE18E0F47 /* ImageEditorView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageEditorView.swift; sourceTree = "<group>"; };
 		5D0B24DE95228CEA6B853324 /* SplittablePane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SplittablePane.swift; sourceTree = "<group>"; };
+		5D870DB81D42B1614D58CE3F /* BoundingBoxGeometry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BoundingBoxGeometry.swift; sourceTree = "<group>"; };
 		5E980A75F8C3912DD4B196DA /* SpatialScene3D.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpatialScene3D.swift; sourceTree = "<group>"; };
 		5ECF56D87D8211DDC932955B /* AnnotationsInspectorPane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnnotationsInspectorPane.swift; sourceTree = "<group>"; };
 		60A05B7F3C09F6A27BE55971 /* FicheroActionIntents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FicheroActionIntents.swift; sourceTree = "<group>"; };
@@ -1551,6 +1555,7 @@
 				166A5110A8453E7D73BF1EEA /* RepresentationStore.swift */,
 				74ECCAE0282E67AA4A150871 /* CoalescingSaveRunner.swift */,
 				6D4DEA1D7E10749DA258D26F /* AnnotationHighlight.swift */,
+				5D870DB81D42B1614D58CE3F /* BoundingBoxGeometry.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1944,6 +1949,7 @@
 				D1BE7613380B23C597C463B1 /* RepresentationView.swift */,
 				E0AF1F41099C45462F7D7658 /* AnnotationToolbar.swift */,
 				032AA7721B1C054A6CD89D4C /* AnnotatableTextView.swift */,
+				382D17DD3ECD79ED5E9AAE08 /* BoundingBoxOverlay.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -2815,6 +2821,8 @@
 				045C6648800D0B7D95D13B32 /* AnnotationHighlight.swift in Sources */,
 				9421EE6C6C84BC6FCAA4F8A9 /* AnnotationToolbar.swift in Sources */,
 				5D621E99ED66F859FD195491 /* AnnotatableTextView.swift in Sources */,
+				9F8F3883E8324E76A746FAF8 /* BoundingBoxGeometry.swift in Sources */,
+				58D2706E3737EB46CA0979B9 /* BoundingBoxOverlay.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero/Models/BoundingBoxGeometry.swift
+++ b/fichero/fichero/Models/BoundingBoxGeometry.swift
@@ -1,0 +1,58 @@
+import CoreGraphics
+
+/// Pure mapping between normalized image-space bounding boxes (`[x, y, w, h]`
+/// in 0…1 of the full image) and view-space rects, accounting for the portion
+/// of the image currently visible in a zoom/pan viewport (#2458).
+///
+/// Kept free of SwiftUI/AppKit so the coordinate math is unit-testable without
+/// a running view — pixel alignment is the one thing worth proving by test.
+enum BoundingBoxGeometry {
+    /// Where a normalized image rect lands in the view, given the normalized
+    /// `visible` window (the sub-rect of the image currently on screen) and the
+    /// view `size`. At fit (visible == unit rect) this is a plain scale.
+    static func viewRect(
+        normalized box: [Double],
+        in size: CGSize,
+        visible: CGRect
+    ) -> CGRect? {
+        guard box.count >= 4, visible.width > 0, visible.height > 0,
+              size.width > 0, size.height > 0 else { return nil }
+        let originX = (box[0] - visible.minX) / visible.width * size.width
+        let originY = (box[1] - visible.minY) / visible.height * size.height
+        let width = box[2] / visible.width * size.width
+        let height = box[3] / visible.height * size.height
+        return CGRect(x: originX, y: originY, width: width, height: height)
+    }
+
+    /// Normalized image rect for a drag between two view points, given the
+    /// visible window and view size. Returns `[x, y, w, h]` clamped to 0…1 with
+    /// a positive size, or `nil` if the drag is degenerate (a tap).
+    static func normalizedBox(
+        from start: CGPoint,
+        to end: CGPoint,
+        in size: CGSize,
+        visible: CGRect,
+        minSpan: CGFloat = 4
+    ) -> [Double]? {
+        guard size.width > 0, size.height > 0 else { return nil }
+        guard abs(end.x - start.x) >= minSpan || abs(end.y - start.y) >= minSpan else { return nil }
+
+        func normalize(_ point: CGPoint) -> (Double, Double) {
+            let normX = visible.minX + Double(point.x / size.width) * visible.width
+            let normY = visible.minY + Double(point.y / size.height) * visible.height
+            return (clamp(normX), clamp(normY))
+        }
+        let (startX, startY) = normalize(start)
+        let (endX, endY) = normalize(end)
+        let minX = min(startX, endX)
+        let minY = min(startY, endY)
+        let width = abs(endX - startX)
+        let height = abs(endY - startY)
+        guard width > 0, height > 0 else { return nil }
+        return [minX, minY, width, height]
+    }
+
+    private static func clamp(_ value: Double) -> Double {
+        min(1, max(0, value))
+    }
+}

--- a/fichero/fichero/Views/Library/BoundingBoxOverlay.swift
+++ b/fichero/fichero/Views/Library/BoundingBoxOverlay.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+/// Draws saved bounding-box annotations over a reader and, in draw mode, lets
+/// the user drag a new box (#2458). Coordinate math lives in
+/// `BoundingBoxGeometry`; this view is the thin SwiftUI layer over it.
+///
+/// Reusable across the image reader (and PDF page regions later). The host
+/// supplies the normalized boxes + the current visible window and owns
+/// persistence via the closure.
+struct BoundingBoxOverlay: View {
+    /// Saved annotation regions as normalized `[x, y, w, h]` image rects.
+    let boxes: [[Double]]
+    /// Normalized sub-rect of the image currently visible (zoom/pan window).
+    let visible: CGRect
+    /// True while the region tool is armed — enables drawing + hit testing.
+    let isDrawing: Bool
+    /// Called with a normalized `[x, y, w, h]` when the user finishes a drag.
+    var onCreate: ([Double]) -> Void
+
+    @State private var dragStart: CGPoint?
+    @State private var dragCurrent: CGPoint?
+
+    var body: some View {
+        GeometryReader { geo in
+            ZStack(alignment: .topLeading) {
+                // Saved regions.
+                ForEach(Array(boxes.enumerated()), id: \.offset) { _, box in
+                    if let rect = BoundingBoxGeometry.viewRect(normalized: box, in: geo.size, visible: visible) {
+                        RoundedRectangle(cornerRadius: 2)
+                            .stroke(Color.accentColor, lineWidth: 1.5)
+                            .background(Color.accentColor.opacity(0.12))
+                            .frame(width: rect.width, height: rect.height)
+                            .offset(x: rect.minX, y: rect.minY)
+                            .allowsHitTesting(false)
+                    }
+                }
+
+                // In-progress drag rectangle.
+                if let start = dragStart, let current = dragCurrent {
+                    let rect = CGRect(
+                        x: min(start.x, current.x),
+                        y: min(start.y, current.y),
+                        width: abs(current.x - start.x),
+                        height: abs(current.y - start.y)
+                    )
+                    RoundedRectangle(cornerRadius: 2)
+                        .stroke(Color.accentColor, style: StrokeStyle(lineWidth: 1.5, dash: [4]))
+                        .background(Color.accentColor.opacity(0.15))
+                        .frame(width: rect.width, height: rect.height)
+                        .offset(x: rect.minX, y: rect.minY)
+                        .allowsHitTesting(false)
+                }
+            }
+            .frame(width: geo.size.width, height: geo.size.height)
+            .contentShape(Rectangle())
+            .gesture(isDrawing ? drawGesture(in: geo.size) : nil)
+        }
+    }
+
+    private func drawGesture(in size: CGSize) -> some Gesture {
+        DragGesture(minimumDistance: 1)
+            .onChanged { value in
+                if dragStart == nil { dragStart = value.startLocation }
+                dragCurrent = value.location
+            }
+            .onEnded { value in
+                defer { dragStart = nil; dragCurrent = nil }
+                let start = dragStart ?? value.startLocation
+                if let box = BoundingBoxGeometry.normalizedBox(
+                    from: start, to: value.location, in: size, visible: visible
+                ) {
+                    onCreate(box)
+                }
+            }
+    }
+}

--- a/fichero/fichero/Views/Library/ImageViewerComponents.swift
+++ b/fichero/fichero/Views/Library/ImageViewerComponents.swift
@@ -44,13 +44,53 @@ struct ZoomableImagePreview: View {
         self.isEditing = isEditing
     }
 
-    /// Annotation tools are present in the unified reader toolbar but their
-    /// region-anchored creation + on-canvas rendering is owned by **#2458**.
-    /// Stub until that lands so the section is visible without orphan writes.
+    /// Annotation tools from the reader toolbar (#2458). Highlight/Note arm a
+    /// region draw over the image; the resulting normalized box is persisted as
+    /// a bounding-box annotation. Bookmark is a whole-image marker (no region).
     private func requestAnnotation(_ tool: ReaderAnnotationTool) {
-        Self.logger.info(
-            "Reader annotation '\(tool.rawValue, privacy: .public)' on image — pending region capture + rendering (#2458)"
-        )
+        switch tool {
+        case .highlight, .note:
+            pendingAnnotationTool = tool
+            isDrawingRegion = true
+        case .bookmark:
+            isDrawingRegion = false
+            createAnnotation(box: nil, tool: .bookmark)
+        }
+    }
+
+    /// Persist a region (or whole-image bookmark) via the typed AnnotationStore.
+    private func createAnnotation(box: [Double]?, tool: ReaderAnnotationTool) {
+        guard let documentId else { return }
+        let kind: AnnotationKind = {
+            switch tool {
+            case .highlight: return .highlight
+            case .note: return .note
+            case .bookmark: return .bookmark
+            }
+        }()
+        isDrawingRegion = false
+        Task {
+            _ = await annotationStore.addNote(
+                scope: .document(documentId),
+                text: "",
+                bbox: box,
+                kind: kind
+            )
+            await annotationStore.loadAnnotations(for: .document(documentId), force: true)
+        }
+    }
+
+    /// Saved region boxes (normalized `[x,y,w,h]`) for the shown image.
+    private var regionBoxes: [[Double]] {
+        guard let documentId else { return [] }
+        return annotationStore.annotations
+            .filter { ($0.documentId == documentId || $0.pageId == documentId) && $0.hasRegion }
+            .compactMap(\.bbox)
+    }
+
+    private func loadAnnotations() {
+        guard let documentId else { return }
+        Task { await annotationStore.loadAnnotations(for: .document(documentId), force: true) }
     }
 
     private static let logger = Logger(subsystem: "app.fichero.fichero", category: "ZoomableImagePreview")
@@ -82,6 +122,12 @@ struct ZoomableImagePreview: View {
     @AppStorage("imagePreview.loupeLocked") private var loupeLocked = false
 
     @EnvironmentObject private var storageService: StorageServiceGenerated
+    @Environment(AnnotationStore.self) private var annotationStore: AnnotationStore
+
+    // Bounding-box annotation state (#2458). `isDrawingRegion` arms the overlay
+    // drag; `pendingAnnotationTool` carries the tool kind into the saved box.
+    @State private var isDrawingRegion = false
+    @State private var pendingAnnotationTool: ReaderAnnotationTool = .highlight
 
     @State private var scale: CGFloat = 1.0
     @State private var minScale: CGFloat = 0.01
@@ -155,6 +201,18 @@ struct ZoomableImagePreview: View {
                             coordinator: $imageCoordinator
                         )
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+                        .overlay {
+                            // Saved bounding boxes + the region-draw layer (#2458).
+                            // Shown whenever there are boxes or the tool is armed.
+                            if !regionBoxes.isEmpty || isDrawingRegion {
+                                BoundingBoxOverlay(
+                                    boxes: regionBoxes,
+                                    visible: visibleRect == .zero ? CGRect(x: 0, y: 0, width: 1, height: 1) : visibleRect,
+                                    isDrawing: isDrawingRegion,
+                                    onCreate: { box in createAnnotation(box: box, tool: pendingAnnotationTool) }
+                                )
+                            }
+                        }
                     } else {
                         ProgressView()
                             .controlSize(.small)
@@ -227,6 +285,14 @@ struct ZoomableImagePreview: View {
                     scale = saved
                 }
             }
+            loadAnnotations()
+        }
+        .onChange(of: documentId) { _, _ in
+            isDrawingRegion = false
+            loadAnnotations()
+        }
+        .onChange(of: annotationStore.changeToken) { _, _ in
+            loadAnnotations()
         }
         .onChange(of: url) { _, newURL in
             image = renderedImage ?? newURL.flatMap { NSImage(contentsOf: $0) }


### PR DESCRIPTION
Slice 2 of #2458. Adds image bounding-box annotations (draw + render saved boxes) on the image reader, building on the slice-1 annotation model/store/service. Persists via the typed client (no raw URLSession; no local paths). Isolated build-for-testing: TEST BUILD SUCCEEDED. Slice 2b (PDF) + 3 (docx) to follow.

Co-Authored-By: Daniel Tubb <dtubb@me.com>