### PR TITLE
fix(app): default multi-user OFF so the app authenticates to its own backend

### DIFF
--- a/fichero/fichero/Services/EngineConfig.swift
+++ b/fichero/fichero/Services/EngineConfig.swift
@@ -176,7 +176,11 @@ enum EngineConfig {
     static var multiuserEnabled: Bool {
         let defaults = UserDefaults.standard
         guard defaults.object(forKey: multiuserEnabledKey) != nil else {
-            return true
+            // Default OFF: multi-user is a shared/multi-person feature and the frontend
+            // has no login flow yet (#2022 auth is cli-only). Defaulting ON spawns the
+            // backend with FICHERO_MULTIUSER=1, whose fail-closed ACL choke-point then
+            // 401/403s the app's own requests so no library loads.
+            return false
         }
         return defaults.bool(forKey: multiuserEnabledKey)
     }


### PR DESCRIPTION
Multi-user defaulted ON (EngineConfig.multiuserEnabled), spawning the embedded backend with FICHERO_MULTIUSER=1 whose fail-closed ACL choke-point then 401/403'd the app's own requests — no login UI exists yet (#2022 auth is cli-only), so no library loaded and the window stayed empty. Defaults OFF until the login UX ships (in progress). Isolated build-for-testing: TEST BUILD SUCCEEDED.

Stopgap — the permanent fix is the multi-user login UX (so ON works); the default will flip back once login exists.

Co-Authored-By: Daniel Tubb <dtubb@me.com>