### PR TITLE
fix: scrub pairing-code secret from validation error, pairing-scoped (#2851)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/pairing.py
+++ b/fichero-engine/src/fichero/api/routes/pairing.py
@@ -10,6 +10,9 @@ import secrets
 import sys
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
+from fastapi.routing import APIRoute
 from pydantic import BaseModel, Field
 
 from fichero import accounts
@@ -26,7 +29,34 @@ PAIRING_RATE_LIMIT = 5
 PAIRING_RATE_WINDOW = timedelta(minutes=1)
 _PAIRING_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"
 
-router = APIRouter(prefix="/pair", tags=["pairing"])
+
+class _PairingValidationRoute(APIRoute):
+    """Route-local validation scrub for pairing secrets.
+
+    Keep FastAPI's default 422 shape everywhere else; only /api/pair* gets a
+    scrubbed response so malformed pairing submissions never reflect the code.
+    """
+
+    def get_route_handler(self):
+        original = super().get_route_handler()
+
+        async def custom_route_handler(request: Request):
+            try:
+                return await original(request)
+            except RequestValidationError:
+                return JSONResponse(
+                    status_code=422,
+                    content={"detail": "invalid pairing request"},
+                )
+
+        return custom_route_handler
+
+
+router = APIRouter(
+    prefix="/pair",
+    tags=["pairing"],
+    route_class=_PairingValidationRoute,
+)
 
 
 @dataclass

--- a/fichero-engine/tests/unit/test_device_auth_boundary.py
+++ b/fichero-engine/tests/unit/test_device_auth_boundary.py
@@ -107,10 +107,6 @@ def test_pairing_owner_endpoints_reject_non_owner_session_scope_with_403(
         _assert_no_secret_leak(response, session_token)
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Validation 422 echoes the submitted pairing code in the error payload; route should reject malformed input without secret reflection.",
-)
 def test_pair_route_malformed_requests_stay_4xx_and_do_not_leak_secrets(
     auth_client, app_db
 ):


### PR DESCRIPTION
Closes #2851. The device pairing route no longer echoes the submitted pairing code (a secret) in its 422 validation error. Scoped to pairing.py only — no global exception handler (an earlier over-broad attempt changed 422 shapes app-wide), pair_device() signature unchanged, shipped adversarial pairing tests (test_pairing_auth_fork_adversarial.py) pass unchanged. The device-auth secret-reflection xfail flipped to passing. Full unit+contracts suite: 6366 passed, 0 failed.

Closes #2851

Co-Authored-By: Daniel Tubb <dtubb@me.com>