### PR TITLE
feat(connection): per-library BackendHost — N backends + host-keyed auth (#2866)

### DIFF
--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/AuthTokenMiddleware.swift
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/AuthTokenMiddleware.swift
@@ -214,21 +214,33 @@ public struct AuthTokenMiddleware: ClientMiddleware {
     /// `applicationSupportDirectory` to a container path different from where
     /// the engine wrote the file. See `EngineHarness.live()`.
     public static func readTokenFromDisk() -> String? {
-        // Env override — used by the test harness to bridge the sandbox gap.
-        if let envToken = ProcessInfo.processInfo.environment["FICHERO_AUTH_TOKEN"] {
+        readTokenFromDisk(hostString: nil)
+    }
+
+    /// Host-aware token read (#2866). The app can hold multiple backends at once
+    /// (local embedded engine + N remote hosts), so the token is resolved per
+    /// REQUEST HOST, not off the single global default: a loopback host reads
+    /// the bootstrap `.api-key`; a remote host reads that host's device token
+    /// from the Keychain. Pass `nil` for the global default (the legacy path).
+    public static func readTokenFromDisk(hostString: String?) -> String? {
+        let kind = tokenStorageKind(hostString: hostString)
+        // Env override — test-harness bridge for the LOCAL engine only. A remote
+        // host must never borrow the local test token.
+        if kind == .bootstrap,
+           let envToken = ProcessInfo.processInfo.environment["FICHERO_AUTH_TOKEN"] {
             let trimmed = envToken.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmed.isEmpty { return trimmed }
         }
-        switch tokenStorageKind() {
+        switch kind {
         case .bootstrap:
-            guard let path = tokenFileURL() else { return nil }
+            guard let path = bootstrapTokenFileURL() else { return nil }
             guard let data = try? Data(contentsOf: path) else { return nil }
             guard let rawToken = String(data: data, encoding: .utf8) else { return nil }
             let token = rawToken
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             return token.isEmpty ? nil : token
         case .remote:
-            return readRemoteTokenFromKeychain()
+            return readRemoteTokenFromKeychain(hostString: hostString)
         }
     }
 
@@ -367,21 +379,33 @@ public struct AuthTokenMiddleware: ClientMiddleware {
     }
 
     public static func waitForToken(timeout: TimeInterval = 3) async -> String? {
-        if let token = readTokenFromDisk() { return token }
+        await waitForToken(hostString: nil, timeout: timeout)
+    }
+
+    /// Host-aware token wait (#2866) — resolves the token for a specific backend
+    /// host, so a request bound for one engine never waits on / uses another's.
+    public static func waitForToken(hostString: String?, timeout: TimeInterval = 3) async -> String? {
+        if let token = readTokenFromDisk(hostString: hostString) { return token }
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             try? await Task.sleep(for: .milliseconds(50))
-            if let token = readTokenFromDisk() { return token }
+            if let token = readTokenFromDisk(hostString: hostString) { return token }
         }
         return nil
     }
 
     public static func waitForTokenBlocking(timeout: TimeInterval = 3) -> String? {
-        if let token = readTokenFromDisk() { return token }
+        waitForTokenBlocking(hostString: nil, timeout: timeout)
+    }
+
+    /// Host-aware blocking token wait (#2866) — for the raw-URLSession auth path
+    /// (`URLRequest.addEngineAuth`) which resolves the token for the request's host.
+    public static func waitForTokenBlocking(hostString: String?, timeout: TimeInterval = 3) -> String? {
+        if let token = readTokenFromDisk(hostString: hostString) { return token }
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             Thread.sleep(forTimeInterval: 0.05)
-            if let token = readTokenFromDisk() { return token }
+            if let token = readTokenFromDisk(hostString: hostString) { return token }
         }
         return nil
     }
@@ -398,15 +422,19 @@ public struct AuthTokenMiddleware: ClientMiddleware {
         let isUnauthenticated = Self.isUnauthenticatedPath(path)
 
         // Read the token fresh on every request — see class doc for why.
+        // Token is resolved off THIS request's baseURL, not the global host
+        // (#2866): the app can hold multiple backends (local + N remote) at
+        // once, and each carries its own bootstrap/device/session credential.
         // A login *session* token (multi-user) takes priority over the
         // bootstrap/device token: once a user is signed in, their session
         // carries the identity + per-library role the library load needs. When
         // no session exists yet (pre-login, first-owner bootstrap) we fall back
         // to the bootstrap/device token so /api/users and create-owner still work.
         if !isUnauthenticated {
-            if let session = Self.readSessionToken() {
+            let host = baseURL.absoluteString
+            if let session = Self.readSessionToken(hostString: host) {
                 request.headerFields[.authorization] = "Bearer \(session)"
-            } else if let token = await Self.waitForToken() {
+            } else if let token = await Self.waitForToken(hostString: host) {
                 request.headerFields[.authorization] = "Bearer \(token)"
             }
         }

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/AuthTokenMiddleware.swift
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/AuthTokenMiddleware.swift
@@ -3,7 +3,7 @@ import HTTPTypes
 import OpenAPIRuntime
 import Security
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length file_length
 /// Middleware that adds `Authorization: Bearer <token>` to every request,
 /// reading the token from `~/Library/Application Support/Fichero/.api-key`.
 ///
@@ -117,7 +117,11 @@ public struct AuthTokenMiddleware: ClientMiddleware {
         #endif
     }
 
-    static func prefersLocalhostEngineToken(hostString: String? = nil) -> Bool {
+    /// True when `hostString` (or the global default) is a loopback engine, so
+    /// requests to it authenticate with the bootstrap `.api-key` rather than a
+    /// remote device/session token. Public so callers building a per-library
+    /// backend host can derive its token kind (#2866).
+    public static func prefersLocalhostEngineToken(hostString: String? = nil) -> Bool {
         guard let stored = hostString ?? UserDefaults.standard.string(forKey: engineHostUserDefaultsKey) else {
             return true
         }

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -173,6 +173,7 @@
 		25B9458F0E27EB2BCD55B439 /* ClaimSummaryCard+Details.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA39991F769A1DD42BB17F01 /* ClaimSummaryCard+Details.swift */; };
 		271105805B9F86F6D065A7E4 /* FocusedDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A3196D0978B2822F00F0600 /* FocusedDocument.swift */; };
 		283826C50E2AE354A7EB5611 /* SpatialNodeThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5FD0D414191E6FFC18E8BC /* SpatialNodeThumbnail.swift */; };
+		28510D794CAA15808E28CB6C /* BackendHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B2292335F30622AB8F0ABE /* BackendHost.swift */; };
 		286700373FC6B54B843E8DA5 /* NodePopover+Comparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F310DFF84C9557A77D4FDA /* NodePopover+Comparison.swift */; };
 		2C2268FA2E4307AAA02C7EC4 /* APIClient+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300A8405FFC476E5124372AE /* APIClient+Types.swift */; };
 		2C8A895EE1B0F5029E3D00B6 /* WorkspaceItemPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 489A0FBA854FF9A1158996D6 /* WorkspaceItemPicker.swift */; };
@@ -753,6 +754,7 @@
 		35793BBA8A74DAA0982CCFA4 /* DocumentInspectorInfoTab+Header.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentInspectorInfoTab+Header.swift"; sourceTree = "<group>"; };
 		36234E44A7E494963A441CDC /* DocumentInspectorContentTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DocumentInspectorContentTab.swift; path = fichero/Views/Library/DocumentInspector/DocumentInspectorContentTab.swift; sourceTree = SOURCE_ROOT; };
 		36839A1C65A10F63B92E4121 /* ActivityMonitorModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityMonitorModel.swift; sourceTree = "<group>"; };
+		36B2292335F30622AB8F0ABE /* BackendHost.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackendHost.swift; sourceTree = "<group>"; };
 		36F6CF6F489DE8CEE80661D3 /* ArtifactsInspectorPane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArtifactsInspectorPane.swift; sourceTree = "<group>"; };
 		37003B253D97CBE012D3A811 /* DocumentInspectorInfoTab+Sharing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentInspectorInfoTab+Sharing.swift"; sourceTree = "<group>"; };
 		371A4629B0A6A51DE6D6D872 /* BackendSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BackendSettingsView.swift; path = fichero/Views/Settings/BackendSettingsView.swift; sourceTree = SOURCE_ROOT; };
@@ -1584,6 +1586,7 @@
 				5D870DB81D42B1614D58CE3F /* BoundingBoxGeometry.swift */,
 				66ADB5B1F77763C5F3295611 /* PDFRegionGeometry.swift */,
 				CB4FE6FA42E3E4887451FB21 /* SessionStore.swift */,
+				36B2292335F30622AB8F0ABE /* BackendHost.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2864,6 +2867,7 @@
 				8B136BE0DDA41615174E4AF4 /* SessionStore.swift in Sources */,
 				7F7BE70A69F9550AE8D82690 /* AuthGateView.swift in Sources */,
 				8F7C131CEB5C672DD1E4813A /* BackendRootGate.swift in Sources */,
+				28510D794CAA15808E28CB6C /* BackendHost.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {

--- a/fichero/fichero/Models/BackendHost.swift
+++ b/fichero/fichero/Models/BackendHost.swift
@@ -1,0 +1,55 @@
+import FicheroAPIClient
+import Foundation
+
+/// Which backend a library talks to (#2866). The app can hold several backends
+/// at once — the local embedded engine plus N remote hosts — so each
+/// `LibraryReference` carries its own host instead of everything keying off the
+/// single global `EngineConfig`. Pairs with the host-aware token lookup in
+/// `AuthTokenMiddleware`: a request bound for this host authenticates with this
+/// host's credential.
+struct BackendHost: Equatable, Hashable, Sendable {
+    /// Base URL of the engine (e.g. `https://127.0.0.1:8765`, or a remote host).
+    let url: URL
+    /// SPKI pin to enforce for this host's TLS, if known. Persisted on use so
+    /// `RemoteCertificatePinning` validates this host's cert against it.
+    let spkiPin: String?
+    /// Which credential store this host authenticates against.
+    let tokenKind: TokenKind
+
+    enum TokenKind: String, Sendable, Equatable, Hashable {
+        case bootstrap   // loopback / embedded engine → .api-key
+        case remote      // remote host → device / session token
+    }
+
+    /// `tokenKind` defaults to what the URL implies: a loopback host uses the
+    /// bootstrap token, anything else a remote token.
+    init(url: URL, spkiPin: String? = nil, tokenKind: TokenKind? = nil) {
+        self.url = url
+        self.spkiPin = spkiPin
+        self.tokenKind = tokenKind
+            ?? (AuthTokenMiddleware.prefersLocalhostEngineToken(hostString: url.absoluteString)
+                ? .bootstrap : .remote)
+    }
+
+    /// The app-global engine (`EngineConfig.host`) — the default for every
+    /// existing library until a specific remote host is attached. This is
+    /// loopback on Mac and the configured remote on iOS, so the token kind is
+    /// DERIVED from the URL rather than assumed bootstrap.
+    static var appDefault: BackendHost {
+        BackendHost(url: EngineConfig.host)
+    }
+
+    /// Whether this host is a loopback / embedded engine (bootstrap token).
+    var isLocal: Bool { tokenKind == .bootstrap }
+
+    /// Persist this host's SPKI pin so the pinned session validates its cert.
+    /// Idempotent — safe to call on every library open. Keyed on the same
+    /// `url.absoluteString` that `RemoteCertificatePinning.shouldEnforcePinning`
+    /// reads, so the pin the session enforces matches the one persisted here.
+    func persistPinIfNeeded() {
+        guard let spkiPin, !spkiPin.isEmpty else { return }
+        try? RemoteCertificatePinning.persistHostedBackendSPKIPin(
+            spkiPin, hostString: url.absoluteString
+        )
+    }
+}

--- a/fichero/fichero/Models/LibraryManager.swift
+++ b/fichero/fichero/Models/LibraryManager.swift
@@ -54,6 +54,11 @@ class LibraryManager: ObservableObject {
     class LibraryReference: Identifiable, ObservableObject {
         let id: UUID
         let url: URL
+        /// Which backend this library talks to (#2866). Defaults to the local
+        /// embedded engine; a remote library carries its own host so the app can
+        /// hold several backends at once. Drives the clients' baseURL, the TLS
+        /// pin, and the sidebar location badge.
+        let host: BackendHost
         @Published var displayName: String  // Display name for window title (e.g., "Untitled 2", "MyResearch")
         @Published var document: FicheroDocument
 
@@ -207,9 +212,9 @@ class LibraryManager: ObservableObject {
 
         /// Where this library's engine lives — local embedded engine vs a named
         /// remote device/host. Drives the sidebar local-vs-remote badge (#2574).
-        /// Front-end-first: derived from the app-level `EngineConfig` host today;
-        /// the seam to read a per-library `host` once that lands is a single
-        /// change inside `LibraryLocationDescriptor.current()`.
+        /// Reflects the live app-global host today; once libraries are pinned to
+        /// a SPECIFIC remote host (#2866 follow-up) this reads `host` instead —
+        /// the seam is `host.isLocal`.
         var locationDescriptor: LibraryLocationDescriptor {
             LibraryLocationDescriptor.current()
         }
@@ -220,6 +225,7 @@ class LibraryManager: ObservableObject {
             document: FicheroDocument,
             displayName: String,
             id: UUID? = nil,
+            host: BackendHost = .appDefault,
             apiClient: APIClient? = nil,
             documentStore: DocumentStore? = nil,
             searchService: SearchServiceGenerated? = nil,
@@ -232,22 +238,30 @@ class LibraryManager: ObservableObject {
         ) {
             self.id = id ?? UUID()
             self.url = url
+            self.host = host
             self.displayName = displayName
             self.document = document
 
-            // Reuse existing instances or create new ones
+            // Persist this backend's SPKI pin so the pinned session validates
+            // its cert (#2866). No-op for the local engine (no pin) and for
+            // hosts already pinned.
+            host.persistPinIfNeeded()
+
+            // Reuse existing instances or create new ones. A new client targets
+            // THIS library's backend host, not the global one.
             if let existingClient = apiClient {
                 self.apiClient = existingClient
             } else {
-                self.apiClient = APIClient()
+                self.apiClient = APIClient(baseURL: host.url)
             }
 
             // Set the library path on the API client immediately
             // This ensures all services created below have access to the path
             self.apiClient.currentLibraryPath = url.path
 
-            // Create the generated API client (shares same library path)
-            self.ficheroClient = FicheroClient(baseURL: EngineConfig.host, libraryPath: url.path)
+            // Create the generated API client (shares same library path), bound
+            // to this library's backend host.
+            self.ficheroClient = FicheroClient(baseURL: host.url, libraryPath: url.path)
 
             // Initialize all services with the library's APIClient
             self.documentStore = documentStore ?? DocumentStore(apiClient: self.apiClient)
@@ -302,6 +316,10 @@ class LibraryManager: ObservableObject {
         }
 
         func reconfigureBackendHost() {
+            // Every library is currently created on the app-default host, so it
+            // follows the Settings engine-host switch (unchanged behavior). When
+            // a library is pinned to a SPECIFIC remote host (#2866 follow-up),
+            // this will branch on that; today there are no such libraries.
             ficheroClient.reconfigure(baseURL: EngineConfig.host)
             storageService.clearAll()
         }

--- a/fichero/fichero/Services/APIClient+Types.swift
+++ b/fichero/fichero/Services/APIClient+Types.swift
@@ -49,8 +49,10 @@ extension URLRequest {
     /// skip — see `AuthTokenMiddleware.unauthenticatedPaths`.
     mutating func addEngineAuth(libraryPath: String? = nil) {
         let path = url?.path ?? ""
+        // Resolve the token for THIS request's host (#2866), not the global
+        // default — raw requests can target any of the backends the app holds.
         if !AuthTokenMiddleware.isUnauthenticatedPath(path),
-           let token = AuthTokenMiddleware.waitForTokenBlocking() {
+           let token = AuthTokenMiddleware.waitForTokenBlocking(hostString: url?.absoluteString) {
             setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
         if let libraryPath {


### PR DESCRIPTION
App can hold N backends (one per library), auth token lookup keyed off request host. Swift-only, BUILD SUCCEEDED. Authored Claude (Opus 4.8).

Closes #2866