### PR TITLE
test: centralized LLM error paths (#1825)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,1 @@
+2026-07-02, f_fichero_codex_docs: added centralized-LLM edge tests covering `chat_workflow` tool/structured/unstructured dispatch, prefer-raise provider/config errors, and caller guards that `react_agent`/`supervisor_agent` use `chat_workflow`; targeted pytest green (`31 passed`).

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,1 +1,0 @@
-2026-07-02, f_fichero_codex_docs: added centralized-LLM edge tests covering `chat_workflow` tool/structured/unstructured dispatch, prefer-raise provider/config errors, and caller guards that `react_agent`/`supervisor_agent` use `chat_workflow`; targeted pytest green (`31 passed`).

--- a/fichero-engine/tests/unit/test_llm_workflow_chat.py
+++ b/fichero-engine/tests/unit/test_llm_workflow_chat.py
@@ -47,6 +47,30 @@ async def test_chat_workflow_uses_structured_chat():
 
 
 @pytest.mark.asyncio
+async def test_chat_workflow_uses_tool_chat_and_preserves_shape():
+    config = LLMConfig(provider="openai", model="gpt-4o-mini")
+    tool_result = {
+        "content": "",
+        "tool_calls": [{"id": "call-1", "name": "search", "args": {"q": "room"}}],
+    }
+
+    with patch(
+        "fichero.llm.chat_with_tools",
+        new=AsyncMock(return_value=tool_result),
+    ) as mock_chat_with_tools:
+        result = await chat_workflow(
+            [{"role": "user", "content": "search for room"}],
+            config,
+            tools=[{"type": "function", "function": {"name": "search"}}],
+        )
+
+    assert result == tool_result
+    assert isinstance(result, dict)
+    assert result["tool_calls"][0]["name"] == "search"
+    assert mock_chat_with_tools.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_chat_workflow_propagates_errors():
     config = LLMConfig(provider="openai", model="gpt-4o-mini")
 
@@ -56,3 +80,31 @@ async def test_chat_workflow_propagates_errors():
     ):
         with pytest.raises(ValueError, match="bad provider config"):
             await chat_workflow("hello", config)
+
+
+@pytest.mark.asyncio
+async def test_chat_workflow_propagates_structured_errors():
+    config = LLMConfig(provider="openai", model="gpt-4o-mini")
+
+    with patch(
+        "fichero.llm.chat_structured",
+        new=AsyncMock(side_effect=RuntimeError("structured provider failure")),
+    ):
+        with pytest.raises(RuntimeError, match="structured provider failure"):
+            await chat_workflow("hello", config, schema=_StructuredReply)
+
+
+@pytest.mark.asyncio
+async def test_chat_workflow_propagates_tool_errors():
+    config = LLMConfig(provider="openai", model="gpt-4o-mini")
+
+    with patch(
+        "fichero.llm.chat_with_tools",
+        new=AsyncMock(side_effect=RuntimeError("tool provider failure")),
+    ):
+        with pytest.raises(RuntimeError, match="tool provider failure"):
+            await chat_workflow(
+                [{"role": "user", "content": "search"}],
+                config,
+                tools=[{"type": "function", "function": {"name": "search"}}],
+            )

--- a/fichero-engine/tests/unit/workflows/test_agent_tool.py
+++ b/fichero-engine/tests/unit/workflows/test_agent_tool.py
@@ -65,6 +65,28 @@ async def test_react_agent_composes_integrity_system_prompt():
 
 
 @pytest.mark.asyncio
+async def test_react_agent_uses_central_chat_workflow_entry_point():
+    inputs = {
+        "task": "Say hello",
+        "tools": [],
+    }
+    state: State = {}
+    llm_config = LLMConfig(provider="openai", model="gpt-4o-mini")
+
+    with patch(
+        "fichero.workflows.tools.agent.chat_workflow",
+        new=AsyncMock(return_value="Hello from central path"),
+    ) as mock_chat, patch(
+        "fichero.llm.get_langchain_model",
+        side_effect=AssertionError("react_agent should use chat_workflow"),
+    ):
+        result = await react_agent(inputs, state, llm_config)
+
+    assert result["result"] == "Hello from central path"
+    assert mock_chat.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_react_agent_with_tools():
     """Test agent execution with tools."""
     # Setup

--- a/fichero-engine/tests/unit/workflows/test_multi_agent.py
+++ b/fichero-engine/tests/unit/workflows/test_multi_agent.py
@@ -113,6 +113,48 @@ class TestSupervisorAgent:
         assert result["result"] == "Final synthesized result."
         assert mock_chat.await_count == 3
 
+    @pytest.mark.asyncio
+    async def test_supervisor_uses_central_chat_workflow_entry_point(
+        self, llm_config, mock_state
+    ):
+        with patch(
+            "fichero.workflows.tools.multi_agent.chat_workflow",
+            new=AsyncMock(
+                side_effect=[
+                    "I will delegate to researcher.",
+                    "Final synthesized result.",
+                ]
+            ),
+        ) as mock_chat, patch(
+            "fichero.llm.get_langchain_model",
+            side_effect=AssertionError("supervisor_agent should use chat_workflow"),
+        ):
+            with patch(
+                "fichero.workflows.tools.multi_agent._run_agent_loop",
+                new=AsyncMock(
+                    return_value=(
+                        "Worker result",
+                        [{"role": "ai", "content": "Worker result"}],
+                        [],
+                        0,
+                    )
+                ),
+            ):
+                result = await supervisor_agent(
+                    inputs={
+                        "task": "Research AI trends",
+                        "workers": [
+                            {"name": "researcher", "description": "Research agent", "tools": []},
+                        ],
+                        "max_iterations": 1,
+                    },
+                    state=mock_state,
+                    llm_config=llm_config,
+                )
+
+        assert result["result"] == "Final synthesized result."
+        assert mock_chat.await_count == 2
+
 
 class TestSwarmAgent:
     """Tests for swarm_agent tool."""


### PR DESCRIPTION
Tests-only. Error-path/edge coverage for the centralized chat()/chat_structured() path: central entry point used (not per-workflow get_langchain_model), structured vs unstructured shapes, provider/config errors propagate (prefer-raise, no silent fallback), provider mocked (no network). 31 passed, 0 failed.

Co-Authored-By: Daniel Tubb <dtubb@me.com>