### PR TITLE
refactor: centralize workflow/tool LLM routing through one chat()/chat_structured() (#1825)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,1 @@
+2026-06-28: #1825 centralized workflow/tool LangChain calls through `chat_workflow`/`chat`/`chat_structured`, updated agent + multi-agent + model-comparison call sites, and passed targeted `ruff` plus 55 unit tests.

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,1 +1,0 @@
-2026-06-28: #1825 centralized workflow/tool LangChain calls through `chat_workflow`/`chat`/`chat_structured`, updated agent + multi-agent + model-comparison call sites, and passed targeted `ruff` plus 55 unit tests.

--- a/fichero-engine/src/fichero/llm.py
+++ b/fichero-engine/src/fichero/llm.py
@@ -1976,7 +1976,12 @@ async def _stream_chat_langchain(
 
 def _convert_to_langchain_messages(messages: list[dict]) -> list:
     """Convert OpenAI-format messages to LangChain message objects."""
-    from langchain_core.messages import HumanMessage, SystemMessage, AIMessage
+    from langchain_core.messages import (
+        AIMessage,
+        HumanMessage,
+        SystemMessage,
+        ToolMessage,
+    )
 
     result = []
     for msg in messages:
@@ -1986,7 +1991,20 @@ def _convert_to_langchain_messages(messages: list[dict]) -> list:
         if role == "system":
             result.append(SystemMessage(content=content))
         elif role == "assistant":
-            result.append(AIMessage(content=content))
+            result.append(
+                AIMessage(
+                    content=content,
+                    tool_calls=msg.get("tool_calls", []),
+                )
+            )
+        elif role == "tool":
+            result.append(
+                ToolMessage(
+                    content=content,
+                    tool_call_id=msg.get("tool_call_id", ""),
+                    name=msg.get("name"),
+                )
+            )
         else:  # user or default
             result.append(HumanMessage(content=content))
 
@@ -2570,6 +2588,48 @@ async def chat_with_tools(
         "content": response.content,
         "tool_calls": tool_calls,
     }
+
+
+def _prepend_system_message(
+    prompt: str | list[dict[str, Any]],
+    system: str | None,
+) -> str | list[dict[str, Any]]:
+    if system is None:
+        return prompt
+    if isinstance(prompt, str):
+        return [
+            {"role": "system", "content": system},
+            {"role": "user", "content": prompt},
+        ]
+    return [{"role": "system", "content": system}, *prompt]
+
+
+async def chat_workflow(
+    prompt: str | list[dict[str, Any]],
+    config: LLMConfig,
+    *,
+    system: str | None = None,
+    schema: type[BaseModel] | None = None,
+    tools: list[Any] | None = None,
+) -> Any:
+    """Single workflow/tool entry point for LangChain-backed LLM calls."""
+    if schema is not None and tools is not None:
+        raise ValueError("Structured output and tools cannot be requested together")
+
+    if schema is not None:
+        if not isinstance(prompt, str):
+            raise ValueError("Structured workflow chat requires a string prompt")
+        return await chat_structured(
+            prompt,
+            schema,
+            config,
+            system=system,
+        )
+
+    effective_prompt = _prepend_system_message(prompt, system)
+    if tools is not None:
+        return await chat_with_tools(effective_prompt, tools, config)
+    return await chat(effective_prompt, config)
 
 
 # =============================================================================

--- a/fichero-engine/src/fichero/workflows/model_comparison.py
+++ b/fichero-engine/src/fichero/workflows/model_comparison.py
@@ -14,6 +14,7 @@ import logging
 import time
 import uuid
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Any
 from datetime import datetime
 
@@ -24,7 +25,7 @@ from pydantic import BaseModel, Field
 from fichero.llm import (
     AppleUnavailableError,
     LLMConfig,
-    get_langchain_model,
+    chat_workflow,
     resolve_model_alias,
     vision,
 )
@@ -516,16 +517,12 @@ class ModelComparisonEngine:
             temperature=spec.temperature,
             max_tokens=spec.max_tokens,
         )
-        model = get_langchain_model(config)
-
-        from langchain_core.messages import HumanMessage, SystemMessage
-
-        messages = []
-        if system_prompt:
-            messages.append(SystemMessage(content=system_prompt))
-        messages.append(HumanMessage(content=prompt))
-
-        return await asyncio.wait_for(model.ainvoke(messages), timeout=timeout_seconds)
+        messages = [{"role": "user", "content": prompt}]
+        content = await asyncio.wait_for(
+            chat_workflow(messages, config, system=system_prompt),
+            timeout=timeout_seconds,
+        )
+        return SimpleNamespace(content=content, response_metadata={})
 
     def get_history(self, limit: int = 10) -> list[dict]:
         """Get recent comparison history."""

--- a/fichero-engine/src/fichero/workflows/tools/agent.py
+++ b/fichero-engine/src/fichero/workflows/tools/agent.py
@@ -7,15 +7,13 @@ Uses LangGraph's create_react_agent for tool-calling agents.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
-from langgraph.prebuilt import create_react_agent
-from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
-
 from fichero.workflows.types import State, PortDef, DataType
 from fichero.workflows.registry import register_tool, get_tool
-from fichero.llm import get_langchain_model, LLMConfig
+from fichero.llm import LLMConfig, chat_workflow
 from fichero.prompts import compose_system_prompt
 
 logger = logging.getLogger(__name__)
@@ -23,6 +21,121 @@ logger = logging.getLogger(__name__)
 _DEFAULT_AGENT_SYSTEM_PROMPT = (
     "You are a helpful AI assistant. Use the available tools to accomplish the task."
 )
+
+
+def _build_agent_messages(
+    task: str,
+    context: Any,
+    system_prompt: str,
+) -> list[dict[str, Any]]:
+    effective_system_prompt = compose_system_prompt(
+        role="agent",
+        extra=system_prompt,
+    )
+    messages: list[dict[str, Any]] = [
+        {"role": "system", "content": effective_system_prompt}
+    ]
+
+    if context:
+        if isinstance(context, str):
+            messages.append({"role": "system", "content": f"Context: {context}"})
+        elif isinstance(context, dict):
+            context_str = "\n".join(f"{k}: {v}" for k, v in context.items())
+            messages.append({"role": "system", "content": f"Context:\n{context_str}"})
+
+    messages.append({"role": "user", "content": task})
+    return messages
+
+
+def _tool_result_to_message_content(result: Any) -> str:
+    if isinstance(result, str):
+        return result
+    return json.dumps(result, default=str)
+
+
+def _serialize_agent_messages(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    role_map = {
+        "assistant": "ai",
+        "user": "human",
+    }
+    serialized = []
+    for msg in messages:
+        serialized_msg = {
+            "role": role_map.get(msg.get("role", ""), msg.get("role", "")),
+            "content": msg.get("content", ""),
+        }
+        if "tool_calls" in msg:
+            serialized_msg["tool_calls"] = msg["tool_calls"]
+        if msg.get("role") == "tool" and "name" in msg:
+            serialized_msg["name"] = msg["name"]
+        serialized.append(serialized_msg)
+    return serialized
+
+
+async def _run_agent_loop(
+    task: str,
+    context: Any,
+    system_prompt: str,
+    tool_specs: list[dict[str, Any]],
+    llm_config: LLMConfig,
+    max_iterations: int,
+) -> tuple[str, list[dict[str, Any]], list[dict[str, Any]], int]:
+    messages = _build_agent_messages(task, context, system_prompt)
+    tool_history: list[dict[str, Any]] = []
+    tool_map = {tool["name"]: tool for tool in tool_specs}
+    iteration = 0
+
+    if not tool_specs:
+        response_text = await chat_workflow(messages, llm_config)
+        messages.append({"role": "assistant", "content": response_text})
+        return response_text, messages, tool_history, iteration
+
+    while iteration < max_iterations:
+        response = await chat_workflow(
+            messages,
+            llm_config,
+            tools=[tool["wrapped"] for tool in tool_specs],
+        )
+        tool_calls = response.get("tool_calls", [])
+        messages.append(
+            {
+                "role": "assistant",
+                "content": response.get("content", ""),
+                "tool_calls": tool_calls,
+            }
+        )
+
+        if not tool_calls:
+            return response.get("content", ""), messages, tool_history, iteration
+
+        for tool_call in tool_calls:
+            tool_name = tool_call.get("name")
+            tool_spec = tool_map.get(tool_name)
+            if tool_spec is None:
+                raise ValueError(f"Tool not found: {tool_name}")
+
+            tool_args = tool_call.get("args", {}) or {}
+            tool_result = await tool_spec["tool_fn"](
+                inputs=tool_args,
+                state={},
+                llm_config=llm_config,
+            )
+            tool_history.append({"tool": tool_name, "args": tool_args})
+            messages.append(
+                {
+                    "role": "tool",
+                    "name": tool_name,
+                    "tool_call_id": tool_call.get("id", tool_name),
+                    "content": _tool_result_to_message_content(tool_result),
+                }
+            )
+
+        iteration += 1
+
+    logger.warning(f"Agent reached max iterations ({max_iterations})")
+    return "", messages, tool_history, iteration
 
 
 @register_tool(
@@ -141,116 +254,33 @@ async def react_agent(
         for tool_name in tool_names:
             tool_fn = get_tool(tool_name)
             if tool_fn:
-                # Wrap workflow tool for LangChain compatibility
-                wrapped_tool = _wrap_workflow_tool(tool_name, tool_fn, llm_config)
-                agent_tools.append(wrapped_tool)
+                agent_tools.append(
+                    {
+                        "name": tool_name,
+                        "tool_fn": tool_fn,
+                        "wrapped": _wrap_workflow_tool(
+                            tool_name, tool_fn, llm_config
+                        ),
+                    }
+                )
             else:
                 logger.warning(f"Tool not found: {tool_name}")
 
         if not agent_tools:
             logger.warning("No tools available for agent, proceeding without tools")
 
-        # Get LangChain model
-        model = get_langchain_model(llm_config)
-
-        # Build message list
-        effective_system_prompt = compose_system_prompt(
-            role="agent",
-            extra=system_prompt,
+        result_text, final_messages, tool_calls, iteration = await _run_agent_loop(
+            task=task,
+            context=context,
+            system_prompt=system_prompt,
+            tool_specs=agent_tools,
+            llm_config=llm_config,
+            max_iterations=max_iterations,
         )
-        messages = [SystemMessage(content=effective_system_prompt)]
-
-        # Add context if provided
-        if context:
-            if isinstance(context, str):
-                messages.append(SystemMessage(content=f"Context: {context}"))
-            elif isinstance(context, dict):
-                context_str = "\n".join(f"{k}: {v}" for k, v in context.items())
-                messages.append(SystemMessage(content=f"Context:\n{context_str}"))
-
-        # Add user task
-        messages.append(HumanMessage(content=task))
-        agent_graph = create_react_agent(
-            model=model,
-            tools=agent_tools if agent_tools else [],
-        )
-
-        # Execute agent with iteration limit
-        agent_state = {"messages": messages}
-
-        # Track iterations to prevent infinite loops
-        iteration = 0
-        while iteration < max_iterations:
-            result = await agent_graph.ainvoke(agent_state)
-
-            # Check if agent is done (no more tool calls)
-            last_message = result["messages"][-1] if result["messages"] else None
-            if (
-                not last_message
-                or not hasattr(last_message, "tool_calls")
-                or not last_message.tool_calls
-            ):
-                # Agent is done
-                agent_state = result
-                break
-
-            # Continue with updated state
-            agent_state = result
-            iteration += 1
-
-        if iteration >= max_iterations:
-            logger.warning(f"Agent reached max iterations ({max_iterations})")
-
-        # Extract result from messages
-        final_messages = agent_state.get("messages", [])
-
-        # Get the last AI message as the result
-        result_text = ""
-        for msg in reversed(final_messages):
-            if isinstance(msg, AIMessage):
-                result_text = msg.content
-                break
-            elif isinstance(msg, dict) and msg.get("type") == "ai":
-                result_text = msg.get("content", "")
-                break
-
-        # Extract tool call history
-        tool_calls = []
-        for msg in final_messages:
-            if isinstance(msg, AIMessage) and hasattr(msg, "tool_calls"):
-                for tc in msg.tool_calls:
-                    tool_calls.append(
-                        {
-                            "tool": tc.get("name", "unknown"),
-                            "args": tc.get("args", {}),
-                        }
-                    )
-            elif isinstance(msg, dict) and "tool_calls" in msg:
-                for tc in msg["tool_calls"]:
-                    tool_calls.append(
-                        {
-                            "tool": tc.get("name", "unknown"),
-                            "args": tc.get("args", {}),
-                        }
-                    )
-
-        # Convert messages to serializable format
-        serializable_messages = []
-        for msg in final_messages:
-            if isinstance(msg, (HumanMessage, AIMessage, SystemMessage)):
-                serializable_messages.append(
-                    {
-                        "role": msg.type,
-                        "content": msg.content,
-                    }
-                )
-            elif isinstance(msg, dict):
-                # Already in dict format (from tests or other sources)
-                serializable_messages.append(msg)
 
         return {
             "result": result_text,
-            "messages": serializable_messages,
+            "messages": _serialize_agent_messages(final_messages),
             "tool_calls": tool_calls,
             "iterations": iteration,
         }

--- a/fichero-engine/src/fichero/workflows/tools/multi_agent.py
+++ b/fichero-engine/src/fichero/workflows/tools/multi_agent.py
@@ -13,14 +13,11 @@ import asyncio
 import logging
 from typing import Any
 
-from langgraph.prebuilt import create_react_agent
-from langchain_core.messages import HumanMessage, AIMessage, SystemMessage
-
 from fichero.workflows.types import State, PortDef, DataType
 from fichero.workflows.registry import register_tool, get_tool
-from fichero.llm import get_langchain_model, LLMConfig
+from fichero.llm import LLMConfig, chat_workflow
 from fichero.prompts import compose_system_prompt
-from fichero.workflows.tools.agent import _wrap_workflow_tool
+from fichero.workflows.tools.agent import _run_agent_loop, _wrap_workflow_tool
 
 logger = logging.getLogger(__name__)
 
@@ -204,27 +201,25 @@ async def supervisor_agent(
             "{workers_description}", workers_desc
         )
 
-        # Get supervisor model
-        model = get_langchain_model(llm_config)
-
         # Create supervisor decision function
         async def get_supervisor_decision(
             task_text: str, context_dict: dict, previous_results: dict
         ) -> dict:
             """Get supervisor's delegation decision."""
             messages = [
-                SystemMessage(
-                    content=compose_system_prompt(
+                {
+                    "role": "system",
+                    "content": compose_system_prompt(
                         role="agent",
                         extra=formatted_prompt,
-                    )
-                ),
+                    ),
+                },
             ]
 
             # Add context if provided
             if context_dict:
                 context_str = "\n".join(f"{k}: {v}" for k, v in context_dict.items())
-                messages.append(SystemMessage(content=f"Context:\n{context_str}"))
+                messages.append({"role": "system", "content": f"Context:\n{context_str}"})
 
             # Add previous results if any
             if previous_results:
@@ -232,26 +227,30 @@ async def supervisor_agent(
                     f"{k}: {v}" for k, v in previous_results.items()
                 )
                 messages.append(
-                    SystemMessage(content=f"Previous worker results:\n{results_str}")
+                    {
+                        "role": "system",
+                        "content": f"Previous worker results:\n{results_str}",
+                    }
                 )
 
             messages.append(
-                HumanMessage(
-                    content=f"Task: {task_text}\n\nDecide which worker(s) should handle this task."
-                )
+                {
+                    "role": "user",
+                    "content": f"Task: {task_text}\n\nDecide which worker(s) should handle this task.",
+                }
             )
 
-            response = await model.ainvoke(messages)
+            response = await chat_workflow(messages, llm_config)
 
             # Parse delegation decision (simplified - in production, use structured output)
             decision = {
-                "reasoning": response.content,
+                "reasoning": response,
                 "workers": [],
                 "done": False,
             }
 
             # Check for worker mentions in response
-            content_lower = response.content.lower()
+            content_lower = response.lower()
             for worker in workers_config:
                 if worker["name"].lower() in content_lower:
                     decision["workers"].append(worker["name"])
@@ -275,39 +274,28 @@ async def supervisor_agent(
             for tool_name in worker_config.get("tools", []):
                 tool_fn = get_tool(tool_name)
                 if tool_fn:
-                    wrapped = _wrap_workflow_tool(tool_name, tool_fn, llm_config)
-                    worker_tools.append(wrapped)
+                    worker_tools.append(
+                        {
+                            "name": tool_name,
+                            "tool_fn": tool_fn,
+                            "wrapped": _wrap_workflow_tool(
+                                tool_name, tool_fn, llm_config
+                            ),
+                        }
+                    )
 
             worker_prompt = worker_config.get(
                 "system_prompt",
                 f"You are the {worker_config['name']} agent. {worker_config.get('description', '')}",
             )
-            worker_system_prompt = compose_system_prompt(
-                role="agent",
-                extra=worker_prompt,
+            response_text, final_messages, _, _ = await _run_agent_loop(
+                task=task_text,
+                context=ctx,
+                system_prompt=worker_prompt,
+                tool_specs=worker_tools,
+                llm_config=llm_config,
+                max_iterations=10,
             )
-
-            worker_model = get_langchain_model(llm_config)
-            worker_graph = create_react_agent(
-                model=worker_model,
-                tools=worker_tools,
-            )
-
-            messages = [SystemMessage(content=worker_system_prompt)]
-            if ctx:
-                ctx_str = "\n".join(f"{k}: {v}" for k, v in ctx.items())
-                messages.append(SystemMessage(content=f"Context:\n{ctx_str}"))
-            messages.append(HumanMessage(content=task_text))
-
-            result = await worker_graph.ainvoke({"messages": messages})
-
-            # Extract final response
-            final_messages = result.get("messages", [])
-            response_text = ""
-            for msg in reversed(final_messages):
-                if isinstance(msg, AIMessage):
-                    response_text = msg.content
-                    break
 
             return {
                 "worker": worker_config["name"],
@@ -434,18 +422,19 @@ async def supervisor_agent(
 
             # Get supervisor to synthesize final result
             final_messages = [
-                SystemMessage(
-                    content=compose_system_prompt(
+                {
+                    "role": "system",
+                    "content": compose_system_prompt(
                         role="agent",
                         extra="Synthesize the worker results into a final comprehensive response.",
-                    )
-                ),
-                HumanMessage(
-                    content=f"Original task: {task}\n\nWorker results:\n{results_summary}"
-                ),
+                    ),
+                },
+                {
+                    "role": "user",
+                    "content": f"Original task: {task}\n\nWorker results:\n{results_summary}",
+                },
             ]
-            final_response = await model.ainvoke(final_messages)
-            final_result = final_response.content
+            final_result = await chat_workflow(final_messages, llm_config)
         else:
             final_result = "No workers executed successfully."
 
@@ -612,8 +601,15 @@ async def swarm_agent(
             for tool_name in current_agent.get("tools", []):
                 tool_fn = get_tool(tool_name)
                 if tool_fn:
-                    wrapped = _wrap_workflow_tool(tool_name, tool_fn, llm_config)
-                    agent_tools.append(wrapped)
+                    agent_tools.append(
+                        {
+                            "name": tool_name,
+                            "tool_fn": tool_fn,
+                            "wrapped": _wrap_workflow_tool(
+                                tool_name, tool_fn, llm_config
+                            ),
+                        }
+                    )
 
             # Build system prompt with handoff instructions
             available_handoffs = current_agent.get("can_handoff_to", [])
@@ -636,35 +632,16 @@ Available agents to hand off to:
             system_prompt = current_agent.get(
                 "system_prompt", f"You are the {current_agent['name']} agent."
             )
-            full_prompt = compose_system_prompt(
-                role="agent",
-                extra=f"{system_prompt}\n{handoff_instructions}".strip(),
+            full_prompt = f"{system_prompt}\n{handoff_instructions}".strip()
+
+            response_text, _, _, _ = await _run_agent_loop(
+                task=current_task,
+                context=shared_context,
+                system_prompt=full_prompt,
+                tool_specs=agent_tools,
+                llm_config=llm_config,
+                max_iterations=10,
             )
-
-            # Create and run agent
-            model = get_langchain_model(llm_config)
-            agent_graph = create_react_agent(
-                model=model,
-                tools=agent_tools,
-            )
-
-            # Build messages
-            messages = [SystemMessage(content=full_prompt)]
-            if shared_context:
-                ctx_str = "\n".join(f"{k}: {v}" for k, v in shared_context.items())
-                messages.append(SystemMessage(content=f"Shared context:\n{ctx_str}"))
-            messages.append(HumanMessage(content=current_task))
-
-            # Execute agent
-            result = await agent_graph.ainvoke({"messages": messages})
-
-            # Get response
-            final_messages = result.get("messages", [])
-            response_text = ""
-            for msg in reversed(final_messages):
-                if isinstance(msg, AIMessage):
-                    response_text = msg.content
-                    break
 
             # Record in handoff chain
             handoff_chain.append(
@@ -865,40 +842,27 @@ async def agent_coordinator(
             for tool_name in agent_config.get("tools", []):
                 tool_fn = get_tool(tool_name)
                 if tool_fn:
-                    wrapped = _wrap_workflow_tool(tool_name, tool_fn, llm_config)
-                    agent_tools.append(wrapped)
+                    agent_tools.append(
+                        {
+                            "name": tool_name,
+                            "tool_fn": tool_fn,
+                            "wrapped": _wrap_workflow_tool(
+                                tool_name, tool_fn, llm_config
+                            ),
+                        }
+                    )
 
             system_prompt = agent_config.get(
                 "system_prompt", f"You are agent {agent_config['name']}."
             )
-            effective_system_prompt = compose_system_prompt(
-                role="agent",
-                extra=system_prompt,
+            response_text, _, _, _ = await _run_agent_loop(
+                task=task,
+                context=context,
+                system_prompt=system_prompt,
+                tool_specs=agent_tools,
+                llm_config=llm_config,
+                max_iterations=10,
             )
-
-            model = get_langchain_model(llm_config)
-            agent_graph = create_react_agent(
-                model=model,
-                tools=agent_tools,
-            )
-
-            messages = [SystemMessage(content=effective_system_prompt)]
-            if context:
-                ctx_str = (
-                    "\n".join(f"{k}: {v}" for k, v in context.items())
-                    if isinstance(context, dict)
-                    else str(context)
-                )
-                messages.append(SystemMessage(content=f"Context:\n{ctx_str}"))
-            messages.append(HumanMessage(content=task))
-
-            result = await agent_graph.ainvoke({"messages": messages})
-
-            response_text = ""
-            for msg in reversed(result.get("messages", [])):
-                if isinstance(msg, AIMessage):
-                    response_text = msg.content
-                    break
 
             return {
                 "name": agent_config["name"],
@@ -967,23 +931,21 @@ async def agent_coordinator(
 
         else:  # synthesis
             # Use LLM to synthesize all results
-            model = get_langchain_model(llm_config)
-
             results_str = "\n\n".join(
                 [f"**{r['name']}**:\n{r['result']}" for r in successful_results]
             )
 
             synthesis_messages = [
-                SystemMessage(
-                    content="Synthesize the following agent responses into a single comprehensive answer. Identify common themes and note any disagreements."
-                ),
-                HumanMessage(
-                    content=f"Original task: {task}\n\nAgent responses:\n{results_str}"
-                ),
+                {
+                    "role": "system",
+                    "content": "Synthesize the following agent responses into a single comprehensive answer. Identify common themes and note any disagreements.",
+                },
+                {
+                    "role": "user",
+                    "content": f"Original task: {task}\n\nAgent responses:\n{results_str}",
+                },
             ]
-
-            synthesis_response = await model.ainvoke(synthesis_messages)
-            combined_result = synthesis_response.content
+            combined_result = await chat_workflow(synthesis_messages, llm_config)
 
         return {
             "combined_result": combined_result,

--- a/fichero-engine/tests/unit/test_llm_workflow_chat.py
+++ b/fichero-engine/tests/unit/test_llm_workflow_chat.py
@@ -1,0 +1,58 @@
+"""Unit tests for the central workflow LLM dispatcher."""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from pydantic import BaseModel
+
+from fichero.llm import LLMConfig, chat_workflow
+
+
+class _StructuredReply(BaseModel):
+    answer: str
+
+
+@pytest.mark.asyncio
+async def test_chat_workflow_uses_unstructured_chat():
+    config = LLMConfig(provider="openai", model="gpt-4o-mini")
+
+    with patch("fichero.llm.chat", new=AsyncMock(return_value="plain reply")) as mock_chat:
+        result = await chat_workflow(
+            [{"role": "user", "content": "hello"}],
+            config,
+        )
+
+    assert result == "plain reply"
+    assert mock_chat.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_workflow_uses_structured_chat():
+    config = LLMConfig(provider="openai", model="gpt-4o-mini")
+    structured = _StructuredReply(answer="done")
+
+    with patch(
+        "fichero.llm.chat_structured",
+        new=AsyncMock(return_value=structured),
+    ) as mock_chat_structured:
+        result = await chat_workflow(
+            "extract this",
+            config,
+            system="system",
+            schema=_StructuredReply,
+        )
+
+    assert result == structured
+    assert mock_chat_structured.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_workflow_propagates_errors():
+    config = LLMConfig(provider="openai", model="gpt-4o-mini")
+
+    with patch(
+        "fichero.llm.chat",
+        new=AsyncMock(side_effect=ValueError("bad provider config")),
+    ):
+        with pytest.raises(ValueError, match="bad provider config"):
+            await chat_workflow("hello", config)

--- a/fichero-engine/tests/unit/test_model_comparison.py
+++ b/fichero-engine/tests/unit/test_model_comparison.py
@@ -146,13 +146,10 @@ class TestModelComparisonEngine:
     @pytest.mark.asyncio
     async def test_compare_single_model(self):
         """Test comparison with single model."""
-        mock_model = MagicMock()
-        mock_response = MagicMock()
-        mock_response.content = "Test response"
-        mock_response.response_metadata = {}
-        mock_model.ainvoke = AsyncMock(return_value=mock_response)
-
-        with patch("fichero.workflows.model_comparison.get_langchain_model", return_value=mock_model):
+        with patch(
+            "fichero.workflows.model_comparison.chat_workflow",
+            new=AsyncMock(return_value="Test response"),
+        ):
             engine = ModelComparisonEngine()
             request = ComparisonRequest(
                 prompt="Hello",
@@ -167,13 +164,10 @@ class TestModelComparisonEngine:
     @pytest.mark.asyncio
     async def test_compare_multiple_models(self):
         """Test comparison with multiple models."""
-        mock_model = MagicMock()
-        mock_response = MagicMock()
-        mock_response.content = "Response"
-        mock_response.response_metadata = {}
-        mock_model.ainvoke = AsyncMock(return_value=mock_response)
-
-        with patch("fichero.workflows.model_comparison.get_langchain_model", return_value=mock_model):
+        with patch(
+            "fichero.workflows.model_comparison.chat_workflow",
+            new=AsyncMock(return_value="Response"),
+        ):
             engine = ModelComparisonEngine()
             request = ComparisonRequest(
                 prompt="Test",
@@ -192,14 +186,14 @@ class TestModelComparisonEngine:
         """Test comparison handles timeout gracefully."""
         import asyncio
 
-        async def slow_response(*args):
+        async def slow_response(*args, **kwargs):
             await asyncio.sleep(10)
-            return MagicMock(content="Slow")
+            return "Slow"
 
-        mock_model = MagicMock()
-        mock_model.ainvoke = slow_response
-
-        with patch("fichero.workflows.model_comparison.get_langchain_model", return_value=mock_model):
+        with patch(
+            "fichero.workflows.model_comparison.chat_workflow",
+            new=AsyncMock(side_effect=slow_response),
+        ):
             engine = ModelComparisonEngine()
             request = ComparisonRequest(
                 prompt="Test",
@@ -214,10 +208,10 @@ class TestModelComparisonEngine:
     @pytest.mark.asyncio
     async def test_compare_handles_error(self):
         """Test comparison handles errors gracefully."""
-        mock_model = MagicMock()
-        mock_model.ainvoke = AsyncMock(side_effect=Exception("API Error"))
-
-        with patch("fichero.workflows.model_comparison.get_langchain_model", return_value=mock_model):
+        with patch(
+            "fichero.workflows.model_comparison.chat_workflow",
+            new=AsyncMock(side_effect=Exception("API Error")),
+        ):
             engine = ModelComparisonEngine()
             request = ComparisonRequest(
                 prompt="Test",
@@ -560,13 +554,10 @@ class TestModelComparisonTool:
     @pytest.mark.asyncio
     async def test_model_comparison_with_prompt(self, llm_config, mock_state):
         """Test tool with prompt and models."""
-        mock_model = MagicMock()
-        mock_response = MagicMock()
-        mock_response.content = "Test response"
-        mock_response.response_metadata = {}
-        mock_model.ainvoke = AsyncMock(return_value=mock_response)
-
-        with patch("fichero.workflows.model_comparison.get_langchain_model", return_value=mock_model):
+        with patch(
+            "fichero.workflows.model_comparison.chat_workflow",
+            new=AsyncMock(return_value="Test response"),
+        ):
             result = await model_comparison(
                 inputs={
                     "prompt": "Hello",

--- a/fichero-engine/tests/unit/workflows/test_agent_tool.py
+++ b/fichero-engine/tests/unit/workflows/test_agent_tool.py
@@ -1,13 +1,7 @@
-"""
-Tests for Agent Tool
-
-Tests the react_agent tool that uses LangGraph's create_react_agent.
-"""
+"""Tests for the react_agent workflow tool."""
 
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
-
-from langchain_core.messages import SystemMessage
 
 from fichero.workflows.tools.agent import react_agent
 from fichero.workflows.types import State
@@ -27,32 +21,22 @@ async def test_react_agent_basic():
     state: State = {}
     llm_config = LLMConfig(provider="openai", model="gpt-4o-mini")
 
-    # Mock the LangGraph agent
-    with patch("fichero.workflows.tools.agent.create_react_agent") as mock_create:
-        with patch("fichero.workflows.tools.agent.get_langchain_model") as mock_get_model:
-            # Setup mocks
-            mock_model = Mock()
-            mock_get_model.return_value = mock_model
+    with patch(
+        "fichero.workflows.tools.agent.chat_workflow",
+        new=AsyncMock(return_value="Hello! How can I help you today?"),
+    ) as mock_chat:
+        result = await react_agent(inputs, state, llm_config)
 
-            mock_agent = Mock()
-            mock_agent.ainvoke = AsyncMock(return_value={
-                "messages": [
-                    {"type": "human", "content": "Say hello"},
-                    {"type": "ai", "content": "Hello! How can I help you today?"},
-                ]
-            })
-            mock_create.return_value = mock_agent
-
-            # Execute
-            result = await react_agent(inputs, state, llm_config)
-
-            # Verify
-            assert "result" in result
-            assert result["result"] == "Hello! How can I help you today?"
-            assert "messages" in result
-            assert len(result["messages"]) == 2
-            assert "tool_calls" in result
-            assert result["tool_calls"] == []
+    assert "result" in result
+    assert result["result"] == "Hello! How can I help you today?"
+    assert "messages" in result
+    assert len(result["messages"]) == 3
+    assert result["messages"][0]["role"] == "system"
+    assert result["messages"][-1]["role"] == "ai"
+    assert "tool_calls" in result
+    assert result["tool_calls"] == []
+    assert mock_chat.await_count == 1
+    assert "tools" not in mock_chat.await_args.kwargs
 
 
 @pytest.mark.asyncio
@@ -64,33 +48,20 @@ async def test_react_agent_composes_integrity_system_prompt():
     }
     state: State = {}
     llm_config = LLMConfig(provider="openai", model="gpt-4o-mini")
-    captured: dict[str, object] = {}
+    async def _capture_messages(messages, *_args, **_kwargs):
+        return "Done."
 
-    with patch("fichero.workflows.tools.agent.create_react_agent") as mock_create:
-        with patch("fichero.workflows.tools.agent.get_langchain_model") as mock_get_model:
-            mock_get_model.return_value = Mock()
+    with patch(
+        "fichero.workflows.tools.agent.chat_workflow",
+        new=AsyncMock(side_effect=_capture_messages),
+    ) as mock_chat:
+        await react_agent(inputs, state, llm_config)
 
-            mock_agent = Mock()
-
-            async def _ainvoke(agent_state):
-                captured["messages"] = agent_state["messages"]
-                return {
-                    "messages": [
-                        {"type": "human", "content": "Inspect the records"},
-                        {"type": "ai", "content": "Done."},
-                    ]
-                }
-
-            mock_agent.ainvoke = _ainvoke
-            mock_create.return_value = mock_agent
-
-            await react_agent(inputs, state, llm_config)
-
-    messages = captured["messages"]
+    messages = mock_chat.await_args.args[0]
     assert isinstance(messages, list)
-    assert isinstance(messages[0], SystemMessage)
-    assert "transparent, local instrument" in messages[0].content
-    assert "Use the archive lookup tool before answering." in messages[0].content
+    assert messages[0]["role"] == "system"
+    assert "transparent, local instrument" in messages[0]["content"]
+    assert "Use the archive lookup tool before answering." in messages[0]["content"]
 
 
 @pytest.mark.asyncio
@@ -105,66 +76,56 @@ async def test_react_agent_with_tools():
     state: State = {}
     llm_config = LLMConfig(provider="openai", model="gpt-4o-mini")
 
-    # Mock the LangGraph agent
-    with patch("fichero.workflows.tools.agent.create_react_agent") as mock_create:
-        with patch("fichero.workflows.tools.agent.get_langchain_model") as mock_get_model:
-            with patch("fichero.workflows.tools.agent.get_tool") as mock_get_tool:
-                with patch("fichero.workflows.registry.TOOL_DEFS") as mock_tool_defs:
-                    # Setup mocks
-                    mock_model = Mock()
-                    mock_get_model.return_value = mock_model
+    with patch("fichero.workflows.tools.agent.get_tool") as mock_get_tool:
+        with patch("fichero.workflows.registry.TOOL_DEFS") as mock_tool_defs:
+            async def multiply_tool(inputs, state, llm_config):
+                a = inputs.get("a", 0)
+                b = inputs.get("b", 0)
+                return {"result": a * b}
 
-                    # Mock tool
-                    async def multiply_tool(inputs, state, llm_config):
-                        a = inputs.get("a", 0)
-                        b = inputs.get("b", 0)
-                        return {"result": a * b}
+            mock_get_tool.return_value = multiply_tool
 
-                    mock_get_tool.return_value = multiply_tool
+            from fichero.workflows.types import ToolDef, PortDef, DataType
 
-                    # Mock tool definition
-                    from fichero.workflows.types import ToolDef, PortDef, DataType
-                    mock_tool_def = ToolDef(
-                        name="multiply",
-                        display_name="Multiply",
-                        description="Multiply two numbers",
-                        category="math",
-                        icon="number",
-                        color="blue",
-                        input_ports=[
-                            PortDef(id="a", name="A", port_type="input", data_type=DataType.NUMBER, required=True),
-                            PortDef(id="b", name="B", port_type="input", data_type=DataType.NUMBER, required=True),
-                        ],
-                        output_ports=[],
-                        config_schema={},
-                    )
-                    mock_tool_defs.get = Mock(return_value=mock_tool_def)
+            mock_tool_def = ToolDef(
+                name="multiply",
+                display_name="Multiply",
+                description="Multiply two numbers",
+                category="math",
+                icon="number",
+                color="blue",
+                input_ports=[
+                    PortDef(id="a", name="A", port_type="input", data_type=DataType.NUMBER, required=True),
+                    PortDef(id="b", name="B", port_type="input", data_type=DataType.NUMBER, required=True),
+                ],
+                output_ports=[],
+                config_schema={},
+            )
+            mock_tool_defs.get = Mock(return_value=mock_tool_def)
 
-                    # Mock agent with tool calls
-                    mock_agent = Mock()
-                    mock_agent.ainvoke = AsyncMock(return_value={
-                        "messages": [
-                            {"type": "human", "content": "Calculate 5 * 3"},
-                            {
-                                "type": "ai",
-                                "content": "",
-                                "tool_calls": [{"name": "multiply", "args": {"a": 5, "b": 3}}]
-                            },
-                            {"type": "tool", "content": "15"},
-                            {"type": "ai", "content": "The result is 15."},
-                        ]
-                    })
-                    mock_create.return_value = mock_agent
+            with patch(
+                "fichero.workflows.tools.agent.chat_workflow",
+                new=AsyncMock(
+                    side_effect=[
+                        {
+                            "content": "",
+                            "tool_calls": [{"id": "call-1", "name": "multiply", "args": {"a": 5, "b": 3}}],
+                        },
+                        {
+                            "content": "The result is 15.",
+                            "tool_calls": [],
+                        },
+                    ]
+                ),
+            ) as mock_chat:
+                result = await react_agent(inputs, state, llm_config)
 
-                    # Execute
-                    result = await react_agent(inputs, state, llm_config)
-
-                    # Verify
-                    assert "result" in result
-                    assert "15" in result["result"]
-                    assert "tool_calls" in result
-                    assert len(result["tool_calls"]) == 1
-                    assert result["tool_calls"][0]["tool"] == "multiply"
+    assert "15" in result["result"]
+    assert len(result["tool_calls"]) == 1
+    assert result["tool_calls"][0]["tool"] == "multiply"
+    assert mock_chat.await_count == 2
+    assert "tools" in mock_chat.await_args_list[0].kwargs
+    assert any(msg["role"] == "tool" for msg in mock_chat.await_args_list[1].args[0])
 
 
 @pytest.mark.asyncio
@@ -199,29 +160,16 @@ async def test_react_agent_with_context():
     state: State = {}
     llm_config = LLMConfig(provider="openai", model="gpt-4o-mini")
 
-    with patch("fichero.workflows.tools.agent.create_react_agent") as mock_create:
-        with patch("fichero.workflows.tools.agent.get_langchain_model") as mock_get_model:
-            # Setup mocks
-            mock_model = Mock()
-            mock_get_model.return_value = mock_model
+    with patch(
+        "fichero.workflows.tools.agent.chat_workflow",
+        new=AsyncMock(return_value="Summary of test data."),
+    ) as mock_chat:
+        result = await react_agent(inputs, state, llm_config)
 
-            mock_agent = Mock()
-            mock_agent.ainvoke = AsyncMock(return_value={
-                "messages": [
-                    {"type": "system", "content": "Context: data: Test data here\nformat: concise"},
-                    {"type": "human", "content": "Summarize the data"},
-                    {"type": "ai", "content": "Summary of test data."},
-                ]
-            })
-            mock_create.return_value = mock_agent
-
-            # Execute
-            result = await react_agent(inputs, state, llm_config)
-
-            # Verify
-            assert "result" in result
-            assert len(result["messages"]) == 3
-            # Context should be included as system message
+    assert "result" in result
+    assert len(result["messages"]) == 4
+    prompt_messages = mock_chat.await_args.args[0]
+    assert prompt_messages[1]["content"] == "Context:\ndata: Test data here\nformat: concise"
 
 
 @pytest.mark.asyncio
@@ -230,47 +178,47 @@ async def test_react_agent_max_iterations():
     # Setup
     inputs = {
         "task": "Count to 100",
-        "tools": [],
+        "tools": ["count"],
         "max_iterations": 3,
     }
     state: State = {}
     llm_config = LLMConfig(provider="openai", model="gpt-4o-mini")
 
-    with patch("fichero.workflows.tools.agent.create_react_agent") as mock_create:
-        with patch("fichero.workflows.tools.agent.get_langchain_model") as mock_get_model:
-            # Setup mocks
-            mock_model = Mock()
-            mock_get_model.return_value = mock_model
+    with patch(
+        "fichero.workflows.tools.agent.chat_workflow",
+        new=AsyncMock(
+            side_effect=[
+                {"content": "Iteration 1", "tool_calls": [{"id": "1", "name": "count", "args": {}}]},
+                {"content": "Iteration 2", "tool_calls": [{"id": "2", "name": "count", "args": {}}]},
+                {"content": "Iteration 3", "tool_calls": [{"id": "3", "name": "count", "args": {}}]},
+            ]
+        ),
+    ):
+        with patch("fichero.workflows.tools.agent.get_tool") as mock_get_tool:
+            with patch("fichero.workflows.registry.TOOL_DEFS") as mock_tool_defs:
+                async def count_tool(inputs, state, llm_config):
+                    return {"ok": True}
 
-            # Mock agent that keeps making tool calls
-            call_count = 0
+                mock_get_tool.return_value = count_tool
+                from fichero.workflows.types import ToolDef
 
-            async def mock_invoke(state):
-                nonlocal call_count
-                call_count += 1
-                if call_count < 5:  # Simulate infinite loop
-                    # Return message with tool calls
-                    mock_msg = Mock()
-                    mock_msg.content = f"Iteration {call_count}"
-                    mock_msg.tool_calls = [{"name": "count", "args": {}}]
-                    return {"messages": [mock_msg]}
-                else:
-                    # Eventually finish
-                    mock_msg = Mock()
-                    mock_msg.content = "Done counting"
-                    mock_msg.tool_calls = []
-                    return {"messages": [mock_msg]}
+                mock_tool_defs.get = Mock(
+                    return_value=ToolDef(
+                        name="count",
+                        display_name="Count",
+                        description="Count",
+                        category="math",
+                        icon="number",
+                        color="blue",
+                        input_ports=[],
+                        output_ports=[],
+                        config_schema={},
+                    )
+                )
+                result = await react_agent(inputs, state, llm_config)
 
-            mock_agent = Mock()
-            mock_agent.ainvoke = mock_invoke
-            mock_create.return_value = mock_agent
-
-            # Execute
-            result = await react_agent(inputs, state, llm_config)
-
-            # Verify - should stop after max_iterations
-            assert "iterations" in result
-            assert result["iterations"] == 3  # Should stop at max
+    assert "iterations" in result
+    assert result["iterations"] == 3
 
 
 @pytest.mark.asyncio
@@ -284,23 +232,15 @@ async def test_react_agent_error_handling():
     state: State = {}
     llm_config = LLMConfig(provider="openai", model="gpt-4o-mini")
 
-    with patch("fichero.workflows.tools.agent.create_react_agent") as mock_create:
-        with patch("fichero.workflows.tools.agent.get_langchain_model") as mock_get_model:
-            # Setup mocks to raise error
-            mock_model = Mock()
-            mock_get_model.return_value = mock_model
+    with patch(
+        "fichero.workflows.tools.agent.chat_workflow",
+        new=AsyncMock(side_effect=Exception("API Error")),
+    ):
+        result = await react_agent(inputs, state, llm_config)
 
-            mock_agent = Mock()
-            mock_agent.ainvoke = AsyncMock(side_effect=Exception("API Error"))
-            mock_create.return_value = mock_agent
-
-            # Execute
-            result = await react_agent(inputs, state, llm_config)
-
-            # Verify
-            assert "error" in result
-            assert "API Error" in result["error"]
-            assert result["result"] == ""
+    assert "error" in result
+    assert "API Error" in result["error"]
+    assert result["result"] == ""
 
 
 @pytest.mark.asyncio
@@ -314,31 +254,16 @@ async def test_react_agent_tool_not_found():
     state: State = {}
     llm_config = LLMConfig(provider="openai", model="gpt-4o-mini")
 
-    with patch("fichero.workflows.tools.agent.create_react_agent") as mock_create:
-        with patch("fichero.workflows.tools.agent.get_langchain_model") as mock_get_model:
-            with patch("fichero.workflows.tools.agent.get_tool") as mock_get_tool:
-                # Setup mocks
-                mock_model = Mock()
-                mock_get_model.return_value = mock_model
+    with patch("fichero.workflows.tools.agent.get_tool", return_value=None):
+        with patch(
+            "fichero.workflows.tools.agent.chat_workflow",
+            new=AsyncMock(return_value="I can help with that."),
+        ) as mock_chat:
+            result = await react_agent(inputs, state, llm_config)
 
-                # Tool not found
-                mock_get_tool.return_value = None
-
-                mock_agent = Mock()
-                mock_agent.ainvoke = AsyncMock(return_value={
-                    "messages": [
-                        {"type": "human", "content": "Test task"},
-                        {"type": "ai", "content": "I can help with that."},
-                    ]
-                })
-                mock_create.return_value = mock_agent
-
-                # Execute - should work but without the tool
-                result = await react_agent(inputs, state, llm_config)
-
-                # Verify - should still work, just without tools
-                assert "result" in result
-                # Agent was created with empty tools list
+    assert "result" in result
+    assert mock_chat.await_count == 1
+    assert "tools" not in mock_chat.await_args.kwargs
 
 
 def test_agent_tool_registration():

--- a/fichero-engine/tests/unit/workflows/test_multi_agent.py
+++ b/fichero-engine/tests/unit/workflows/test_multi_agent.py
@@ -1,8 +1,7 @@
 """Unit tests for multi-agent workflow tools."""
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
-from langchain_core.messages import AIMessage
+from unittest.mock import AsyncMock, patch
 
 from fichero.workflows.tools.multi_agent import (
     supervisor_agent,
@@ -82,21 +81,20 @@ class TestSupervisorAgent:
     @pytest.mark.asyncio
     async def test_supervisor_with_workers(self, llm_config, mock_state):
         """Test supervisor with workers (mocked)."""
-        # Mock the LLM and agent execution
-        mock_model = MagicMock()
-        mock_model.ainvoke = AsyncMock(return_value=AIMessage(
-            content="I will delegate to researcher. Task complete."
-        ))
-
-        with patch("fichero.workflows.tools.multi_agent.get_langchain_model", return_value=mock_model):
-            with patch("fichero.workflows.tools.multi_agent.create_react_agent") as mock_create:
-                # Mock worker agent
-                mock_worker = MagicMock()
-                mock_worker.ainvoke = AsyncMock(return_value={
-                    "messages": [AIMessage(content="Worker result")]
-                })
-                mock_create.return_value = mock_worker
-
+        with patch(
+            "fichero.workflows.tools.multi_agent.chat_workflow",
+            new=AsyncMock(
+                side_effect=[
+                    "I will delegate to researcher.",
+                    "Task complete.",
+                    "Final synthesized result.",
+                ]
+            ),
+        ) as mock_chat:
+            with patch(
+                "fichero.workflows.tools.multi_agent._run_agent_loop",
+                new=AsyncMock(return_value=("Worker result", [{"role": "ai", "content": "Worker result"}], [], 0)),
+            ):
                 result = await supervisor_agent(
                     inputs={
                         "task": "Research AI trends",
@@ -110,9 +108,10 @@ class TestSupervisorAgent:
                     llm_config=llm_config,
                 )
 
-                # Should have execution log
-                assert "execution_log" in result
-                assert isinstance(result["execution_log"], list)
+        assert "execution_log" in result
+        assert isinstance(result["execution_log"], list)
+        assert result["result"] == "Final synthesized result."
+        assert mock_chat.await_count == 3
 
 
 class TestSwarmAgent:
@@ -159,66 +158,52 @@ class TestSwarmAgent:
     @pytest.mark.asyncio
     async def test_swarm_single_agent_no_handoff(self, llm_config, mock_state):
         """Test swarm with single agent that doesn't hand off."""
-        mock_model = MagicMock()
+        with patch(
+            "fichero.workflows.tools.multi_agent._run_agent_loop",
+            new=AsyncMock(return_value=("Final answer without handoff", [], [], 0)),
+        ):
+            result = await swarm_agent(
+                inputs={
+                    "task": "Simple task",
+                    "agents": [
+                        {"name": "agent1", "description": "First agent"},
+                    ],
+                },
+                state=mock_state,
+                llm_config=llm_config,
+            )
 
-        with patch("fichero.workflows.tools.multi_agent.get_langchain_model", return_value=mock_model):
-            with patch("fichero.workflows.tools.multi_agent.create_react_agent") as mock_create:
-                mock_agent = MagicMock()
-                mock_agent.ainvoke = AsyncMock(return_value={
-                    "messages": [AIMessage(content="Final answer without handoff")]
-                })
-                mock_create.return_value = mock_agent
-
-                result = await swarm_agent(
-                    inputs={
-                        "task": "Simple task",
-                        "agents": [
-                            {"name": "agent1", "description": "First agent"},
-                        ],
-                    },
-                    state=mock_state,
-                    llm_config=llm_config,
-                )
-
-                assert result["result"] == "Final answer without handoff"
-                assert len(result["handoff_chain"]) == 1
-                assert result["handoff_chain"][0]["agent"] == "agent1"
+        assert result["result"] == "Final answer without handoff"
+        assert len(result["handoff_chain"]) == 1
+        assert result["handoff_chain"][0]["agent"] == "agent1"
 
     @pytest.mark.asyncio
     async def test_swarm_with_handoff(self, llm_config, mock_state):
         """Test swarm with handoff between agents."""
-        mock_model = MagicMock()
-        call_count = 0
+        with patch(
+            "fichero.workflows.tools.multi_agent._run_agent_loop",
+            new=AsyncMock(
+                side_effect=[
+                    ("HANDOFF: agent2 Continue with this", [], [], 0),
+                    ("Final answer from agent2", [], [], 0),
+                ]
+            ),
+        ):
+            result = await swarm_agent(
+                inputs={
+                    "task": "Complex task",
+                    "agents": [
+                        {"name": "agent1", "description": "First agent", "can_handoff_to": ["agent2"]},
+                        {"name": "agent2", "description": "Second agent"},
+                    ],
+                    "entry_agent": "agent1",
+                },
+                state=mock_state,
+                llm_config=llm_config,
+            )
 
-        async def mock_ainvoke(state):
-            nonlocal call_count
-            call_count += 1
-            if call_count == 1:
-                return {"messages": [AIMessage(content="HANDOFF: agent2 Continue with this")]}
-            else:
-                return {"messages": [AIMessage(content="Final answer from agent2")]}
-
-        with patch("fichero.workflows.tools.multi_agent.get_langchain_model", return_value=mock_model):
-            with patch("fichero.workflows.tools.multi_agent.create_react_agent") as mock_create:
-                mock_agent = MagicMock()
-                mock_agent.ainvoke = mock_ainvoke
-                mock_create.return_value = mock_agent
-
-                result = await swarm_agent(
-                    inputs={
-                        "task": "Complex task",
-                        "agents": [
-                            {"name": "agent1", "description": "First agent", "can_handoff_to": ["agent2"]},
-                            {"name": "agent2", "description": "Second agent"},
-                        ],
-                        "entry_agent": "agent1",
-                    },
-                    state=mock_state,
-                    llm_config=llm_config,
-                )
-
-                assert result["result"] == "Final answer from agent2"
-                assert len(result["handoff_chain"]) == 2
+        assert result["result"] == "Final answer from agent2"
+        assert len(result["handoff_chain"]) == 2
 
 
 class TestAgentCoordinator:
@@ -265,22 +250,14 @@ class TestAgentCoordinator:
     @pytest.mark.asyncio
     async def test_coordinator_parallel_execution(self, llm_config, mock_state):
         """Test coordinator runs agents in parallel."""
-        mock_model = MagicMock()
-        mock_model.ainvoke = AsyncMock(return_value=AIMessage(
-            content="Synthesized response"
-        ))
-
-        with patch("fichero.workflows.tools.multi_agent.get_langchain_model", return_value=mock_model):
-            with patch("fichero.workflows.tools.multi_agent.create_react_agent") as mock_create:
-                # Create mock agents with different responses
-                mock_agent = MagicMock()
-
-                async def mock_ainvoke(state):
-                    return {"messages": [AIMessage(content="Agent response")]}
-
-                mock_agent.ainvoke = mock_ainvoke
-                mock_create.return_value = mock_agent
-
+        with patch(
+            "fichero.workflows.tools.multi_agent._run_agent_loop",
+            new=AsyncMock(return_value=("Agent response", [], [], 0)),
+        ):
+            with patch(
+                "fichero.workflows.tools.multi_agent.chat_workflow",
+                new=AsyncMock(return_value="Synthesized response"),
+            ):
                 result = await agent_coordinator(
                     inputs={
                         "task": "Analyze document",
@@ -294,66 +271,52 @@ class TestAgentCoordinator:
                     llm_config=llm_config,
                 )
 
-                # Should have results from both agents
-                assert "agent_results" in result
-                assert "analyzer1" in result["agent_results"]
-                assert "analyzer2" in result["agent_results"]
-                assert "agreement_score" in result
+        assert "agent_results" in result
+        assert "analyzer1" in result["agent_results"]
+        assert "analyzer2" in result["agent_results"]
+        assert "agreement_score" in result
 
     @pytest.mark.asyncio
     async def test_coordinator_voting_method(self, llm_config, mock_state):
         """Test coordinator with voting combination."""
-        mock_model = MagicMock()
+        with patch(
+            "fichero.workflows.tools.multi_agent._run_agent_loop",
+            new=AsyncMock(return_value=("Same answer", [], [], 0)),
+        ):
+            result = await agent_coordinator(
+                inputs={
+                    "task": "Simple question",
+                    "agents": [
+                        {"name": "voter1"},
+                        {"name": "voter2"},
+                    ],
+                    "combination_method": "voting",
+                },
+                state=mock_state,
+                llm_config=llm_config,
+            )
 
-        with patch("fichero.workflows.tools.multi_agent.get_langchain_model", return_value=mock_model):
-            with patch("fichero.workflows.tools.multi_agent.create_react_agent") as mock_create:
-                mock_agent = MagicMock()
-                mock_agent.ainvoke = AsyncMock(return_value={
-                    "messages": [AIMessage(content="Same answer")]
-                })
-                mock_create.return_value = mock_agent
-
-                result = await agent_coordinator(
-                    inputs={
-                        "task": "Simple question",
-                        "agents": [
-                            {"name": "voter1"},
-                            {"name": "voter2"},
-                        ],
-                        "combination_method": "voting",
-                    },
-                    state=mock_state,
-                    llm_config=llm_config,
-                )
-
-                assert result["combined_result"] == "Same answer"
+        assert result["combined_result"] == "Same answer"
 
     @pytest.mark.asyncio
     async def test_coordinator_weighted_average(self, llm_config, mock_state):
         """Test coordinator with weighted average."""
-        mock_model = MagicMock()
+        with patch(
+            "fichero.workflows.tools.multi_agent._run_agent_loop",
+            new=AsyncMock(return_value=("Weighted response", [], [], 0)),
+        ):
+            result = await agent_coordinator(
+                inputs={
+                    "task": "Expert question",
+                    "agents": [
+                        {"name": "expert", "weight": 3.0},
+                        {"name": "novice", "weight": 1.0},
+                    ],
+                    "combination_method": "weighted_average",
+                },
+                state=mock_state,
+                llm_config=llm_config,
+            )
 
-        with patch("fichero.workflows.tools.multi_agent.get_langchain_model", return_value=mock_model):
-            with patch("fichero.workflows.tools.multi_agent.create_react_agent") as mock_create:
-                mock_agent = MagicMock()
-                mock_agent.ainvoke = AsyncMock(return_value={
-                    "messages": [AIMessage(content="Weighted response")]
-                })
-                mock_create.return_value = mock_agent
-
-                result = await agent_coordinator(
-                    inputs={
-                        "task": "Expert question",
-                        "agents": [
-                            {"name": "expert", "weight": 3.0},
-                            {"name": "novice", "weight": 1.0},
-                        ],
-                        "combination_method": "weighted_average",
-                    },
-                    state=mock_state,
-                    llm_config=llm_config,
-                )
-
-                # Should include weight percentages in output
-                assert "expert" in result["combined_result"]
-                assert "%" in result["combined_result"]
+        assert "expert" in result["combined_result"]
+        assert "%" in result["combined_result"]


### PR DESCRIPTION
Closes #1825. All workflow/tool LLM calls now route through a single central chat()/chat_structured() entry point instead of per-workflow get_langchain_model. langchain provider path (litellm is cost-only, not routing). Prefer-raise on provider/config errors — no silent fallback. Net -14 lines across agent/multi_agent/model_comparison + new test_llm_workflow_chat.py. Full unit+contracts suite: 6237 passed, 0 failed.

Closes #1825

Co-Authored-By: Daniel Tubb <dtubb@me.com>