### PR TITLE
feat(library): wire bookmark endpoints into the SwiftUI surface (#2755)

### DIFF
--- a/fichero-engine/tests/contracts/ui_wiring_allowlist_swiftui.json
+++ b/fichero-engine/tests/contracts/ui_wiring_allowlist_swiftui.json
@@ -14,8 +14,6 @@
     "/api/agents/write/audit": "baseline: not yet wired",
     "/api/agents/write/audit/{record_id}": "baseline: not yet wired",
     "/api/annotations/crop": "annotation crop endpoint surfaced by OpenAPI regen; SwiftUI wiring tracked in #2755",
-    "/api/bookmarks": "node-model fold F4 (#2591) — bookmark nodes, backend-only; SwiftUI wiring tracked in #2755",
-    "/api/bookmarks/{bookmark_id}/resolve": "node-model fold F4 (#2591) — bookmark resolve, backend-only; SwiftUI wiring tracked in #2755",
     "/api/auth/login": "#2022 multi-user backend - cli-only, frontend deferred",
     "/api/auth/logout": "#2022 multi-user backend - cli-only, frontend deferred",
     "/api/auth/me": "#2022 multi-user backend - cli-only, frontend deferred",

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		047 /* ChatServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146 /* ChatServiceGenerated.swift */; };
 		048 /* WorkflowExecutionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149 /* WorkflowExecutionObserver.swift */; };
 		049 /* DocumentServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148 /* DocumentServiceGenerated.swift */; };
+		04EC79C508ADFCB840661C01 /* BookmarksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA02CD36EF110174B8E2206 /* BookmarksView.swift */; };
 		05B00350827A7FD40C53676B /* FocusedCitation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFF948011DDF9E51FDC3995D /* FocusedCitation.swift */; };
 		079E7B626FA4EE5877BB24B0 /* FicheroApp_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29941DE439073B7364322ECF /* FicheroApp_iOS.swift */; };
 		08A233915452687AD06DA9DE /* DocumentInspectorArtifactsTab+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BB27716102361159F020CD /* DocumentInspectorArtifactsTab+Previews.swift */; };
@@ -494,6 +495,7 @@
 		C994E1D675749951376E8FEA /* FocusedAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5004AD7FDB9A8BE0953643C5 /* FocusedAnnotation.swift */; };
 		CB8C5EB090F3F95C861D1A2E /* InspectorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8FD4EEA01D859C3DB5EADB /* InspectorPresenter.swift */; };
 		CC357CD884EE29BAE8A64F4B /* PlatformPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772A6A57C4986C2765A174EE /* PlatformPasteboard.swift */; };
+		CC8B35B398A7393E4D687941 /* BookmarkServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3133E93619FB262825F4F55 /* BookmarkServiceGenerated.swift */; };
 		CFC9C70DBE40510A012E46EE /* WorkflowExecutionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669F81AC0106B415218C419D /* WorkflowExecutionStore.swift */; };
 		D0D540A3F924325236C1E440 /* DocumentInspectorArtifactsTab+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FDDBCA3101A6E468A3105D2 /* DocumentInspectorArtifactsTab+Shared.swift */; };
 		D2A64087B8C786EE95E842A5 /* LocalModelsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4F4939BDACA726554E086D /* LocalModelsSettingsView.swift */; };
@@ -764,6 +766,7 @@
 		3D455270E3396946CF4F1939 /* NodeComparisonSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NodeComparisonSheet.swift; sourceTree = "<group>"; };
 		3DC44420C3D37275174DF38F /* Spatial2DCanvasGestures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Spatial2DCanvasGestures.swift; sourceTree = "<group>"; };
 		3E8C3EFBCE91C295309468AB /* ThinkingModePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThinkingModePicker.swift; sourceTree = "<group>"; };
+		3EA02CD36EF110174B8E2206 /* BookmarksView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookmarksView.swift; sourceTree = "<group>"; };
 		4119 /* CacheModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CacheModel.swift; sourceTree = "<group>"; };
 		4121 /* PerformanceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceService.swift; sourceTree = "<group>"; };
 		4123 /* ErrorService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorService.swift; sourceTree = "<group>"; };
@@ -1104,6 +1107,7 @@
 		F1CE0962968DEE7EAB60E454 /* ClaimSummaryCard+Provenance.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ClaimSummaryCard+Provenance.swift"; sourceTree = "<group>"; };
 		F23C597BA2DF9A27BE94F609 /* DocumentInspectorArtifactsTab+KGModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentInspectorArtifactsTab+KGModels.swift"; sourceTree = "<group>"; };
 		F259EE92E81B78CBE35C9947 /* DocumentInspectorArtifactsTab+CurationHistory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentInspectorArtifactsTab+CurationHistory.swift"; sourceTree = "<group>"; };
+		F3133E93619FB262825F4F55 /* BookmarkServiceGenerated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BookmarkServiceGenerated.swift; sourceTree = "<group>"; };
 		F348C1F78D105C8017210F17 /* SourceOutlineView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SourceOutlineView.swift; sourceTree = "<group>"; };
 		F4189C51250E0B39E05CD87B /* AISettingsView+Tabs.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AISettingsView+Tabs.swift"; sourceTree = "<group>"; };
 		F42C41E0F485064FDA5EAEB9 /* InterpretationStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InterpretationStore.swift; sourceTree = "<group>"; };
@@ -1629,6 +1633,7 @@
 				28B629229088E72B485569FC /* LibraryChangeStream.swift */,
 				6175F28D959ABB4DB0C2F4CD /* ActionInvokeService.swift */,
 				44352F043915E2760BB0DD30 /* ImportServiceGenerated+Upload.swift */,
+				F3133E93619FB262825F4F55 /* BookmarkServiceGenerated.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1956,6 +1961,7 @@
 				032AA7721B1C054A6CD89D4C /* AnnotatableTextView.swift */,
 				382D17DD3ECD79ED5E9AAE08 /* BoundingBoxOverlay.swift */,
 				DE5606100E6EBCE163DFA3D7 /* DocumentTextReader.swift */,
+				3EA02CD36EF110174B8E2206 /* BookmarksView.swift */,
 			);
 			path = Library;
 			sourceTree = "<group>";
@@ -2831,6 +2837,8 @@
 				58D2706E3737EB46CA0979B9 /* BoundingBoxOverlay.swift in Sources */,
 				538B4B2C658DECF4B98FA0CD /* PDFRegionGeometry.swift in Sources */,
 				585BEF3C8DF7D89644E44302 /* DocumentTextReader.swift in Sources */,
+				CC8B35B398A7393E4D687941 /* BookmarkServiceGenerated.swift in Sources */,
+				04EC79C508ADFCB840661C01 /* BookmarksView.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero/Models/LibraryManager.swift
+++ b/fichero/fichero/Models/LibraryManager.swift
@@ -62,6 +62,7 @@ class LibraryManager: ObservableObject {
         let ficheroClient: FicheroClient  // Generated API client
         let documentStore: DocumentStore
         let savedSearchServiceGenerated: SavedSearchServiceGenerated  // Generated saved search service
+        let bookmarkServiceGenerated: BookmarkServiceGenerated  // Generated bookmark service (#2755)
         let searchService: SearchServiceGenerated
         let conversationServiceGenerated: ConversationServiceGenerated  // Generated conversation service
         let chatServiceGenerated: ChatServiceGenerated  // Generated chat service
@@ -251,6 +252,7 @@ class LibraryManager: ObservableObject {
             // Initialize all services with the library's APIClient
             self.documentStore = documentStore ?? DocumentStore(apiClient: self.apiClient)
             self.savedSearchServiceGenerated = SavedSearchServiceGenerated(ficheroClient: self.ficheroClient)
+            self.bookmarkServiceGenerated = BookmarkServiceGenerated(ficheroClient: self.ficheroClient)
             self.searchService = searchService ?? SearchServiceGenerated(ficheroClient: self.ficheroClient)
             self.conversationServiceGenerated = ConversationServiceGenerated(ficheroClient: self.ficheroClient)
             self.chatServiceGenerated = ChatServiceGenerated(ficheroClient: self.ficheroClient)

--- a/fichero/fichero/Services/BookmarkServiceGenerated.swift
+++ b/fichero/fichero/Services/BookmarkServiceGenerated.swift
@@ -1,0 +1,91 @@
+import Combine
+import FicheroAPIClient
+import Foundation
+import OSLog
+
+/// A bookmark node (node-model fold F4, #2591): a saved pointer to a target
+/// document. Lightweight — the list view only needs the id + name; opening
+/// resolves to the target via the backend.
+struct BookmarkItem: Identifiable, Hashable {
+    let id: String
+    let name: String
+}
+
+/// Typed wrapper over the `/api/bookmarks` endpoints (#2755). All calls go
+/// through the generated client — no hand-rolled URLSession. Degrades
+/// gracefully: failures set `error` and leave `bookmarks` untouched.
+@MainActor
+final class BookmarkServiceGenerated: ObservableObject {
+    private let client: FicheroClient
+    @Published private(set) var bookmarks: [BookmarkItem] = []
+    @Published var error: String?
+
+    private let logger = Logger(subsystem: "app.fichero.fichero", category: "BookmarkService")
+
+    init(ficheroClient: FicheroClient) {
+        self.client = ficheroClient
+    }
+
+    /// GET /api/bookmarks — bookmark nodes, optionally under a parent folder.
+    func loadBookmarks(parentId: String? = nil) async {
+        do {
+            let response = try await client.api.listBookmarksApiBookmarksGet(
+                .init(query: .init(parentId: parentId))
+            )
+            guard case .ok(let okResponse) = response else {
+                error = "Could not load bookmarks"
+                return
+            }
+            bookmarks = try okResponse.body.json.items.compactMap { doc in
+                guard let id = doc.id else { return nil }
+                return BookmarkItem(id: id, name: doc.name)
+            }
+            error = nil
+        } catch {
+            logger.warning("list bookmarks failed: \(error.localizedDescription, privacy: .public)")
+            self.error = "Could not load bookmarks"
+        }
+    }
+
+    /// POST /api/bookmarks — bookmark `targetId` under `parentId`. Reloads on success.
+    @discardableResult
+    func createBookmark(targetId: String, name: String, parentId: String? = nil) async -> Bool {
+        do {
+            let request = Components.Schemas.BookmarkCreate(
+                targetId: targetId,
+                parentId: parentId,
+                name: name
+            )
+            let response = try await client.api.createBookmarkApiBookmarksPost(.init(body: .json(request)))
+            guard case .created = response else {
+                error = "Could not create bookmark"
+                return false
+            }
+            error = nil
+            await loadBookmarks(parentId: parentId)
+            return true
+        } catch {
+            logger.warning("create bookmark failed: \(error.localizedDescription, privacy: .public)")
+            self.error = "Could not create bookmark"
+            return false
+        }
+    }
+
+    /// GET /api/bookmarks/{id}/resolve — the target document id the bookmark points to.
+    func resolveBookmark(id: String) async -> String? {
+        do {
+            let response = try await client.api.resolveBookmarkApiBookmarksBookmarkIdResolveGet(
+                .init(path: .init(bookmarkId: id))
+            )
+            guard case .ok(let okResponse) = response else {
+                error = "Could not resolve bookmark"
+                return nil
+            }
+            return try okResponse.body.json.id
+        } catch {
+            logger.warning("resolve bookmark failed: \(error.localizedDescription, privacy: .public)")
+            self.error = "Could not resolve bookmark"
+            return nil
+        }
+    }
+}

--- a/fichero/fichero/Views/Library/BookmarksView.swift
+++ b/fichero/fichero/Views/Library/BookmarksView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+/// Bookmark surface (#2755): bookmark the current document, list saved
+/// bookmarks, and open one (resolve → its target document). All persistence
+/// goes through the typed `BookmarkServiceGenerated`.
+struct BookmarksView: View {
+    /// The document offered for bookmarking (the row the sheet was opened from).
+    let document: Document
+    /// Opens a resolved target document in the host window.
+    var onOpen: (Document) -> Void
+
+    @EnvironmentObject private var bookmarkService: BookmarkServiceGenerated
+    @EnvironmentObject private var documentService: DocumentServiceGenerated
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var name: String = ""
+    @State private var isWorking = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Bookmarks")
+                .font(.headline)
+
+            HStack(spacing: 8) {
+                TextField("Bookmark name", text: $name)
+                    .textFieldStyle(.roundedBorder)
+                Button("Add", action: addBookmark)
+                    .keyboardShortcut(.defaultAction)
+                    .disabled(isWorking || trimmedName.isEmpty)
+            }
+            .help("Bookmark “\(document.name)”")
+
+            Divider()
+
+            if bookmarkService.bookmarks.isEmpty {
+                Text("No bookmarks yet.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                    .padding(.vertical, 16)
+            } else {
+                List(bookmarkService.bookmarks) { bookmark in
+                    Button { open(bookmark) } label: {
+                        Label(bookmark.name, systemImage: "bookmark")
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+                .frame(minHeight: 160)
+            }
+
+            if let error = bookmarkService.error {
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.red)
+            }
+
+            HStack {
+                Spacer()
+                Button("Done") { dismiss() }
+            }
+        }
+        .padding(16)
+        .frame(width: 360)
+        .task {
+            name = document.name
+            await bookmarkService.loadBookmarks()
+        }
+    }
+
+    private var trimmedName: String {
+        name.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func addBookmark() {
+        let bookmarkName = trimmedName
+        guard !bookmarkName.isEmpty else { return }
+        isWorking = true
+        Task {
+            _ = await bookmarkService.createBookmark(targetId: document.id, name: bookmarkName)
+            isWorking = false
+        }
+    }
+
+    private func open(_ bookmark: BookmarkItem) {
+        isWorking = true
+        Task {
+            defer { isWorking = false }
+            guard let targetId = await bookmarkService.resolveBookmark(id: bookmark.id),
+                  let target = try? await documentService.getDocument(targetId) else { return }
+            dismiss()
+            onOpen(target)
+        }
+    }
+}

--- a/fichero/fichero/Views/Library/FocusedDocument.swift
+++ b/fichero/fichero/Views/Library/FocusedDocument.swift
@@ -114,6 +114,7 @@ struct DocumentDetailWindow: View {
             .environmentObject(library.artifactService)
             .environmentObject(library.kgCurationService)
             .environmentObject(library.savedSearchServiceGenerated)
+            .environmentObject(library.bookmarkServiceGenerated)
             .environmentObject(library.searchService)
             .environmentObject(library.conversationServiceGenerated)
             .environmentObject(library.chatServiceGenerated)

--- a/fichero/fichero/Views/Library/LibraryView+FilterAndBatch.swift
+++ b/fichero/fichero/Views/Library/LibraryView+FilterAndBatch.swift
@@ -484,6 +484,13 @@ extension LibraryView {
             Label("Add to Workspace…", systemImage: "square.grid.2x2")
         }
 
+        // Bookmark this document — a saved pointer node (#2755).
+        Button {
+            bookmarkPickerDocument = document
+        } label: {
+            Label("Bookmark…", systemImage: "bookmark")
+        }
+
         Button {
             Task {
                 await toggleExcludeFromProcessing(

--- a/fichero/fichero/Views/Library/LibraryView.swift
+++ b/fichero/fichero/Views/Library/LibraryView.swift
@@ -87,6 +87,8 @@ struct LibraryView: View {
     /// Document pending presentation in the Add-to-Workspace picker (#1494).
     /// Non-nil drives the `.sheet(item:)` below.
     @State var workspacePickerDocument: Document?
+    /// Non-nil presents the bookmark sheet for this document (#2755).
+    @State var bookmarkPickerDocument: Document?
 
     @EnvironmentObject var libraryManager: LibraryManager
     @EnvironmentObject var windowState: WindowState
@@ -313,6 +315,9 @@ struct LibraryView: View {
             .sheet(item: $workspacePickerDocument) { document in
                 WorkspaceItemPicker(document: document)
                     .environment(executionObserver)
+            }
+            .sheet(item: $bookmarkPickerDocument) { document in
+                BookmarksView(document: document, onOpen: { openDocument($0) })
             }
             .focusedSceneValue(
                 \.runWorkflowOnSelection,

--- a/fichero/fichero/Views/Library/LibraryWorkspaceRoot.swift
+++ b/fichero/fichero/Views/Library/LibraryWorkspaceRoot.swift
@@ -61,6 +61,7 @@ struct LibraryWorkspaceRoot: View {
             )
             .environmentObject(windowState)
             .environmentObject(library.savedSearchServiceGenerated)
+            .environmentObject(library.bookmarkServiceGenerated)
             .environmentObject(library.searchService)
             .environmentObject(library.conversationServiceGenerated)
             .environmentObject(library.chatServiceGenerated)


### PR DESCRIPTION
Closes the bookmark half of #2755. New BookmarksView + typed BookmarkServiceGenerated client calling /api/bookmarks + /api/bookmarks/{id}/resolve (the F4 backend fold). Drops the two bookmark entries from ui_wiring_allowlist_swiftui.json — the CI ui-wiring guardrail confirms they're now detected as called (3 passed). Isolated build-for-testing: TEST BUILD SUCCEEDED. (crop/geo/eleventy-site remain allowlisted — separate follow-ups.)

Co-Authored-By: Daniel Tubb <dtubb@me.com>