### PR TITLE
fix: serialize lazy table reconciliation in Database — concurrency race (#2837)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,1 +1,0 @@
-2026-07-03 #2837: serialized Database._ensure_table under the existing DB lock to eliminate concurrent claim/entity lazy-column races; test_mutation_concurrency.py now fully passes (`6 passed`).

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,1 @@
+2026-07-03 #2837: serialized Database._ensure_table under the existing DB lock to eliminate concurrent claim/entity lazy-column races; test_mutation_concurrency.py now fully passes (`6 passed`).

--- a/fichero-engine/src/fichero/db.py
+++ b/fichero-engine/src/fichero/db.py
@@ -3905,60 +3905,61 @@ class Database(DatabaseEmbeddingMixin):
         table = self._table_name(model)
         sql_table = self._sql_table_name(model)
 
-        if table in self._tables_created:
-            return
+        with self._lock:
+            if table in self._tables_created:
+                return
 
-        # Build column definitions from Pydantic model
-        columns = []
-        for name, field_info in model.model_fields.items():
-            col_type = self._python_to_duckdb_type(field_info.annotation)
-            columns.append(f"{name} {col_type}")
-
-        self._execute(f"""
-            CREATE TABLE IF NOT EXISTS {sql_table} (
-                {", ".join(columns)},
-                PRIMARY KEY (id)
-            )
-        """)
-
-        # Reconcile columns for tables that already existed from an earlier
-        # schema. The 0.0.x no-migration rule says "add the field to the model
-        # and fresh DBs pick it up" — but a pre-existing library (created before
-        # the field was added) keeps its old table and CREATE TABLE IF NOT
-        # EXISTS is a no-op for it. Without this, `save()` of a model with a new
-        # field hits "Table X does not have a column named Y" (e.g.
-        # provenance_chain on a Document table from before that field landed).
-        # ADD COLUMN is non-destructive and idempotent, so this is the generic
-        # mechanism that makes the no-migration rule hold for existing DBs too.
-        try:
-            existing = {
-                row[1]
-                for row in self._execute(f"PRAGMA table_info({sql_table})").fetchall()
-            }
-        except Exception:
-            existing = {
-                row[0]
-                for row in self._execute(
-                    f"SELECT column_name FROM information_schema.columns "
-                    f"WHERE table_name = '{table}'"
-                ).fetchall()
-            }
-        for name, field_info in model.model_fields.items():
-            if name not in existing:
+            # Build column definitions from Pydantic model
+            columns = []
+            for name, field_info in model.model_fields.items():
                 col_type = self._python_to_duckdb_type(field_info.annotation)
-                self._execute(
-                    f"ALTER TABLE {sql_table} ADD COLUMN {name} {col_type}"
+                columns.append(f"{name} {col_type}")
+
+            self._execute(f"""
+                CREATE TABLE IF NOT EXISTS {sql_table} (
+                    {", ".join(columns)},
+                    PRIMARY KEY (id)
                 )
+            """)
 
-        self._tables_created.add(table)
+            # Reconcile columns for tables that already existed from an earlier
+            # schema. The 0.0.x no-migration rule says "add the field to the model
+            # and fresh DBs pick it up" — but a pre-existing library (created before
+            # the field was added) keeps its old table and CREATE TABLE IF NOT
+            # EXISTS is a no-op for it. Without this, `save()` of a model with a new
+            # field hits "Table X does not have a column named Y" (e.g.
+            # provenance_chain on a Document table from before that field landed).
+            # ADD COLUMN is non-destructive and idempotent, so this is the generic
+            # mechanism that makes the no-migration rule hold for existing DBs too.
+            try:
+                existing = {
+                    row[1]
+                    for row in self._execute(f"PRAGMA table_info({sql_table})").fetchall()
+                }
+            except Exception:
+                existing = {
+                    row[0]
+                    for row in self._execute(
+                        f"SELECT column_name FROM information_schema.columns "
+                        f"WHERE table_name = '{table}'"
+                    ).fetchall()
+                }
+            for name, field_info in model.model_fields.items():
+                if name not in existing:
+                    col_type = self._python_to_duckdb_type(field_info.annotation)
+                    self._execute(
+                        f"ALTER TABLE {sql_table} ADD COLUMN {name} {col_type}"
+                    )
 
-        # Apply knowledge-table indices once both knowledgeclaims AND
-        # knowledgeentitys exist. Cheap (each CREATE INDEX IF NOT EXISTS
-        # is a no-op when already present); critical for query latency
-        # at 50K+ claims. (#991 — scaling-review bottleneck 2)
-        if table in {"knowledgeclaims", "knowledgeentitys"}:
-            from fichero.db_migrations import migrate_knowledge_indices
-            migrate_knowledge_indices(self.conn)
+            self._tables_created.add(table)
+
+            # Apply knowledge-table indices once both knowledgeclaims AND
+            # knowledgeentitys exist. Cheap (each CREATE INDEX IF NOT EXISTS
+            # is a no-op when already present); critical for query latency
+            # at 50K+ claims. (#991 — scaling-review bottleneck 2)
+            if table in {"knowledgeclaims", "knowledgeentitys"}:
+                from fichero.db_migrations import migrate_knowledge_indices
+                migrate_knowledge_indices(self.conn)
 
     def _python_to_duckdb_type(self, python_type) -> str:
         """Map Python types to DuckDB types."""

--- a/fichero-engine/tests/unit/test_mutation_concurrency.py
+++ b/fichero-engine/tests/unit/test_mutation_concurrency.py
@@ -157,31 +157,15 @@ class TestAuditedMutationConcurrency:
         assert all(db.get(Document, doc_id).parent_id == parent.id for doc_id in doc_ids)
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason=(
-            "Concurrent claim.create requests can race in Database._ensure_table and "
-            "raise DuckDB CatalogException while adding the knowledgeclaims.id column; "
-            "real concurrency bug, tracked by this stress test."
-        ),
-        strict=True,
-    )
     async def test_claim_create_concurrent_writes_audit_emit_and_rows(
         self, client, db, emit_calls
     ):
-        try:
-            responses = await asyncio.gather(
-                *[
-                    _post_json(client, "/api/claims", {"text": f"Claim {i}"})
-                    for i in range(CLAIM_N)
-                ]
-            )
-        except Exception as exc:  # pragma: no cover - xfail path is the point
-            if "Column with name id already exists!" not in str(exc):
-                raise
-            pytest.xfail(
-                "Reproduced claim.create concurrency race in Database._ensure_table "
-                "(DuckDB CatalogException adding knowledgeclaims.id)."
-            )
+        responses = await asyncio.gather(
+            *[
+                _post_json(client, "/api/claims", {"text": f"Claim {i}"})
+                for i in range(CLAIM_N)
+            ]
+        )
 
         assert all(response.status_code == 200 for response in responses)
         claim_ids = [response.json()["id"] for response in responses]
@@ -191,41 +175,21 @@ class TestAuditedMutationConcurrency:
         emitted_ids = _emitted_claim_ids(emit_calls, "claim.updated")
         assert len(emitted_ids) == CLAIM_N
         assert set(emitted_ids) == set(claim_ids)
-        pytest.xfail(
-            "Known flaky claim.create concurrency race did not reproduce this run; "
-            "keeping strict xfail until Database._ensure_table is serialized."
-        )
 
     @pytest.mark.asyncio
-    @pytest.mark.xfail(
-        reason=(
-            "Concurrent entity.create requests can race in Database._ensure_table and "
-            "raise DuckDB CatalogException while adding the knowledgeentitys.id column; "
-            "real concurrency bug, tracked by this stress test."
-        ),
-        strict=True,
-    )
     async def test_entity_create_concurrent_writes_audit_emit_and_rows(
         self, client, db, emit_calls
     ):
-        try:
-            responses = await asyncio.gather(
-                *[
-                    _post_json(
-                        client,
-                        "/api/entities",
-                        {"canonical_name": f"Entity {i}", "entity_type": "person"},
-                    )
-                    for i in range(ENTITY_N)
-                ]
-            )
-        except Exception as exc:  # pragma: no cover - xfail path is the point
-            if "Column with name id already exists!" not in str(exc):
-                raise
-            pytest.xfail(
-                "Reproduced entity.create concurrency race in Database._ensure_table "
-                "(DuckDB CatalogException adding knowledgeentitys.id)."
-            )
+        responses = await asyncio.gather(
+            *[
+                _post_json(
+                    client,
+                    "/api/entities",
+                    {"canonical_name": f"Entity {i}", "entity_type": "person"},
+                )
+                for i in range(ENTITY_N)
+            ]
+        )
 
         assert all(response.status_code == 200 for response in responses)
         entity_ids = [response.json()["id"] for response in responses]
@@ -235,10 +199,6 @@ class TestAuditedMutationConcurrency:
         emitted_ids = _emitted_entity_ids(emit_calls, "entity.created")
         assert len(emitted_ids) == ENTITY_N
         assert set(emitted_ids) == set(entity_ids)
-        pytest.xfail(
-            "Known flaky entity.create concurrency race did not reproduce this run; "
-            "keeping strict xfail until Database._ensure_table is serialized."
-        )
 
     @pytest.mark.asyncio
     async def test_room_create_concurrent_writes_audit_emit_and_dual_write(


### PR DESCRIPTION
Closes #2837. Concurrent claim.create/entity.create raced in Database._ensure_table while lazily adding the id column, raising DuckDB CatalogException. Serializes the lazy table/column reconciliation so parallel writers no longer race on schema mutation. The 2 concurrency-stress xfails flipped to passing. Full unit+contracts suite: 6332 passed, 0 failed.

Closes #2837

Co-Authored-By: Daniel Tubb <dtubb@me.com>