### PR TITLE
fix: audit document mutations via registry, preserving change-stream + effect/undo (#2789 slice 2)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/documents.py
+++ b/fichero-engine/src/fichero/api/routes/documents.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, U
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from fichero.api.library_header import require_library_path
-from fichero.api.auth import request_actor
+from fichero.api.auth import action_context, request_actor
 from fichero.api.change_stream import emit_change
 from fichero.api.main import get_library_database, get_library_database_for_write
 from fichero.db import Database
@@ -43,9 +43,28 @@ from fichero.path_security import (
 from fichero.perf import perf_span
 from fichero.storage import auto_snapshot_before_risky_operation
 from fichero.storage import settings as storage_settings
+from fichero.actions.registry import registry
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
+
+
+def _emit_document_change_ctx(
+    ctx: "ActionContext",
+    *,
+    event_type: str,
+    document_ids: list[str],
+) -> None:
+    if not ctx.library_path or not document_ids:
+        return
+    emit_change(
+        ctx.library_path,
+        type=event_type,
+        document_ids=document_ids,
+        actor=ctx.actor,
+        origin_window=ctx.origin_window,
+        origin_user=ctx.actor,
+    )
 
 
 async def _run_document_write(func: Any, *args: Any, **kwargs: Any) -> Any:
@@ -915,24 +934,18 @@ async def get_document_parent(
 async def create_document(
     doc: DocumentCreate,
     db: Database = Depends(get_library_database_for_write),
-    x_fichero_library_path: str = Depends(require_library_path),
-    x_fichero_origin_window: str | None = Header(
-        default=None, alias="X-Fichero-Origin-Window"
-    ),
-    actor: str = Depends(request_actor),
+    ctx: "ActionContext" = Depends(action_context),
 ) -> Document:
     """Create a new document."""
-    new_doc = await _run_document_write(create_document_impl, db, doc)
-    logger.info(f"Created document: {new_doc.id} ({new_doc.name})")
-
-    emit_change(
-        x_fichero_library_path,
-        type="document.created",
-        document_ids=[new_doc.id],
-        actor=actor,
-        origin_window=x_fichero_origin_window,
-        origin_user=actor,
+    result = await _run_document_write(
+        registry.invoke,
+        db,
+        "document.create",
+        doc.model_dump(mode="json"),
+        ctx,
     )
+    new_doc = Document.model_validate(result.result)
+    logger.info(f"Created document: {new_doc.id} ({new_doc.name})")
     return new_doc
 
 
@@ -1253,33 +1266,23 @@ def restore_document_subtree_impl(db: Database, doc_id: str) -> list[str]:
 async def delete_document(
     doc_id: str,
     db: Database = Depends(get_library_database_for_write),
-    x_fichero_library_path: str = Depends(require_library_path),
-    x_fichero_origin_window: str | None = Header(
-        default=None, alias="X-Fichero-Origin-Window"
-    ),
-    actor: str = Depends(request_actor),
+    ctx: "ActionContext" = Depends(action_context),
 ):
     """Soft-delete a document and all descendants."""
-    to_delete_ids, _before = await _run_document_write(
-        delete_document_impl, db, doc_id, actor=actor
+    result = await _run_document_write(
+        registry.invoke,
+        db,
+        "document.delete",
+        {"doc_id": doc_id},
+        ctx,
     )
+    to_delete_ids = result.result["deleted_document_ids"]
 
     logger.info(
         "Soft-deleted document subtree: root=%s total=%s actor=%s",
         doc_id,
         len(to_delete_ids),
-        actor,
-    )
-
-    # Observable data layer (#1863): broadcast the deleted subtree so every
-    # window's DocumentStore drops the rows. Best-effort — never breaks delete.
-    emit_change(
-        x_fichero_library_path,
-        type="document.deleted",
-        document_ids=to_delete_ids,
-        actor=actor,
-        origin_window=x_fichero_origin_window,
-        origin_user=actor,
+        ctx.actor,
     )
 
 
@@ -1674,27 +1677,21 @@ async def move_document(
     doc_id: str,
     parent_id: Optional[str] = Query(None),
     db: Database = Depends(get_library_database_for_write),
-    x_fichero_library_path: str = Depends(require_library_path),
-    x_fichero_origin_window: str | None = Header(
-        default=None, alias="X-Fichero-Origin-Window"
-    ),
-    actor: str = Depends(request_actor),
+    ctx: "ActionContext" = Depends(action_context),
 ) -> Document:
     """Move a document to a new parent location.
 
     Accepts parent_id as either a query parameter or in the request body for flexibility.
     """
-    doc, _before = await _run_document_write(move_document_impl, db, doc_id, parent_id)
-    logger.info(f"Moved document: {doc_id} to parent: {parent_id}")
-
-    emit_change(
-        x_fichero_library_path,
-        type="document.updated",
-        document_ids=[doc_id],
-        actor=actor,
-        origin_window=x_fichero_origin_window,
-        origin_user=actor,
+    result = await _run_document_write(
+        registry.invoke,
+        db,
+        "document.move",
+        {"doc_id": doc_id, "parent_id": parent_id},
+        ctx,
     )
+    doc = Document.model_validate(result.result)
+    logger.info(f"Moved document: {doc_id} to parent: {parent_id}")
 
     return doc
 
@@ -2319,11 +2316,15 @@ def _action_create_document(
     db: Database, params: DocumentCreate, ctx: ActionContext
 ) -> tuple[dict, ChangeSpec]:
     new_doc = create_document_impl(db, params)
+    _emit_document_change_ctx(
+        ctx,
+        event_type="document.created",
+        document_ids=[new_doc.id],
+    )
     spec = ChangeSpec(
         domains=["document"],
         target_ids=[new_doc.id],
         after={"document_id": new_doc.id},
-        emit_type="document.created",
         document_ids=[new_doc.id],
     )
     return new_doc.model_dump(mode="json"), spec
@@ -2362,12 +2363,16 @@ def _action_move_document(
     db: Database, params: DocumentMoveParams, ctx: ActionContext
 ) -> tuple[dict, ChangeSpec]:
     doc, before = move_document_impl(db, params.doc_id, params.parent_id)
+    _emit_document_change_ctx(
+        ctx,
+        event_type="document.updated",
+        document_ids=[doc.id],
+    )
     spec = ChangeSpec(
         domains=["document"],
         target_ids=[doc.id],
         before=before,
         after=doc.model_dump(mode="json"),
-        emit_type="document.updated",
         document_ids=[doc.id],
     )
     return doc.model_dump(mode="json"), spec
@@ -2456,12 +2461,16 @@ def _action_delete_document(
     to_delete_ids, document_snapshots = delete_document_impl(
         db, params.doc_id, actor=ctx.actor
     )
+    _emit_document_change_ctx(
+        ctx,
+        event_type="document.deleted",
+        document_ids=to_delete_ids,
+    )
     spec = ChangeSpec(
         domains=["document"],
         target_ids=to_delete_ids,
         before={"documents": document_snapshots},
         after={"document_ids": to_delete_ids},
-        emit_type="document.deleted",
         document_ids=to_delete_ids,
     )
     return {

--- a/fichero-engine/tests/unit/test_api.py
+++ b/fichero-engine/tests/unit/test_api.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 import tempfile
 
+from fichero.models import ActionAudit
 from fichero.models import Document, DocType, FileType, Status, Artifact
 
 
@@ -836,7 +837,9 @@ class TestDocumentHierarchy:
         data = response.json()
         assert data["id"] == sample_doc.id
         assert data["parent_id"] == sample_collection.id
-        mock_db.save.assert_called_once()
+        saved_rows = [call.args[0] for call in mock_db.save.call_args_list]
+        assert sum(isinstance(row, Document) for row in saved_rows) == 1
+        assert sum(isinstance(row, ActionAudit) for row in saved_rows) == 1
 
     def test_move_document_to_root(self, client, mock_db, sample_doc):
         """Move document to root (no parent)."""

--- a/fichero-engine/tests/unit/test_document_actions.py
+++ b/fichero-engine/tests/unit/test_document_actions.py
@@ -46,12 +46,18 @@ def _ctx() -> ActionContext:
 
 @pytest.fixture
 def spy_emit(monkeypatch):
-    """Capture emit_change calls at the SOURCE module the registry imports."""
+    """Capture emit_change calls from both document emit paths.
+
+    The audited create/move/delete actions emit through the documents route
+    module so the route-patched change-stream tests and the action tests observe
+    the same call. Other document actions still use the registry's generic
+    change-stream emit path. Both append into the same sink here.
+    """
     calls: list[tuple] = []
-    monkeypatch.setattr(
-        "fichero.api.change_stream.emit_change",
-        lambda *a, **k: calls.append((a, k)),
-    )
+    def spy(*a, **k):
+        calls.append((a, k))
+    monkeypatch.setattr("fichero.api.routes.documents.emit_change", spy)
+    monkeypatch.setattr("fichero.api.change_stream.emit_change", spy)
     return calls
 
 

--- a/fichero-engine/tests/unit/test_node_model_action_audit.py
+++ b/fichero-engine/tests/unit/test_node_model_action_audit.py
@@ -284,10 +284,6 @@ def test_bookmark_create_route_writes_action_audit(client, db):
     assert audits[0].target_ids == [bookmark_id]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="POST /api/documents still calls create_document_impl directly and writes no ActionAudit row.",
-)
 def test_document_create_route_writes_action_audit(client, db):
     response = client.post("/api/documents", json={"name": "Route Doc"})
     assert response.status_code == 201
@@ -300,10 +296,6 @@ def test_document_create_route_writes_action_audit(client, db):
     assert audits[0].target_ids == [doc_id]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="POST /api/documents with doc_type=folder still calls create_document_impl directly and writes no ActionAudit row.",
-)
 def test_folder_create_route_writes_action_audit(client, db):
     response = client.post(
         "/api/documents",
@@ -319,10 +311,6 @@ def test_folder_create_route_writes_action_audit(client, db):
     assert audits[0].target_ids == [folder_id]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="PUT /api/documents/{doc_id}/move still calls move_document_impl directly and writes no ActionAudit row.",
-)
 def test_document_move_route_writes_action_audit(client, db):
     parent = Document(name="Route Parent", doc_type=DocType.folder)
     child = Document(name="Route Child", doc_type=DocType.file)
@@ -339,10 +327,6 @@ def test_document_move_route_writes_action_audit(client, db):
     assert audits[0].target_ids == [child.id]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="DELETE /api/documents/{doc_id} still calls delete_document_impl directly and writes no ActionAudit row.",
-)
 def test_document_delete_route_writes_action_audit(client, db):
     doc = Document(name="Route Delete Doc", doc_type=DocType.file)
     db.save(doc)

--- a/fichero-engine/tests/unit/test_routes_documents.py
+++ b/fichero-engine/tests/unit/test_routes_documents.py
@@ -14,6 +14,7 @@ import pytest
 
 
 from fichero import storage as storage_module
+from fichero.actions.registry import ActionContext, ActionResult
 from fichero.api.routes import documents as documents_routes
 from fichero.api.routes.documents import related_documents
 from fichero.knowledge_models import (
@@ -38,6 +39,10 @@ def _make_doc(db, name: str = "Test Doc", parent_id: str | None = None) -> Docum
     doc = Document(name=name, parent_id=parent_id, doc_type=DocType.file)
     db.save(doc)
     return doc
+
+
+def _ctx() -> ActionContext:
+    return ActionContext(actor="tester", library_path="/tmp/library.fichero")
 
 
 # ---------------------------------------------------------------------------
@@ -681,50 +686,50 @@ class TestCreateDocument:
     ):
         request = documents_routes.DocumentCreate(name="Threaded Doc")
         doc = Document(id="threaded-doc", name="Threaded Doc", doc_type=DocType.file)
-        to_thread = AsyncMock(return_value=doc)
-        emitted: list[list[str]] = []
+        to_thread = AsyncMock(
+            return_value=ActionResult(
+                ok=True,
+                result=doc.model_dump(mode="json"),
+                audit_id="audit-1",
+                changed_domains=["document"],
+            )
+        )
 
         monkeypatch.setattr(documents_routes.asyncio, "to_thread", to_thread)
-        monkeypatch.setattr(
-            documents_routes,
-            "emit_change",
-            lambda *_args, document_ids, **_kwargs: emitted.append(document_ids),
-        )
 
         result = asyncio.run(
             documents_routes.create_document(
                 doc=request,
                 db=db,
-                x_fichero_library_path="/tmp/library.fichero",
-                actor="tester",
+                ctx=_ctx(),
             )
         )
 
         to_thread.assert_awaited_once()
         assert to_thread.await_args.args == (
-            documents_routes.create_document_impl,
+            documents_routes.registry.invoke,
             db,
-            request,
+            "document.create",
+            request.model_dump(mode="json"),
+            _ctx(),
         )
-        assert result is doc
-        assert emitted == [["threaded-doc"]]
+        assert result.id == doc.id
 
     def test_slow_create_write_does_not_starve_event_loop(self, db, monkeypatch):
         request = documents_routes.DocumentCreate(name="Slow Doc")
         doc = Document(id="slow-doc", name="Slow Doc", doc_type=DocType.file)
-        emitted: list[list[str]] = []
-
-        def slow_create_impl(_db, _request):
+        
+        def slow_invoke(_db, _action_name, _params, _ctx):
             time.sleep(0.05)
-            return doc
+            return ActionResult(
+                ok=True,
+                result=doc.model_dump(mode="json"),
+                audit_id="audit-2",
+                changed_domains=["document"],
+            )
 
         monkeypatch.setattr(
-            documents_routes, "create_document_impl", slow_create_impl
-        )
-        monkeypatch.setattr(
-            documents_routes,
-            "emit_change",
-            lambda *_args, document_ids, **_kwargs: emitted.append(document_ids),
+            documents_routes.registry, "invoke", slow_invoke
         )
 
         async def run_with_probe():
@@ -732,8 +737,7 @@ class TestCreateDocument:
                 documents_routes.create_document(
                     doc=request,
                     db=db,
-                    x_fichero_library_path="/tmp/library.fichero",
-                    actor="tester",
+                    ctx=_ctx(),
                 )
             )
             started_at = time.perf_counter()
@@ -745,15 +749,14 @@ class TestCreateDocument:
         probe_elapsed, result = asyncio.run(run_with_probe())
 
         assert probe_elapsed < 0.04
-        assert result is doc
-        assert emitted == [["slow-doc"]]
+        assert result.id == doc.id
 
     @pytest.mark.parametrize(
-        ("route", "impl", "args", "thread_result"),
+        ("route", "action_name", "args", "thread_result"),
         [
             (
                 documents_routes.update_document,
-                documents_routes.update_document_impl,
+                None,
                 ("doc-1", documents_routes.DocumentUpdate(page_content="updated")),
                 (
                     Document(id="doc-1", name="Doc", page_content="updated"),
@@ -763,59 +766,76 @@ class TestCreateDocument:
             ),
             (
                 documents_routes.move_document,
-                documents_routes.move_document_impl,
+                "document.move",
                 ("doc-1", "parent-1"),
-                (Document(id="doc-1", name="Doc", parent_id="parent-1"), {}),
+                ActionResult(
+                    ok=True,
+                    result=Document(
+                        id="doc-1", name="Doc", parent_id="parent-1"
+                    ).model_dump(mode="json"),
+                    audit_id="audit-move",
+                    changed_domains=["document"],
+                ),
             ),
             (
                 documents_routes.delete_document,
-                documents_routes.delete_document_impl,
+                "document.delete",
                 ("doc-1",),
-                (["doc-1"], []),
+                ActionResult(
+                    ok=True,
+                    result={"deleted_document_ids": ["doc-1"]},
+                    audit_id="audit-delete",
+                    changed_domains=["document"],
+                ),
             ),
         ],
     )
     def test_write_routes_offload_sync_db_work_to_thread(
-        self, db, monkeypatch, route, impl, args, thread_result
+        self, db, monkeypatch, route, action_name, args, thread_result
     ):
         to_thread = AsyncMock(return_value=thread_result)
-        emitted: list[tuple[str, list[str]]] = []
 
         monkeypatch.setattr(documents_routes.asyncio, "to_thread", to_thread)
-        monkeypatch.setattr(
-            documents_routes,
-            "emit_change",
-            lambda *_args, type, document_ids, **_kwargs: emitted.append(
-                (type, document_ids)
-            ),
-        )
 
-        kwargs = {
-            "db": db,
-            "x_fichero_library_path": "/tmp/library.fichero",
-            "actor": "tester",
-        }
-        if route is documents_routes.move_document:
-            kwargs["parent_id"] = args[1]
-            call_args = (args[0],)
-            expected_thread_args = (impl, db, args[0], args[1])
-        elif route is documents_routes.delete_document:
-            call_args = (args[0],)
-            expected_thread_args = (impl, db, args[0])
-        else:
+        if route is documents_routes.update_document:
+            kwargs = {
+                "db": db,
+                "x_fichero_library_path": "/tmp/library.fichero",
+                "actor": "tester",
+            }
             call_args = args
-            expected_thread_args = (impl, db, *args)
+            expected_thread_args = (
+                documents_routes.update_document_impl,
+                db,
+                *args,
+            )
+        elif route is documents_routes.move_document:
+            kwargs = {"db": db, "ctx": _ctx()}
+            call_args = (args[0],)
+            kwargs["parent_id"] = args[1]
+            expected_thread_args = (
+                documents_routes.registry.invoke,
+                db,
+                action_name,
+                {"doc_id": args[0], "parent_id": args[1]},
+                _ctx(),
+            )
+        elif route is documents_routes.delete_document:
+            kwargs = {"db": db, "ctx": _ctx()}
+            call_args = (args[0],)
+            expected_thread_args = (
+                documents_routes.registry.invoke,
+                db,
+                action_name,
+                {"doc_id": args[0]},
+                _ctx(),
+            )
 
         asyncio.run(route(*call_args, **kwargs))
 
         to_thread.assert_awaited_once()
         assert to_thread.await_args.args == expected_thread_args
-        if route is documents_routes.delete_document:
-            assert to_thread.await_args.kwargs == {"actor": "tester"}
-            assert emitted == [("document.deleted", ["doc-1"])]
-        else:
-            assert to_thread.await_args.kwargs == {}
-            assert emitted == [("document.updated", ["doc-1"])]
+        assert to_thread.await_args.kwargs == {}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes the document-domain half of #2789. POST /api/documents, folder-create, PUT move, DELETE now route through the action registry -> ActionAudit while preserving the change-stream emit AND the action effect/undo semantics (one emit location observed by all test families; move still saves exactly once). 4 xfail audit guards flipped to passing. Full unit+contracts suite: 6255 passed, 0 failed.

Co-Authored-By: Daniel Tubb <dtubb@me.com>