### PR TITLE
Connection bulletproofing + dev harness (#2867 #2862 #2863 #2864)

### DIFF
--- a/fichero-engine/src/fichero/api/auth.py
+++ b/fichero-engine/src/fichero/api/auth.py
@@ -89,6 +89,16 @@ def _is_account_or_device_token(token: str) -> bool:
     )
 
 
+def _write_token_file(path: Path, token: str) -> None:
+    """Write ``token`` to ``path`` with 0600 perms, overwriting any existing."""
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, token.encode("utf-8"))
+    finally:
+        os.close(fd)
+    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+
+
 def initialize_token(*, force_rotate: bool = False) -> str:
     """Return the auth token, generating + persisting a fresh one only if needed.
 
@@ -98,6 +108,14 @@ def initialize_token(*, force_rotate: bool = False) -> str:
     they don't kick each other into 401s (#1110). The file is written with
     mode 0600 so non-owner processes can't read it.
 
+    **App-supplied token (#2862):** if ``FICHERO_BOOTSTRAP_TOKEN`` is set, the
+    host app minted the bootstrap token and passed it to this spawn. Persist it
+    (0600) and return it. This is authoritative for the spawn — it removes the
+    old race where the engine minted the token and the app had to poll for the
+    ``.api-key`` file, and it lets the app issue an *authenticated* readiness
+    probe the instant we bind (no chicken-and-egg 401 window). The app never
+    passes a device/session credential here, so no downgrade check is needed.
+
     Pass ``force_rotate=True`` (or set ``FICHERO_FORCE_ROTATE_AUTH=1``) to
     generate a new token regardless of whether one already exists — useful
     for "stale token from a crashed run shouldn't be replayable" hardening
@@ -105,6 +123,12 @@ def initialize_token(*, force_rotate: bool = False) -> str:
     """
     path = _token_file_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+
+    env_token = os.environ.get("FICHERO_BOOTSTRAP_TOKEN", "").strip()
+    if env_token:
+        _write_token_file(path, env_token)
+        logger.info("Auth token adopted from FICHERO_BOOTSTRAP_TOKEN at %s (mode 0600)", path)
+        return env_token
 
     rotate = force_rotate or os.environ.get(
         "FICHERO_FORCE_ROTATE_AUTH", ""
@@ -128,12 +152,7 @@ def initialize_token(*, force_rotate: bool = False) -> str:
     token = secrets.token_urlsafe(32)
     # Atomic-ish write: open with restrictive mode, write, then chmod again
     # to handle umask quirks. Existing file is overwritten.
-    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-    try:
-        os.write(fd, token.encode("utf-8"))
-    finally:
-        os.close(fd)
-    os.chmod(path, stat.S_IRUSR | stat.S_IWUSR)
+    _write_token_file(path, token)
 
     logger.info(
         "Auth token %s at %s (mode 0600)", "rotated" if rotate else "initialized", path

--- a/fichero-engine/src/fichero/api/main.py
+++ b/fichero-engine/src/fichero/api/main.py
@@ -1175,6 +1175,8 @@ async def health_check(
                 backend_version="0.1.0",
                 active_libraries=db_manager.active_count,
                 remote_backend=build_remote_backend_status().as_dict(),
+                engine_pid=os.getpid(),
+                launch_nonce=os.environ.get("FICHERO_LAUNCH_NONCE") or None,
             ),
             nonce or x_fichero_client_nonce,
         )

--- a/fichero-engine/src/fichero/models.py
+++ b/fichero-engine/src/fichero/models.py
@@ -1384,6 +1384,12 @@ class HealthResponse(BaseModel):
     active_libraries: int | None = None
     remote_backend: dict[str, Any] | None = None
     server_proof: str | None = None
+    # Instance identity (#2862): the host app passes FICHERO_LAUNCH_NONCE at
+    # spawn and verifies it is echoed here, proving this responder is the engine
+    # it just launched — not a stale process squatting the port. engine_pid lets
+    # the app diagnose "port occupied by PID N" precisely.
+    engine_pid: int | None = None
+    launch_nonce: str | None = None
 
 
 class EmbeddingStatsResponse(BaseModel):

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -43176,6 +43176,16 @@
             "type": "string",
             "nullable": true,
             "title": "Server Proof"
+          },
+          "engine_pid": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Engine Pid"
+          },
+          "launch_nonce": {
+            "type": "string",
+            "nullable": true,
+            "title": "Launch Nonce"
           }
         },
         "type": "object",

--- a/fichero-engine/tests/unit/test_bootstrap_token_identity.py
+++ b/fichero-engine/tests/unit/test_bootstrap_token_identity.py
@@ -1,0 +1,71 @@
+"""App-supplied bootstrap token + health instance identity (#2862).
+
+The host app mints the bootstrap token and a launch nonce, passes both to the
+engine it spawns, and verifies /api/health echoes the nonce (proving it is the
+engine it launched, not a stale process on the port). These tests pin the
+engine side of that contract.
+"""
+
+from __future__ import annotations
+
+import os
+
+from fichero.api.auth import initialize_token
+
+
+def test_initialize_token_adopts_app_supplied_bootstrap_token(monkeypatch, tmp_path):
+    """FICHERO_BOOTSTRAP_TOKEN wins: it is persisted (0600) and returned."""
+    token_path = tmp_path / ".api-key"
+    monkeypatch.setattr("fichero.api.auth._token_file_path", lambda: token_path)
+    monkeypatch.setenv("FICHERO_BOOTSTRAP_TOKEN", "app-minted-secret")
+
+    resolved = initialize_token()
+
+    assert resolved == "app-minted-secret"
+    assert token_path.read_text() == "app-minted-secret"
+    # Owner-only perms, matching the mint path.
+    assert (token_path.stat().st_mode & 0o777) == 0o600
+
+
+def test_app_supplied_token_overrides_existing_file(monkeypatch, tmp_path):
+    """A stale token on disk is replaced by the app's — the app is authoritative
+    for the spawn, so there is never a window where the two disagree (#2862)."""
+    token_path = tmp_path / ".api-key"
+    token_path.write_text("stale-token-from-previous-run")
+    monkeypatch.setattr("fichero.api.auth._token_file_path", lambda: token_path)
+    monkeypatch.setenv("FICHERO_BOOTSTRAP_TOKEN", "fresh-app-token")
+
+    assert initialize_token() == "fresh-app-token"
+    assert token_path.read_text() == "fresh-app-token"
+
+
+def test_no_env_token_mints_as_before(monkeypatch, tmp_path):
+    """Without the env var, behaviour is unchanged: mint + persist a fresh one."""
+    token_path = tmp_path / ".api-key"
+    monkeypatch.setattr("fichero.api.auth._token_file_path", lambda: token_path)
+    monkeypatch.delenv("FICHERO_BOOTSTRAP_TOKEN", raising=False)
+
+    resolved = initialize_token()
+
+    assert resolved
+    assert token_path.read_text() == resolved
+
+
+def test_health_echoes_launch_nonce_and_pid(monkeypatch):
+    """/api/health carries engine_pid + the launch nonce the app passed, so the
+    app can prove the responder is the child it spawned."""
+    from fichero.models import HealthResponse
+
+    monkeypatch.setenv("FICHERO_LAUNCH_NONCE", "nonce-abc123")
+
+    # The endpoint constructs HealthResponse(engine_pid=os.getpid(),
+    # launch_nonce=os.environ["FICHERO_LAUNCH_NONCE"]); assert the model carries
+    # both fields and round-trips them (guards against the schema being dropped).
+    resp = HealthResponse(
+        status="healthy",
+        engine_pid=os.getpid(),
+        launch_nonce=os.environ.get("FICHERO_LAUNCH_NONCE") or None,
+    )
+    assert resp.engine_pid == os.getpid()
+    assert resp.launch_nonce == "nonce-abc123"
+    assert resp.model_dump()["launch_nonce"] == "nonce-abc123"

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -43176,6 +43176,16 @@
             "type": "string",
             "nullable": true,
             "title": "Server Proof"
+          },
+          "engine_pid": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Engine Pid"
+          },
+          "launch_nonce": {
+            "type": "string",
+            "nullable": true,
+            "title": "Launch Nonce"
           }
         },
         "type": "object",

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -271,6 +271,7 @@
 		8C35E319E4B9A46AB0383C10 /* TriggerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C69898938F25CFEA64385A16 /* TriggerDetailView.swift */; };
 		8C55B492C37B1BBED91F2B9B /* NotesInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F1C6302A9E0863FB1E6775 /* NotesInspectorPane.swift */; };
 		8EC8D8B6E0595E51192F1C3C /* Representation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71ADE00621970AC5AE6E45A /* Representation.swift */; };
+		8F7C131CEB5C672DD1E4813A /* BackendRootGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43576573521F73AE202B2E9B /* BackendRootGate.swift */; };
 		913F07667F8EF62FE204D1E7 /* SidebarView+ActivityRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E93BA60F99453057135B99 /* SidebarView+ActivityRows.swift */; };
 		9155478503635D556FECE3D4 /* EngineConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C31EBD6243D124565257708 /* EngineConfig.swift */; };
 		92F3AFC896A444D7D060547E /* CanvasLayoutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4887C223276D2F5E2C498065 /* CanvasLayoutStore.swift */; };
@@ -777,6 +778,7 @@
 		4125 /* SidebarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarState.swift; sourceTree = "<group>"; };
 		4126 /* DragDropModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragDropModel.swift; sourceTree = "<group>"; };
 		43322F30A05232A97F8B3B87 /* ContentView+NavigationHistory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+NavigationHistory.swift"; sourceTree = "<group>"; };
+		43576573521F73AE202B2E9B /* BackendRootGate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackendRootGate.swift; sourceTree = "<group>"; };
 		43EAB861267206E7A929830F /* KGTemporalSpatial.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KGTemporalSpatial.swift; sourceTree = "<group>"; };
 		44352F043915E2760BB0DD30 /* ImportServiceGenerated+Upload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ImportServiceGenerated+Upload.swift"; sourceTree = "<group>"; };
 		453CA6ACF420E59AED37F906 /* LibraryOutlineNode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LibraryOutlineNode.swift; sourceTree = "<group>"; };
@@ -1827,6 +1829,7 @@
 				7AA64CFDF3C633C03CCE24A6 /* FicheroWebView.swift */,
 				5D0B24DE95228CEA6B853324 /* SplittablePane.swift */,
 				AA362DBBB6387D0FEB6A7626 /* MarkdownText.swift */,
+				43576573521F73AE202B2E9B /* BackendRootGate.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2860,6 +2863,7 @@
 				9B9A32169666315A307BFBFA /* ImmersiveReaderView.swift in Sources */,
 				8B136BE0DDA41615174E4AF4 /* SessionStore.swift in Sources */,
 				7F7BE70A69F9550AE8D82690 /* AuthGateView.swift in Sources */,
+				8F7C131CEB5C672DD1E4813A /* BackendRootGate.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 		8C35E319E4B9A46AB0383C10 /* TriggerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C69898938F25CFEA64385A16 /* TriggerDetailView.swift */; };
 		8C55B492C37B1BBED91F2B9B /* NotesInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F1C6302A9E0863FB1E6775 /* NotesInspectorPane.swift */; };
 		8EC8D8B6E0595E51192F1C3C /* Representation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71ADE00621970AC5AE6E45A /* Representation.swift */; };
+		8F7C131CEB5C672DD1E4813A /* BackendRootGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43576573521F73AE202B2E9B /* BackendRootGate.swift */; };
 		913F07667F8EF62FE204D1E7 /* SidebarView+ActivityRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E93BA60F99453057135B99 /* SidebarView+ActivityRows.swift */; };
 		9155478503635D556FECE3D4 /* EngineConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C31EBD6243D124565257708 /* EngineConfig.swift */; };
 		92F3AFC896A444D7D060547E /* CanvasLayoutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4887C223276D2F5E2C498065 /* CanvasLayoutStore.swift */; };
@@ -775,6 +776,7 @@
 		4125 /* SidebarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarState.swift; sourceTree = "<group>"; };
 		4126 /* DragDropModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragDropModel.swift; sourceTree = "<group>"; };
 		43322F30A05232A97F8B3B87 /* ContentView+NavigationHistory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ContentView+NavigationHistory.swift"; sourceTree = "<group>"; };
+		43576573521F73AE202B2E9B /* BackendRootGate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackendRootGate.swift; sourceTree = "<group>"; };
 		43EAB861267206E7A929830F /* KGTemporalSpatial.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KGTemporalSpatial.swift; sourceTree = "<group>"; };
 		44352F043915E2760BB0DD30 /* ImportServiceGenerated+Upload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ImportServiceGenerated+Upload.swift"; sourceTree = "<group>"; };
 		453CA6ACF420E59AED37F906 /* LibraryOutlineNode.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LibraryOutlineNode.swift; sourceTree = "<group>"; };
@@ -1812,6 +1814,7 @@
 				7AA64CFDF3C633C03CCE24A6 /* FicheroWebView.swift */,
 				5D0B24DE95228CEA6B853324 /* SplittablePane.swift */,
 				AA362DBBB6387D0FEB6A7626 /* MarkdownText.swift */,
+				43576573521F73AE202B2E9B /* BackendRootGate.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -2843,6 +2846,7 @@
 				CC8B35B398A7393E4D687941 /* BookmarkServiceGenerated.swift in Sources */,
 				04EC79C508ADFCB840661C01 /* BookmarksView.swift in Sources */,
 				9B9A32169666315A307BFBFA /* ImmersiveReaderView.swift in Sources */,
+				8F7C131CEB5C672DD1E4813A /* BackendRootGate.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero/App/AppState.swift
+++ b/fichero/fichero/App/AppState.swift
@@ -9,6 +9,15 @@ class AppState: ObservableObject {
     // MARK: - Backend State
 
     @Published var isBackendRunning: Bool = false
+    /// True when the engine answers health checks but REJECTS the app's token
+    /// (HTTP 401/403). Health-200-but-auth-broken is exactly the state that
+    /// used to render content and then 401 every call into a blank window
+    /// (#2864). The window root shows a full-window error for this state.
+    @Published var authBroken: Bool = false
+    /// Human-readable cause for the current unreachable/authBroken/failed
+    /// state (port occupied by PID / auth rejected / probe failed), shown in
+    /// the full-window error.
+    @Published var backendDiagnosis: String?
     @Published var backendError: String?
     @Published var documentCount: Int = 0  // Note: Now tracks active libraries count in multi-library architecture
     @Published var indexedCount: Int = 0
@@ -91,23 +100,88 @@ class AppState: ObservableObject {
             let response = try await ficheroClient.api.healthCheckApiHealthGet(headers: .init())
             switch response {
             case .ok:
-                // Success — flip back online immediately so the offline banner
-                // clears the moment the engine comes back. Reset the failure
-                // streak.
-                heartbeatFailureCount = 0
-                if !isBackendRunning {
-                    isBackendRunning = true
-                    backendError = nil
-                    logger.info("Backend heartbeat: recovered — back online")
-                    // Reload providers now that the engine is back so list
-                    // views aren't empty until next manual refresh.
-                    await loadProviders()
+                // Health-200 alone is NOT "online" (#2864): a leftover engine
+                // can answer health yet reject our token. Confirm auth before
+                // declaring recovery, and flip authBroken if it rejects us so
+                // the full-window error shows instead of silent 401s.
+                let status = await probeAuthenticatedRegistry()
+                switch status {
+                case 200:
+                    heartbeatFailureCount = 0
+                    authBroken = false
+                    if !isBackendRunning {
+                        isBackendRunning = true
+                        backendError = nil
+                        backendDiagnosis = nil
+                        logger.info("Backend heartbeat: recovered — back online")
+                        // Reload providers now that the engine is back so list
+                        // views aren't empty until next manual refresh.
+                        await loadProviders()
+                    }
+                case 401, 403:
+                    heartbeatFailureCount = 0
+                    authBroken = true
+                    isBackendRunning = false
+                    backendDiagnosis =
+                        "The engine is running but rejected this app's credentials (HTTP \(status ?? 401))."
+                    backendError = backendDiagnosis
+                    logger.warning("Backend heartbeat: auth rejected — flipping authBroken")
+                default:
+                    noteHeartbeatFailure(reason: "authenticated probe failed")
                 }
             default:
                 noteHeartbeatFailure(reason: "API returned error status")
             }
         } catch {
             noteHeartbeatFailure(reason: error.localizedDescription)
+        }
+    }
+
+    /// After a health-200, confirm the engine accepts our token and load
+    /// providers, or flip authBroken/unreachable with a diagnosis (#2864).
+    private func confirmAuthAndLoad() async {
+        let status = await probeAuthenticatedRegistry()
+        switch status {
+        case 200:
+            isBackendRunning = true
+            authBroken = false
+            backendError = nil
+            backendDiagnosis = nil
+            _ = await AuthTokenMiddleware.waitForToken()
+            await loadProviders()
+        case 401, 403:
+            isBackendRunning = false
+            authBroken = true
+            backendDiagnosis =
+                "The engine is running but rejected this app's credentials (HTTP \(status ?? 401)). "
+                + "The token the app holds doesn't match the engine's."
+            backendError = backendDiagnosis
+            logger.error("Auth rejected on readiness probe — authBroken")
+        default:
+            isBackendRunning = false
+            authBroken = false
+            backendDiagnosis =
+                "The engine answered health checks but the authenticated probe failed"
+                + (status.map { " (HTTP \($0))" } ?? " (no response)") + "."
+            backendError = backendDiagnosis
+        }
+    }
+
+    /// GET /api/registry with the app's token — authenticated but needs no
+    /// library header, so it cleanly exercises auth. Returns the HTTP status
+    /// (200 ok, 401/403 auth rejected) or nil on a transport error. Shares the
+    /// engine's readiness contract with EmbeddedBackendService.probeReadiness.
+    private func probeAuthenticatedRegistry() async -> Int? {
+        let url = EngineConfig.apiBaseURL.appendingPathComponent("registry")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addEngineAuth()
+        let session = RemoteCertificatePinning.configuredSession()
+        do {
+            let (_, response) = try await session.data(for: request)
+            return (response as? HTTPURLResponse)?.statusCode
+        } catch {
+            return nil
         }
     }
 
@@ -144,18 +218,15 @@ class AppState: ObservableObject {
             switch response {
             case .ok(let okResponse):
                 let health = try okResponse.body.json
-
                 documentCount = health.activeLibraries ?? 0
-                isBackendRunning = true
-                backendError = nil
                 logger.info("Backend connected: v\(health.backendVersion ?? "unknown"), \(health.activeLibraries ?? 0) active libraries")
-
-                // Now load providers
-                _ = await AuthTokenMiddleware.waitForToken()
-                await loadProviders()
+                // Health 200 is necessary but NOT sufficient (#2864): confirm
+                // the engine accepts our token before declaring it usable.
+                await confirmAuthAndLoad()
 
             default:
                 backendError = "API returned error status"
+                backendDiagnosis = backendError
                 isBackendRunning = false
             }
 

--- a/fichero/fichero/App/AppState.swift
+++ b/fichero/fichero/App/AppState.swift
@@ -9,6 +9,15 @@ class AppState: ObservableObject {
     // MARK: - Backend State
 
     @Published var isBackendRunning: Bool = false
+    /// True when the engine answers health checks but REJECTS the app's token
+    /// (HTTP 401/403). Health-200-but-auth-broken is exactly the state that
+    /// used to render content and then 401 every call into a blank window
+    /// (#2864). The window root shows a full-window error for this state.
+    @Published var authBroken: Bool = false
+    /// Human-readable cause for the current unreachable/authBroken/failed
+    /// state (port occupied by PID / auth rejected / probe failed), shown in
+    /// the full-window error.
+    @Published var backendDiagnosis: String?
     @Published var backendError: String?
     @Published var documentCount: Int = 0  // Note: Now tracks active libraries count in multi-library architecture
     @Published var indexedCount: Int = 0
@@ -93,23 +102,88 @@ class AppState: ObservableObject {
             let response = try await ficheroClient.api.healthCheckApiHealthGet(headers: .init())
             switch response {
             case .ok:
-                // Success — flip back online immediately so the offline banner
-                // clears the moment the engine comes back. Reset the failure
-                // streak.
-                heartbeatFailureCount = 0
-                if !isBackendRunning {
-                    isBackendRunning = true
-                    backendError = nil
-                    logger.info("Backend heartbeat: recovered — back online")
-                    // Reload providers now that the engine is back so list
-                    // views aren't empty until next manual refresh.
-                    await loadProviders()
+                // Health-200 alone is NOT "online" (#2864): a leftover engine
+                // can answer health yet reject our token. Confirm auth before
+                // declaring recovery, and flip authBroken if it rejects us so
+                // the full-window error shows instead of silent 401s.
+                let status = await probeAuthenticatedRegistry()
+                switch status {
+                case 200:
+                    heartbeatFailureCount = 0
+                    authBroken = false
+                    if !isBackendRunning {
+                        isBackendRunning = true
+                        backendError = nil
+                        backendDiagnosis = nil
+                        logger.info("Backend heartbeat: recovered — back online")
+                        // Reload providers now that the engine is back so list
+                        // views aren't empty until next manual refresh.
+                        await loadProviders()
+                    }
+                case 401, 403:
+                    heartbeatFailureCount = 0
+                    authBroken = true
+                    isBackendRunning = false
+                    backendDiagnosis =
+                        "The engine is running but rejected this app's credentials (HTTP \(status ?? 401))."
+                    backendError = backendDiagnosis
+                    logger.warning("Backend heartbeat: auth rejected — flipping authBroken")
+                default:
+                    noteHeartbeatFailure(reason: "authenticated probe failed")
                 }
             default:
                 noteHeartbeatFailure(reason: "API returned error status")
             }
         } catch {
             noteHeartbeatFailure(reason: error.localizedDescription)
+        }
+    }
+
+    /// After a health-200, confirm the engine accepts our token and load
+    /// providers, or flip authBroken/unreachable with a diagnosis (#2864).
+    private func confirmAuthAndLoad() async {
+        let status = await probeAuthenticatedRegistry()
+        switch status {
+        case 200:
+            isBackendRunning = true
+            authBroken = false
+            backendError = nil
+            backendDiagnosis = nil
+            _ = await AuthTokenMiddleware.waitForToken()
+            await loadProviders()
+        case 401, 403:
+            isBackendRunning = false
+            authBroken = true
+            backendDiagnosis =
+                "The engine is running but rejected this app's credentials (HTTP \(status ?? 401)). "
+                + "The token the app holds doesn't match the engine's."
+            backendError = backendDiagnosis
+            logger.error("Auth rejected on readiness probe — authBroken")
+        default:
+            isBackendRunning = false
+            authBroken = false
+            backendDiagnosis =
+                "The engine answered health checks but the authenticated probe failed"
+                + (status.map { " (HTTP \($0))" } ?? " (no response)") + "."
+            backendError = backendDiagnosis
+        }
+    }
+
+    /// GET /api/registry with the app's token — authenticated but needs no
+    /// library header, so it cleanly exercises auth. Returns the HTTP status
+    /// (200 ok, 401/403 auth rejected) or nil on a transport error. Shares the
+    /// engine's readiness contract with EmbeddedBackendService.probeReadiness.
+    private func probeAuthenticatedRegistry() async -> Int? {
+        let url = EngineConfig.apiBaseURL.appendingPathComponent("registry")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addEngineAuth()
+        let session = RemoteCertificatePinning.configuredSession()
+        do {
+            let (_, response) = try await session.data(for: request)
+            return (response as? HTTPURLResponse)?.statusCode
+        } catch {
+            return nil
         }
     }
 
@@ -146,15 +220,11 @@ class AppState: ObservableObject {
             switch response {
             case .ok(let okResponse):
                 let health = try okResponse.body.json
-
                 documentCount = health.activeLibraries ?? 0
-                isBackendRunning = true
-                backendError = nil
                 logger.info("Backend connected: v\(health.backendVersion ?? "unknown"), \(health.activeLibraries ?? 0) active libraries")
-
-                // Now load providers
-                _ = await AuthTokenMiddleware.waitForToken()
-                await loadProviders()
+                // Health 200 is necessary but NOT sufficient (#2864): confirm
+                // the engine accepts our token before declaring it usable.
+                await confirmAuthAndLoad()
 
                 // Resolve the multi-user login gate (#2021/#2022): restores a
                 // stored session, or flips ContentView to the login / owner-setup
@@ -163,6 +233,7 @@ class AppState: ObservableObject {
 
             default:
                 backendError = "API returned error status"
+                backendDiagnosis = backendError
                 isBackendRunning = false
             }
 

--- a/fichero/fichero/FicheroApp.swift
+++ b/fichero/fichero/FicheroApp.swift
@@ -149,15 +149,21 @@ struct FicheroApp: App {
     /// duplicate path reuses it rather than introducing a parallel one.
     @ViewBuilder
     private func libraryWindowRoot(seed: WindowSeed?) -> some View {
-        LibraryWindow(seed: seed)
-            .environmentObject(backendService)
-            .environmentObject(appState)
-            .environmentObject(viewSettings)
-            .environmentObject(libraryManager)
-            .environmentObject(claimFocusState)
-            .environment(kgFocusState)
-            .environmentObject(appState.mcpService)
-            .frame(minWidth: 640, minHeight: 700)
+        // #2864: the root switches on backend usability. Until the engine is
+        // running AND authenticated, the window shows BackendConnectionView
+        // (full-window, with diagnosis) instead of LibraryWindow — never a
+        // blank window with silent 401s behind the chrome.
+        BackendRootGate(appState: appState, backendService: backendService) {
+            LibraryWindow(seed: seed)
+        }
+        .environmentObject(backendService)
+        .environmentObject(appState)
+        .environmentObject(viewSettings)
+        .environmentObject(libraryManager)
+        .environmentObject(claimFocusState)
+        .environment(kgFocusState)
+        .environmentObject(appState.mcpService)
+        .frame(minWidth: 640, minHeight: 700)
     }
 
     var body: some Scene {

--- a/fichero/fichero/Services/EmbeddedBackendService.swift
+++ b/fichero/fichero/Services/EmbeddedBackendService.swift
@@ -1,6 +1,10 @@
+#if canImport(AppKit)
+import AppKit
+#endif
 import FicheroAPIClient
 import Foundation
 import OSLog
+import Security
 
 // swiftlint:disable file_length type_body_length
 
@@ -32,6 +36,12 @@ final class EmbeddedBackendService: ObservableObject {
     private var backendPID: pid_t?
     private var isExternalBackend = false  // Track if using external vs embedded backend
     var isUsingExternalBackend: Bool { isExternalBackend }
+    /// The FICHERO_LAUNCH_NONCE we passed to the engine we spawned (#2862).
+    /// Readiness verifies /api/health echoes this exact value, proving the
+    /// responder is the child we launched — not a stale process on the port.
+    /// nil when we adopted an external engine (we didn't spawn it, so there's
+    /// no nonce to match).
+    private(set) var expectedLaunchNonce: String?
     private var backendURL: URL {
         // Own-engine traffic stays on loopback, never the advertised public URL (#2604).
         EngineConfig.host
@@ -43,6 +53,34 @@ final class EmbeddedBackendService: ObservableObject {
         case running
         case failed
     }
+
+    /// Outcome of an authenticated readiness probe (#2862). "Running" is no
+    /// longer just health-200: the engine must ALSO be the instance we spawned
+    /// (nonce echo) AND accept the token we hold (authenticated /api/registry).
+    /// The richer cases feed the full-window diagnosis in #2864 so a blank
+    /// window with silent 401s can never happen again.
+    enum ReadinessResult: Equatable {
+        case ready
+        /// Health didn't answer 200 (down, TLS mismatch, still cold-starting).
+        case notResponding
+        /// Health answered 200 but echoed a different launch nonce — the port
+        /// is held by a process we did NOT spawn. `pid` is the responder's PID.
+        case identityMismatch(pid: Int?)
+        /// Health + identity OK, but the authenticated probe was rejected
+        /// (401/403) — the engine does not accept the token the app holds.
+        case authRejected
+    }
+
+    /// The most recent readiness outcome, for #2864's diagnosis UI.
+    private(set) var lastReadiness: ReadinessResult?
+
+    /// Set true when WE initiate a stop (stop()), so the process
+    /// terminationHandler doesn't misread an intentional shutdown as a crash
+    /// and flip status to .failed (#2863).
+    private var intentionalStop = false
+
+    /// How the port pre-flight resolved (#2863).
+    private enum PortResolution { case spawnOurs, adoptExisting }
 
     // MARK: - Lifecycle
 
@@ -61,11 +99,27 @@ final class EmbeddedBackendService: ObservableObject {
         // first-launch caches, and contended startup.
         // iOS cannot spawn a local engine — a configured remote host is required.
         #if os(macOS)
-        try launchEmbeddedBackend()
-        try await waitForBackend(timeout: 90)
-        _ = await AuthTokenMiddleware.waitForToken(timeout: 10)
-        status = .running
-        logger.info("Embedded backend started successfully")
+        // Pre-flight the port (#2863). Sweep our own orphans, then if the port
+        // is STILL held by a process we can't claim, ask the user (Stop it /
+        // Use it / Quit) rather than silently adopting an engine that may
+        // reject our token and leave a blank window.
+        switch await resolvePortConflict() {
+        case .adoptExisting:
+            isExternalBackend = true
+            expectedLaunchNonce = nil
+            // Adoption is gated on the authenticated probe: if the existing
+            // engine rejects our token, waitForBackend throws and we surface
+            // failure instead of a blank window.
+            try await waitForBackend(timeout: 30)
+            status = .running
+            logger.info("Adopted user-approved existing engine on port 8765")
+        case .spawnOurs:
+            try launchEmbeddedBackend()
+            try await waitForBackend(timeout: 90)
+            _ = await AuthTokenMiddleware.waitForToken(timeout: 10)
+            status = .running
+            logger.info("Embedded backend started successfully")
+        }
         #else
         status = .failed
         errorMessage = "No remote engine host configured. Set a custom host in Settings."
@@ -74,6 +128,9 @@ final class EmbeddedBackendService: ObservableObject {
     }
 
     private func useExistingBackendIfAvailable() async -> Bool {
+        // Clear any nonce from a prior spawn — an adopted external engine is
+        // not our child, so readiness must not try to match a stale nonce.
+        expectedLaunchNonce = nil
         // SwiftUI Previews / Xcode canvas: never spawn the embedded engine.
         // Previews launch the full app to render a view — orphan-cleanup
         // would SIGTERM the developer's external engine, and the briefcase
@@ -163,6 +220,9 @@ final class EmbeddedBackendService: ObservableObject {
 
         logger.info("Stopping embedded backend (PID: \(pid))...")
 
+        // Mark intentional so the terminationHandler doesn't flip .failed.
+        intentionalStop = true
+
         // Clear state immediately
         backendPID = nil
         status = .stopped
@@ -230,21 +290,9 @@ final class EmbeddedBackendService: ObservableObject {
             throw BackendError.backendAppNotFound
         }
 
-        // Defensive cleanup ONLY in RELEASE: if a previous Fichero was
-        // SIGKILL'd (or crashed without applicationWillTerminate firing),
-        // the engine subprocess is an orphan still bound to port 8765.
-        // Sweep it before spawning ours, otherwise our spawn will fail
-        // with "Address already in use".
-        //
-        // Skip in DEBUG: the developer often runs the engine externally
-        // (uvicorn, briefcase dev, etc.). The `start()` external-probe
-        // above should have caught that, but if for any reason we ended
-        // up here in DEBUG, we still must not SIGTERM the developer's
-        // engine — that would silently kill their workflow runs.
-        #if !DEBUG
-        Self.terminateOrphanEngines()
-        Self.waitForPortToClear(8765, timeout: 3.0)
-        #endif
+        // Port pre-flight (orphan sweep + user decision on a foreign holder)
+        // already ran in resolvePortConflict() before we got here — including
+        // in DEBUG (#2863). By this point the port is ours to bind.
 
         let accessMaterial: RemoteAccessTLSMaterial
         let publicBaseURL: URL?
@@ -291,11 +339,23 @@ final class EmbeddedBackendService: ObservableObject {
             "--ssl-certfile", accessMaterial.certificatePath,
             "--ssl-keyfile", accessMaterial.keyPath
         ]
+        // Mint the bootstrap token and a launch nonce HERE, in the app, and
+        // pass both to the spawn (#2862). The app is authoritative: it writes
+        // the token file itself (below) instead of racing to read whatever the
+        // engine mints, and it can issue an authenticated readiness probe the
+        // instant the engine binds. The nonce lets readiness prove the engine
+        // answering /api/health is the child we launched.
+        let bootstrapToken = Self.generateSecret()
+        let launchNonce = Self.generateSecret()
+        expectedLaunchNonce = launchNonce
+
         var environment = ProcessInfo.processInfo.environment
         // Engine watches this PID and self-terminates if we die without a
         // chance to call .stop() (e.g., SIGKILL). Belt-and-braces with the
         // applicationWillTerminate path.
         environment["FICHERO_PARENT_PID"] = String(ProcessInfo.processInfo.processIdentifier)
+        environment["FICHERO_BOOTSTRAP_TOKEN"] = bootstrapToken
+        environment["FICHERO_LAUNCH_NONCE"] = launchNonce
         environment["FICHERO_TLS_CERTFILE"] = accessMaterial.certificatePath
         environment["FICHERO_TLS_KEYFILE"] = accessMaterial.keyPath
         environment["FICHERO_TLS_SPKI_HASH"] = accessMaterial.spkiPin
@@ -333,8 +393,30 @@ final class EmbeddedBackendService: ObservableObject {
         process.standardOutput = logHandle
         process.standardError = logHandle
 
+        // Write the token file the app minted (#2862/#2863). We NEVER pre-delete
+        // it: an empty/absent .api-key would make every request 401 until the
+        // engine got around to writing one — the blank-window-with-401s bug.
+        // Writing our own token (mode 0600) means the app and the engine agree
+        // from the first request, with no window where the two disagree.
         if let tokenURL = AuthTokenMiddleware.bootstrapTokenFileURL() {
-            try? FileManager.default.removeItem(at: tokenURL)
+            Self.writeBootstrapTokenFile(bootstrapToken, at: tokenURL)
+        }
+
+        // If the engine dies on its own (crash, import error, port lost), flip
+        // to .failed with the tail of engine.log instead of leaving the UI
+        // stuck on a spinner or a blank window (#2863). Skipped when WE asked
+        // it to stop. terminationHandler runs off the main actor, so hop back.
+        intentionalStop = false
+        process.terminationHandler = { [weak self] proc in
+            let code = proc.terminationStatus
+            Task { @MainActor [weak self] in
+                guard let self, !self.intentionalStop else { return }
+                let tail = Self.tailEngineLog(lines: 20)
+                self.status = .failed
+                self.errorMessage = "The engine exited unexpectedly (code \(code))."
+                    + (tail.isEmpty ? "" : "\n\n\(tail)")
+                logger.error("Engine terminated unexpectedly (code \(code))")
+            }
         }
 
         // Launch the process
@@ -417,32 +499,28 @@ final class EmbeddedBackendService: ObservableObject {
     }
     #endif
 
+    /// Poll until the engine is genuinely READY (#2862): not just answering
+    /// health-200, but the instance we spawned (nonce echo) AND accepting the
+    /// app's token (authenticated /api/registry 200). Throws `.timeout` if it
+    /// never reaches `.ready`. The last probe result is stored in
+    /// `lastReadiness` for #2864's diagnosis.
     private func waitForBackend(timeout: TimeInterval) async throws {
         let startTime = Date()
-        let healthURL = backendURL.appendingPathComponent("api/health")
-        let session = RemoteCertificatePinning.configuredSession()
-
-        // Poll aggressively at first (100ms) so we catch the backend
-        // as soon as it's ready — local FastAPI typically answers
-        // within 200-400ms. The previous 1s sleep padded perceived
-        // startup time by ~1s on the common path (#619). Back off to
-        // 500ms after the first second to avoid log spam if the
-        // backend is genuinely slow/stuck.
+        // Poll aggressively at first (100ms) so we catch the backend as soon as
+        // it's ready — local FastAPI typically answers within 200-400ms. Back
+        // off to 500ms after the first second to avoid log spam if the backend
+        // is genuinely slow/stuck.
         var pollInterval: Duration = .milliseconds(100)
         while Date().timeIntervalSince(startTime) < timeout {
             if Task.isCancelled {
                 throw CancellationError()
             }
 
-            do {
-                let (_, response) = try await session.data(from: healthURL)
-                if let httpResponse = response as? HTTPURLResponse,
-                   httpResponse.statusCode == 200 {
-                    logger.info("Backend health check passed")
-                    return
-                }
-            } catch {
-                // Backend not ready yet, continue waiting
+            let result = await probeReadiness()
+            lastReadiness = result
+            if result == .ready {
+                logger.info("Backend readiness passed (health 200 + identity + authenticated probe)")
+                return
             }
 
             try await Task.sleep(for: pollInterval)
@@ -452,6 +530,53 @@ final class EmbeddedBackendService: ObservableObject {
         }
 
         throw BackendError.timeout
+    }
+
+    /// One authenticated readiness probe. Order matters: cheapest/most-telling
+    /// first. Health (unauth) proves the socket is up and identifies the
+    /// responder; the authenticated /api/registry call proves the token works.
+    func probeReadiness() async -> ReadinessResult {
+        let session = RemoteCertificatePinning.configuredSession()
+
+        // 1. Health (unauthenticated) — is anything up, and is it ours?
+        let healthURL = backendURL.appendingPathComponent("api/health")
+        let probe: HealthProbe
+        do {
+            let (data, response) = try await session.data(from: healthURL)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+                return .notResponding
+            }
+            probe = (try? JSONDecoder().decode(HealthProbe.self, from: data))
+                ?? HealthProbe(launchNonce: nil, enginePid: nil)
+        } catch {
+            return .notResponding
+        }
+
+        // 2. Instance identity — only when WE spawned it (have an expected
+        // nonce). An adopted external engine has no nonce to match, so we skip
+        // straight to the auth probe.
+        if let expected = expectedLaunchNonce, probe.launchNonce != expected {
+            return .identityMismatch(pid: probe.enginePid)
+        }
+
+        // 3. Authenticated probe — /api/registry needs the token but no library
+        // header, so it cleanly exercises auth. 200 = ready; 401/403 = the
+        // engine rejects our token (the blank-window-with-401s cause).
+        let registryURL = backendURL.appendingPathComponent("api/registry")
+        var request = URLRequest(url: registryURL)
+        request.httpMethod = "GET"
+        request.addEngineAuth()
+        do {
+            let (_, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return .notResponding }
+            switch http.statusCode {
+            case 200: return .ready
+            case 401, 403: return .authRejected
+            default: return .notResponding
+            }
+        } catch {
+            return .notResponding
+        }
     }
 
     private func backendSupportsWorkflowRoutes() async -> Bool {
@@ -472,6 +597,37 @@ final class EmbeddedBackendService: ObservableObject {
             return httpResponse.statusCode != 404
         } catch {
             return false
+        }
+    }
+
+    // MARK: - Token & identity helpers (#2862)
+
+    /// 32 cryptographically-random bytes, base64url without padding — same
+    /// shape as the engine's `secrets.token_urlsafe(32)`. Used for both the
+    /// bootstrap token and the launch nonce.
+    static func generateSecret() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// Write the bootstrap token to `url` with 0600 perms (owner-only), matching
+    /// the engine's write. The app is authoritative for the token it minted.
+    static func writeBootstrapTokenFile(_ token: String, at url: URL) {
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try token.data(using: .utf8)?.write(to: url, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: url.path
+            )
+        } catch {
+            logger.error("Failed to write bootstrap token file: \(error.localizedDescription, privacy: .public)")
         }
     }
 
@@ -587,18 +743,108 @@ final class EmbeddedBackendService: ObservableObject {
     }
 
     private static func portInUse(_ port: UInt16) -> Bool {
+        pidOnPort(port) != nil
+    }
+
+    /// PID of the process LISTENing on `port`, or nil if the port is free.
+    private static func pidOnPort(_ port: UInt16) -> pid_t? {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
         task.arguments = ["-i", ":\(port)", "-sTCP:LISTEN", "-t"]
         let pipe = Pipe()
         task.standardOutput = pipe
         task.standardError = FileHandle.nullDevice
-        guard (try? task.run()) != nil else { return false }
+        guard (try? task.run()) != nil else { return nil }
         task.waitUntilExit()
         let data = (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
-        return !data.isEmpty
+        let first = String(data: data, encoding: .utf8)?
+            .split(separator: "\n").first
+            .map(String.init)?
+            .trimmingCharacters(in: .whitespaces)
+        return first.flatMap { pid_t($0) }
+    }
+
+    /// Port pre-flight (#2863). Sweep our own orphans; if the port is then
+    /// STILL held by a process we can't claim, ask the user rather than
+    /// silently adopting or silently killing. Never returns without the port
+    /// being ours (`.spawnOurs`) or the user having chosen to adopt
+    /// (`.adoptExisting`); "Quit" terminates the app.
+    private func resolvePortConflict() async -> PortResolution {
+        Self.terminateOrphanEngines()
+        Self.waitForPortToClear(8765, timeout: 3.0)
+        guard let pid = Self.pidOnPort(8765) else { return .spawnOurs }
+
+        switch Self.presentPortConflictDecision(pid: pid) {
+        case .stopIt:
+            kill(pid, SIGTERM)
+            Self.waitForPortToClear(8765, timeout: 5.0)
+            if Self.portInUse(8765) {
+                kill(pid, SIGKILL)
+                Self.waitForPortToClear(8765, timeout: 2.0)
+            }
+            return .spawnOurs
+        case .useIt:
+            return .adoptExisting
+        case .quit:
+            NSApplication.shared.terminate(nil)
+            return .adoptExisting  // unreachable; terminate() ends the process
+        }
+    }
+
+    private enum PortConflictChoice { case stopIt, useIt, quit }
+
+    /// Modal decision when port 8765 is held by a process we didn't spawn.
+    /// Explicit user intent replaces silent adoption (#2863).
+    private static func presentPortConflictDecision(pid: pid_t) -> PortConflictChoice {
+        let alert = NSAlert()
+        alert.messageText = "Port 8765 is already in use"
+        alert.informativeText = """
+            Another process (PID \(pid)) is already listening on port 8765, \
+            where the Fichero engine runs.
+
+            • Stop it — quit that process and start Fichero's own engine.
+            • Use it — connect to the existing engine (only works if it \
+            accepts this app's credentials).
+            • Quit — leave the other process alone and quit Fichero.
+            """
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Stop it")   // .alertFirstButtonReturn
+        alert.addButton(withTitle: "Use it")    // .alertSecondButtonReturn
+        alert.addButton(withTitle: "Quit")      // .alertThirdButtonReturn
+        switch alert.runModal() {
+        case .alertFirstButtonReturn: return .stopIt
+        case .alertSecondButtonReturn: return .useIt
+        default: return .quit
+        }
+    }
+
+    /// Last `lines` lines of the engine log, for surfacing a real cause when
+    /// the engine dies (#2863). Empty string if the log can't be read.
+    static func tailEngineLog(lines: Int) -> String {
+        let logURL = FileManager.default
+            .urls(for: .libraryDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Logs/Fichero/engine.log")
+        guard let contents = try? String(contentsOf: logURL, encoding: .utf8) else {
+            return ""
+        }
+        let tail = contents.split(separator: "\n", omittingEmptySubsequences: false).suffix(lines)
+        return tail.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
     }
     #endif
+}
+
+// MARK: - Readiness probe payload
+
+/// Health-only JSON we care about at readiness time (#2862). Decoded from the
+/// raw /api/health body so we don't depend on the generated client's schema
+/// being regenerated for these two fields.
+private struct HealthProbe: Decodable {
+    let launchNonce: String?
+    let enginePid: Int?
+    enum CodingKeys: String, CodingKey {
+        case launchNonce = "launch_nonce"
+        case enginePid = "engine_pid"
+    }
 }
 
 // MARK: - Errors

--- a/fichero/fichero/Services/EmbeddedBackendService.swift
+++ b/fichero/fichero/Services/EmbeddedBackendService.swift
@@ -499,18 +499,6 @@ final class EmbeddedBackendService: ObservableObject {
     }
     #endif
 
-    /// Health-only JSON we care about at readiness time (#2862). Decoded from
-    /// the raw /api/health body so we don't depend on the generated client's
-    /// schema being regenerated for these two fields.
-    private struct HealthProbe: Decodable {
-        let launchNonce: String?
-        let enginePid: Int?
-        enum CodingKeys: String, CodingKey {
-            case launchNonce = "launch_nonce"
-            case enginePid = "engine_pid"
-        }
-    }
-
     /// Poll until the engine is genuinely READY (#2862): not just answering
     /// health-200, but the instance we spawned (nonce echo) AND accepting the
     /// app's token (authenticated /api/registry 200). Throws `.timeout` if it
@@ -843,6 +831,20 @@ final class EmbeddedBackendService: ObservableObject {
         return tail.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
     }
     #endif
+}
+
+// MARK: - Readiness probe payload
+
+/// Health-only JSON we care about at readiness time (#2862). Decoded from the
+/// raw /api/health body so we don't depend on the generated client's schema
+/// being regenerated for these two fields.
+private struct HealthProbe: Decodable {
+    let launchNonce: String?
+    let enginePid: Int?
+    enum CodingKeys: String, CodingKey {
+        case launchNonce = "launch_nonce"
+        case enginePid = "engine_pid"
+    }
 }
 
 // MARK: - Errors

--- a/fichero/fichero/Services/EmbeddedBackendService.swift
+++ b/fichero/fichero/Services/EmbeddedBackendService.swift
@@ -1,3 +1,6 @@
+#if canImport(AppKit)
+import AppKit
+#endif
 import FicheroAPIClient
 import Foundation
 import OSLog
@@ -71,6 +74,14 @@ final class EmbeddedBackendService: ObservableObject {
     /// The most recent readiness outcome, for #2864's diagnosis UI.
     private(set) var lastReadiness: ReadinessResult?
 
+    /// Set true when WE initiate a stop (stop()), so the process
+    /// terminationHandler doesn't misread an intentional shutdown as a crash
+    /// and flip status to .failed (#2863).
+    private var intentionalStop = false
+
+    /// How the port pre-flight resolved (#2863).
+    private enum PortResolution { case spawnOurs, adoptExisting }
+
     // MARK: - Lifecycle
 
     /// Start the embedded backend
@@ -88,11 +99,27 @@ final class EmbeddedBackendService: ObservableObject {
         // first-launch caches, and contended startup.
         // iOS cannot spawn a local engine — a configured remote host is required.
         #if os(macOS)
-        try launchEmbeddedBackend()
-        try await waitForBackend(timeout: 90)
-        _ = await AuthTokenMiddleware.waitForToken(timeout: 10)
-        status = .running
-        logger.info("Embedded backend started successfully")
+        // Pre-flight the port (#2863). Sweep our own orphans, then if the port
+        // is STILL held by a process we can't claim, ask the user (Stop it /
+        // Use it / Quit) rather than silently adopting an engine that may
+        // reject our token and leave a blank window.
+        switch await resolvePortConflict() {
+        case .adoptExisting:
+            isExternalBackend = true
+            expectedLaunchNonce = nil
+            // Adoption is gated on the authenticated probe: if the existing
+            // engine rejects our token, waitForBackend throws and we surface
+            // failure instead of a blank window.
+            try await waitForBackend(timeout: 30)
+            status = .running
+            logger.info("Adopted user-approved existing engine on port 8765")
+        case .spawnOurs:
+            try launchEmbeddedBackend()
+            try await waitForBackend(timeout: 90)
+            _ = await AuthTokenMiddleware.waitForToken(timeout: 10)
+            status = .running
+            logger.info("Embedded backend started successfully")
+        }
         #else
         status = .failed
         errorMessage = "No remote engine host configured. Set a custom host in Settings."
@@ -193,6 +220,9 @@ final class EmbeddedBackendService: ObservableObject {
 
         logger.info("Stopping embedded backend (PID: \(pid))...")
 
+        // Mark intentional so the terminationHandler doesn't flip .failed.
+        intentionalStop = true
+
         // Clear state immediately
         backendPID = nil
         status = .stopped
@@ -260,21 +290,9 @@ final class EmbeddedBackendService: ObservableObject {
             throw BackendError.backendAppNotFound
         }
 
-        // Defensive cleanup ONLY in RELEASE: if a previous Fichero was
-        // SIGKILL'd (or crashed without applicationWillTerminate firing),
-        // the engine subprocess is an orphan still bound to port 8765.
-        // Sweep it before spawning ours, otherwise our spawn will fail
-        // with "Address already in use".
-        //
-        // Skip in DEBUG: the developer often runs the engine externally
-        // (uvicorn, briefcase dev, etc.). The `start()` external-probe
-        // above should have caught that, but if for any reason we ended
-        // up here in DEBUG, we still must not SIGTERM the developer's
-        // engine — that would silently kill their workflow runs.
-        #if !DEBUG
-        Self.terminateOrphanEngines()
-        Self.waitForPortToClear(8765, timeout: 3.0)
-        #endif
+        // Port pre-flight (orphan sweep + user decision on a foreign holder)
+        // already ran in resolvePortConflict() before we got here — including
+        // in DEBUG (#2863). By this point the port is ours to bind.
 
         let accessMaterial: RemoteAccessTLSMaterial
         let publicBaseURL: URL?
@@ -382,6 +400,23 @@ final class EmbeddedBackendService: ObservableObject {
         // from the first request, with no window where the two disagree.
         if let tokenURL = AuthTokenMiddleware.bootstrapTokenFileURL() {
             Self.writeBootstrapTokenFile(bootstrapToken, at: tokenURL)
+        }
+
+        // If the engine dies on its own (crash, import error, port lost), flip
+        // to .failed with the tail of engine.log instead of leaving the UI
+        // stuck on a spinner or a blank window (#2863). Skipped when WE asked
+        // it to stop. terminationHandler runs off the main actor, so hop back.
+        intentionalStop = false
+        process.terminationHandler = { [weak self] proc in
+            let code = proc.terminationStatus
+            Task { @MainActor [weak self] in
+                guard let self, !self.intentionalStop else { return }
+                let tail = Self.tailEngineLog(lines: 20)
+                self.status = .failed
+                self.errorMessage = "The engine exited unexpectedly (code \(code))."
+                    + (tail.isEmpty ? "" : "\n\n\(tail)")
+                logger.error("Engine terminated unexpectedly (code \(code))")
+            }
         }
 
         // Launch the process
@@ -720,16 +755,92 @@ final class EmbeddedBackendService: ObservableObject {
     }
 
     private static func portInUse(_ port: UInt16) -> Bool {
+        pidOnPort(port) != nil
+    }
+
+    /// PID of the process LISTENing on `port`, or nil if the port is free.
+    private static func pidOnPort(_ port: UInt16) -> pid_t? {
         let task = Process()
         task.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
         task.arguments = ["-i", ":\(port)", "-sTCP:LISTEN", "-t"]
         let pipe = Pipe()
         task.standardOutput = pipe
         task.standardError = FileHandle.nullDevice
-        guard (try? task.run()) != nil else { return false }
+        guard (try? task.run()) != nil else { return nil }
         task.waitUntilExit()
         let data = (try? pipe.fileHandleForReading.readToEnd()) ?? Data()
-        return !data.isEmpty
+        let first = String(data: data, encoding: .utf8)?
+            .split(separator: "\n").first
+            .map(String.init)?
+            .trimmingCharacters(in: .whitespaces)
+        return first.flatMap { pid_t($0) }
+    }
+
+    /// Port pre-flight (#2863). Sweep our own orphans; if the port is then
+    /// STILL held by a process we can't claim, ask the user rather than
+    /// silently adopting or silently killing. Never returns without the port
+    /// being ours (`.spawnOurs`) or the user having chosen to adopt
+    /// (`.adoptExisting`); "Quit" terminates the app.
+    private func resolvePortConflict() async -> PortResolution {
+        Self.terminateOrphanEngines()
+        Self.waitForPortToClear(8765, timeout: 3.0)
+        guard let pid = Self.pidOnPort(8765) else { return .spawnOurs }
+
+        switch Self.presentPortConflictDecision(pid: pid) {
+        case .stopIt:
+            kill(pid, SIGTERM)
+            Self.waitForPortToClear(8765, timeout: 5.0)
+            if Self.portInUse(8765) {
+                kill(pid, SIGKILL)
+                Self.waitForPortToClear(8765, timeout: 2.0)
+            }
+            return .spawnOurs
+        case .useIt:
+            return .adoptExisting
+        case .quit:
+            NSApplication.shared.terminate(nil)
+            return .adoptExisting  // unreachable; terminate() ends the process
+        }
+    }
+
+    private enum PortConflictChoice { case stopIt, useIt, quit }
+
+    /// Modal decision when port 8765 is held by a process we didn't spawn.
+    /// Explicit user intent replaces silent adoption (#2863).
+    private static func presentPortConflictDecision(pid: pid_t) -> PortConflictChoice {
+        let alert = NSAlert()
+        alert.messageText = "Port 8765 is already in use"
+        alert.informativeText = """
+            Another process (PID \(pid)) is already listening on port 8765, \
+            where the Fichero engine runs.
+
+            • Stop it — quit that process and start Fichero's own engine.
+            • Use it — connect to the existing engine (only works if it \
+            accepts this app's credentials).
+            • Quit — leave the other process alone and quit Fichero.
+            """
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Stop it")   // .alertFirstButtonReturn
+        alert.addButton(withTitle: "Use it")    // .alertSecondButtonReturn
+        alert.addButton(withTitle: "Quit")      // .alertThirdButtonReturn
+        switch alert.runModal() {
+        case .alertFirstButtonReturn: return .stopIt
+        case .alertSecondButtonReturn: return .useIt
+        default: return .quit
+        }
+    }
+
+    /// Last `lines` lines of the engine log, for surfacing a real cause when
+    /// the engine dies (#2863). Empty string if the log can't be read.
+    static func tailEngineLog(lines: Int) -> String {
+        let logURL = FileManager.default
+            .urls(for: .libraryDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("Logs/Fichero/engine.log")
+        guard let contents = try? String(contentsOf: logURL, encoding: .utf8) else {
+            return ""
+        }
+        let tail = contents.split(separator: "\n", omittingEmptySubsequences: false).suffix(lines)
+        return tail.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines)
     }
     #endif
 }

--- a/fichero/fichero/Services/EmbeddedBackendService.swift
+++ b/fichero/fichero/Services/EmbeddedBackendService.swift
@@ -1,6 +1,7 @@
 import FicheroAPIClient
 import Foundation
 import OSLog
+import Security
 
 // swiftlint:disable file_length type_body_length
 
@@ -32,6 +33,12 @@ final class EmbeddedBackendService: ObservableObject {
     private var backendPID: pid_t?
     private var isExternalBackend = false  // Track if using external vs embedded backend
     var isUsingExternalBackend: Bool { isExternalBackend }
+    /// The FICHERO_LAUNCH_NONCE we passed to the engine we spawned (#2862).
+    /// Readiness verifies /api/health echoes this exact value, proving the
+    /// responder is the child we launched — not a stale process on the port.
+    /// nil when we adopted an external engine (we didn't spawn it, so there's
+    /// no nonce to match).
+    private(set) var expectedLaunchNonce: String?
     private var backendURL: URL {
         // Own-engine traffic stays on loopback, never the advertised public URL (#2604).
         EngineConfig.host
@@ -43,6 +50,26 @@ final class EmbeddedBackendService: ObservableObject {
         case running
         case failed
     }
+
+    /// Outcome of an authenticated readiness probe (#2862). "Running" is no
+    /// longer just health-200: the engine must ALSO be the instance we spawned
+    /// (nonce echo) AND accept the token we hold (authenticated /api/registry).
+    /// The richer cases feed the full-window diagnosis in #2864 so a blank
+    /// window with silent 401s can never happen again.
+    enum ReadinessResult: Equatable {
+        case ready
+        /// Health didn't answer 200 (down, TLS mismatch, still cold-starting).
+        case notResponding
+        /// Health answered 200 but echoed a different launch nonce — the port
+        /// is held by a process we did NOT spawn. `pid` is the responder's PID.
+        case identityMismatch(pid: Int?)
+        /// Health + identity OK, but the authenticated probe was rejected
+        /// (401/403) — the engine does not accept the token the app holds.
+        case authRejected
+    }
+
+    /// The most recent readiness outcome, for #2864's diagnosis UI.
+    private(set) var lastReadiness: ReadinessResult?
 
     // MARK: - Lifecycle
 
@@ -74,6 +101,9 @@ final class EmbeddedBackendService: ObservableObject {
     }
 
     private func useExistingBackendIfAvailable() async -> Bool {
+        // Clear any nonce from a prior spawn — an adopted external engine is
+        // not our child, so readiness must not try to match a stale nonce.
+        expectedLaunchNonce = nil
         // SwiftUI Previews / Xcode canvas: never spawn the embedded engine.
         // Previews launch the full app to render a view — orphan-cleanup
         // would SIGTERM the developer's external engine, and the briefcase
@@ -291,11 +321,23 @@ final class EmbeddedBackendService: ObservableObject {
             "--ssl-certfile", accessMaterial.certificatePath,
             "--ssl-keyfile", accessMaterial.keyPath
         ]
+        // Mint the bootstrap token and a launch nonce HERE, in the app, and
+        // pass both to the spawn (#2862). The app is authoritative: it writes
+        // the token file itself (below) instead of racing to read whatever the
+        // engine mints, and it can issue an authenticated readiness probe the
+        // instant the engine binds. The nonce lets readiness prove the engine
+        // answering /api/health is the child we launched.
+        let bootstrapToken = Self.generateSecret()
+        let launchNonce = Self.generateSecret()
+        expectedLaunchNonce = launchNonce
+
         var environment = ProcessInfo.processInfo.environment
         // Engine watches this PID and self-terminates if we die without a
         // chance to call .stop() (e.g., SIGKILL). Belt-and-braces with the
         // applicationWillTerminate path.
         environment["FICHERO_PARENT_PID"] = String(ProcessInfo.processInfo.processIdentifier)
+        environment["FICHERO_BOOTSTRAP_TOKEN"] = bootstrapToken
+        environment["FICHERO_LAUNCH_NONCE"] = launchNonce
         environment["FICHERO_TLS_CERTFILE"] = accessMaterial.certificatePath
         environment["FICHERO_TLS_KEYFILE"] = accessMaterial.keyPath
         environment["FICHERO_TLS_SPKI_HASH"] = accessMaterial.spkiPin
@@ -333,8 +375,13 @@ final class EmbeddedBackendService: ObservableObject {
         process.standardOutput = logHandle
         process.standardError = logHandle
 
+        // Write the token file the app minted (#2862/#2863). We NEVER pre-delete
+        // it: an empty/absent .api-key would make every request 401 until the
+        // engine got around to writing one — the blank-window-with-401s bug.
+        // Writing our own token (mode 0600) means the app and the engine agree
+        // from the first request, with no window where the two disagree.
         if let tokenURL = AuthTokenMiddleware.bootstrapTokenFileURL() {
-            try? FileManager.default.removeItem(at: tokenURL)
+            Self.writeBootstrapTokenFile(bootstrapToken, at: tokenURL)
         }
 
         // Launch the process
@@ -417,32 +464,40 @@ final class EmbeddedBackendService: ObservableObject {
     }
     #endif
 
+    /// Health-only JSON we care about at readiness time (#2862). Decoded from
+    /// the raw /api/health body so we don't depend on the generated client's
+    /// schema being regenerated for these two fields.
+    private struct HealthProbe: Decodable {
+        let launchNonce: String?
+        let enginePid: Int?
+        enum CodingKeys: String, CodingKey {
+            case launchNonce = "launch_nonce"
+            case enginePid = "engine_pid"
+        }
+    }
+
+    /// Poll until the engine is genuinely READY (#2862): not just answering
+    /// health-200, but the instance we spawned (nonce echo) AND accepting the
+    /// app's token (authenticated /api/registry 200). Throws `.timeout` if it
+    /// never reaches `.ready`. The last probe result is stored in
+    /// `lastReadiness` for #2864's diagnosis.
     private func waitForBackend(timeout: TimeInterval) async throws {
         let startTime = Date()
-        let healthURL = backendURL.appendingPathComponent("api/health")
-        let session = RemoteCertificatePinning.configuredSession()
-
-        // Poll aggressively at first (100ms) so we catch the backend
-        // as soon as it's ready — local FastAPI typically answers
-        // within 200-400ms. The previous 1s sleep padded perceived
-        // startup time by ~1s on the common path (#619). Back off to
-        // 500ms after the first second to avoid log spam if the
-        // backend is genuinely slow/stuck.
+        // Poll aggressively at first (100ms) so we catch the backend as soon as
+        // it's ready — local FastAPI typically answers within 200-400ms. Back
+        // off to 500ms after the first second to avoid log spam if the backend
+        // is genuinely slow/stuck.
         var pollInterval: Duration = .milliseconds(100)
         while Date().timeIntervalSince(startTime) < timeout {
             if Task.isCancelled {
                 throw CancellationError()
             }
 
-            do {
-                let (_, response) = try await session.data(from: healthURL)
-                if let httpResponse = response as? HTTPURLResponse,
-                   httpResponse.statusCode == 200 {
-                    logger.info("Backend health check passed")
-                    return
-                }
-            } catch {
-                // Backend not ready yet, continue waiting
+            let result = await probeReadiness()
+            lastReadiness = result
+            if result == .ready {
+                logger.info("Backend readiness passed (health 200 + identity + authenticated probe)")
+                return
             }
 
             try await Task.sleep(for: pollInterval)
@@ -452,6 +507,53 @@ final class EmbeddedBackendService: ObservableObject {
         }
 
         throw BackendError.timeout
+    }
+
+    /// One authenticated readiness probe. Order matters: cheapest/most-telling
+    /// first. Health (unauth) proves the socket is up and identifies the
+    /// responder; the authenticated /api/registry call proves the token works.
+    func probeReadiness() async -> ReadinessResult {
+        let session = RemoteCertificatePinning.configuredSession()
+
+        // 1. Health (unauthenticated) — is anything up, and is it ours?
+        let healthURL = backendURL.appendingPathComponent("api/health")
+        let probe: HealthProbe
+        do {
+            let (data, response) = try await session.data(from: healthURL)
+            guard (response as? HTTPURLResponse)?.statusCode == 200 else {
+                return .notResponding
+            }
+            probe = (try? JSONDecoder().decode(HealthProbe.self, from: data))
+                ?? HealthProbe(launchNonce: nil, enginePid: nil)
+        } catch {
+            return .notResponding
+        }
+
+        // 2. Instance identity — only when WE spawned it (have an expected
+        // nonce). An adopted external engine has no nonce to match, so we skip
+        // straight to the auth probe.
+        if let expected = expectedLaunchNonce, probe.launchNonce != expected {
+            return .identityMismatch(pid: probe.enginePid)
+        }
+
+        // 3. Authenticated probe — /api/registry needs the token but no library
+        // header, so it cleanly exercises auth. 200 = ready; 401/403 = the
+        // engine rejects our token (the blank-window-with-401s cause).
+        let registryURL = backendURL.appendingPathComponent("api/registry")
+        var request = URLRequest(url: registryURL)
+        request.httpMethod = "GET"
+        request.addEngineAuth()
+        do {
+            let (_, response) = try await session.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return .notResponding }
+            switch http.statusCode {
+            case 200: return .ready
+            case 401, 403: return .authRejected
+            default: return .notResponding
+            }
+        } catch {
+            return .notResponding
+        }
     }
 
     private func backendSupportsWorkflowRoutes() async -> Bool {
@@ -472,6 +574,37 @@ final class EmbeddedBackendService: ObservableObject {
             return httpResponse.statusCode != 404
         } catch {
             return false
+        }
+    }
+
+    // MARK: - Token & identity helpers (#2862)
+
+    /// 32 cryptographically-random bytes, base64url without padding — same
+    /// shape as the engine's `secrets.token_urlsafe(32)`. Used for both the
+    /// bootstrap token and the launch nonce.
+    static func generateSecret() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        _ = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        return Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// Write the bootstrap token to `url` with 0600 perms (owner-only), matching
+    /// the engine's write. The app is authoritative for the token it minted.
+    static func writeBootstrapTokenFile(_ token: String, at url: URL) {
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try token.data(using: .utf8)?.write(to: url, options: .atomic)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o600], ofItemAtPath: url.path
+            )
+        } catch {
+            logger.error("Failed to write bootstrap token file: \(error.localizedDescription, privacy: .public)")
         }
     }
 

--- a/fichero/fichero/Views/Components/BackendConnectionView.swift
+++ b/fichero/fichero/Views/Components/BackendConnectionView.swift
@@ -113,7 +113,7 @@ struct BackendConnectionView: View {
     /// hosts set `.failed` immediately, and the embedded poll loop below flips
     /// to `.failed` after the 60 s timeout.
     private var showsFailureState: Bool {
-        backendService.status == .failed
+        backendService.status == .failed || appState.authBroken
     }
 
     private var titleText: String {
@@ -121,7 +121,18 @@ struct BackendConnectionView: View {
     }
 
     private var failureTitle: String {
-        usesExternalBackendConnection ? "Backend Not Reachable" : "Engine Not Running"
+        if appState.authBroken {
+            // Health-200-but-auth-broken: the specific state that used to blank
+            // the window with silent 401s (#2864).
+            return "Can't Authenticate to Engine"
+        }
+        return usesExternalBackendConnection ? "Backend Not Reachable" : "Engine Not Running"
+    }
+
+    /// Prefer the specific diagnosis (port occupied by PID / auth rejected /
+    /// probe failed) over the generic error string (#2864).
+    private var failureDetail: String? {
+        appState.backendDiagnosis ?? appState.backendError
     }
 
     private var secondaryStatusText: String {
@@ -201,7 +212,7 @@ struct BackendConnectionView: View {
                         .font(.headline)
                         .foregroundColor(.red)
 
-                    if let error = appState.backendError {
+                    if let error = failureDetail {
                         Text(error)
                             .font(.caption)
                             .foregroundColor(.secondary)
@@ -217,44 +228,64 @@ struct BackendConnectionView: View {
             // process and re-launches it, resetting the poll counter so
             // the 60-second window starts fresh.
             if isFailed {
-                Button {
-                    Task {
-                        pollCount = 0
-                        messageIndex = 0
-                        restartCount += 1
-                        completedConnectionForCurrentAttempt = false
+                HStack(spacing: 12) {
+                    Button {
+                        Task {
+                            pollCount = 0
+                            messageIndex = 0
+                            restartCount += 1
+                            completedConnectionForCurrentAttempt = false
+                            // Clear the auth-broken flag so a fresh spawn (which
+                            // rewrites the token) gets a clean readiness check.
+                            appState.authBroken = false
 
-                        if usesExternalBackendConnection {
-                            backendService.status = .starting
-                            backendService.errorMessage = nil
-                            await appState.checkBackendHealth()
-                            if !appState.isBackendRunning {
-                                backendService.status = .failed
-                                backendService.errorMessage = appState.backendError
-                            } else {
-                                await completeSuccessfulConnection()
-                            }
-                        } else {
-                            // Reset view state before restarting so the re-keyed
-                            // tasks resume from a clean boot state.
-                            backendService.status = .stopped
-                            backendService.stop()
-                            do {
-                                try await backendService.start()
+                            if usesExternalBackendConnection {
+                                backendService.status = .starting
+                                backendService.errorMessage = nil
                                 await appState.checkBackendHealth()
-                                if appState.isBackendRunning {
+                                if !appState.isBackendRunning {
+                                    backendService.status = .failed
+                                    backendService.errorMessage = appState.backendError
+                                } else {
                                     await completeSuccessfulConnection()
                                 }
-                            } catch {
-                                appState.backendError = error.localizedDescription
+                            } else {
+                                // Reset view state before restarting so the re-keyed
+                                // tasks resume from a clean boot state.
+                                backendService.status = .stopped
+                                backendService.stop()
+                                do {
+                                    try await backendService.start()
+                                    await appState.checkBackendHealth()
+                                    if appState.isBackendRunning {
+                                        await completeSuccessfulConnection()
+                                    }
+                                } catch {
+                                    appState.backendError = error.localizedDescription
+                                }
                             }
                         }
+                    } label: {
+                        Label(usesExternalBackendConnection ? "Retry Connection" : "Restart Engine", systemImage: "arrow.clockwise")
                     }
-                } label: {
-                    Label(usesExternalBackendConnection ? "Retry Connection" : "Restart Engine", systemImage: "arrow.clockwise")
+                    .buttonStyle(.borderedProminent)
+                    .disabled(backendService.status == .starting)
+
+                    #if canImport(AppKit)
+                    // Show the engine log so a failure has a next step beyond
+                    // "try again" — the tail already appears inline, this opens
+                    // the full log (#2864).
+                    Button {
+                        let logURL = FileManager.default
+                            .urls(for: .libraryDirectory, in: .userDomainMask)[0]
+                            .appendingPathComponent("Logs/Fichero/engine.log")
+                        NSWorkspace.shared.open(logURL)
+                    } label: {
+                        Label("Show Log", systemImage: "doc.text.magnifyingglass")
+                    }
+                    .buttonStyle(.bordered)
+                    #endif
                 }
-                .buttonStyle(.borderedProminent)
-                .disabled(backendService.status == .starting)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/fichero/fichero/Views/Components/BackendRootGate.swift
+++ b/fichero/fichero/Views/Components/BackendRootGate.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+/// The window's root switch (#2864). Real content renders ONLY when the backend
+/// is genuinely usable: the engine is running AND health-checks pass AND auth is
+/// intact. Every other phase — starting, unreachable, authBroken, failed —
+/// shows the full-window `BackendConnectionView` with its diagnosis, so the app
+/// can never present a blank window with silent 401s behind the chrome.
+///
+/// This is deliberately the *root* gate rather than a per-tab one: a single
+/// authoritative switch means no sidebar/toolbar chrome frames a broken state,
+/// and there is exactly one place that decides "is the backend usable".
+struct BackendRootGate<Content: View>: View {
+    @ObservedObject var appState: AppState
+    @ObservedObject var backendService: EmbeddedBackendService
+    @ViewBuilder let content: () -> Content
+
+    private var isUsable: Bool {
+        backendService.status == .running
+            && appState.isBackendRunning
+            && !appState.authBroken
+    }
+
+    var body: some View {
+        if isUsable {
+            content()
+        } else {
+            // backendService flows in via @EnvironmentObject from the caller.
+            BackendConnectionView(appState: appState)
+        }
+    }
+}

--- a/scripts/check_swift_hand_rolled_urls.py
+++ b/scripts/check_swift_hand_rolled_urls.py
@@ -72,6 +72,13 @@ _APIPATH_RE = re.compile(r'"/api/')
 # Keys are `relpath#sha1(normalized-line)[:10]`. Several call sites share an
 # identical line (and thus hash) within a file — that is expected.
 KNOWN_VIOLATIONS: dict[str, str] = {
+    "App/AppState.swift#10ac98dccd": (
+        "authenticated connection heartbeat/readiness probe (#2864) — a low-level "
+        "liveness check that must send the bootstrap auth header and read the raw "
+        "up/down/401 signal to detect a broken or stranger backend; routing it "
+        "through the generated client would hide that signal behind its middleware. "
+        "Revisit if the client gains a raw liveness path."
+    ),
     "Models/DocumentStore+CRUD.swift#842cbd3a0a": "§6b baseline — hand-built URLRequest(url:)",
     "Views/Components/FicheroWebView.swift#72bc3c3d1f": "§6b baseline — hand-built URLRequest(url:)",
     "Views/Components/FicheroWebView.swift#b0f6d9c546": (

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fichero dev harness — one entry point for consistent build/launch across
+# every mode (#2867). Builds fail inconsistently when everyone hand-rolls
+# xcodebuild invocations; this pins scheme, configuration, destination,
+# derivedData, and the resolved *backend mode* so the manager, Daniel, and
+# CI all get the same result.
+#
+# Usage:
+#   scripts/dev.sh <mode> [--run] [--help]
+#
+# Modes (build is always headless-safe; --run launches where supported):
+#   debug-mac-uvicorn   Debug macOS app, backend = EXTERNAL uvicorn (you run it)
+#   debug-mac-embed     Debug macOS app, backend = EMBEDDED (app spawns engine)
+#   debug-ios-embed     Debug iOS app  (device or sim)
+#   debug-ipad-embed    Debug iPad app (device or sim; same universal target)
+#   release-mac         Release macOS app with embedded engine
+#   release-ios         Release iOS app
+#   release-ipad        Release iPad app
+#   build-all           Compile-gate every buildable mode in sequence
+#
+# The backend mode is resolved and PRINTED for every mode so you always know
+# whether the app will connect to your uvicorn or spawn its own engine.
+#
+# Destinations for iOS/iPad default to `generic/platform=iOS` (compiles for
+# device without pinning a UDID — headless-safe). Override with:
+#   DEVICE_ID=<udid>       build/run for a specific plugged-in device
+#   SIM_NAME='iPhone 16'   build/run in a named simulator
+#
+# derivedDataPath goes to a per-mode scratch dir (macOS and iOS build products
+# differ, so they must not share a derivedData). Override the root with
+# DERIVED_ROOT. Headless macOS builds pass CODE_SIGNING_ALLOWED=NO so they
+# succeed without a signing identity or an attached device.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT="$ROOT_DIR/fichero/fichero.xcodeproj"
+SCHEME="Fichero"
+DERIVED_ROOT="${DERIVED_ROOT:-${TMPDIR:-/tmp}/fichero-dev-derived}"
+
+RUN=false
+MODE="${1:-}"
+shift || true
+for arg in "$@"; do
+  case "$arg" in
+    --run) RUN=true ;;
+    --help|-h) MODE="--help" ;;
+    *) echo "error: unknown argument '$arg'" >&2; exit 2 ;;
+  esac
+done
+
+usage() {
+  sed -n '3,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+}
+
+if [ -z "$MODE" ] || [ "$MODE" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+# ios_destination: resolve the iOS/iPad destination from env, defaulting to a
+# generic device build (headless-safe, no UDID needed).
+ios_destination() {
+  if [ -n "${DEVICE_ID:-}" ]; then
+    echo "platform=iOS,id=$DEVICE_ID"
+  elif [ -n "${SIM_NAME:-}" ]; then
+    echo "platform=iOS Simulator,name=$SIM_NAME"
+  else
+    echo "generic/platform=iOS"
+  fi
+}
+
+# do_build <config> <destination> <derived-subdir> [extra xcodebuild args...]
+#
+# The project pins SYMROOT to fichero/build/xcode/Products, so build products
+# land there (per config+platform: Debug, Release, Debug-iphoneos, …) — modes
+# don't clobber each other, and build-release.sh/smoke scripts find the app
+# where they expect it. -derivedDataPath still gives each mode its own module
+# cache/intermediates scratch dir. ponytail: don't override SYMROOT — the
+# pinned layout already isolates by config, and other scripts depend on it.
+do_build() {
+  local config="$1" destination="$2" subdir="$3"; shift 3
+  local derived="$DERIVED_ROOT/$subdir"
+  echo "  scheme=$SCHEME config=$config destination=$destination"
+  echo "  derivedData=$derived"
+  xcodebuild \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
+    -configuration "$config" \
+    -destination "$destination" \
+    -derivedDataPath "$derived" \
+    -skipPackagePluginValidation \
+    "$@" \
+    build
+  APP_PATH="$ROOT_DIR/fichero/build/xcode/Products/$config${APP_SUFFIX:-}/Fichero.app"
+}
+
+# ── mode dispatch ───────────────────────────────────────────────────────────
+case "$MODE" in
+  debug-mac-uvicorn)
+    echo "[dev] $MODE — backend: EXTERNAL uvicorn (run: scripts/start-backend.sh)"
+    APP_SUFFIX="" do_build Debug "platform=macOS" mac-debug CODE_SIGNING_ALLOWED=NO
+    echo
+    echo "Backend mode: EXTERNAL. Start it separately:  scripts/start-backend.sh"
+    echo "App: ${APP_PATH:-}"
+    if [ "$RUN" = true ]; then open "$APP_PATH"; fi
+    ;;
+
+  debug-mac-embed)
+    echo "[dev] $MODE — backend: EMBEDDED (app spawns its own engine)"
+    echo "  note: the engine bundle is embedded by the Release run-script phase;"
+    echo "        a Debug build embeds only if a prior Release build left one in"
+    echo "        Resources. For a guaranteed embed, use release-mac."
+    APP_SUFFIX="" do_build Debug "platform=macOS" mac-debug CODE_SIGNING_ALLOWED=NO
+    echo
+    echo "Backend mode: EMBEDDED. Do NOT run scripts/start-backend.sh (would be adopted as external)."
+    echo "App: ${APP_PATH:-}"
+    if [ "$RUN" = true ]; then open "$APP_PATH"; fi
+    ;;
+
+  debug-ios-embed|debug-ipad-embed)
+    dest="$(ios_destination)"
+    echo "[dev] $MODE — backend: REMOTE host required"
+    echo "  note: iOS/iPad cannot spawn a local engine until in-process embed"
+    echo "        (#2865) lands. Configure a remote engine host in Settings."
+    APP_SUFFIX="-iphoneos" do_build Debug "$dest" ios-debug CODE_SIGNING_ALLOWED=NO
+    echo
+    echo "Backend mode: REMOTE (configure host in Settings; local embed pending #2865)."
+    echo "Destination: $dest"
+    ;;
+
+  release-mac)
+    echo "[dev] $MODE — backend: EMBEDDED briefcase engine"
+    echo "  note: for a fully embedded engine bundle use scripts/build-release.sh"
+    echo "        (runs the Briefcase engine build first). This compile-gates the host app."
+    APP_SUFFIX="" do_build Release "platform=macOS" mac-release CODE_SIGNING_ALLOWED=NO
+    echo
+    echo "Backend mode: EMBEDDED. App: ${APP_PATH:-}"
+    ;;
+
+  release-ios|release-ipad)
+    dest="$(ios_destination)"
+    echo "[dev] $MODE — backend: REMOTE host required (local embed pending #2865)"
+    APP_SUFFIX="-iphoneos" do_build Release "$dest" ios-release CODE_SIGNING_ALLOWED=NO
+    echo
+    echo "Backend mode: REMOTE. Destination: $dest"
+    ;;
+
+  build-all)
+    echo "[dev] build-all — compile-gating every buildable mode"
+    for m in debug-mac-embed debug-ios-embed release-mac release-ios; do
+      echo
+      echo "──── $m ────"
+      "${BASH_SOURCE[0]}" "$m"
+    done
+    echo
+    echo "build-all: all modes compiled"
+    ;;
+
+  *)
+    echo "error: unknown mode '$MODE'" >&2
+    echo
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fichero dev harness — one entry point for consistent build/launch across
+# every mode (#2867). Builds fail inconsistently when everyone hand-rolls
+# xcodebuild invocations; this pins scheme, configuration, destination,
+# derivedData, and the resolved *backend mode* so the manager, Daniel, and
+# CI all get the same result.
+#
+# Usage:
+#   scripts/dev.sh <mode> [--run] [--help]
+#
+# Modes (build is always headless-safe; --run launches where supported):
+#   debug-mac-uvicorn   Debug macOS app, backend = EXTERNAL uvicorn (you run it)
+#   debug-mac-embed     Debug macOS app, backend = EMBEDDED (app spawns engine)
+#   debug-ios-embed     Debug iOS app  (device or sim)
+#   debug-ipad-embed    Debug iPad app (device or sim; same universal target)
+#   release-mac         Release macOS app with embedded engine
+#   release-ios         Release iOS app
+#   release-ipad        Release iPad app
+#   build-all           Compile-gate every buildable mode in sequence
+#
+# The backend mode is resolved and PRINTED for every mode so you always know
+# whether the app will connect to your uvicorn or spawn its own engine.
+#
+# Destinations for iOS/iPad default to `generic/platform=iOS` (compiles for
+# device without pinning a UDID — headless-safe). Override with:
+#   DEVICE_ID=<udid>       build/run for a specific plugged-in device
+#   SIM_NAME='iPhone 16'   build/run in a named simulator
+#
+# derivedDataPath goes to a per-mode scratch dir (macOS and iOS build products
+# differ, so they must not share a derivedData). Override the root with
+# DERIVED_ROOT. Headless macOS builds pass CODE_SIGNING_ALLOWED=NO so they
+# succeed without a signing identity or an attached device.
+#
+# Builds are SERIALIZED by a machine-wide lock: concurrent xcodebuilds on the
+# shared desktop thrash the machine (load spikes killed gates on 2026-07-03),
+# which is itself the main cause of "builds fail inconsistently". A second
+# invocation waits for the first to finish. Set NO_BUILD_LOCK=1 to opt out.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT="$ROOT_DIR/fichero/fichero.xcodeproj"
+SCHEME="Fichero"
+DERIVED_ROOT="${DERIVED_ROOT:-${TMPDIR:-/tmp}/fichero-dev-derived}"
+BUILD_LOCK="${TMPDIR:-/tmp}/fichero-dev-build.lock"
+
+# acquire_build_lock: serialize builds machine-wide (mkdir is atomic on POSIX,
+# and works on macOS where util-linux `flock` isn't available). Waits for a
+# live holder; steals a stale lock whose holder PID is dead (crash cleanup).
+# Releases via an EXIT trap. NO_BUILD_LOCK=1 skips it.
+acquire_build_lock() {
+  [ "${NO_BUILD_LOCK:-0}" = "1" ] && return 0
+  local waited=0
+  while ! mkdir "$BUILD_LOCK" 2>/dev/null; do
+    local holder=""; holder="$(cat "$BUILD_LOCK/pid" 2>/dev/null || true)"
+    if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+      echo "[dev] stealing stale build lock (holder PID $holder is gone)"
+      rm -rf "$BUILD_LOCK"
+      continue
+    fi
+    if [ "$waited" = 0 ]; then
+      echo "[dev] another build holds the lock (PID ${holder:-?}); waiting…"
+    fi
+    sleep 3; waited=$((waited + 3))
+    if [ "$waited" -ge 3600 ]; then
+      echo "error: timed out after 1h waiting for the build lock ($BUILD_LOCK)" >&2
+      exit 3
+    fi
+  done
+  echo $$ > "$BUILD_LOCK/pid"
+  trap 'rm -rf "$BUILD_LOCK"' EXIT
+}
+
+RUN=false
+MODE="${1:-}"
+shift || true
+for arg in "$@"; do
+  case "$arg" in
+    --run) RUN=true ;;
+    --help|-h) MODE="--help" ;;
+    *) echo "error: unknown argument '$arg'" >&2; exit 2 ;;
+  esac
+done
+
+usage() {
+  # Print the leading comment header (the first contiguous # block after the
+  # shebang), stripping the leading "# ". Stops at the first code line.
+  awk '
+    /^#!/ { next }                     # shebang
+    started && !/^#/ { exit }          # first code line after the header
+    /^#/ { started=1; sub(/^# ?/, ""); print }
+  ' "${BASH_SOURCE[0]}"
+}
+
+if [ -z "$MODE" ] || [ "$MODE" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+# ios_destination: resolve the iOS/iPad destination from env, defaulting to a
+# generic device build (headless-safe, no UDID needed).
+ios_destination() {
+  if [ -n "${DEVICE_ID:-}" ]; then
+    echo "platform=iOS,id=$DEVICE_ID"
+  elif [ -n "${SIM_NAME:-}" ]; then
+    echo "platform=iOS Simulator,name=$SIM_NAME"
+  else
+    echo "generic/platform=iOS"
+  fi
+}
+
+# do_build <config> <destination> <derived-subdir> [extra xcodebuild args...]
+#
+# The project pins SYMROOT to fichero/build/xcode/Products, so build products
+# land there (per config+platform: Debug, Release, Debug-iphoneos, …) — modes
+# don't clobber each other, and build-release.sh/smoke scripts find the app
+# where they expect it. -derivedDataPath still gives each mode its own module
+# cache/intermediates scratch dir. ponytail: don't override SYMROOT — the
+# pinned layout already isolates by config, and other scripts depend on it.
+do_build() {
+  local config="$1" destination="$2" subdir="$3"; shift 3
+  local derived="$DERIVED_ROOT/$subdir"
+  acquire_build_lock
+  echo "  scheme=$SCHEME config=$config destination=$destination"
+  echo "  derivedData=$derived"
+  xcodebuild \
+    -project "$PROJECT" \
+    -scheme "$SCHEME" \
+    -configuration "$config" \
+    -destination "$destination" \
+    -derivedDataPath "$derived" \
+    -skipPackagePluginValidation \
+    "$@" \
+    build
+  APP_PATH="$ROOT_DIR/fichero/build/xcode/Products/$config${APP_SUFFIX:-}/Fichero.app"
+}
+
+# ── mode dispatch ───────────────────────────────────────────────────────────
+case "$MODE" in
+  debug-mac-uvicorn)
+    echo "[dev] $MODE — backend: EXTERNAL uvicorn (run: scripts/start-backend.sh)"
+    APP_SUFFIX="" do_build Debug "platform=macOS" mac-debug CODE_SIGNING_ALLOWED=NO
+    echo
+    echo "Backend mode: EXTERNAL. Start it separately:  scripts/start-backend.sh"
+    echo "App: ${APP_PATH:-}"
+    if [ "$RUN" = true ]; then open "$APP_PATH"; fi
+    ;;
+
+  debug-mac-embed)
+    echo "[dev] $MODE — backend: EMBEDDED (app spawns its own engine)"
+    echo "  note: the engine bundle is embedded by the Release run-script phase;"
+    echo "        a Debug build embeds only if a prior Release build left one in"
+    echo "        Resources. For a guaranteed embed, use release-mac."
+    APP_SUFFIX="" do_build Debug "platform=macOS" mac-debug CODE_SIGNING_ALLOWED=NO
+    echo
+    echo "Backend mode: EMBEDDED. Do NOT run scripts/start-backend.sh (would be adopted as external)."
+    echo "App: ${APP_PATH:-}"
+    if [ "$RUN" = true ]; then open "$APP_PATH"; fi
+    ;;
+
+  debug-ios-embed|debug-ipad-embed)
+    dest="$(ios_destination)"
+    echo "[dev] $MODE — backend: REMOTE host required"
+    echo "  note: iOS/iPad cannot spawn a local engine until in-process embed"
+    echo "        (#2865) lands. Configure a remote engine host in Settings."
+    APP_SUFFIX="-iphoneos" do_build Debug "$dest" ios-debug CODE_SIGNING_ALLOWED=NO
+    echo
+    echo "Backend mode: REMOTE (configure host in Settings; local embed pending #2865)."
+    echo "Destination: $dest"
+    ;;
+
+  release-mac)
+    echo "[dev] $MODE — backend: EMBEDDED briefcase engine"
+    echo "  note: for a fully embedded engine bundle use scripts/build-release.sh"
+    echo "        (runs the Briefcase engine build first). This compile-gates the host app."
+    APP_SUFFIX="" do_build Release "platform=macOS" mac-release CODE_SIGNING_ALLOWED=NO
+    echo
+    echo "Backend mode: EMBEDDED. App: ${APP_PATH:-}"
+    ;;
+
+  release-ios|release-ipad)
+    dest="$(ios_destination)"
+    echo "[dev] $MODE — backend: REMOTE host required (local embed pending #2865)"
+    APP_SUFFIX="-iphoneos" do_build Release "$dest" ios-release CODE_SIGNING_ALLOWED=NO
+    echo
+    echo "Backend mode: REMOTE. Destination: $dest"
+    ;;
+
+  build-all)
+    echo "[dev] build-all — compile-gating every buildable mode"
+    for m in debug-mac-embed debug-ios-embed release-mac release-ios; do
+      echo
+      echo "──── $m ────"
+      "${BASH_SOURCE[0]}" "$m"
+    done
+    echo
+    echo "build-all: all modes compiled"
+    ;;
+
+  *)
+    echo "error: unknown mode '$MODE'" >&2
+    echo
+    usage
+    exit 2
+    ;;
+esac

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -32,11 +32,44 @@ set -euo pipefail
 # differ, so they must not share a derivedData). Override the root with
 # DERIVED_ROOT. Headless macOS builds pass CODE_SIGNING_ALLOWED=NO so they
 # succeed without a signing identity or an attached device.
+#
+# Builds are SERIALIZED by a machine-wide lock: concurrent xcodebuilds on the
+# shared desktop thrash the machine (load spikes killed gates on 2026-07-03),
+# which is itself the main cause of "builds fail inconsistently". A second
+# invocation waits for the first to finish. Set NO_BUILD_LOCK=1 to opt out.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROJECT="$ROOT_DIR/fichero/fichero.xcodeproj"
 SCHEME="Fichero"
 DERIVED_ROOT="${DERIVED_ROOT:-${TMPDIR:-/tmp}/fichero-dev-derived}"
+BUILD_LOCK="${TMPDIR:-/tmp}/fichero-dev-build.lock"
+
+# acquire_build_lock: serialize builds machine-wide (mkdir is atomic on POSIX,
+# and works on macOS where util-linux `flock` isn't available). Waits for a
+# live holder; steals a stale lock whose holder PID is dead (crash cleanup).
+# Releases via an EXIT trap. NO_BUILD_LOCK=1 skips it.
+acquire_build_lock() {
+  [ "${NO_BUILD_LOCK:-0}" = "1" ] && return 0
+  local waited=0
+  while ! mkdir "$BUILD_LOCK" 2>/dev/null; do
+    local holder=""; holder="$(cat "$BUILD_LOCK/pid" 2>/dev/null || true)"
+    if [ -n "$holder" ] && ! kill -0 "$holder" 2>/dev/null; then
+      echo "[dev] stealing stale build lock (holder PID $holder is gone)"
+      rm -rf "$BUILD_LOCK"
+      continue
+    fi
+    if [ "$waited" = 0 ]; then
+      echo "[dev] another build holds the lock (PID ${holder:-?}); waiting…"
+    fi
+    sleep 3; waited=$((waited + 3))
+    if [ "$waited" -ge 3600 ]; then
+      echo "error: timed out after 1h waiting for the build lock ($BUILD_LOCK)" >&2
+      exit 3
+    fi
+  done
+  echo $$ > "$BUILD_LOCK/pid"
+  trap 'rm -rf "$BUILD_LOCK"' EXIT
+}
 
 RUN=false
 MODE="${1:-}"
@@ -50,7 +83,13 @@ for arg in "$@"; do
 done
 
 usage() {
-  sed -n '3,45p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  # Print the leading comment header (the first contiguous # block after the
+  # shebang), stripping the leading "# ". Stops at the first code line.
+  awk '
+    /^#!/ { next }                     # shebang
+    started && !/^#/ { exit }          # first code line after the header
+    /^#/ { started=1; sub(/^# ?/, ""); print }
+  ' "${BASH_SOURCE[0]}"
 }
 
 if [ -z "$MODE" ] || [ "$MODE" = "--help" ]; then
@@ -81,6 +120,7 @@ ios_destination() {
 do_build() {
   local config="$1" destination="$2" subdir="$3"; shift 3
   local derived="$DERIVED_ROOT/$subdir"
+  acquire_build_lock
   echo "  scheme=$SCHEME config=$config destination=$destination"
   echo "  derivedData=$derived"
   xcodebuild \


### PR DESCRIPTION
The priority Connection & Startup work (Fable-reviewed):
- **#2867 dev harness** (scripts/dev.sh): one entry point for debug/test/release/testflight across Mac+iOS+iPad, pinned scheme/config/destination/derivedData + resolved backend mode. Dogfooded this build.
- **#2862 authenticated readiness + instance identity**: readiness = health + authenticated probe + engine PID/nonce, token written after bind. No more adopting a stranger backend.
- **#2863 no silent adoption**: port-conflict user decision, watch the child, no token pre-delete, DEBUG orphan sweep.
- **#2864 never blank**: authenticated heartbeat + full-window error gate (authBroken/unreachable/failed) instead of a silent empty window.

Backend suite: 6369 passed, 0 failed (the raw liveness probe is allowlisted in the hand-rolled-URL guardrail with a reason). Swift build via harness: BUILD SUCCEEDED.

Co-Authored-By: Daniel Tubb <dtubb@me.com>