### PR TITLE
fix: propagate chat provider failures instead of a 200 apology (#2838)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/chat.py
+++ b/fichero-engine/src/fichero/api/routes/chat.py
@@ -394,32 +394,25 @@ async def chat(
     except Exception as e:
         logger.warning(f"Search failed, proceeding without context: {e}")
 
-    # Generate response with LangChain LLM
-    # Pass through request values - _get_langchain_llm handles None by looking up configured providers
-    try:
-        llm = _get_langchain_llm(db, provider=request.provider, model=request.model)
-        # Build model_used string for response
-        provider = request.provider or "auto"
-        model = request.model or "auto"
-        model_used = f"{provider}/{model}"
+    # Generate response with LangChain LLM.
+    # Pass through request values - _get_langchain_llm handles None by looking up configured providers.
+    llm = _get_langchain_llm(db, provider=request.provider, model=request.model)
+    provider = request.provider or "auto"
+    model = request.model or "auto"
+    model_used = f"{provider}/{model}"
 
-        if context_docs:
-            user_prompt = _build_rag_user_prompt(request.message, context_docs)
-        else:
-            user_prompt = f"Question: {request.message}"
+    if context_docs:
+        user_prompt = _build_rag_user_prompt(request.message, context_docs)
+    else:
+        user_prompt = f"Question: {request.message}"
 
-        messages = [
-            SystemMessage(content=_build_chat_system_prompt(bool(context_docs))),
-            HumanMessage(content=user_prompt),
-        ]
+    messages = [
+        SystemMessage(content=_build_chat_system_prompt(bool(context_docs))),
+        HumanMessage(content=user_prompt),
+    ]
 
-        response = llm.invoke(messages)
-        response_text = response.content
-
-    except Exception as e:
-        logger.error(f"LLM generation failed: {e}")
-        response_text = f"I apologize, but I encountered an error while processing your request. Please try again. (Error: {str(e)[:100]})"
-        model_used = "error"
+    response = llm.invoke(messages)
+    response_text = response.content
 
     # Add assistant message
     conv.messages.append({"role": "assistant", "content": response_text})

--- a/fichero-engine/tests/unit/test_routes_chat.py
+++ b/fichero-engine/tests/unit/test_routes_chat.py
@@ -372,10 +372,6 @@ class TestChatWithSources:
             }
         ]
 
-    @pytest.mark.xfail(
-        strict=True,
-        reason="Route still swallows LLM/provider failures and returns a 200 apology instead of raising cleanly.",
-    )
     def test_chat_provider_error_prefers_raise_over_silent_fallback(
         self, client, monkeypatch
     ):
@@ -388,16 +384,15 @@ class TestChatWithSources:
             lambda *_args, **_kwargs: _BrokenLLM(),
         )
 
-        response = client.post(
-            "/api/chat",
-            json={
-                "message": "hello",
-                "provider": "openai",
-                "model": "gpt-4o-mini",
-            },
-        )
-
-        assert response.status_code >= 500
+        with pytest.raises(RuntimeError, match="provider misconfigured"):
+            client.post(
+                "/api/chat",
+                json={
+                    "message": "hello",
+                    "provider": "openai",
+                    "model": "gpt-4o-mini",
+                },
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #2838. The chat route caught LLM/provider failures and returned a 200 with an apology, hiding outages/misconfig. Now provider/config errors propagate as proper errors (prefer-raise); genuine user-facing validation stays 4xx. The chat-swallow xfail flipped to passing. Full unit+contracts suite: 6333 passed, 0 failed.

Closes #2838

Co-Authored-By: Daniel Tubb <dtubb@me.com>