### PR TITLE
a11y(reader): VoiceOver labels for icon-only reader controls (#2804)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -11,7 +11,16 @@
 - SidebarViewExtensions bottom action bar (New Item, Remove, Export, Import Files, New Workflow menus/buttons) + SidebarView+ViewComponents filter clear button.
 - SKIPPED: PinnedNavigationRows (Label-based: Chat with Docs etc.), filter magnifying-glass (decorative).
 
-### STOPPED HERE. REMAINING (inspector panes pass — ~15+ icon buttons with .help, no label):
-ArtifactListView, ArtifactsInspectorPane, CitationsInspectorPane, AnnotationsInspectorPane, DocumentInspector, DocumentInspectorArtifactsTab+KGSection (4), DocumentInspectorArtifactsTab+EntitiesTab (3), FocusedDocument (detail windows). Same approach (help→accessibilityLabel; skip Label/decorative). Recommend one commit for the inspector pass.
+### Inspector — DONE (commit b9244510)
+- DocumentInspector tab-picker buttons (tab.rawValue), ArtifactListView "Reviewed" seal, DocumentInspectorArtifactsTab+KGSection (filter kinds, text digest, list view, reload — 4), DocumentInspectorArtifactsTab+EntitiesTab (reload, filter kinds — 2).
+- SKIPPED (already Label-based/decorative): ArtifactsInspectorPane pin Toggle, CitationsInspectorPane / AnnotationsInspectorPane "Open in Window" toggles, FocusedDocument back button — all use Label(_, systemImage:).
 
-macOS build green for both committed passes; a11y is cross-platform so it also benefits iOS VoiceOver. NOT pushed.
+### Reader — DONE (commit <this>)
+- ImageViewerComponents iOS (#elseif canImport(UIKit)) in-content controls: Zoom Out, Zoom In, Fit to Window, Actual Size, folder Previous/Next image.
+- SKIPPED: View/Close Full Screen (already had labels); macOS reader controls covered by ReaderToolbar in the toolbars pass; AnnotationToolbar (all Label-based); PDFPageWithToolbar/PageContentPane (no icon-only .help buttons).
+- NOTE: reader edits sit in the iOS-only branch, so the macOS build doesn't compile them — file still compiles as a whole for macOS; manager's iOS build gate exercises the branch.
+
+macOS build green for all four passes (only the environmental Embed Fichero Engine script phase fails, no swiftc errors); a11y is cross-platform so it also benefits iOS VoiceOver. NOT pushed.
+
+## #2838 — chat route error propagation — 2026-07-03, f_fichero_codex_docs
+Removed the `/api/chat` fake-success apology fallback so provider/LLM failures now propagate instead of returning a misleading 200; flipped the former strict-`xfail` repro in `test_routes_chat.py` to a passing prefer-raise assertion. Targeted gate: `PYTHONPATH=fichero-engine/src /Users/danieltubb/code/fichero/.venv/bin/pytest fichero-engine/tests/unit/test_routes_chat.py -q` → `24 passed`.

--- a/fichero/fichero/Views/Library/ImageViewerComponents.swift
+++ b/fichero/fichero/Views/Library/ImageViewerComponents.swift
@@ -610,6 +610,7 @@ struct ZoomableImagePreview: View {
                     }
                     .buttonStyle(.plain)
                     .help("Zoom Out")
+                    .accessibilityLabel("Zoom Out")
 
                     Text("\(Int(scale * 100))%")
                         .font(.caption)
@@ -621,6 +622,7 @@ struct ZoomableImagePreview: View {
                     }
                     .buttonStyle(.plain)
                     .help("Zoom In")
+                    .accessibilityLabel("Zoom In")
 
                     Divider()
                         .frame(height: 16)
@@ -630,12 +632,14 @@ struct ZoomableImagePreview: View {
                     }
                     .buttonStyle(.plain)
                     .help("Fit to Window")
+                    .accessibilityLabel("Fit to Window")
 
                     Button(action: actualSize) {
                         Image(systemName: "1.square")
                     }
                     .buttonStyle(.plain)
                     .help("Actual Size (100%)")
+                    .accessibilityLabel("Actual Size (100%)")
 
                     // Immersive full-screen entry on iPad regular width too, not
                     // just iPhone-compact. Reuses the #2607 FullScreenImagePreview
@@ -712,6 +716,7 @@ struct ZoomableImagePreview: View {
                         .buttonStyle(.borderedProminent)
                         .disabled(previousAction == nil)
                         .help("Show the previous image in this folder")
+                        .accessibilityLabel("Previous image")
                         .accessibilityIdentifier("folderImagePrev")
 
                         Button {
@@ -724,6 +729,7 @@ struct ZoomableImagePreview: View {
                         .buttonStyle(.borderedProminent)
                         .disabled(nextAction == nil)
                         .help("Show the next image in this folder")
+                        .accessibilityLabel("Next image")
                         .accessibilityIdentifier("folderImageNext")
                     }
                     .padding(.bottom, 16)


### PR DESCRIPTION
Final pass of #2804 — VoiceOver labels on the reader's icon-only controls, completing the accessibility-label sweep across toolbars, sidebar, inspector, and reader. Isolated build-for-testing: TEST BUILD SUCCEEDED.

Closes #2804

Co-Authored-By: Daniel Tubb <dtubb@me.com>