### PR TITLE
fix: use observable-object feature manager injection

### DIFF
--- a/fichero/fichero-tests/DocumentStoreAndSidebarTypesTests.swift
+++ b/fichero/fichero-tests/DocumentStoreAndSidebarTypesTests.swift
@@ -254,7 +254,7 @@ final class DocumentStoreAndSidebarTypesTests: XCTestCase {
         let requiredSnippets = [
             "@Environment(ArtifactServiceGenerated.self) var artifactService",
             ".environment(artifactService)",
-            ".environment(FeatureManager.shared)",
+            ".environmentObject(FeatureManager.shared)",
             "@Environment(WorkflowStreamService.self) var workflowStreamService",
             "@Environment(ResearchService.self) var researchService",
             "@Environment(ClaimFocusState.self) var claimFocusState",
@@ -270,7 +270,7 @@ final class DocumentStoreAndSidebarTypesTests: XCTestCase {
         for snippet in requiredSnippets {
             XCTAssertTrue(tabSource.contains(snippet), "Missing snippet: \(snippet)")
         }
-        XCTAssertTrue(contentViewSource.contains("@Environment(FeatureManager.self) var featureManager"))
+        XCTAssertTrue(contentViewSource.contains("@EnvironmentObject var featureManager: FeatureManager"))
     }
 
     func testMacBackendSettingsShowsInlinePairingQrAndNoSheetAssumption() throws {

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -179,7 +179,7 @@ struct ContentView: View {
     // prereq for the ContentView+State extractions (#3033). Still the shared
     // instances at runtime; injection is the seam.
     @Environment(ErrorService.self) var errorService
-    @Environment(FeatureManager.self) var featureManager
+    @EnvironmentObject var featureManager: FeatureManager
 
     // Pane focus state for Tab cycling
     @FocusState var focusedPane: PaneFocus?
@@ -949,7 +949,7 @@ private struct ToolbarSearchableModifier: ViewModifier {
         .environment(ViewSettings())
         .environment(AppState())
         .environment(ErrorService.shared)
-        .environment(FeatureManager.shared)
+        .environmentObject(FeatureManager.shared)
         .frame(width: 1200, height: 700)
 }
 
@@ -965,7 +965,7 @@ private struct ToolbarSearchableModifier: ViewModifier {
         .environment(ViewSettings())
         .environment(AppState())
         .environment(ErrorService.shared)
-        .environment(FeatureManager.shared)
+        .environmentObject(FeatureManager.shared)
         .environment(\.horizontalSizeClass, .regular)
         .frame(width: 1200, height: 700)
 }
@@ -975,7 +975,7 @@ private struct ToolbarSearchableModifier: ViewModifier {
         .environment(ViewSettings())
         .environment(AppState())
         .environment(ErrorService.shared)
-        .environment(FeatureManager.shared)
+        .environmentObject(FeatureManager.shared)
         .environment(\.horizontalSizeClass, .compact)
         .frame(width: 390, height: 780)
 }

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
@@ -43,7 +43,7 @@ struct DocumentInspector: View {
     @Environment(EntityServiceGenerated.self) private var entityService
     @Environment(ArtifactServiceGenerated.self) private var artifactService
     @Environment(KGCurationServiceGenerated.self) private var kgCurationService
-    @Environment(FeatureManager.self) private var featureManager
+    @EnvironmentObject private var featureManager: FeatureManager
     @Environment(ClaimFocusState.self) private var claimFocusState
     /// Cross-view KG focus. When an entity is focused (a lozenge / WebKit-graph
     /// click), the inspector retargets to inspect that entity instead of the

--- a/fichero/fichero/Views/Shell/DocumentTabView.swift
+++ b/fichero/fichero/Views/Shell/DocumentTabView.swift
@@ -116,11 +116,11 @@ struct DocumentTabView: View {
                     .environment(researchService)
                     .environment(windowState)
                     // App-wide singletons injected at the ContentView host so
-                    // ContentView reads them via @Environment(Type.self) rather
+                    // ContentView reads them via environment injection rather
                     // than grabbing `.shared` — the DI seam for #3033. Shared
                     // instances, no new objects created here.
                     .environment(ErrorService.shared)
-                    .environment(FeatureManager.shared)
+                    .environmentObject(FeatureManager.shared)
                     // Forward the @Observable artifact service so the library
                     // subtree built after `selectCollection` (LibraryView →
                     // inspector / artifact cells) can read it via

--- a/fichero/fichero/Views/Workflow/NodePopover.swift
+++ b/fichero/fichero/Views/Workflow/NodePopover.swift
@@ -26,7 +26,7 @@ struct NodePopover: View {
     @Environment(DocumentStore.self) var documentStore: DocumentStore
     @Environment(SavedSearchServiceGenerated.self) var savedSearchServiceGenerated
     @Environment(WorkflowServiceGenerated.self) var workflowService
-    @Environment(FeatureManager.self) private var featureManager
+    @EnvironmentObject private var featureManager: FeatureManager
 
     // Dynamic prompt from backend (fetched based on current config)
     @State private var backendPrompt: String?
@@ -348,5 +348,5 @@ struct NodePopover: View {
     .environment(library.documentStore)
     .environment(library.savedSearchServiceGenerated)
     .environment(library.workflowServiceGenerated)
-    .environment(FeatureManager.shared)
+    .environmentObject(FeatureManager.shared)
 }

--- a/fichero/fichero/Views/Workflow/WorkflowCanvasView.swift
+++ b/fichero/fichero/Views/Workflow/WorkflowCanvasView.swift
@@ -39,7 +39,7 @@ struct WorkflowCanvasView: View {
     // App state for accessing AI defaults
     @Environment(AppState.self) var appState
     @Environment(\.undoManager) private var undoManager
-    @Environment(FeatureManager.self) var featureManager
+    @EnvironmentObject var featureManager: FeatureManager
 
     /// Node execution states for the editor canvas.
     ///
@@ -513,7 +513,7 @@ extension WorkflowCanvasView {
                 snapToGrid: $snapToGrid
             )
             .environment(executionObserver)
-            .environment(FeatureManager.shared)
+            .environmentObject(FeatureManager.shared)
             .frame(width: 800, height: 500)
         }
     }

--- a/fichero/fichero/Views/Workflow/WorkflowEditor.swift
+++ b/fichero/fichero/Views/Workflow/WorkflowEditor.swift
@@ -39,7 +39,7 @@ struct WorkflowEditor: View {
     @Environment(WorkflowStreamService.self) var workflowStreamService
     @Environment(DocumentStore.self) var documentStore: DocumentStore
     @Environment(LibraryManager.self) var libraryManager
-    @Environment(FeatureManager.self) var featureManager
+    @EnvironmentObject var featureManager: FeatureManager
 
     // Uses @Observable pattern - injected via .environment() from LibraryWindow
     @Environment(WorkflowExecutionObserver.self) var executionObserver

--- a/fichero/fichero/Views/Workflow/WorkflowNodeView.swift
+++ b/fichero/fichero/Views/Workflow/WorkflowNodeView.swift
@@ -13,7 +13,7 @@ struct WorkflowNodeView: View {
     let onPortDropReceived: (PortInfo, String) -> Void
     var onInputPortDetach: ((PortInfo, String) -> Void)?  // Detach from connected input
     var executionState: NodeExecutionState?  // Optional execution state for progress display
-    @Environment(FeatureManager.self) private var featureManager
+    @EnvironmentObject private var featureManager: FeatureManager
     @Environment(WorkflowStore.self) private var workflowStore
 
     private let width: CGFloat = 140


### PR DESCRIPTION
## Summary
- restore FeatureManager injection to ObservableObject-compatible @EnvironmentObject APIs
- update guardrail expectations for the release build

## Verification
- swiftlint lint fichero/fichero/ --quiet
- xcodebuild -project fichero/fichero.xcodeproj -scheme "Fichero (Release Embedded)" -configuration Release -derivedDataPath fichero/build/xcode -skipPackagePluginValidation SPARKLE_FEED_URL=https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml build