### PR TITLE
fix: repair Swift build after inspector batch

### DIFF
--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -799,7 +799,7 @@ extension ContentView {
                     }
                 }
             )
-            .environment(documentService)
+            .environment(documentStore.documentService)
             .environment(artifactService)
             .environment(entityService)
             .environment(kgCurationService)

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -719,7 +719,7 @@ extension ContentView {
     /// LEADING zone: back/forward history navigation in the content-column toolbar.
     @ToolbarContentBuilder
     private var leadingToolbarContent: some ToolbarContent {
-        ToolbarItemGroup(id: ContentToolbarID.navigationHistory, placement: .navigation) {
+        ToolbarItemGroup(placement: .navigation) {
             Button {
                 navigateBack()
             } label: {
@@ -786,7 +786,7 @@ extension ContentView {
         // hidden (#2813).
         if supportsReadingWorkspace
             && !Self.shouldUseCompactNavigationFlow(horizontalSizeClass: horizontalSizeClass) {
-            ToolbarItemGroup(id: ContentToolbarID.contentPaneToggles, placement: .automatic) {
+            ToolbarItemGroup(placement: .automatic) {
                 if showViewModePicker && availableViewDisplayModes.count > 1 {
                     viewDisplayModeMenu
                 }

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -380,7 +380,7 @@ struct DocumentInspectorEntitiesTab: View {
             action: { payloads, _ in
                 handleEntityDrop(payloads: payloads, onto: entity)
             },
-            isTargeted: dropTargetBinding(for: entity)
+            isTargeted: dropTargetHandler(for: entity)
         )
         .simultaneousGesture(
             TapGesture(count: 2).onEnded { openEntity(entity) }
@@ -642,19 +642,16 @@ struct DocumentInspectorEntitiesTab: View {
         onEntitySelect?(id)
     }
 
-    private func dropTargetBinding(
+    private func dropTargetHandler(
         for entity: Components.Schemas.KnowledgeEntity
-    ) -> Binding<Bool> {
-        Binding(
-            get: { dropTargetEntityId == entity.stableInspectorId },
-            set: { isTargeted in
-                if isTargeted {
-                    dropTargetEntityId = entity.stableInspectorId
-                } else if dropTargetEntityId == entity.stableInspectorId {
-                    dropTargetEntityId = nil
-                }
+    ) -> (Bool) -> Void {
+        { isTargeted in
+            if isTargeted {
+                dropTargetEntityId = entity.stableInspectorId
+            } else if dropTargetEntityId == entity.stableInspectorId {
+                dropTargetEntityId = nil
             }
-        )
+        }
     }
 
     @ViewBuilder

--- a/fichero/fichero/Views/Library/LibraryOutlineNode.swift
+++ b/fichero/fichero/Views/Library/LibraryOutlineNode.swift
@@ -245,7 +245,7 @@ final class LibraryOutlineModel {
               !entityRequested.contains(documentId) else { return }
         entityRequested.insert(documentId)
         do {
-            entitiesByDocumentId[documentId] = try await artifactService.listInspectorEntitiesForDocument(
+            entitiesByDocumentId[documentId] = try await service.listInspectorEntitiesForDocument(
                 documentId: documentId
             )
         } catch {
@@ -258,7 +258,7 @@ final class LibraryOutlineModel {
               !claimRequested.contains(documentId) else { return }
         claimRequested.insert(documentId)
         do {
-            claimsByDocumentId[documentId] = try await artifactService.listClaims(
+            claimsByDocumentId[documentId] = try await service.listClaims(
                 sourceDocumentId: documentId,
                 includeDescendants: false,
                 limit: 500

--- a/fichero/fichero/Views/Library/LibraryView+TableMapViews.swift
+++ b/fichero/fichero/Views/Library/LibraryView+TableMapViews.swift
@@ -1,3 +1,4 @@
+import FicheroAPIClient
 import SwiftUI
 // swiftlint:disable file_length
 
@@ -79,7 +80,23 @@ extension LibraryView {
             outlineColumns
         } rows: {
             ForEach(outlineNodes) { node in
-                outlineTableRow(node)
+                if nodeCanExpand(node) {
+                    DisclosureTableRow(node, isExpanded: expansionBinding(for: node)) {
+                        ForEach(node.children ?? []) { childGroup in
+                            if nodeCanExpand(childGroup) {
+                                DisclosureTableRow(childGroup, isExpanded: expansionBinding(for: childGroup)) {
+                                    ForEach(childGroup.children ?? []) { child in
+                                        TableRow(child)
+                                    }
+                                }
+                            } else {
+                                TableRow(childGroup)
+                            }
+                        }
+                    }
+                } else {
+                    TableRow(node)
+                }
             }
         }
         .onChange(of: selection) { _, newSelection in
@@ -109,19 +126,6 @@ extension LibraryView {
                     )
                 }
             }
-        }
-    }
-
-    @ViewBuilder
-    private func outlineTableRow(_ node: LibraryOutlineNode) -> some View {
-        if nodeCanExpand(node) {
-            DisclosureTableRow(node, isExpanded: expansionBinding(for: node)) {
-                ForEach(node.children ?? []) { child in
-                    outlineTableRow(child)
-                }
-            }
-        } else {
-            TableRow(node)
         }
     }
 

--- a/fichero/fichero/Views/Sidebar/SidebarItemRow+Presentation+Body.swift
+++ b/fichero/fichero/Views/Sidebar/SidebarItemRow+Presentation+Body.swift
@@ -148,7 +148,7 @@ extension SidebarItemRow {
     /// SwiftUI's tap-vs-drag disambiguation (#711 follow-up).
     private var leafLabel: some View {
         fullWidthLabel
-            .sidebarDropHighlight(isDropTargeted)
+            .sidebarDropHighlight(isDropTargeted, stronger: false)
             .onDrop(
                 of: [UTType.utf8PlainText, UTType.item],
                 isTargeted: $isDropTargeted


### PR DESCRIPTION
## Summary
- fixes Swift compile breaks after the inspector batch merge
- updates library outline table rows to use a bounded DisclosureTableRow hierarchy
- routes entity/claim outline loads through the correct generated service
- adjusts toolbar, inspector environment, sidebar drop highlight, and dropDestination API call sites for the current SDK

## Verification
- swiftlint lint on touched Swift files
- xcodebuild -project fichero/fichero.xcodeproj -scheme 'Fichero (Dev Local)' -destination 'platform=macOS' -skipPackagePluginValidation build