### PR TITLE
test: harden chat backend coverage (#246)

### DIFF
--- a/fichero-engine/tests/unit/test_llm.py
+++ b/fichero-engine/tests/unit/test_llm.py
@@ -829,6 +829,42 @@ async def test_chat_default_local_only_off_preserves_remote_provider_behavior(mo
     assert result == "remote response"
 
 
+@pytest.mark.asyncio
+async def test_chat_streaming_returns_chunks_from_langchain_stream():
+    from fichero.llm import chat
+
+    config = LLMConfig(provider="openai", model="gpt-5")
+
+    async def fake_stream():
+        for chunk in ("hello", " ", "world"):
+            yield chunk
+
+    fake_model = MagicMock()
+
+    with patch("fichero.llm.get_langchain_model", return_value=fake_model), patch(
+        "fichero.llm._stream_chat_langchain",
+        return_value=fake_stream(),
+    ) as stream_mock:
+        result = await chat("hi", config=config, stream=True)
+        chunks = [chunk async for chunk in result]
+
+    assert chunks == ["hello", " ", "world"]
+    assert stream_mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_chat_propagates_provider_errors_without_fallback():
+    from fichero.llm import chat
+
+    config = LLMConfig(provider="openai", model="gpt-5")
+    fake_model = MagicMock()
+    fake_model.ainvoke = AsyncMock(side_effect=RuntimeError("provider down"))
+
+    with patch("fichero.llm.get_langchain_model", return_value=fake_model):
+        with pytest.raises(RuntimeError, match="provider down"):
+            await chat("hi", config=config)
+
+
 def test_get_langchain_model_reuses_cached_model_for_identical_config(monkeypatch):
     llm._LANGCHAIN_MODEL_CACHE.clear()
     llm._LANGCHAIN_MODEL_CACHE_NO_LOOP.clear()

--- a/fichero-engine/tests/unit/test_routes_chat.py
+++ b/fichero-engine/tests/unit/test_routes_chat.py
@@ -5,6 +5,7 @@ is out of scope here — tests focus on conversation CRUD (list, get, update,
 delete, reorder) and the providers list. Chat routes live at /api/chat/...
 """
 
+import pytest
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from fichero.models import Conversation, DocType, Document
@@ -312,6 +313,91 @@ class TestChatWithSources:
             },
         )
         assert r.status_code == 422
+
+    def test_chat_rejects_empty_message_with_400(self, client):
+        response = client.post("/api/chat", json={"message": "   "})
+
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Message cannot be empty"
+
+    def test_chat_rejects_missing_required_message_field(self, client):
+        response = client.post("/api/chat", json={"include_sources": True})
+
+        assert response.status_code == 422
+
+    def test_chat_surfaces_retrieval_sources_when_present(self, client, monkeypatch):
+        class _FakeRetriever:
+            def retrieve(self, **_kwargs):
+                payload = _FakeRetrievalPayload()
+                payload.context_docs = [
+                    {
+                        "kind": "document",
+                        "id": "doc-1",
+                        "name": "Archive note",
+                        "content": "Ada kept detailed archival notes.",
+                    }
+                ]
+                payload.sources = [
+                    {
+                        "document_id": "doc-1",
+                        "document_name": "Archive note",
+                        "excerpt": "Ada kept detailed archival notes.",
+                        "relevance_score": 0.91,
+                    }
+                ]
+                return payload
+
+        fake_llm = _FakeLLM()
+        monkeypatch.setattr(
+            "fichero.api.routes.chat._get_langchain_llm",
+            lambda *_args, **_kwargs: fake_llm,
+        )
+        monkeypatch.setattr(
+            "fichero.api.routes.chat.GraphAwareRetriever",
+            lambda *_args, **_kwargs: _FakeRetriever(),
+        )
+
+        response = client.post(
+            "/api/chat",
+            json={"message": "What do the notes say?", "include_sources": True},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["sources"] == [
+            {
+                "document_id": "doc-1",
+                "document_name": "Archive note",
+                "excerpt": "Ada kept detailed archival notes.",
+                "relevance_score": 0.91,
+            }
+        ]
+
+    @pytest.mark.xfail(
+        strict=True,
+        reason="Route still swallows LLM/provider failures and returns a 200 apology instead of raising cleanly.",
+    )
+    def test_chat_provider_error_prefers_raise_over_silent_fallback(
+        self, client, monkeypatch
+    ):
+        class _BrokenLLM:
+            def invoke(self, _messages):
+                raise RuntimeError("provider misconfigured")
+
+        monkeypatch.setattr(
+            "fichero.api.routes.chat._get_langchain_llm",
+            lambda *_args, **_kwargs: _BrokenLLM(),
+        )
+
+        response = client.post(
+            "/api/chat",
+            json={
+                "message": "hello",
+                "provider": "openai",
+                "model": "gpt-4o-mini",
+            },
+        )
+
+        assert response.status_code >= 500
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Tests-only. Chat stability/QA coverage: chat endpoint response shape, central chat()/chat_structured() path, provider/config error propagation (prefer-raise, mocked), malformed request handling, retrieval sources. 83 passed, 1 xfail (a chat behavior bug documented).

Co-Authored-By: Daniel Tubb <dtubb@me.com>