### PR TITLE
fix(swiftui): canvas touch targets + chains list primaryAction (#2806)

### DIFF
--- a/fichero/fichero/Views/Spatial/Spatial2DCanvasGestures.swift
+++ b/fichero/fichero/Views/Spatial/Spatial2DCanvasGestures.swift
@@ -24,10 +24,19 @@ extension Spatial2DCanvas {
 
     /// Native corner grab handle shown on a selected item; drag to resize.
     func resizeHandle(for item: CanvasItemDisplay) -> some View {
-        Circle()
+        // Keep the 12pt visual dot but expand the drag target to 44pt on touch
+        // so a finger can grab it (#2806). Mac keeps the precise 12pt target.
+        #if os(macOS)
+        let hitTarget: CGFloat = 12
+        #else
+        let hitTarget: CGFloat = 44
+        #endif
+        return Circle()
             .fill(Color.accentColor)
             .overlay(Circle().stroke(.white, lineWidth: 1.5))
             .frame(width: 12, height: 12)
+            .frame(width: hitTarget, height: hitTarget)
+            .contentShape(Circle())
             .offset(x: 6, y: 6)
             .gesture(resizeGesture(for: item))
             .help("Drag to resize")

--- a/fichero/fichero/Views/Workflow/WorkflowChainListView/ChainListContent.swift
+++ b/fichero/fichero/Views/Workflow/WorkflowChainListView/ChainListContent.swift
@@ -37,40 +37,22 @@ struct ChainListContent: View {
                     }
                 }
             } else {
+                // Native List selection + a selection-aware context menu with a
+                // primaryAction (double-click on Mac, tap-to-open on touch). No
+                // custom tap gesture — a `.onTapGesture(count:2)` on a
+                // `List(selection:)` row fought the built-in selection (#2806).
                 List(filteredChains, selection: $selectedChainIds) { chain in
                     ChainListRow(
                         chain: chain,
                         isExecuting: executingChainId == chain.id
                     )
                     .tag(chain.id)
-                    .contentShape(Rectangle())
-                    .onTapGesture(count: 2) {
-                        onSelectChain(chain.id)
-                    }
-                    .contextMenu {
-                        Button {
-                            onSelectChain(chain.id)
-                        } label: {
-                            Label("View Details", systemImage: "info.circle")
-                        }
-
-                        Button {
-                            onExecuteChain(chain)
-                        } label: {
-                            Label("Execute", systemImage: "play.fill")
-                        }
-
-                        Divider()
-
-                        Button(role: .destructive) {
-                            if selectedChainIds.contains(chain.id) {
-                                onConfirmDeleteSelection()
-                            } else {
-                                onConfirmDelete(chain)
-                            }
-                        } label: {
-                            Label("Delete", systemImage: "trash")
-                        }
+                }
+                .contextMenu(forSelectionType: String.self) { ids in
+                    chainContextMenu(for: ids)
+                } primaryAction: { ids in
+                    if let id = ids.first {
+                        onSelectChain(id)
                     }
                 }
             }
@@ -104,5 +86,42 @@ struct ChainListContent: View {
         #if os(macOS)
         .onDeleteCommand(perform: onConfirmDeleteSelection)
         #endif
+    }
+
+    /// Context menu for the current List selection. A single row offers its
+    /// details / execute / delete; a multi-selection offers delete-all.
+    @ViewBuilder
+    private func chainContextMenu(for ids: Set<String>) -> some View {
+        if ids.count == 1, let id = ids.first {
+            Button {
+                onSelectChain(id)
+            } label: {
+                Label("View Details", systemImage: "info.circle")
+            }
+
+            if let chain = filteredChains.first(where: { $0.id == id }) {
+                Button {
+                    onExecuteChain(chain)
+                } label: {
+                    Label("Execute", systemImage: "play.fill")
+                }
+            }
+
+            Divider()
+
+            Button(role: .destructive) {
+                if let chain = filteredChains.first(where: { $0.id == id }) {
+                    onConfirmDelete(chain)
+                }
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        } else if !ids.isEmpty {
+            Button(role: .destructive) {
+                onConfirmDeleteSelection()
+            } label: {
+                Label("Delete \(ids.count) Chains", systemImage: "trash")
+            }
+        }
     }
 }

--- a/fichero/fichero/Views/Workflow/WorkflowPortView.swift
+++ b/fichero/fichero/Views/Workflow/WorkflowPortView.swift
@@ -42,6 +42,13 @@ struct WorkflowPortView: View {
             }
         }
         .help(portTooltip)
+        #if !os(macOS)
+        // The 12pt port dot is far below the 44pt touch minimum. Keep the small
+        // visual but expand the tappable area to 44pt so a finger can grab the
+        // connection point (#2806). Mac keeps the precise mouse-sized target.
+        .frame(width: 44, height: 44)
+        .contentShape(Circle())
+        #endif
     }
 
     private var portColor: Color {


### PR DESCRIPTION
Two polish-sweep items (#2806):
- Expand workflow/canvas grab-handle touch targets to 44pt on touch platforms (kept 12pt visual).
- Chains list uses native List primaryAction instead of a tap gesture that fights List selection.

Isolated build-for-testing (merged tree): TEST BUILD SUCCEEDED. More #2806 items in progress.

Co-Authored-By: Daniel Tubb <dtubb@me.com>