### PR TITLE
fix: advance inspector and knowledge graph interactions

### DIFF
--- a/fichero/fichero-tests/ClaimSummaryCardTests.swift
+++ b/fichero/fichero-tests/ClaimSummaryCardTests.swift
@@ -106,6 +106,15 @@ final class ClaimSummaryCardTests: XCTestCase {
         XCTAssertFalse(svoRenderer.contains("ficheroEntitySearchRequested"))
     }
 
+    func testVerbAndObjectChipsEnterInlineEditing() throws {
+        let source = try Self.appSource("Views/KnowledgeGraph/OntologyBrowser/ClaimSummaryCardView.swift")
+
+        XCTAssertTrue(source.contains("private func beginInlineEditing()"))
+        XCTAssertTrue(source.contains("Text(svo.verb)"))
+        XCTAssertTrue(source.contains("Text(svo.object)"))
+        XCTAssertTrue(source.contains("beginInlineEditing()"))
+    }
+
     func testExpandedDetailsShowSourceClaimText() throws {
         let source = try Self.appSource("Views/KnowledgeGraph/OntologyBrowser/ClaimSummaryCard+Details.swift")
 

--- a/fichero/fichero-tests/ClaimSummaryCardTests.swift
+++ b/fichero/fichero-tests/ClaimSummaryCardTests.swift
@@ -4,6 +4,7 @@ import Foundation
 import XCTest
 
 @MainActor
+// swiftlint:disable:next type_body_length
 final class ClaimSummaryCardTests: XCTestCase {
 
     private static func appSource(_ relativePath: String) throws -> String {
@@ -342,6 +343,14 @@ final class ClaimSummaryCardTests: XCTestCase {
         XCTAssertEqual(candidates.first?.score, 0.91)
         XCTAssertEqual(candidates.last?.name, "Andagoia")    // "name" fallback when no canonical_name
         XCTAssertTrue(EntityDetailView.parseDuplicateCandidates(Data(), excluding: "x").isEmpty)
+    }
+
+    func testLocationEntitiesHideGenericClaimsSection() {
+        let location = makeKnowledgeEntity(id: "entity-1", name: "Andagoya", type: .location)
+        let person = makeKnowledgeEntity(id: "entity-2", name: "Crawfurd", type: .person)
+
+        XCTAssertFalse(EntityDetailView.showsClaimsSection(for: location))
+        XCTAssertTrue(EntityDetailView.showsClaimsSection(for: person))
     }
 
     private func decodeClaim(_ json: String) throws -> Components.Schemas.KnowledgeClaim {

--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -84,6 +84,18 @@ final class DocumentInspectorTests: XCTestCase {
         XCTAssertTrue(source.contains("openWindow(id: \"artifact-detail\")"))
     }
 
+    func testInspectorListsUseFullRowContentShapes() throws {
+        let artifactList = try Self.appSource("Views/Library/Inspector/ArtifactListView.swift")
+        let annotationList = try Self.appSource("Views/Library/Inspector/AnnotationListView.swift")
+        let citationList = try Self.appSource("Views/Library/Inspector/CitationListView.swift")
+        let noteList = try Self.appSource("Views/Notes/NoteListView.swift")
+
+        XCTAssertTrue(artifactList.contains(".contentShape(Rectangle())"))
+        XCTAssertTrue(annotationList.contains(".contentShape(Rectangle())"))
+        XCTAssertTrue(citationList.contains(".contentShape(Rectangle())"))
+        XCTAssertTrue(noteList.contains(".contentShape(Rectangle())"))
+    }
+
     func testDocumentInspectorNoLongerIncludesOutlineTabSurface() throws {
         let source = try Self.appSource("Views/Library/DocumentInspector/DocumentInspector.swift")
 

--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -68,6 +68,22 @@ final class DocumentInspectorTests: XCTestCase {
         XCTAssertFalse(annotationsSource.localizedCaseInsensitiveContains("back to document"))
     }
 
+    func testArtifactInspectorListSupportsDoubleClickOpenInWindow() throws {
+        let source = try Self.appSource("Views/Library/Inspector/ArtifactListView.swift")
+
+        XCTAssertTrue(source.contains(".onTapGesture(count: 2)"))
+        XCTAssertTrue(source.contains("focused.select(artifact.id, in: store.items)"))
+        XCTAssertTrue(source.contains("onOpenInWindow()"))
+    }
+
+    func testOutlineArtifactDoubleClickOpensArtifactWindowInsteadOfParentDocument() throws {
+        let source = try Self.appSource("Views/Library/LibraryView+TableMapViews.swift")
+
+        XCTAssertTrue(source.contains("handleOutlineDoubleClickSelection()"))
+        XCTAssertTrue(source.contains("if let artifactSelection = artifactSelectionForNodeId(firstId)"))
+        XCTAssertTrue(source.contains("openWindow(id: \"artifact-detail\")"))
+    }
+
     func testDocumentInspectorNoLongerIncludesOutlineTabSurface() throws {
         let source = try Self.appSource("Views/Library/DocumentInspector/DocumentInspector.swift")
 

--- a/fichero/fichero-tests/EntityStoreTests.swift
+++ b/fichero/fichero-tests/EntityStoreTests.swift
@@ -3,6 +3,7 @@ import FicheroAPIClient
 import Foundation
 import XCTest
 
+// swiftlint:disable file_length
 @MainActor
 // swiftlint:disable:next type_body_length
 final class EntityStoreTests: XCTestCase {
@@ -292,6 +293,37 @@ final class EntityStoreTests: XCTestCase {
         )
     }
 
+    func testDocumentBucketsKeepSeparateInspectorScopesPerDocument() async throws {
+        MockFicheroURLProtocol.configure(
+            responses: [
+                .init(
+                    method: "GET", path: "/api/documents/doc-1/inspector",
+                    statusCode: 200,
+                    body: makeDocumentInspectorResponse(
+                        documentId: "doc-1",
+                        entities: [makeEntityJSON(id: "entity-1", name: "Alpha")]
+                    )
+                ),
+                .init(
+                    method: "GET", path: "/api/documents/doc-2/inspector",
+                    statusCode: 200,
+                    body: makeDocumentInspectorResponse(
+                        documentId: "doc-2",
+                        entities: [makeEntityJSON(id: "entity-2", name: "Beta")]
+                    )
+                )
+            ]
+        )
+
+        let store = makeStore()
+        await store.loadEntities(forDocument: "doc-1")
+        await store.loadEntities(forDocument: "doc-2")
+
+        XCTAssertEqual(store.entities(forDocument: "doc-1").map(\.canonicalName), ["Alpha"])
+        XCTAssertEqual(store.entities(forDocument: "doc-2").map(\.canonicalName), ["Beta"])
+        XCTAssertEqual(store.entities.map(\.canonicalName), ["Beta"])
+    }
+
     private func makeStore() -> EntityStore {
         let client = FicheroClient(baseURL: URL(string: "https://127.0.0.1:8765")!, libraryPath: "/tmp/test.fichero")
         let entityService = EntityServiceGenerated(ficheroClient: client)
@@ -317,9 +349,12 @@ final class EntityStoreTests: XCTestCase {
         try? Data("test-token\n".utf8).write(to: tokenFile, options: [.atomic])
     }
 
-    private func makeDocumentInspectorResponse(entities: [[String: Any]]) -> Data {
+    private func makeDocumentInspectorResponse(
+        documentId: String = "doc-1",
+        entities: [[String: Any]]
+    ) -> Data {
         let payload: [String: Any] = [
-            "document_id": "doc-1",
+            "document_id": documentId,
             "document": [:],
             "source_metadata": [:],
             "claim_count": 0,

--- a/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
+++ b/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
@@ -361,6 +361,17 @@ final class KnowledgeGraphInspectorSectionTests: XCTestCase {
         XCTAssertTrue(storeSource.contains("func entities(forDocument documentId: String)"))
     }
 
+    func testKnowledgeGraphTextDigestUsesStableEntryIds() throws {
+        let source = try Self.appSource(
+            "Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift"
+        )
+
+        XCTAssertTrue(source.contains("private struct TextDigestEntry: Identifiable"))
+        XCTAssertTrue(source.contains("id: item.id"))
+        XCTAssertTrue(source.contains("ForEach(entries) { entry in"))
+        XCTAssertFalse(source.contains("ForEach(entries, id: \\.displayName)"))
+    }
+
     func testInspectorDeleteActionsUseGeneratedEntityAndClaimClients() throws {
         let entitiesSource = try Self.appSource(
             "Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift"

--- a/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
+++ b/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
@@ -336,6 +336,18 @@ final class KnowledgeGraphInspectorSectionTests: XCTestCase {
         XCTAssertTrue(source.contains("restoreSelectionAfterEntityRefresh(entityId: plan.entityId)"))
     }
 
+    func testInspectorEntitiesTabUsesSharedBottomMiniToolbarForSelectionActions() throws {
+        let source = try Self.appSource(
+            "Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift"
+        )
+
+        XCTAssertTrue(source.contains("private var entitiesMiniToolbar: some View"))
+        XCTAssertTrue(source.contains("MiniToolbar {"))
+        XCTAssertTrue(source.contains("if entitySelection.count > 1 {"))
+        XCTAssertTrue(source.contains("mergeActionMenu(targetEntities: selectedEntities, menuTitle: \"Merge\")"))
+        XCTAssertTrue(source.contains("deleteActionButton(targetEntities: selectedEntities)"))
+    }
+
     func testInspectorDeleteActionsUseGeneratedEntityAndClaimClients() throws {
         let entitiesSource = try Self.appSource(
             "Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift"

--- a/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
+++ b/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
@@ -348,6 +348,19 @@ final class KnowledgeGraphInspectorSectionTests: XCTestCase {
         XCTAssertTrue(source.contains("deleteActionButton(targetEntities: selectedEntities)"))
     }
 
+    func testInspectorEntitiesTabReadsPerDocumentEntityStoreBuckets() throws {
+        let source = try Self.appSource(
+            "Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift"
+        )
+        let storeSource = try Self.appSource("Models/EntityStore.swift")
+
+        XCTAssertTrue(source.contains("entityStore.entities(forDocument: documentId)"))
+        XCTAssertTrue(source.contains("entityStore.loadError(forDocument: documentId)"))
+        XCTAssertTrue(source.contains("entityStore.isLoading(forDocument: documentId)"))
+        XCTAssertTrue(storeSource.contains("private(set) var entitiesByDocumentId"))
+        XCTAssertTrue(storeSource.contains("func entities(forDocument documentId: String)"))
+    }
+
     func testInspectorDeleteActionsUseGeneratedEntityAndClaimClients() throws {
         let entitiesSource = try Self.appSource(
             "Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift"

--- a/fichero/fichero-tests/WorkflowProvenancePanelTests.swift
+++ b/fichero/fichero-tests/WorkflowProvenancePanelTests.swift
@@ -84,3 +84,18 @@ struct WorkflowProvenanceSortTests {
         #expect(sorted[1].startedAt == "2024-01-01T00:00:00Z")
     }
 }
+
+@Suite("WorkflowProvenancePanel error handling")
+struct WorkflowProvenanceErrorHandlingTests {
+    @Test("404 missing history maps to empty state instead of raw error")
+    func notFoundBecomesEmptyState() {
+        let error = EntityServiceGenerated.ServiceError.unexpectedResponse(404)
+        #expect(WorkflowProvenancePanel.loadErrorMessage(for: error) == nil)
+    }
+
+    @Test("non-404 responses still surface an error")
+    func otherResponsesStillSurfaceError() {
+        let error = EntityServiceGenerated.ServiceError.unexpectedResponse(500)
+        #expect(WorkflowProvenancePanel.loadErrorMessage(for: error) == error.localizedDescription)
+    }
+}

--- a/fichero/fichero/Models/EntityStore.swift
+++ b/fichero/fichero/Models/EntityStore.swift
@@ -23,6 +23,9 @@ final class EntityStore: ObservableDomainStore {
     private(set) var entities: [Components.Schemas.KnowledgeEntity] = []
     private(set) var isLoading = false
     private(set) var loadError: String?
+    private(set) var entitiesByDocumentId: [String: [Components.Schemas.KnowledgeEntity]] = [:]
+    private(set) var loadingDocumentIds: Set<String> = []
+    private(set) var loadErrorsByDocumentId: [String: String] = [:]
 
     // ─── Transport: the EXISTING generated wrappers, unchanged ───
     private let entityService: EntityServiceGenerated
@@ -30,9 +33,11 @@ final class EntityStore: ObservableDomainStore {
     private let libraryPath: String
     private let log = Logger(subsystem: "app.fichero.fichero", category: "EntityStore")
 
-    /// Per-document scoping cache — the inspector loads "entities for THIS
-    /// document". `loadEntities` is idempotent against it unless forced.
-    private var loadedDocumentId: String?
+    /// Document scopes that have been loaded successfully. Multiple inspector
+    /// windows on the same library can keep different document buckets warm
+    /// without thrashing each other's visible list (#1908).
+    private var loadedDocumentIds: Set<String> = []
+    private var lastLoadedDocumentId: String?
 
     init(
         entityService: EntityServiceGenerated,
@@ -50,25 +55,37 @@ final class EntityStore: ObservableDomainStore {
     /// same already-populated scope is a no-op unless `force` is set (reload
     /// button / post-mutation refresh).
     func loadEntities(forDocument documentId: String, force: Bool = false) async {
-        if !force, loadedDocumentId == documentId, !entities.isEmpty { return }
-        isLoading = true
-        loadError = nil
-        defer { isLoading = false }
+        if !force, loadedDocumentIds.contains(documentId), loadErrorsByDocumentId[documentId] == nil {
+            syncLegacyScope(documentId: documentId)
+            return
+        }
+
+        lastLoadedDocumentId = documentId
+        loadingDocumentIds.insert(documentId)
+        loadErrorsByDocumentId[documentId] = nil
+        syncLegacyScope(documentId: documentId)
+        defer {
+            loadingDocumentIds.remove(documentId)
+            syncLegacyScope(documentId: documentId)
+        }
         do {
             let loaded = try await entityService.listInspectorEntitiesForDocument(
                 documentId: documentId
             )
-            entities = loaded
-            loadedDocumentId = documentId
+            entitiesByDocumentId[documentId] = loaded
+            loadErrorsByDocumentId.removeValue(forKey: documentId)
+            loadedDocumentIds.insert(documentId)
+            syncLegacyScope(documentId: documentId)
             log.debug(
                 "Loaded \(loaded.count, privacy: .public) entities for \(documentId, privacy: .public)"
             )
         } catch is CancellationError {
             // Superseded by a newer document selection — keep current state.
         } catch {
-            loadError = "Couldn't load entities: \(error.localizedDescription)"
-            entities = []
-            loadedDocumentId = documentId
+            entitiesByDocumentId[documentId] = []
+            loadErrorsByDocumentId[documentId] = "Couldn't load entities: \(error.localizedDescription)"
+            loadedDocumentIds.remove(documentId)
+            syncLegacyScope(documentId: documentId)
             log.error(
                 "Failed to load entities for \(documentId, privacy: .public): \(error.localizedDescription, privacy: .public)"
             )
@@ -77,8 +94,24 @@ final class EntityStore: ObservableDomainStore {
 
     /// Re-fetch the current document scope (post-mutation / reconnect resync).
     func reload() async {
-        guard let documentId = loadedDocumentId else { return }
-        await loadEntities(forDocument: documentId, force: true)
+        let documentIds = loadedDocumentIds.isEmpty
+            ? (lastLoadedDocumentId.map { [$0] } ?? [])
+            : Array(loadedDocumentIds)
+        for documentId in documentIds {
+            await loadEntities(forDocument: documentId, force: true)
+        }
+    }
+
+    func entities(forDocument documentId: String) -> [Components.Schemas.KnowledgeEntity] {
+        entitiesByDocumentId[documentId] ?? []
+    }
+
+    func isLoading(forDocument documentId: String) -> Bool {
+        loadingDocumentIds.contains(documentId)
+    }
+
+    func loadError(forDocument documentId: String) -> String? {
+        loadErrorsByDocumentId[documentId]
     }
 
     // MARK: - Named actions (map 1:1 to the audited action layer, #1848)
@@ -195,4 +228,10 @@ final class EntityStore: ObservableDomainStore {
     /// (called above for non-delete verbs) and `resync()` are provided by the
     /// `ObservableDomainStore` extension — no per-store copies.
     let reloadDebouncer = ReloadDebouncer()
+
+    private func syncLegacyScope(documentId: String) {
+        entities = entitiesByDocumentId[documentId] ?? []
+        isLoading = loadingDocumentIds.contains(documentId)
+        loadError = loadErrorsByDocumentId[documentId]
+    }
 }

--- a/fichero/fichero/Models/EntityStore.swift
+++ b/fichero/fichero/Models/EntityStore.swift
@@ -150,7 +150,7 @@ final class EntityStore: ObservableDomainStore {
             absorbingEntityId: survivorId,
             absorbedEntityIds: absorbedIds
         )
-        if loadedDocumentId != nil {
+        if hasDocumentScope {
             await reload()
             return
         }
@@ -184,7 +184,7 @@ final class EntityStore: ObservableDomainStore {
         to entityType: String
     ) async throws -> Components.Schemas.KnowledgeEntity {
         let updated = try await entityService.patchEntity(entityId, entityType: entityType)
-        if loadedDocumentId != nil {
+        if hasDocumentScope {
             await reload()
         } else if let index = entities.firstIndex(where: { $0.id == entityId }) {
             entities[index] = updated
@@ -233,5 +233,9 @@ final class EntityStore: ObservableDomainStore {
         entities = entitiesByDocumentId[documentId] ?? []
         isLoading = loadingDocumentIds.contains(documentId)
         loadError = loadErrorsByDocumentId[documentId]
+    }
+
+    private var hasDocumentScope: Bool {
+        !loadedDocumentIds.isEmpty || lastLoadedDocumentId != nil
     }
 }

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/ClaimSummaryCardView.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/ClaimSummaryCardView.swift
@@ -17,6 +17,7 @@ private func isOpaqueIdentifier(_ value: String) -> Bool {
     return trimmed.rangeOfCharacter(from: hexAndDashes.inverted) == nil
 }
 
+// swiftlint:disable:next type_body_length
 struct ClaimSummaryCard: View {
     let claim: Components.Schemas.KnowledgeClaim
     var focusedEntityId: String?
@@ -264,6 +265,10 @@ struct ClaimSummaryCard: View {
         focusClaim()
     }
 
+    private func beginInlineEditing() {
+        isInlineEditing = true
+    }
+
     /// The headline of the card. When SVO metadata is present, render
     /// it as three individually-tappable chips with distinct styling for
     /// subject, verb, and object. When absent, surface a "KG not generated" hint instead
@@ -291,7 +296,7 @@ struct ClaimSummaryCard: View {
 
                 // Verb chip — reveal the underlying claim in place.
                 Button(action: {
-                    revealSourceClaimInline()
+                    beginInlineEditing()
                 }, label: {
                     Text(svo.verb)
                         .font(bodyTextFont)
@@ -307,7 +312,7 @@ struct ClaimSummaryCard: View {
 
                 // Object chip — reveal the underlying claim in place.
                 Button(action: {
-                    revealSourceClaimInline()
+                    beginInlineEditing()
                 }, label: {
                     Text(svo.object)
                         .font(bodyTextFont)

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView.swift
@@ -143,7 +143,9 @@ struct EntityDetailView: View {
                     possibleDuplicatesSection
                     mentionsSection
                     metadataSection
-                    claimsSection
+                    if Self.showsClaimsSection(for: entity) {
+                        claimsSection
+                    }
                     auditSection
                     EntityNotesSection(entityId: entity.id ?? "")
                 }
@@ -155,6 +157,12 @@ struct EntityDetailView: View {
                 await loadDuplicateCandidates()
             }
         }
+    }
+
+    static func showsClaimsSection(
+        for entity: Components.Schemas.KnowledgeEntity
+    ) -> Bool {
+        entity.entityType != .location
     }
 
     // MARK: - Source-groups top bar

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -49,11 +49,11 @@ struct DocumentInspectorEntitiesTab: View {
         )
     }
 
-    // ponytail: recompute inputs — entityStore.entities, hiddenKindsCSV
+    // ponytail: recompute inputs — scopedEntities, hiddenKindsCSV
     @State private var grouped: [(EntityKind, [Components.Schemas.KnowledgeEntity])] = []
 
     private func recomputeGrouped() {
-        let dict = Dictionary(grouping: entityStore.entities) { entity in
+        let dict = Dictionary(grouping: scopedEntities) { entity in
             EntityKind(apiType: entity.entityType) ?? .other
         }
         let hidden = hiddenKinds
@@ -84,6 +84,18 @@ struct DocumentInspectorEntitiesTab: View {
         return selectedEntities.first
     }
 
+    private var scopedEntities: [Components.Schemas.KnowledgeEntity] {
+        entityStore.entities(forDocument: documentId)
+    }
+
+    private var scopedLoadError: String? {
+        entityStore.loadError(forDocument: documentId)
+    }
+
+    private var isScopedLoading: Bool {
+        entityStore.isLoading(forDocument: documentId)
+    }
+
     private var bulkActionScopeLabel: String {
         document.docType == .page ? "This page only" : "This folder only"
     }
@@ -103,16 +115,16 @@ struct DocumentInspectorEntitiesTab: View {
                     .padding(.horizontal)
             }
 
-            if entityStore.isLoading {
+            if isScopedLoading {
                 ProgressView()
                     .padding(.vertical, 8)
                     .padding(.horizontal)
-            } else if let loadError = entityStore.loadError {
+            } else if let loadError = scopedLoadError {
                 Label(loadError, systemImage: "exclamationmark.triangle")
                     .font(.caption)
                     .foregroundStyle(.orange)
                     .padding(.horizontal)
-            } else if entityStore.entities.isEmpty {
+            } else if scopedEntities.isEmpty {
                 Text("No entities for this document yet.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
@@ -142,7 +154,7 @@ struct DocumentInspectorEntitiesTab: View {
         // The store owns fetching; the view just scopes it to this document.
         .task(id: documentId) { await entityStore.loadEntities(forDocument: documentId) }
         .onAppear { recomputeGrouped() }
-        .onChange(of: entityStore.entities) { _, _ in
+        .onChange(of: scopedEntities) { _, _ in
             recomputeGrouped()
             syncSelectionToLoadedEntities()
         }
@@ -210,7 +222,7 @@ struct DocumentInspectorEntitiesTab: View {
 
     private var header: some View {
         HStack(spacing: 8) {
-            Text("\(entityStore.entities.count) entities")
+            Text("\(scopedEntities.count) entities")
                 .font(.caption)
                 .foregroundStyle(.secondary)
             Spacer()
@@ -262,7 +274,7 @@ struct DocumentInspectorEntitiesTab: View {
         if let selectedEntity {
             return selectedEntity.canonicalName
         }
-        return "\(entityStore.entities.count) entities"
+        return "\(scopedEntities.count) entities"
     }
 
     @ViewBuilder
@@ -311,7 +323,7 @@ struct DocumentInspectorEntitiesTab: View {
     private var emptyVisibleGroupsState: some View {
         if hasActiveKindFilter {
             VStack(alignment: .leading, spacing: 6) {
-                Text("Loaded \(entityStore.entities.count) entities, but the current filter hides every kind.")
+                Text("Loaded \(scopedEntities.count) entities, but the current filter hides every kind.")
                     .font(.caption)
                     .foregroundStyle(.secondary)
                 Button("Show all kinds") {
@@ -325,7 +337,7 @@ struct DocumentInspectorEntitiesTab: View {
         } else {
             VStack(alignment: .leading, spacing: 6) {
                 Label(
-                    "Loaded \(entityStore.entities.count) entities, but none mapped into a visible section.",
+                    "Loaded \(scopedEntities.count) entities, but none mapped into a visible section.",
                     systemImage: "exclamationmark.triangle"
                 )
                 .font(.caption)
@@ -333,7 +345,7 @@ struct DocumentInspectorEntitiesTab: View {
                 .padding(.horizontal)
 
                 List(selection: $entitySelection) {
-                    entityKindSection(kind: .other, entities: entityStore.entities)
+                    entityKindSection(kind: .other, entities: scopedEntities)
                 }
                 .listStyle(.plain)
                 .frame(maxHeight: .infinity)

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -120,15 +120,21 @@ struct DocumentInspectorEntitiesTab: View {
             } else if grouped.isEmpty {
                 emptyVisibleGroupsState
             } else {
-                PlatformVSplitView {
-                    List(selection: $entitySelection) {
-                        ForEach(grouped, id: \.0) { kind, items in
-                            entityKindSection(kind: kind, entities: items)
+                VStack(spacing: 0) {
+                    PlatformVSplitView {
+                        List(selection: $entitySelection) {
+                            ForEach(grouped, id: \.0) { kind, items in
+                                entityKindSection(kind: kind, entities: items)
+                            }
                         }
-                    }
-                    .listStyle(.plain)
+                        .listStyle(.plain)
 
-                    entityDetailPane
+                        entityDetailPane
+                    }
+                    Divider()
+                    entitiesMiniToolbar
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 6)
                 }
             }
         }
@@ -218,6 +224,45 @@ struct DocumentInspectorEntitiesTab: View {
             .help("Reload entities")
             .accessibilityLabel("Reload entities")
         }
+    }
+
+    private var entitiesMiniToolbar: some View {
+        MiniToolbar {
+            Text(entitiesToolbarStatusText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            filterMenu
+
+            Button {
+                Task { await entityStore.loadEntities(forDocument: documentId, force: true) }
+            } label: {
+                Image(systemName: "arrow.clockwise")
+            }
+            .buttonStyle(.plain)
+            .help("Reload entities")
+            .accessibilityLabel("Reload entities")
+
+            if entitySelection.count > 1 {
+                bulkActionMenu(title: "Approve", systemImage: "checkmark.circle", action: .approve)
+                bulkActionMenu(title: "Reject", systemImage: "xmark.circle", action: .reject)
+                bulkActionMenu(title: "Suppress", systemImage: "eye.slash", action: .suppress)
+                mergeActionMenu(targetEntities: selectedEntities, menuTitle: "Merge")
+                deleteActionButton(targetEntities: selectedEntities)
+            }
+        }
+    }
+
+    private var entitiesToolbarStatusText: String {
+        if entitySelection.count > 1 {
+            return "\(entitySelection.count) selected"
+        }
+        if let selectedEntity {
+            return selectedEntity.canonicalName
+        }
+        return "\(entityStore.entities.count) entities"
     }
 
     @ViewBuilder

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift
@@ -182,7 +182,8 @@ struct KnowledgeGraphInspectorSection: View {
 
     // MARK: - Text digest data
 
-    private struct TextDigestEntry {
+    private struct TextDigestEntry: Identifiable {
+        let id: String
         let displayName: String
         let kind: EntityKind
         // Each element is "verb objectPhrase" or bare claim text.
@@ -199,7 +200,12 @@ struct KnowledgeGraphInspectorSection: View {
         grouped.map { kind, items in
             let entries = items.map { item in
                 let lines = [item.context] + item.extraClaims.map(\.context)
-                return TextDigestEntry(displayName: item.displayName, kind: kind, svoLines: lines)
+                return TextDigestEntry(
+                    id: item.id,
+                    displayName: item.displayName,
+                    kind: kind,
+                    svoLines: lines
+                )
             }
             return (kind, entries)
         }
@@ -221,7 +227,7 @@ struct KnowledgeGraphInspectorSection: View {
                             .font(typeLabelFont)
                             .foregroundStyle(.secondary)
 
-                        ForEach(entries, id: \.displayName) { entry in
+                        ForEach(entries) { entry in
                             let prose = entry.svoLines.joined(separator: "; ")
                             // SwiftUI markdown bold for the entity name.
                             let raw = "**\(entry.displayName)** \(prose)"

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab+Workflow.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab+Workflow.swift
@@ -9,6 +9,7 @@ import SwiftUI
 struct WorkflowProvenancePanel: View {
     let documentId: String
 
+    @Environment(EntityServiceGenerated.self) private var entityService
     @State private var runs: [Components.Schemas.WorkflowRunProvenanceResponse] = []
     @State private var isLoading = false
     @State private var loadError: String?
@@ -85,15 +86,14 @@ struct WorkflowProvenancePanel: View {
     }
 
     private func load() async {
-        guard let library = LibraryManager.shared.globalLibrary else { return }
         isLoading = true
         loadError = nil
         defer { isLoading = false }
         do {
-            let fetched = try await library.entityService.listDocumentWorkflowRuns(documentId: documentId)
+            let fetched = try await entityService.listDocumentWorkflowRuns(documentId: documentId)
             runs = WorkflowProvenancePanel.sortNewestFirst(fetched)
         } catch {
-            loadError = error.localizedDescription
+            loadError = Self.loadErrorMessage(for: error)
         }
     }
 
@@ -109,6 +109,13 @@ struct WorkflowProvenancePanel: View {
             let rhsDate = rhs.startedAt.flatMap { fmt.date(from: $0) } ?? .distantPast
             return lhsDate > rhsDate
         }
+    }
+
+    static func loadErrorMessage(for error: Error) -> String? {
+        if case EntityServiceGenerated.ServiceError.unexpectedResponse(404) = error {
+            return nil
+        }
+        return error.localizedDescription
     }
 }
 

--- a/fichero/fichero/Views/Library/Inspector/AnnotationListView.swift
+++ b/fichero/fichero/Views/Library/Inspector/AnnotationListView.swift
@@ -64,6 +64,7 @@ struct AnnotationListView: View {
     @ViewBuilder
     private func row(for annotation: DocumentAnnotation) -> some View {
         AnnotationRow(annotation: annotation)
+            .contentShape(Rectangle())
     }
 
     private var emptyState: some View {

--- a/fichero/fichero/Views/Library/Inspector/ArtifactListView.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactListView.swift
@@ -121,6 +121,7 @@ struct ArtifactListView: View {
     private func row(for artifact: Artifact) -> some View {
         ArtifactRow(artifact: artifact)
             .tag(artifact.id)
+            .contentShape(Rectangle())
             .onTapGesture(count: 2) {
                 guard let onOpenInWindow else { return }
                 focused.select(artifact.id, in: store.items)

--- a/fichero/fichero/Views/Library/Inspector/ArtifactListView.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactListView.swift
@@ -121,6 +121,11 @@ struct ArtifactListView: View {
     private func row(for artifact: Artifact) -> some View {
         ArtifactRow(artifact: artifact)
             .tag(artifact.id)
+            .onTapGesture(count: 2) {
+                guard let onOpenInWindow else { return }
+                focused.select(artifact.id, in: store.items)
+                onOpenInWindow()
+            }
             .contextMenu {
                 if let onOpenInWindow {
                     Button("Open in Window") {

--- a/fichero/fichero/Views/Library/Inspector/CitationListView.swift
+++ b/fichero/fichero/Views/Library/Inspector/CitationListView.swift
@@ -57,6 +57,7 @@ struct CitationListView: View {
     private func row(for item: CitationItem) -> some View {
         CitationRow(item: item)
             .tag(item.id)
+            .contentShape(Rectangle())
             .contextMenu {
                 if let onOpenInWindow {
                     Button("Open in Window") {

--- a/fichero/fichero/Views/Library/LibraryView+TableMapViews.swift
+++ b/fichero/fichero/Views/Library/LibraryView+TableMapViews.swift
@@ -35,12 +35,30 @@ extension LibraryView {
             }
         }
         .onTapGesture(count: 2) {
-            if let firstId = selection.first,
-               let doc = filteredDocuments.first(where: { $0.id == documentId(forNodeId: firstId) }) {
-                handleDoubleClick(doc)
-            }
+            handleOutlineDoubleClickSelection()
         }
         .padding(.leading, browserLeadingInset)
+    }
+
+    private func handleOutlineDoubleClickSelection() {
+        guard let firstId = selection.first else { return }
+        if let artifactSelection = artifactSelectionForNodeId(firstId) {
+            openArtifactDetailWindow(for: artifactSelection)
+            return
+        }
+        if let doc = filteredDocuments.first(where: { $0.id == documentId(forNodeId: firstId) }) {
+            handleDoubleClick(doc)
+        }
+    }
+
+    private func openArtifactDetailWindow(for selection: (document: Document, artifact: Artifact)) {
+        FocusedArtifact.shared.select(
+            selection.artifact.id,
+            documentId: selection.document.id,
+            documentName: selection.document.name,
+            in: [selection.artifact]
+        )
+        openWindow(id: "artifact-detail")
     }
 
     /// Strip a child-group node's `:type` suffix back to the document id.

--- a/fichero/fichero/Views/Notes/NoteListView.swift
+++ b/fichero/fichero/Views/Notes/NoteListView.swift
@@ -108,6 +108,7 @@ struct NoteListView: View {
     @ViewBuilder
     private func row(for item: NoteSelectionItem) -> some View {
         NoteRow(item: item)
+            .contentShape(Rectangle())
     }
 
     private func promptDeleteSelectedNotes() {
@@ -181,6 +182,7 @@ private struct NoteRow: View {
             }
         }
         .padding(.vertical, 2)
+        .contentShape(Rectangle())
     }
 
     private var metadataLine: String? {

--- a/scripts/check_docs_paths.py
+++ b/scripts/check_docs_paths.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import json
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -93,6 +94,13 @@ def missing() -> dict[str, list[str]]:
     return out
 
 
+def is_git_ignored(path: str) -> bool:
+    return subprocess.run(
+        ["git", "-C", str(ROOT), "check-ignore", "-q", path],
+        check=False,
+    ).returncode == 0
+
+
 def main() -> int:
     argv = sys.argv[1:]
     if any(a in ("-h", "--help") for a in argv):
@@ -136,7 +144,7 @@ def main() -> int:
         return 0
 
     new = {p: v for p, v in absent.items() if p not in allowed}
-    stale = sorted(allowed - set(absent))
+    stale = sorted(p for p in allowed - set(absent) if not is_git_ignored(p))
 
     if "--list" in argv:
         print(f"absent paths named in docs ({len(absent)}):\n")

--- a/scripts/check_docs_paths_allowlist.json
+++ b/scripts/check_docs_paths_allowlist.json
@@ -1,7 +1,11 @@
 {
   "_doc": "Repo paths named in docs that do not exist, on purpose (build artifacts, or things described as deleted). Every other absent path is a bug. See AGENTS.md.",
   "known_absent_paths": [
+    "build/releases",
     "build/verify_all_needs_fixing.json",
-    "fichero-engine/build/fichero-backend/macos/app/FicheroBackend.app"
+    "fichero-engine/build/fichero-backend/macos/app/FicheroBackend.app",
+    "fichero/build/xcode/Products/Release",
+    "fichero/build/xcode/Products/Release/Fichero.app",
+    "fichero/fichero-api-client/.build"
   ]
 }


### PR DESCRIPTION
## Summary
- restore artifact double-click detail windows and full-row inspector list hit targets
- add shared inspector bottom mini-toolbar and normalize workflow-history 404s
- isolate entity-store document scopes, stabilize KG inspector text digest IDs, and improve entity/claim editing details
- keep docs path guardrail portable across clean worktrees and repair the document-scoped entity-store build

## Verification
- source /Users/danieltubb/code/fichero/.venv/bin/activate && bash scripts/verify_all.sh --fast
- xcodebuild -quiet -project fichero/fichero.xcodeproj -scheme 'Fichero (Dev Local)' -destination 'platform=macOS' -skipPackagePluginValidation build

Issues: #3395 #3397 #3414 #3409 #1908 #1966 #1775 #1777 #3402