### PR TITLE
choose_next due-order fix (#2913) + developer docs (#1797) + worker-loop model & prompts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,30 @@ the target paths don't overlap another live lane. When a collision slips through
 worker that *wrote* the code reconciles it; the manager does not blind-`--theirs` a
 test whose semantics it can't verify.
 
+### Workers run a self-continuing LOOP, and signal the manager
+
+A worker is dispatched a **whole milestone**, not one issue. It **drains the
+milestone in a loop**: pick next ready issue → smallest correct slice + a test →
+commit-only (`Closes #n`, authored as itself) → **`bash scripts/notify_manager.sh
+"done #n (<sha>); next #m"`** → repeat. It never stops-and-waits between issues;
+the manager gates asynchronously. Blocked on a design wall →
+`notify_manager.sh --blocked "why"` and move on.
+
+`notify_manager.sh` appends to `~/.fichero-manager-inbox`; the manager arms a
+**Monitor** on that file so a completion wakes it immediately (no timer polling).
+
+**Every worker uses jcodemunch + ponytail.** Navigate code via the jcodemunch MCP
+(`search_symbols`/`get_file_outline`/`get_symbol_source`/`find_references`/
+`get_blast_radius`), reading only the file about to be edited — never grep-dumps.
+Write ponytail code: shortest working diff, stdlib/native/existing-dep before new
+code, no speculative abstractions, delete over add, one runnable test per
+non-trivial change, `ponytail:` comments for deliberate simplifications.
+
+**Reusable prompts:** `agents/prompts/worker-loop.md` (the standing worker
+contract, with `{{LANE}}`/`{{MILESTONE}}` placeholders) and
+`agents/prompts/manager-loop.md` (the manager cadence). Dispatch by pasting the
+filled worker-loop template.
+
 ---
 
 ## Working in Xcode

--- a/agents/prompts/manager-loop.md
+++ b/agents/prompts/manager-loop.md
@@ -1,0 +1,50 @@
+# Manager loop prompt
+
+The manager (`f_manager`) holds the control lane. It writes no feature code — it
+picks work, dispatches, gates, merges, and keeps the fleet looping. Standing
+cadence:
+
+## Pick + dispatch
+
+1. `python3 scripts/choose_next.py` — walks the `## Tier` spine in `docs/ROADMAP.md`
+   (foundations-first, milestones by due-date), returns the top ready milestone/batch.
+   The **board organizer** owns this script + the spine; if it returns the wrong
+   milestone, file a bug and hand it to the board — do NOT hand-edit ROADMAP order.
+2. `python3 scripts/dispatch_advisor.py <issue#>` → `mini | regular | frontier`.
+   `needs-design` / `frontier` keystones are NOT for free-model workers — escalate.
+3. Dispatch the **whole milestone** to one worker by lane label (`backend`→codex,
+   `client:swiftui`→claude, `docs`→codex-docs) using `agents/prompts/worker-loop.md`.
+   The worker drains the milestone in a loop; you don't re-dispatch per issue.
+
+## React to worker signals (don't poll)
+
+- Workers call `scripts/notify_manager.sh` after each commit → appends to
+  `~/.fichero-manager-inbox`. Arm a **Monitor** on that file so a completion wakes
+  you immediately. Drain + clear the inbox each time you act.
+- `--blocked` lines are design walls (e.g. a `needs-design` keystone) — surface to
+  Daniel or route to a frontier/design pass.
+
+## Gate + merge (the manager owns the one build + full suite)
+
+- Merge the worker's lane into `~/code/fichero-worktrees/integrate` (never Daniel's
+  `~/code/fichero` checkout). Resolve worker-scratch/`WORKER-REPORT.md` conflicts by
+  dropping them; a real code conflict on a test = the authoring worker reconciles it.
+- **Gate from the repo ROOT** (some contract tests read source via root-relative
+  paths): `bash scripts/verify_all.sh --standard|--full`, or the PYTHONPATH-forced
+  backend gate (`PYTHONPATH=<integrate>/fichero-engine/src pytest … from the root`).
+  Manager may run `verify_all.sh --full` / `xcodebuild test` serially; workers never.
+- Green → PR-merge to main, close issues, reset the worker's worktree to new main
+  (CHECK it has 0 uncommitted + 0 unmerged first — resetting over fresh commits
+  orphans them). Red → `python3 scripts/tests_to_issues.py <junit.xml>` files one
+  tracked issue per failure; route each to its lane.
+
+## File new issues via the script, never raw gh
+
+`scripts/file_issue.sh --title … --type … --lane …` — validates the milestone is
+OPEN, enforces the 15 canonical labels, auto-routes by keyword. Only the board
+organizer creates milestones.
+
+## Serialize builds (slow machine)
+
+ONE `xcodebuild`/full-suite at a time, machine-wide. Workers are commit-only. Never
+start a second build while one runs. `pkill -9 xcodebuild` for emergency load relief.

--- a/agents/prompts/worker-loop.md
+++ b/agents/prompts/worker-loop.md
@@ -1,0 +1,60 @@
+# Worker loop prompt (template)
+
+Fill in `{{LANE}}`, `{{MILESTONE}}`, `{{RUNTIME}}`, `{{AUTHOR}}` and paste to a
+worker tmux. This is the standing contract for a milestone-draining worker.
+
+---
+
+You are a Fichero **{{LANE}}** worker in your own git worktree
+(`~/code/fichero-worktrees/ms-*`), running `{{RUNTIME}}`. Author every commit as
+**{{AUTHOR}}** — never Daniel.
+
+## Your job — drain a milestone in a LOOP (don't stop after one issue)
+
+1. `git fetch origin && git reset --hard origin/main` — start clean on latest.
+2. List open issues in the **{{MILESTONE}}** milestone. Pick the next *ready* one
+   — SKIP `needs-design`, `needs:human`, screenshot/GUI-capture tasks, and
+   anything assigned or `status:in-progress`.
+3. Implement the **smallest correct slice** + a test (see Test bar).
+4. **Commit only** — NEVER build, NEVER run the full suite or `xcodebuild`
+   (the machine is slow; the manager gates serially). Backend: you may `ruff`
+   your own diff, but do NOT run pytest. `Closes #n` in the message.
+5. **Signal the manager:** `bash scripts/notify_manager.sh "done #n (<sha>); next #m"`
+6. **REPEAT from step 2.** Only stop when the milestone has no ready issue — then
+   `notify_manager.sh "milestone {{MILESTONE}} drained"` and idle. Never wait for
+   the manager between issues; it gates/merges your commits asynchronously.
+7. Blocked (design decision, ambiguity, cross-lane need)?
+   `bash scripts/notify_manager.sh --blocked "why"` and move to the next issue.
+
+## Code navigation — jcodemunch, not grep-dumps
+
+Use the **jcodemunch MCP** to find and understand code: `plan_turn` to start,
+`search_symbols` / `get_file_outline` / `get_symbol_source` / `find_references` /
+`get_blast_radius`. Read only the specific file you are about to edit. Do NOT
+bulk `grep`/`Read` to explore — it wastes context and misses structure.
+
+## Ponytail — lazy senior developer
+
+The best code is the code never written. Shortest working diff wins.
+Stdlib → native platform feature → already-installed dep → one line → minimum
+code, in that order. No speculative abstractions, no scaffolding "for later", no
+config for a value that never changes. Deletion over addition. Mark a deliberate
+simplification with a `ponytail:` comment naming the ceiling. If the explanation
+is longer than the code, delete the explanation.
+
+## Lane discipline — never touch another lane's files
+
+Stay strictly in **{{LANE}}**'s files:
+- `backend` → `fichero-engine/src/**` + engine `tests/**`
+- `docs` → `docs/**` (NOT `src/` unit tests — those are backend's)
+- `client:swiftui` → `fichero/**` Swift
+- `sharing`/features → authz + sharing routes/membership
+
+Two workers editing one file = an unmergeable collision. If your issue needs a
+file another lane owns, `notify_manager.sh --blocked` instead of reaching across.
+
+## Test bar (non-negotiable)
+
+Every change ships with a test. For a bug, write the failing repro FIRST. Cover
+edge / undo / validation / side-effect — not happy-path only. Test the logic
+(state, predicates, builders, ID parsing), not rendered pixels.

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,9 @@ Full user manual: [docs/user/README.md](user/README.md)
 
 Contributors and anyone building on or integrating with Fichero.
 
+- [Developer Overview](developer/README.md) — the short developer entry point.
+- [How Fichero Works](developer/how-fichero-works.md) — app ↔ engine runtime
+  model, storage, workflows, KG extraction, and curation.
 - [Architecture Overview](contributor/architecture-overview.md) — the two-part system: SwiftUI frontend + Python engine.
 - [OpenAPI and Generated Clients](contributor/openapi-and-clients.md) — the contract path from Python to Swift.
 - [Data Layer, Search, and Knowledge Graph Storage](contributor/data-search-and-kg.md) — DuckDB, LanceDB, entity writing.

--- a/docs/architecture/action_layer.md
+++ b/docs/architecture/action_layer.md
@@ -1,116 +1,108 @@
-# Action Layer — One Audited Action (EPIC #1848)
+# Action Layer — Current Architecture
 
-**Status:** PROPOSED — awaiting Daniel's approval before implementation.
-**Date:** 2026-06-10. **Twin of:** the Observable Data Layer (reads/change-stream); this is the writes/audit side.
+**Status:** BUILT core, with ongoing route-by-route adoption. This page
+describes what is on `main` today and marks remaining rollout work as planned.
 
-## The idea
+## What exists now
 
-Every app capability that changes state becomes ONE named, typed **action** in a backend
-registry, exposed once over the OpenAPI contract. The same action is then reached five ways:
-**UI buttons · chat tools (#1847) · App Intents (#1837) · tests · audit log**. One definition,
-one assertion, one record of who/when/how — and undo falls out of the audit.
+Fichero has a shipped backend action registry in
+`fichero-engine/src/fichero/actions/registry.py`. The registry is the canonical
+audited mutation path for routes that have been folded onto it.
 
-## Why (it answers four threads at once)
+The core pieces are built:
 
-- **Merge-bug class** → today there are ~95 mutating call sites, ~28 hand-rolled (raw
-  URLRequest / `additionalProperties`), each its own untested path. One action + one test = caught.
-- **UI verification** → a button that just calls a named action is testable: the test (and the
-  chat agent) call the same action and assert the persisted effect. Finishes #1230/#1810 but
-  asserts via the action contract, not pixel-poking.
-- **Agentic chat (#1847)** → the registry IS the tool set.
-- **Who-changed-what + undo** → the action layer is the single choke point to log actor +
-  before/after, and the before/after IS the undo payload. Decoupled from permissions (#1844).
+- `ActionContext`: carries `actor`, `origin_window`, `run_id`, and
+  `library_path`.
+- `ActionResult`: returns `ok`, `result`, `audit_id`, and `changed_domains`.
+- `ChangeSpec`: actions return audit payload (`before`, `after`, `target_ids`)
+  and change-stream payload (`emit_type`, typed id lists, optional `emit_fn`).
+- `registry.invoke(...)`: validates params, enforces write auth, executes the
+  action, writes `ActionAudit`, then emits the observable-layer change event.
 
-## Inventory (2026-06-10 audit) — what exists today
+This is not just a design sketch. The registry code is live and used by shipped
+mutation routes such as:
 
-~95 distinct mutating actions across 18 domains (entity, claim, annotation, note, document,
-batch, workflow, provider, conversation, saved-search, bibliography/citation, classification/
-ontology, image-editing, import, interpretation, action, …). ~67 use the typed OpenAPI client;
-**~28 are hand-rolled.** The 19 priority hand-rolled targets live in `ArtifactServiceGenerated`
-(claim-links, claim transitions, classification/claim-kind/epistemic-status CRUD, entity aliases,
-bibliography metadata/import/export). Image-editing (8 ops) hand-rolls for binary PNG previews.
+- documents in `api/routes/documents.py`
+- claims in `api/routes/claims.py`
+- notes in `api/routes/notes.py`
+- entities in `api/routes/entities.py`
+- bookmarks in `api/routes/bookmarks.py`
+- saved searches in `api/routes/search.py`
+- room writes in `api/routes/mind_palace.py`
 
-**5 capabilities lack a single endpoint** (need an action defined): duplicate/merge/relink
-annotation, UI search-index refresh, single-shot "run workflow" (today = batch+execute two-step).
+## Actual invoke contract
 
-Most non-annotation mutations have **no test asserting their effect**. (Annotations are the
-exception — `AnnotationServiceTests.swift`.)
+`registry.invoke(...)` does **not** compute separate before/after snapshots on
+its own. The built contract is:
 
-## Design
+1. look up the registered action by name
+2. validate the raw params against the action's Pydantic model
+3. enforce write access through `authz.py`
+4. run `execute(db, params, ctx) -> (result, ChangeSpec)`
+5. write an `ActionAudit` row from the returned `ChangeSpec`
+6. emit the observable-layer event from the same `ChangeSpec`
+7. return `ActionResult`
 
-### 1. Backend action registry — the ONE write path (do it right, systematically)
-The app is unreleased, so we standardize the **entire** mutation surface now rather than leaving
-two styles. **Every** mutation becomes a registered action; the **28 hand-rolled ops get
-rewritten** onto typed + audited actions (raw `URLRequest`/`additionalProperties` silently loses
-writes under Pydantic `extra="allow"` — constitution rule #4, and how merge broke — so none
-survive). The ONE thing we wrap-not-rewrite is each route's proven **business logic** (merge's
-reconciliation algorithm, the extraction pipeline): re-deriving correct algorithms risks
-regressions for no gain. So: rewrite all the **plumbing** to one uniform audited path; keep the
-**algorithms** intact behind it. **Test-first per domain** — capture current behavior in a test,
-refactor onto the action layer, keep it green, then add audit/undo assertions.
+That detail matters because the action implementation can include ids it
+created in `ChangeSpec.after`, which a blind registry snapshot could not.
 
-Introduce an `ActionRegistry` that routes delegate to:
+## Atomicity on current main
 
-```
-@action("entity.merge", params=MergeEntitiesParams, undoable=True)
-def merge_entities(db, params, ctx) -> ActionResult: ...
-```
+The registry now has an `atomic` flag on each action registration. For normal
+actions (`atomic=True`, the default), `registry.invoke(...)` wraps the execute +
+audit write in `db.transaction()`. That means an audit-write failure rolls back
+the mutation for actions using the default atomic path.
 
-- Each action: a stable **name** (`<domain>.<verb>`), a typed Pydantic **params** model, an
-  `execute(db, params, ctx)`, and (if undoable) an `invert(before, after) -> Action|None`.
-- Existing route handlers call `registry.invoke(name, params, ctx)` instead of mutating directly.
-  The route signature stays — minimal churn, OpenAPI unchanged for now.
-- `registry.invoke` is the choke point: it snapshots **before**, runs execute, snapshots **after**,
-  writes the **audit record**, and `emit_change(...)` (reusing the observable layer). One place.
-- A thin `POST /api/actions/invoke {name, params, actor, origin_window}` exposes the whole registry
-  generically (this is what chat tools + App Intents + UI-action tests drive).
+Emission is intentionally **best-effort after audit**:
 
-### 2. Audit record (reuse provenance #1832)
-`action_audit`: `id, action_name, actor, target_ids[], params, before, after, run_id, ts, undone`.
-Actor = device/session id now; a real user id once multi-user (#1844) lands. `before/after` are the
-domain-object snapshots needed to invert. Generalizes the existing entity `undoEntityAudit`.
+- `ActionAudit` write failure is fatal
+- `emit_change(...)` failure is logged and does not roll back the committed
+  mutation
 
-### 3. Undo
-- Backend: `POST /api/actions/audit/{id}/undo` applies the action's `invert(before, after)` (itself
-  an audited action → redo works, and undo-of-undo). Generalize entity audit-undo to all undoable
-  actions.
-- Frontend: register each invoked action with macOS **`UndoManager`** per window so **⌘Z / ⌘⇧Z**
-  work with real names ("Undo Merge Entities"). The view calls the action → gets the audit id →
-  registers an undo that POSTs the undo endpoint. The observable change-stream propagates the
-  undone state to other windows automatically.
+This matches the shipped split between durable mutation history and live UI
+observer updates.
 
-### 4. Per-action UI-action test
-For each registered action, a test invokes it (via `/api/actions/invoke` or the typed route) and
-asserts (a) the persisted effect and (b) an audit row was written. This is the durable
-replacement for "does this button actually work".
+## What "single audited write path" means in practice
 
-### 5. Chat tools (#1847) + App Intents (#1837)
-Generate both from the registry — same verbs, same params schemas. No second definition.
+For a migrated mutation, the route should:
 
-## Build order (sub-issues)
+- build or resolve an `ActionContext`
+- call `registry.invoke(...)`
+- let the registered action return a `ChangeSpec`
 
-1. **Registry + audit core** (backend keystone): `ActionRegistry`, `@action`, `ActionContext`,
-   `action_audit` table (via `db.py` `_ensure_table`, 0.0.x no-migration), `invoke` choke point
-   (snapshot→execute→snapshot→audit→emit), generic `POST /api/actions/invoke`. + tests.
-2. **Route ALL mutations through the registry, test-first, domain-by-domain**: start with
-   **entity.merge** (exhibit A), then sweep every domain — **rewriting all 28 hand-rolled ops**
-   (the 19 `ArtifactServiceGenerated` + 8 image-editing) onto typed + audited actions, and threading
-   the ~67 already-typed ones through `invoke`. Each action gets a test that captures current
-   behavior first, stays green through the refactor, then asserts the persisted effect + audit row.
-   Several waves; one domain per worker; full coverage, not just the priority subset.
-3. **Undo**: generalize audit-undo + `POST /api/actions/audit/{id}/undo` (backend) → **⌘Z
-   UndoManager** wiring (frontend).
-4. **Chat tools**: expose registry as agent tools (#1847).
-5. **App Intents**: expose registry as App Intents / Shortcuts / Spotlight (#1837).
-6. **Define the 5 missing actions** (annotation duplicate/merge/relink, search reindex, workflow
-   single-run).
+The action should:
 
-## Constraints
-- Engine may be remote → actions go over OpenAPI/HTTP, never local paths.
-- **Rewrite the plumbing, wrap the algorithms.** All 28 hand-rolled ops get rewritten onto typed +
-  audited actions; routes' proven business logic is wrapped, not re-derived (no gratuitous algorithm
-  rewrites). This is consistent with the iterate-not-replace rule: we retire *genuine wrong-pattern
-  duplication* by collapsing onto the canonical audited path — we don't build a parallel system.
-- **Test-first, no false greens:** capture behavior before refactor; the full unit suite is the gate
-  after any change to a shared file (change_stream/db/registry).
-- Milestone-at-a-time: the registry+audit core (step 1) unblocks the rest.
+- perform the business mutation
+- return the durable undo/audit payload in `before` / `after`
+- return the observer payload in `emit_type` and typed changed-id lists
+
+This is the invariant documented in
+`docs/contributor/backend-development-standards.md`: a complete mutation must
+do both audit and change-stream on the same path.
+
+## Current rollout boundary
+
+The registry core is built, but not every historical mutation in the engine has
+been normalized yet. Treat these categories separately:
+
+- **Built and canonical:** the folded routes already using `registry.invoke(...)`
+- **Still being migrated:** older direct-write routes that have not yet been
+  folded onto the action layer
+
+So the accurate statement on current `main` is:
+
+- the action layer is real and production code
+- it is the standard path for migrated mutations
+- full route-surface adoption is still ongoing, not finished
+
+## Why other docs refer to it
+
+This action layer is the write-side counterpart to the observable data layer:
+
+- `ActionAudit` gives durable mutation history and undo metadata
+- `emit_change(...)` gives live observer refresh
+- chat tools and other automation surfaces can reuse the same mutation path by
+  calling `registry.invoke(...)` instead of inventing a second writer
+
+That is why architecture docs for chat tools, node-model folds, and multi-user
+authorization all point back to the action registry.

--- a/docs/architecture/ai_infrastructure.md
+++ b/docs/architecture/ai_infrastructure.md
@@ -7,30 +7,43 @@
 
 ## 1. Current-state map
 
-### 1.1 The model-access choke point — `llm.py` (BUILT, mostly canonical)
+### 1.1 The model-access choke point — `llm.py` (BUILT)
 
-`fichero-engine/src/fichero/llm.py` is the de-facto single entry layer for all
-text/vision LLM traffic. Every workflow tool, CLI path, and route reaches a
-provider through one of its public coroutines:
+`fichero-engine/src/fichero/llm.py` is the shipped entry layer for LLM calls.
+The current public call surface is the set of coroutines in `llm.py`; provider
+construction sits underneath them.
+
+For workflow tools and agent/tool execution, the important built entry points
+are `chat(...)`, `chat_structured(...)`, `chat_with_tools(...)`, and the helper
+`chat_workflow(...)`. `chat_workflow(...)` dispatches to those shared functions
+instead of each workflow building its own model path.
+
+Every provider-backed path still bottoms out in `get_langchain_model(...)` for
+LangChain model construction, but that factory is now an internal model-builder
+under the higher-level chat functions, not the top-level workflow API.
+
+Current public coroutines:
 
 | Capability | Entry symbol (`llm.py`) | Notes |
 |---|---|---|
-| Chat | `chat` | LangChain-routed; Apple branch dispatches to fm-bridge |
+| Chat | `chat` | Main unstructured entry point; Apple branch dispatches to fm-bridge before LangChain |
 | Chat + Apple→cloud fallback | `chat_with_fallback` | **GAP: no paid-fallback gate — see §3** |
-| Structured output | `chat_structured` | provider-routed |
+| Structured output | `chat_structured` | Main structured entry point; Apple branch or LangChain structured output |
 | Structured + fallback chain | `chat_structured_with_fallback` | correctly gated by `_paid_remote_fallbacks_enabled` |
 | Tool/function calling | `chat_with_tools` | |
+| Workflow/tool dispatch | `chat_workflow` | Shared workflow/tool entry point that delegates to `chat`, `chat_structured`, or `chat_with_tools` |
 | Vision | `vision` → `_apple_vision_dispatch` / `get_langchain_model` | Apple-routed by `config.provider == "apple"` |
 | HF vision (direct) | `vision_inference_api` | **bypasses LangChain** — second vision path |
 | Translation | `translate_text` / `_translate_with_deepl` | |
 | Apple Intelligence | `_apple_intelligence_chat`, `_apple_intelligence_structured` | subprocess fm-bridge |
-| Model construction | `get_langchain_model` | the single place a LangChain ChatModel is built |
+| Model construction | `get_langchain_model` | internal LangChain ChatModel factory used by the shared chat helpers |
 
 Provider selection funnels through:
 - `LLMConfig` (the typed config object; `god-node` — `get_blast_radius` before changing).
 - `resolve_model_alias` — resolves `$small`/`$medium`/`$large` against app settings
   (`default_<tier>_provider` / `default_<tier>_model`) or `FICHERO_<TIER>_*` env.
-- `get_langchain_model` (`llm.py:2550`) — the canonical ChatModel factory, with
+- `get_langchain_model` — the canonical ChatModel factory under the shared chat
+  helpers, with
   OpenAI-compatible base-URL handling (`_OPENAI_COMPATIBLE_BASE_URLS`,
   `_KEYLESS_OPENAI_COMPATIBLE = {ollama, lmstudio, omlx}`) and OpenRouter quirks
   (`_make_openrouter_http_client`, `_openrouter_strip_parallel_tool_use`).
@@ -41,9 +54,14 @@ Provider **metadata** lives separately in `fichero-engine/src/fichero/providers.
 the static capability registry; `_is_local_or_builtin_provider` (llm.py) reads it
 to decide free-vs-paid.
 
-**Verdict:** `llm.py` IS the canonical text/vision choke point. The iterate-don't-replace
-move is to *fold* the gaps below onto it, not to introduce a new "model gateway"
-module.
+`litellm` is present in this module, but on current `main` it is not the model
+routing layer. The routing and model construction path is LangChain plus the
+Apple fm-bridge branch; `litellm` is used for cost/model metadata helpers, not
+as the canonical workflow/provider dispatch path.
+
+**Verdict:** `llm.py` is the canonical text/vision choke point, and the shipped
+workflow/tool convention is "call `chat(...)` / `chat_structured(...)`" rather
+than "call `get_langchain_model(...)` directly".
 
 ### 1.2 Embeddings — a SEPARATE, duplicated path (BUILT, two layers)
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -41,6 +41,7 @@ than deleting databases.
 
 ## Canonical architecture docs
 
+- Audited mutation path / action registry: `docs/architecture/action_layer.md`
 - API/backend architecture: `docs/architecture/api/overview.md`
 - AI infrastructure and model policy: `docs/architecture/ai_infrastructure.md`
 - Image editing backend strategy: `docs/architecture/image_editing_backend_strategy.md`

--- a/docs/developer/README.md
+++ b/docs/developer/README.md
@@ -1,0 +1,29 @@
+# Developer Docs
+
+This section is the short, code-grounded entry point for developers who need
+to understand how the current Fichero app fits together before diving into the
+deeper contributor reference.
+
+## Start here
+
+- [How Fichero Works](./how-fichero-works.md) — the runtime shape of the SwiftUI
+  app, the FastAPI engine, storage, workflows, the KG extraction path, and
+  curation.
+
+## Then use the deeper reference
+
+The detailed contributor manuals remain under `docs/contributor/`:
+
+- [Contributor Overview](../contributor/README.md)
+- [Architecture Overview](../contributor/architecture-overview.md)
+- [OpenAPI and Generated Clients](../contributor/openapi-and-clients.md)
+- [Data, Search, and Knowledge Graph](../contributor/data-search-and-kg.md)
+- [Workflows, Activity, and Curation](../contributor/workflows-activity-and-curation.md)
+- [Action Registry](../contributor/action-registry.md)
+- [Security Model](../contributor/security-model.md)
+- [Setup and Contributing](../contributor/setup-and-contributing.md)
+
+The split is intentional:
+
+- `docs/developer/` is the quick "how the shipped system works" layer
+- `docs/contributor/` is the broader maintenance and implementation reference

--- a/docs/developer/how-fichero-works.md
+++ b/docs/developer/how-fichero-works.md
@@ -1,0 +1,172 @@
+# How Fichero Works
+
+This page describes the current shipped architecture on `main`. It is grounded
+in the SwiftUI app under `fichero/fichero/` and the FastAPI engine under
+`fichero-engine/src/fichero/`.
+
+## 1. Top-level runtime model
+
+Fichero is a two-part system:
+
+- `fichero/fichero/`: the Apple client, built in SwiftUI
+- `fichero-engine/src/fichero/`: the Python FastAPI engine
+
+The normal app path is not "Swift reads and writes the library directly." The
+app talks to the engine over the HTTP API and the engine owns persistence,
+workflows, search, and AI behavior.
+
+On the client side:
+
+- `EngineConfig.swift` defines the engine host and `/api` base URL
+- `EmbeddedBackendService.swift` manages the embedded/local-engine path on macOS
+- `FicheroApp.swift` mounts `LibraryWindow`
+- `LibraryWindow.swift` injects the per-library environment and opens
+  `DocumentTabView`
+- `DocumentTabView.swift` hosts `ContentView`, which is the main workspace shell
+
+On current `main`, macOS can use a local engine host, while iPhone and iPad use
+the configured external-host path rather than starting an embedded engine.
+
+## 2. Frontend → backend contract
+
+The frontend uses the generated OpenAPI client plus hand-written Swift service
+wrappers:
+
+- `fichero/fichero/Services/APIClient.swift` is the shared client wrapper
+- many domain services are generated wrappers such as
+  `DocumentServiceGenerated.swift`, `SearchServiceGenerated.swift`,
+  `WorkflowServiceGenerated.swift`, and `ChatServiceGenerated.swift`
+- some richer surfaces use hand-written wrappers around the same client, such as
+  `AnnotationService.swift`, `NoteService.swift`, and stores under
+  `fichero/fichero/Models/`
+
+The important architectural rule is that the app does not invent a second
+backend protocol. The contract is the engine's OpenAPI surface plus the typed
+Swift wrappers built on top of it.
+
+## 3. Backend shape
+
+The engine entry point is `fichero.api.main`. Feature behavior is mostly split
+by route module under `fichero/api/routes/`.
+
+Examples:
+
+- documents and folders: `api/routes/documents.py`
+- search and saved searches: `api/routes/search.py`
+- entities: `api/routes/entities.py`
+- claims: `api/routes/claims.py`
+- claim curation: `api/routes/claim_curation.py`
+- entity curation: `api/routes/kg_entity_curation.py`
+- workflows: `api/routes/workflows.py`
+
+That route layer sits on top of shared storage and workflow modules rather than
+each route owning its own persistence strategy.
+
+## 4. Storage: DuckDB + LanceDB
+
+`fichero-engine/src/fichero/db.py` is the main storage wrapper.
+
+Current built split:
+
+- DuckDB stores the typed library rows and most queryable metadata
+- LanceDB stores vector indexes used for semantic search and KG embeddings
+
+The `Database` class in `db.py` wraps both layers. The database comments and
+helper methods on current `main` are explicit that one process owns a library
+read-write, DuckDB is the structured store, and LanceDB is the vector store.
+
+Related pieces:
+
+- `db_manager.py` manages per-library `Database` instances
+- `db_embeddings.py` owns the canonical embedding write/search helpers
+
+## 5. Workflows and the execution engine
+
+The workflow engine is LangGraph-backed on current `main`.
+
+Grounded code points:
+
+- `fichero-engine/src/fichero/execution/runner.py` builds and compiles a
+  LangGraph `StateGraph`
+- workflow tools live under `fichero-engine/src/fichero/workflows/tools/`
+- tool registration lives in `fichero-engine/src/fichero/workflows/registry.py`
+- `workflows/tools/agent.py` wraps workflow tools for LangChain/LangGraph agent
+  use
+
+So the accurate description is:
+
+- route layer accepts workflow requests
+- execution runner builds the LangGraph graph
+- tools do the real document/AI/search/KG work
+
+## 6. LLM path
+
+The centralized LLM entry surface is `fichero-engine/src/fichero/llm.py`.
+
+For current workflow/tool code, the important public helpers are:
+
+- `chat(...)`
+- `chat_structured(...)`
+- `chat_with_tools(...)`
+- `chat_workflow(...)`
+
+`chat_workflow(...)` is the shared workflow/tool dispatcher. It delegates to
+the same centralized helpers rather than each workflow constructing its own
+provider path. `get_langchain_model(...)` still exists, but as the LangChain
+model factory under those higher-level entry points.
+
+## 7. Knowledge-graph extraction path
+
+The current KG extraction pipeline is not one monolithic "KG route." It is a
+workflow/tool pipeline that produces and persists `KnowledgeEntity` and
+`KnowledgeClaim` rows.
+
+The main shipped path is:
+
+- extract text/records from documents
+- run extractor tools
+- turn extracted items into entity/claim rows
+- optionally write or finalize KG payloads for downstream workflow steps
+
+Grounded code points:
+
+- `workflows/tools/extract_all.py` is the combined extraction tool and can emit
+  `kg_payload`
+- `workflows/tools/extractors.py` contains the typed extractor logic and the
+  persistence helpers that turn extractor output into `KnowledgeEntity` and
+  `KnowledgeClaim` rows
+- `workflows/tools/_entity_writer.py` is the shared entity/claim write path for
+  deduping, upserting entities, and saving claims
+- `workflows/tools/kg_writer.py` is the downstream writer for `kg_payload` when
+  a workflow splits extraction from persistence
+
+That means "KG extraction" is currently a workflow/tool concern first, and a
+query/render concern second.
+
+## 8. Entity and claim curation
+
+Entity/claim curation is built as explicit API and workflow surfaces, not just
+an internal post-processing step.
+
+Current built pieces include:
+
+- CRUD and query routes for entities in `api/routes/entities.py`
+- CRUD and query routes for claims in `api/routes/claims.py`
+- entity curation routes in `api/routes/kg_entity_curation.py`
+- claim curation routes in `api/routes/claim_curation.py`
+- workflow cleanup/merge passes in `workflows/tools/cleanup.py` and
+  `workflows/tools/merge_dedup_only.py`
+
+So there are two complementary layers:
+
+- the route layer for reviewer-facing curation and API access
+- the workflow/tool layer for extraction cleanup, dedup, and merge flows
+
+## 9. Where to read next
+
+Use this page as the short mental model, then drill down:
+
+- deeper backend/frontend split: [../contributor/architecture-overview.md](../contributor/architecture-overview.md)
+- OpenAPI client path: [../contributor/openapi-and-clients.md](../contributor/openapi-and-clients.md)
+- storage and KG details: [../contributor/data-search-and-kg.md](../contributor/data-search-and-kg.md)
+- workflows and curation: [../contributor/workflows-activity-and-curation.md](../contributor/workflows-activity-and-curation.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -105,6 +105,9 @@ nav:
       - Search & Knowledge Graph: user/search-knowledge-graph.md
       - Curation, Notes & Workflows: user/curation-notes-workflows.md
       - AI & Privacy: user/ai-and-privacy.md
+  - Developer:
+      - Overview: developer/README.md
+      - How Fichero Works: developer/how-fichero-works.md
   - Contributor:
       - Overview: contributor/README.md
       - Architecture Overview: contributor/architecture-overview.md

--- a/scripts/choose_next.py
+++ b/scripts/choose_next.py
@@ -353,26 +353,35 @@ def select_batch(tiers: list[RoadmapTier], all_issues: list[Issue]) -> dict[str,
         if not ready:
             continue
 
-        big = sorted((issue for issue in ready if issue.is_big), key=tier_sort_key)
-        if big:
-            selected = [big[0]]
-            mode = "one-big"
-        else:
-            grouped: dict[str, list[Issue]] = defaultdict(list)
-            for issue in ready:
-                grouped[issue.milestone].append(issue)
-            milestone_order = [*tier.milestones, *[issue.milestone for issue in ready]]
-            selected = []
-            for milestone in _dedupe_keep_order(milestone_order):
-                group = sorted(grouped.get(milestone, []), key=tier_sort_key)
-                if len(group) >= 3:
-                    selected = group[:10]
-                    break
-            if selected:
+        # Milestone order within a tier is authoritative: tier.milestones is written in
+        # ascending due-date order, so the earliest-due milestone with ready work wins.
+        # We must NOT jump to a big/keystone issue in a LATER milestone while an earlier
+        # milestone still has ready work (#2913). Big-vs-batch is decided WITHIN the
+        # first ready milestone only.
+        grouped: dict[str, list[Issue]] = defaultdict(list)
+        for issue in ready:
+            grouped[issue.milestone].append(issue)
+        milestone_order = _dedupe_keep_order([*tier.milestones, *[issue.milestone for issue in ready]])
+
+        selected: list[Issue] = []
+        mode = ""
+        for milestone in milestone_order:
+            group = sorted(grouped.get(milestone, []), key=tier_sort_key)
+            if not group:
+                continue
+            bigs = [issue for issue in group if issue.is_big]
+            if bigs:
+                selected = [bigs[0]]
+                mode = "one-big"
+            elif len(group) >= 3:
+                selected = group[:10]
                 mode = "small-batch"
             else:
-                selected = sorted(ready, key=tier_sort_key)[:1]
-                mode = "one-ready-fallback"
+                selected = group
+                mode = "small-batch" if len(group) > 1 else "one-ready-fallback"
+            break
+        if not selected:
+            continue
 
         return {
             "tier": {"key": tier.key, "title": tier.title},
@@ -472,6 +481,33 @@ def run_self_test() -> int:
     assert big_selection["tier"]["key"] == "1", big_selection
     assert big_selection["mode"] == "one-big", big_selection
     assert [issue["number"] for issue in big_selection["issues"]] == [74], big_selection
+
+    # Regression #2913: within a tier, the earliest-due milestone with ready work wins.
+    # A big/keystone issue in a LATER milestone must NOT jump ahead of an earlier
+    # milestone's ready batch (was: choose_next returned Developer Experience's keystone
+    # #2888 instead of Dev & Build Harness's ready batch).
+    spine_tier = [RoadmapTier("1", "Foundation", ("Dev & Build Harness", "Developer Experience"), ())]
+    spine_issues = [
+        Issue(2860, "dev builds should not prompt move to Applications", ("client:swiftui",), (), "Dev & Build Harness"),
+        Issue(2870, "nightly build + changelog", ("backend",), (), "Dev & Build Harness"),
+        Issue(2871, "verify_all incremental", ("backend",), (), "Dev & Build Harness"),
+        Issue(2888, "CLI keystone: route through the audited action registry", ("backend",), (), "Developer Experience"),
+    ]
+    assert spine_issues[3].is_big, "fixture invalid: #2888 must be big (keystone marker)"
+    spine_sel = select_batch(spine_tier, spine_issues)
+    assert spine_sel["milestone"] == "Dev & Build Harness", spine_sel
+    assert spine_sel["mode"] == "small-batch", spine_sel
+    spine_nums = {issue["number"] for issue in spine_sel["issues"]}
+    assert spine_nums == {2860, 2870, 2871}, spine_sel
+    assert 2888 not in spine_nums, spine_sel
+
+    # Regression #2913: the real spine must list Dev & Build Harness (#109, due 07-05)
+    # before Developer Experience (#64, due 07-09) in Tier 1.
+    if DEFAULT_ROADMAP.exists():
+        t1 = next((t for t in parse_roadmap(DEFAULT_ROADMAP) if t.key == "1"), None)
+        assert t1 is not None, "no Tier 1 in real ROADMAP"
+        assert "Dev & Build Harness" in t1.milestones and "Developer Experience" in t1.milestones, t1
+        assert t1.milestones.index("Dev & Build Harness") < t1.milestones.index("Developer Experience"), t1
 
     current_roadmap = """
 ### ▶▶ REFINED ORDER (2026-06-11 PM design session) — authoritative over the 4 phases below


### PR DESCRIPTION
Picker now returns Dev & Build Harness #109 first (verified). Adds worker-loop/manager-loop prompts + notify_manager loop model in AGENTS. Docs+scripts only. Authored Claude/Codex.