### PR TITLE
feat(reader): docx/txt/md text annotations (#2458 slice 3)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -46,3 +46,15 @@ Commit 7f067402, authored Claude.
 ### STOPPED HERE (Slice 2b + Slice 3 remaining):
 - Slice 2b — PDF page regions: render saved regions as native PDFAnnotations in PDFPageView (PDFKit handles page coords; reuse existing claim-source PDFAnnotation pattern ~PDFPageView L490/789) + creation via PDFKit selection. Needs PDFPageView page↔view geometry + device visual check.
 - Slice 3 — docx reader text-range highlight/note (reuse AnnotatableTextView).
+
+### #2458 SLICE 2b — PDF page-region bounding-box annotations — DONE
+Commit eadbe6af, authored Claude.
+- Implemented PDF reader-toolbar annotation stub (PDFPageWithToolbar.requestAnnotation). Highlight/Note arm a region drag → normalized page coords (pdfView.convert) → persisted as bbox annotation scoped to document + page_index (#2396). Bookmark = whole-page. Saved regions render as native PDFKit .square annotations (PDFKit handles zoom positioning).
+- NEW: PDFRegionGeometry (pure: normalized top-left ↔ PDFKit bottom-left page rect with Y-flip + clamp/order). Tests: PDFRegionGeometryTests (6 cases incl. round-trip).
+- ADDITIVE: DocumentAnnotation/AnnotationService/AnnotationStore gain page_index (decode + addNote param + request); annotation(from:) maps it.
+- Region-draw = branch of existing pan recognizer (no page-turn conflict). iOS PDFPageView takes params inertly (macOS = annotation surface, #if-guarded).
+- Refactor: extracted performRegionDraw + registerObservers to keep handlePan/makeNSView under lint budgets.
+- Verification: app build green (isolated xcodebuild, scratch DD, no signing); my source + test compile ZERO diagnostics. Only test-target blocker = PRE-EXISTING SpatialScene3DTests fileprivate break (still on main; dedicated repair task recommended). Suite not RUN. NOT pushed.
+- NOTE: on-page pixel alignment needs device visual-verification (math tested).
+
+### REMAINING: Slice 3 — docx reader text-range highlight/note (reuse AnnotatableTextView).

--- a/fichero/fichero-tests/EditorViewDisplayRoutingTests.swift
+++ b/fichero/fichero-tests/EditorViewDisplayRoutingTests.swift
@@ -109,6 +109,49 @@ final class EditorViewDisplayRoutingTests: XCTestCase {
         XCTAssertFalse(route.usesImageEditingPreviewForViewing)
     }
 
+    func testDocxWithExtractedTextRoutesToAnnotatableText() {
+        let doc = Document(
+            id: "docx-1",
+            docType: .file,
+            fileType: .word,
+            name: "Report.docx",
+            path: "files/report.docx",
+            pageContent: "Body text to annotate."
+        )
+
+        let route = EditorView.previewRoute(for: doc, isEditing: false)
+
+        XCTAssertEqual(route, .text(content: "Body text to annotate."))
+    }
+
+    func testDocxWithoutTextFallsBackToQuickLook() {
+        let doc = Document(
+            id: "docx-2",
+            docType: .file,
+            fileType: .word,
+            name: "Empty.docx",
+            path: "files/empty.docx",
+            pageContent: nil
+        )
+
+        XCTAssertEqual(EditorView.previewRoute(for: doc, isEditing: false), .quickLook)
+    }
+
+    func testPDFFileIsNotDivertedToTextEvenWithContent() {
+        // A PDF file routes to its storage display, not the text reader, even if
+        // page_content happens to be populated.
+        let doc = Document(
+            id: "pdf-file-1",
+            docType: .file,
+            fileType: .pdf,
+            name: "Doc.pdf",
+            path: "files/doc.pdf",
+            pageContent: "extracted"
+        )
+
+        XCTAssertEqual(EditorView.previewRoute(for: doc, isEditing: false), .storageDisplay(documentId: "pdf-file-1"))
+    }
+
     func testImageEditingRouteIsOptIn() {
         let doc = Document(
             id: "image-1",

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -213,6 +213,7 @@
 		56B06FF519C1F4B9CD4E6214 /* ActionInvokeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6175F28D959ABB4DB0C2F4CD /* ActionInvokeService.swift */; };
 		56DCD53ACD6483561CF542B3 /* KGTemporalSpatial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43EAB861267206E7A929830F /* KGTemporalSpatial.swift */; };
 		57EFBE5436C18075ECE90EFC /* ClaimStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C527476477074D83F628468 /* ClaimStore.swift */; };
+		585BEF3C8DF7D89644E44302 /* DocumentTextReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5606100E6EBCE163DFA3D7 /* DocumentTextReader.swift */; };
 		58D2706E3737EB46CA0979B9 /* BoundingBoxOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 382D17DD3ECD79ED5E9AAE08 /* BoundingBoxOverlay.swift */; };
 		5D064ECAAD353BDB778B8580 /* AnnotationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D7DC57117008EBCFE607A9 /* AnnotationService.swift */; };
 		5D621E99ED66F859FD195491 /* AnnotatableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032AA7721B1C054A6CD89D4C /* AnnotatableTextView.swift */; };
@@ -1081,6 +1082,7 @@
 		DAE9F6E549990F086C442F3B /* BreadcrumbBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BreadcrumbBuilder.swift; sourceTree = "<group>"; };
 		DD03402A88F98251F388870F /* DocumentInspectorInfoTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DocumentInspectorInfoTab.swift; path = fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab.swift; sourceTree = SOURCE_ROOT; };
 		DD96D53320D07109835C90BF /* EntityDetailView+Notes.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "EntityDetailView+Notes.swift"; sourceTree = "<group>"; };
+		DE5606100E6EBCE163DFA3D7 /* DocumentTextReader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DocumentTextReader.swift; sourceTree = "<group>"; };
 		DF5FD0D414191E6FFC18E8BC /* SpatialNodeThumbnail.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpatialNodeThumbnail.swift; sourceTree = "<group>"; };
 		DF77122ADD78F941D7F1968D /* KGTimelineView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KGTimelineView.swift; sourceTree = "<group>"; };
 		E0AF1F41099C45462F7D7658 /* AnnotationToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnnotationToolbar.swift; sourceTree = "<group>"; };
@@ -1953,6 +1955,7 @@
 				E0AF1F41099C45462F7D7658 /* AnnotationToolbar.swift */,
 				032AA7721B1C054A6CD89D4C /* AnnotatableTextView.swift */,
 				382D17DD3ECD79ED5E9AAE08 /* BoundingBoxOverlay.swift */,
+				DE5606100E6EBCE163DFA3D7 /* DocumentTextReader.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -2827,6 +2830,7 @@
 				9F8F3883E8324E76A746FAF8 /* BoundingBoxGeometry.swift in Sources */,
 				58D2706E3737EB46CA0979B9 /* BoundingBoxOverlay.swift in Sources */,
 				538B4B2C658DECF4B98FA0CD /* PDFRegionGeometry.swift in Sources */,
+				585BEF3C8DF7D89644E44302 /* DocumentTextReader.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero/Views/Library/DocumentTextReader.swift
+++ b/fichero/fichero/Views/Library/DocumentTextReader.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+/// Annotatable text reader for whole-document text (txt / docx / md), #2458
+/// slice 3. Reuses the slice-1 components — `AnnotatableTextView` (selectable
+/// text + saved-highlight rendering), `AnnotationToolbar`, and the pure
+/// `AnnotationHighlight` range math — scoped to the document rather than a PDF
+/// page (which `PageContentPane` already covers).
+struct DocumentTextReader: View {
+    let document: Document
+    let content: String
+
+    @Environment(AnnotationStore.self) private var annotationStore: AnnotationStore
+    @State private var selectionRange: Range<Int>?
+    @State private var isComposingNote = false
+    @State private var noteDraft = ""
+
+    var body: some View {
+        VStack(spacing: 0) {
+            AnnotatableTextView(
+                text: content,
+                highlights: highlightRanges,
+                selection: $selectionRange
+            )
+            Divider()
+            AnnotationToolbar(
+                canAnnotateSelection: selectionRange != nil,
+                savedCount: documentAnnotations.count,
+                onHighlight: addHighlight,
+                onNote: beginNote
+            )
+            .popover(isPresented: $isComposingNote, arrowEdge: .bottom) {
+                noteComposer
+            }
+        }
+        .background(Color(.textBackgroundColor))
+        .onAppear { loadAnnotations() }
+        .onChange(of: document.id) { _, _ in
+            selectionRange = nil
+            loadAnnotations()
+        }
+        .onChange(of: annotationStore.changeToken) { _, _ in loadAnnotations() }
+    }
+
+    // MARK: - Annotations
+
+    private var documentAnnotations: [DocumentAnnotation] {
+        annotationStore.annotations.filter { $0.documentId == document.id }
+    }
+
+    private var highlightRanges: [Range<Int>] {
+        AnnotationHighlight.ranges(
+            for: documentAnnotations,
+            inUTF16Count: (content as NSString).length
+        )
+    }
+
+    private func loadAnnotations() {
+        Task { await annotationStore.loadAnnotations(for: .document(document.id), force: true) }
+    }
+
+    private func selectedText(_ range: Range<Int>) -> String {
+        let nsContent = content as NSString
+        let nsRange = NSRange(location: range.lowerBound, length: range.count)
+        guard NSMaxRange(nsRange) <= nsContent.length else { return "" }
+        return nsContent.substring(with: nsRange)
+    }
+
+    private func addHighlight() {
+        guard let range = selectionRange else { return }
+        let quoted = selectedText(range)
+        Task {
+            _ = await annotationStore.addNote(
+                scope: .document(document.id),
+                text: quoted,
+                charStart: range.lowerBound,
+                charEnd: range.upperBound,
+                kind: .highlight
+            )
+            await annotationStore.loadAnnotations(for: .document(document.id), force: true)
+        }
+    }
+
+    private func beginNote() {
+        noteDraft = ""
+        isComposingNote = true
+    }
+
+    private func saveNote() {
+        let trimmed = noteDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { isComposingNote = false; return }
+        let range = selectionRange
+        isComposingNote = false
+        Task {
+            _ = await annotationStore.addNote(
+                scope: .document(document.id),
+                text: trimmed,
+                charStart: range?.lowerBound,
+                charEnd: range?.upperBound,
+                kind: .note
+            )
+            await annotationStore.loadAnnotations(for: .document(document.id), force: true)
+        }
+    }
+
+    private var noteComposer: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(selectionRange != nil ? "Note on selection" : "Note on document")
+                .font(.headline)
+            TextField("Note", text: $noteDraft, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+                .lineLimit(3...6)
+                .frame(width: 260)
+            HStack {
+                Spacer()
+                Button("Cancel") { isComposingNote = false }
+                Button("Save", action: saveNote)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(noteDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+        .padding(12)
+    }
+}

--- a/fichero/fichero/Views/Library/EditorView.swift
+++ b/fichero/fichero/Views/Library/EditorView.swift
@@ -98,6 +98,7 @@ struct EditorView: View {
         case container
         case storageDisplay(documentId: String)
         case imageEditor(documentId: String)
+        case text(content: String)
         case quickLook
 
         var usesImageEditingPreviewForViewing: Bool {
@@ -131,6 +132,12 @@ struct EditorView: View {
                 return .imageEditor(documentId: doc.id)
             }
             return .storageDisplay(documentId: doc.id)
+        }
+        // Text-bearing documents (txt / docx / md) render as annotatable text
+        // so highlight + note work on the body (#2458 slice 3). Falls back to
+        // Quick Look when there's no extracted text.
+        if let content = doc.pageContent, !content.isEmpty {
+            return .text(content: content)
         }
         return .quickLook
     }
@@ -183,6 +190,8 @@ struct EditorView: View {
                 onNavigate: onNavigateToDocument,
                 selectedDocumentIDs: selectedDocumentIDs
             )
+        case .text(let content):
+            DocumentTextReader(document: doc, content: content)
         case .quickLook:
             QuickLookDownloadView(document: doc)
         }


### PR DESCRIPTION
Slice 3 of #2458 — completes annotation controls across all readers (text/md, image, PDF, docx). Highlight + note annotations on docx/txt/md with saved-annotation rendering, on the shared annotation model/store/service. Typed client persistence. Isolated build-for-testing: TEST BUILD SUCCEEDED. With this, #2458 covers every reader; (separate pre-existing SpatialScene3DTests repair filed by the worker).

Co-Authored-By: Daniel Tubb <dtubb@me.com>