### PR TITLE
fix: audit entity/note update+delete mutations via registry (#2849)

### DIFF
--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,0 +1,1 @@
+2026-07-03 Codex: routed entity.patch + note.patch/delete through registry.invoke so audit + emit now both hold; targeted pytest set green (112 passed).

--- a/WORKER-REPORT.md
+++ b/WORKER-REPORT.md
@@ -1,1 +1,0 @@
-2026-07-03 Codex: routed entity.patch + note.patch/delete through registry.invoke so audit + emit now both hold; targeted pytest set green (112 passed).

--- a/fichero-engine/src/fichero/api/routes/entities.py
+++ b/fichero-engine/src/fichero/api/routes/entities.py
@@ -900,11 +900,12 @@ async def patch_entity(
     entity_id: str,
     request: EntityPatchRequest,
     db: Database = Depends(get_library_database_for_write),
-    x_fichero_library_path: str = Depends(require_library_path),
-    x_fichero_origin_window: str | None = Header(
+    x_fichero_library_path: str | object = Depends(require_library_path),
+    x_fichero_origin_window: str | object | None = Header(
         default=None, alias="X-Fichero-Origin-Window"
     ),
-    actor: str = Depends(request_actor),
+    actor: str | object = Depends(request_actor),
+    ctx: ActionContext | object = Depends(action_context),
 ) -> KnowledgeEntity:
     """Partial-update a knowledge entity.
 
@@ -914,85 +915,42 @@ async def patch_entity(
     entity = db.get(KnowledgeEntity, entity_id)
     if entity is None:
         raise HTTPException(status_code=404, detail=f"Entity not found: {entity_id}")
-
-    # Snapshot the before-state for the MutationLog so this edit is
-    # reversible via /api/kg/undo. (#901)
-    before_state = entity.model_dump(mode="json")
-
-    changed_fields: list[str] = []
-    if request.canonical_name is not None:
-        entity.canonical_name = request.canonical_name.strip()
-        changed_fields.append("canonical_name")
-    if request.entity_type is not None:
-        entity.entity_type = request.entity_type
-        changed_fields.append("entity_type")
-    if request.aliases is not None:
-        entity.aliases = sorted(set(a.strip() for a in request.aliases if a.strip()))
-        changed_fields.append("aliases")
-    if request.description is not None:
-        entity.description = request.description
-        changed_fields.append("description")
-    if request.language is not None:
-        entity.language = request.language
-        changed_fields.append("language")
-    if request.metadata is not None:
-        entity.metadata = request.metadata
-        changed_fields.append("metadata")
-    entity.updated_at = datetime.now()
-    db.save(entity)
-
-    # Mutation log row — captures before + after for undo.
-    try:
-        from fichero.knowledge_models import MutationLog, MutationOperationType
-
-        db.save(
-            MutationLog(
-                entity_type="KnowledgeEntity",
-                entity_id=entity.id,
-                operation=MutationOperationType.update,
-                before_state=before_state,
-                after_state=entity.model_dump(mode="json"),
-                changed_fields=changed_fields,
-            )
-        )
-    except Exception as exc:
-        import logging
-
-        logging.getLogger(__name__).warning(
-            "patch_entity: mutation log write failed: %s", exc
-        )
-
-    # Refresh the LanceDB vector so cosine search reflects the edit.
-    try:
-        from fichero.kg import entity_vectors
-
-        entity_vectors.index_entity(
-            db=db,
-            entity_id=entity.id,
-            entity_type=entity.entity_type,
-            canonical_name=entity.canonical_name,
-            description=entity.description,
-        )
-    except Exception as exc:
-        # Don't fail the API call if vector refresh fails — the
-        # DuckDB row is the canonical store.
-        import logging
-
-        logging.getLogger(__name__).warning(
-            "patch_entity: vector refresh failed for %s: %s", entity.id, exc
-        )
-
-    # Observable data layer (#1863): broadcast the edit so every window's
-    # EntityStore refreshes. Best-effort.
-    emit_change(
-        x_fichero_library_path,
-        type="entity.updated",
-        entity_ids=[entity.id],
+    ctx = _resolve_action_ctx(
+        ctx,
         actor=actor,
+        library_path=x_fichero_library_path,
         origin_window=x_fichero_origin_window,
-        origin_user=actor,
     )
-    return entity
+    result = registry.invoke(
+        db,
+        "entity.update",
+        {
+            "entity_id": entity_id,
+            "canonical_name": (
+                request.canonical_name
+                if request.canonical_name is not None
+                else entity.canonical_name
+            ),
+            "entity_type": (
+                request.entity_type
+                if request.entity_type is not None
+                else entity.entity_type
+            ),
+            "aliases": request.aliases if request.aliases is not None else entity.aliases,
+            "description": (
+                request.description
+                if request.description is not None
+                else entity.description
+            ),
+            "language": (
+                request.language if request.language is not None else entity.language
+            ),
+            "metadata": request.metadata if request.metadata is not None else entity.metadata,
+            "source_document_ids": entity.source_document_ids or [],
+        },
+        ctx,
+    )
+    return KnowledgeEntity.model_validate(result.result)
 
 
 @router.delete("/{entity_id}", status_code=204)

--- a/fichero-engine/src/fichero/api/routes/notes.py
+++ b/fichero-engine/src/fichero/api/routes/notes.py
@@ -271,22 +271,18 @@ async def patch_note(
     note_id: str,
     request: NotePatchRequest,
     db: Database = Depends(get_library_database_for_write),
-    x_fichero_library_path: str = Depends(require_library_path),
-    x_fichero_origin_window: str | None = Header(
-        default=None, alias="X-Fichero-Origin-Window"
-    ),
-    actor: str = Depends(request_actor),
+    ctx: "ActionContext" = Depends(action_context),
 ) -> Note:
-    note, _before = patch_note_impl(db, note_id, request)
-    emit_change(
-        x_fichero_library_path,
-        type="note.updated",
-        document_ids=_note_scope_document_ids(note),
-        actor=actor,
-        origin_window=x_fichero_origin_window,
-        origin_user=actor,
+    result = registry.invoke(
+        db,
+        "note.update",
+        {
+            "note_id": note_id,
+            "update": request.model_dump(mode="json", exclude_unset=True),
+        },
+        ctx,
     )
-    return note
+    return Note.model_validate(result.result)
 
 
 def delete_note_impl(db: Database, note_id: str) -> tuple[list[str], dict]:
@@ -321,21 +317,9 @@ def restore_note_impl(db: Database, snapshot: dict) -> Note:
 async def delete_note(
     note_id: str,
     db: Database = Depends(get_library_database_for_write),
-    x_fichero_library_path: str = Depends(require_library_path),
-    x_fichero_origin_window: str | None = Header(
-        default=None, alias="X-Fichero-Origin-Window"
-    ),
-    actor: str = Depends(request_actor),
+    ctx: "ActionContext" = Depends(action_context),
 ) -> None:
-    document_ids, _before = delete_note_impl(db, note_id)
-    emit_change(
-        x_fichero_library_path,
-        type="note.deleted",
-        document_ids=document_ids,
-        actor=actor,
-        origin_window=x_fichero_origin_window,
-        origin_user=actor,
-    )
+    registry.invoke(db, "note.delete", {"note_id": note_id}, ctx)
 
 
 # =============================================================================

--- a/fichero-engine/tests/unit/test_mutation_audit_lock.py
+++ b/fichero-engine/tests/unit/test_mutation_audit_lock.py
@@ -249,30 +249,9 @@ def test_node_model_create_routes_write_audit_and_emit_change(
         ("claim.patch", _patch_claim),
         ("claim.delete", _delete_claim),
         ("entity.upsert", _entity_upsert_update),
-        pytest.param(
-            "entity.patch",
-            _patch_entity,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="PATCH /api/entities/{entity_id} still updates directly on main and does not write entity.update ActionAudit.",
-            ),
-        ),
-        pytest.param(
-            "note.patch",
-            _patch_note,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="PATCH /api/notes/{note_id} still bypasses registry.invoke on main and does not write note.update ActionAudit.",
-            ),
-        ),
-        pytest.param(
-            "note.delete",
-            _delete_note,
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="DELETE /api/notes/{note_id} still bypasses registry.invoke on main and does not write note.delete ActionAudit.",
-            ),
-        ),
+        ("entity.patch", _patch_entity),
+        ("note.patch", _patch_note),
+        ("note.delete", _delete_note),
         ("room.update", _update_room),
         ("room.delete", _delete_room),
     ],

--- a/fichero-engine/tests/unit/test_node_model_action_audit.py
+++ b/fichero-engine/tests/unit/test_node_model_action_audit.py
@@ -357,10 +357,6 @@ def test_entity_create_route_writes_action_audit(client, db):
     assert audits[0].target_ids == [entity_id]
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="PATCH /api/entities/{entity_id} updates entities directly and no entity.update audited action exists yet.",
-)
 def test_entity_patch_route_writes_action_audit(client, db):
     entity = KnowledgeEntity(canonical_name="Before Patch")
     db.save(entity)


### PR DESCRIPTION
Closes #2849. Routes PATCH /api/entities/{id} (entity.update), PATCH /api/notes/{id} (note.update), DELETE /api/notes/{id} (note.delete) through registry.invoke -> ActionAudit + emit_change — the last audit-coverage gaps. All 3 audit-lock xfails flipped to passing; also cleared a duplicate now-passing xfail in test_node_model_action_audit.py. Full unit+contracts suite: 6361 passed, 0 failed.

With this the audit sweep covers CREATE + UPDATE + DELETE + UPSERT across notes/documents/claims/entities/rooms.

Closes #2849

Co-Authored-By: Daniel Tubb <dtubb@me.com>