### PR TITLE
test: multiuser authz enforcement on audited mutations (#2841)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,1 @@
+2026-07-03 Codex: added multiuser authz coverage for audited note/document/claim/entity/room creates; viewer denied with no audit/state change and editor allowed, targeted pytest green.

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,1 +1,0 @@
-2026-07-03 Codex: added multiuser authz coverage for audited note/document/claim/entity/room creates; viewer denied with no audit/state change and editor allowed, targeted pytest green.

--- a/fichero-engine/tests/unit/test_mutation_authz.py
+++ b/fichero-engine/tests/unit/test_mutation_authz.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from urllib.parse import quote
+
+import pytest
+from fastapi.testclient import TestClient
+
+from fichero import accounts, authz
+from fichero.knowledge_models import Note
+from fichero.models import ActionAudit, AccountUser, Document, KnowledgeClaim, KnowledgeEntity
+from fichero.spatial_models import SpatialRoom
+
+
+@pytest.fixture
+def users(app_db):
+    owner = app_db.create_user(
+        username="owner",
+        display_name="Owner",
+        password_hash=accounts.hash_password("password"),
+        is_owner=True,
+    )
+    editor = app_db.create_user(
+        username="editor",
+        display_name="Editor",
+        password_hash=accounts.hash_password("password"),
+    )
+    viewer = app_db.create_user(
+        username="viewer",
+        display_name="Viewer",
+        password_hash=accounts.hash_password("password"),
+    )
+    return SimpleNamespace(owner=owner, editor=editor, viewer=viewer)
+
+
+def _grant(app_db, user: AccountUser, library_path: str, role: str) -> None:
+    app_db.set_library_role(
+        user_id=user.id,
+        library_path=authz.normalize_library_path(library_path),
+        role=role,
+    )
+
+
+@pytest.fixture
+def multiuser_client(test_package, app_db, monkeypatch):
+    monkeypatch.setenv("FICHERO_MULTIUSER", "1")
+    monkeypatch.setenv("FICHERO_DISABLE_AUTH", "0")
+
+    import fichero.api.main as api_main
+
+    api_main = importlib.reload(api_main)
+    client = TestClient(
+        api_main.app,
+        headers={"X-Fichero-Library-Path": quote(str(test_package), safe="/")},
+    )
+
+    def _login(username: str) -> dict[str, str]:
+        response = client.post(
+            "/api/auth/login",
+            json={"username": username, "password": "password"},
+        )
+        assert response.status_code == 200
+        token = response.json()["session_token"]
+        return {"Authorization": f"Bearer {token}"}
+
+    try:
+        yield client, _login, str(test_package)
+    finally:
+        client.close()
+        api_main.app.dependency_overrides.clear()
+        monkeypatch.setenv("FICHERO_DISABLE_AUTH", "1")
+        importlib.reload(api_main)
+
+
+def _room_document_count(db) -> int:
+    return len([doc for doc in db.all(Document) if doc.node_kind == "room"])
+
+
+CASES = [
+    {
+        "id": "note",
+        "path": "/api/notes",
+        "payload": {"title": "ACL Note", "body": "Denied for viewer"},
+        "status_code": 200,
+        "action_name": "note.create",
+        "snapshot": lambda db: len(db.all(Note)),
+    },
+    {
+        "id": "document",
+        "path": "/api/documents",
+        "payload": {"name": "ACL Document"},
+        "status_code": 201,
+        "action_name": "document.create",
+        "snapshot": lambda db: len(db.all(Document)),
+    },
+    {
+        "id": "claim",
+        "path": "/api/claims",
+        "payload": {"text": "ACL Claim"},
+        "status_code": 200,
+        "action_name": "claim.create",
+        "snapshot": lambda db: len(db.all(KnowledgeClaim)),
+    },
+    {
+        "id": "entity",
+        "path": "/api/entities",
+        "payload": {"canonical_name": "ACL Entity", "entity_type": "person"},
+        "status_code": 200,
+        "action_name": "entity.create",
+        "snapshot": lambda db: len(db.all(KnowledgeEntity)),
+    },
+    {
+        "id": "room",
+        "path": "/api/mind-palace/rooms",
+        "payload": {"name": "ACL Room", "room_type": "research"},
+        "status_code": 200,
+        "action_name": "room.create",
+        "snapshot": lambda db: (len(db.all(SpatialRoom)), _room_document_count(db)),
+    },
+]
+
+
+@pytest.mark.parametrize("case", CASES, ids=[case["id"] for case in CASES])
+def test_audited_create_mutations_enforce_multiuser_write_authz(
+    case, db, app_db, users, multiuser_client
+):
+    client, login, library_path = multiuser_client
+    _grant(app_db, users.viewer, library_path, "viewer")
+    _grant(app_db, users.editor, library_path, "editor")
+
+    viewer_headers = login("viewer")
+    editor_headers = login("editor")
+
+    before_state = case["snapshot"](db)
+    before_audits = len(db.all(ActionAudit))
+
+    denied = client.post(case["path"], headers=viewer_headers, json=case["payload"])
+    assert denied.status_code == 403
+    assert case["snapshot"](db) == before_state
+    assert len(db.all(ActionAudit)) == before_audits
+
+    allowed = client.post(case["path"], headers=editor_headers, json=case["payload"])
+    assert allowed.status_code == case["status_code"]
+    assert case["snapshot"](db) != before_state
+
+    audits = db.all(ActionAudit)
+    assert len(audits) == before_audits + 1
+    assert audits[-1].action_name == case["action_name"]
+    assert audits[-1].actor == "editor"


### PR DESCRIPTION
Tests-only. Verifies the ACL choke-point enforces authz on all 5 audited mutation domains: under FICHERO_MULTIUSER, an actor without write permission is denied (no ActionAudit, no state change) on note/document/claim/entity/room create; authorized actor succeeds. 5 passed — enforcement confirmed (no gap).

Co-Authored-By: Daniel Tubb <dtubb@me.com>