### PR TITLE
fix: improve artifact inspector provenance and mini toolbar

### DIFF
--- a/fichero/fichero-tests/ArtifactSelectionTests.swift
+++ b/fichero/fichero-tests/ArtifactSelectionTests.swift
@@ -22,6 +22,24 @@ struct ArtifactSelectionTests {
         [artifact("a"), artifact("b"), artifact("c")]
     }
 
+    private func document(
+        _ id: String,
+        parentId: String? = nil,
+        docType: DocType = .file,
+        name: String,
+        sequence: Int? = nil
+    ) -> Document {
+        Document(
+            id: id,
+            parentId: parentId,
+            docType: docType,
+            fileType: docType == .file ? .pdf : nil,
+            name: name,
+            sequence: sequence,
+            status: .completed
+        )
+    }
+
     // MARK: - resolve (delete acts on the full selection)
 
     @Test("resolve returns every selected artifact, in list order")
@@ -108,5 +126,66 @@ struct ArtifactSelectionTests {
                 inspectedDocumentId: "doc-99"
             ) == false
         )
+    }
+
+    @Test("artifact provenance marks descendant page outputs with page labels")
+    func artifactProvenanceDescendantPage() {
+        let pdf = document("doc-parent", name: "Notebook.pdf")
+        let page = document("page-3", parentId: pdf.id, docType: .page, name: "page_0003", sequence: 3)
+        let artifact = artifact("artifact-1", documentId: page.id)
+
+        let display = ArtifactProvenance.display(
+            for: artifact,
+            inspectedDocument: pdf,
+            documentsById: [pdf.id: pdf, page.id: page]
+        )
+
+        #expect(display.sourceLabel == "Page 3")
+        #expect(display.pageLabel == "3")
+        #expect(display.relation == .descendantPage)
+    }
+
+    @Test("artifact provenance marks same-document outputs as local")
+    func artifactProvenanceCurrentDocument() {
+        let pdf = document("doc-parent", name: "Notebook.pdf")
+        let artifact = artifact("artifact-1", documentId: pdf.id)
+
+        let display = ArtifactProvenance.display(
+            for: artifact,
+            inspectedDocument: pdf,
+            documentsById: [pdf.id: pdf]
+        )
+
+        #expect(display.sourceLabel == "This document")
+        #expect(display.relation == .currentDocument)
+    }
+
+    @Test("artifact provenance row subtitle joins source workflow and provider")
+    func artifactProvenanceRowSubtitle() {
+        let pdf = document("doc-parent", name: "Notebook.pdf")
+        let artifact = Artifact(
+            id: "artifact-1",
+            documentId: pdf.id,
+            sourceArtifactId: nil,
+            version: 1,
+            artifactType: "transcription",
+            content: nil,
+            data: nil,
+            runId: nil,
+            provider: "OpenAI",
+            model: "gpt-4.1",
+            stepName: "OCR",
+            confidence: nil,
+            reviewed: false,
+            createdAt: Date()
+        )
+
+        let display = ArtifactProvenance.display(
+            for: artifact,
+            inspectedDocument: pdf,
+            documentsById: [pdf.id: pdf]
+        )
+
+        #expect(display.rowSubtitle == "This document · OCR · OpenAI · gpt-4.1")
     }
 }

--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -47,6 +47,15 @@ final class DocumentInspectorTests: XCTestCase {
         XCTAssertTrue(source.contains("Task { await store.reload() }"))
     }
 
+    func testArtifactsPaneRoutesProvenanceClicksThroughSharedSourceNavigation() throws {
+        let source = try Self.appSource("Views/Library/Inspector/ArtifactsInspectorPane.swift")
+        let detailSource = try Self.appSource("Views/Library/Inspector/ArtifactDetailView.swift")
+
+        XCTAssertTrue(source.contains("NotificationCenter.default.post("))
+        XCTAssertTrue(source.contains("name: .ficheroOpenClaimSource"))
+        XCTAssertTrue(detailSource.contains("LabeledContent(\"Source\")"))
+    }
+
     func testFocusedEntityRoutesToEntitiesTabInsteadOfReplacingInspector() throws {
         let source = try Self.appSource("Views/Library/DocumentInspector/DocumentInspector.swift")
 

--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -56,6 +56,13 @@ final class DocumentInspectorTests: XCTestCase {
         XCTAssertTrue(detailSource.contains("LabeledContent(\"Source\")"))
     }
 
+    func testArtifactsPaneUsesOwnOnlyArtifactScope() throws {
+        let source = try Self.appSource("Views/Library/Inspector/ArtifactsInspectorPane.swift")
+
+        XCTAssertTrue(source.contains("includeDescendants: false"))
+        XCTAssertFalse(source.contains("private var includesDescendantArtifacts"))
+    }
+
     func testFocusedEntityRoutesToEntitiesTabInsteadOfReplacingInspector() throws {
         let source = try Self.appSource("Views/Library/DocumentInspector/DocumentInspector.swift")
 

--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -63,6 +63,14 @@ final class DocumentInspectorTests: XCTestCase {
         XCTAssertFalse(source.contains("private var includesDescendantArtifacts"))
     }
 
+    func testEntitiesInspectorUsesSharedBottomMiniToolbar() throws {
+        let inspectorSource = try Self.appSource("Views/Library/DocumentInspector/DocumentInspector.swift")
+        let entitiesSource = try Self.appSource("Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift")
+
+        XCTAssertTrue(inspectorSource.contains("struct InspectorBottomMiniToolbar"))
+        XCTAssertTrue(entitiesSource.contains("InspectorBottomMiniToolbar(statusText: entitiesToolbarStatusText)"))
+    }
+
     func testFocusedEntityRoutesToEntitiesTabInsteadOfReplacingInspector() throws {
         let source = try Self.appSource("Views/Library/DocumentInspector/DocumentInspector.swift")
 

--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -71,6 +71,17 @@ final class DocumentInspectorTests: XCTestCase {
         XCTAssertTrue(entitiesSource.contains("InspectorBottomMiniToolbar(statusText: entitiesToolbarStatusText)"))
     }
 
+    func testEntitySearchRoutingUsesTypedStateInsteadOfNotificationBus() throws {
+        let contentSource = try Self.appSource("Views/ContentView.swift")
+        let sharedSource = try Self.appSource("Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift")
+        let entitiesSource = try Self.appSource("Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift")
+
+        XCTAssertTrue(sharedSource.contains("final class EntitySearchState"))
+        XCTAssertTrue(contentSource.contains(".onChange(of: entitySearchState.requestID)"))
+        XCTAssertTrue(entitiesSource.contains("EntitySearchState.shared.request("))
+        XCTAssertFalse(sharedSource.contains("ficheroEntitySearchRequested"))
+    }
+
     func testFocusedEntityRoutesToEntitiesTabInsteadOfReplacingInspector() throws {
         let source = try Self.appSource("Views/Library/DocumentInspector/DocumentInspector.swift")
 

--- a/fichero/fichero/Models/Artifact.swift
+++ b/fichero/fichero/Models/Artifact.swift
@@ -145,3 +145,83 @@ extension Artifact {
         }
     }
 }
+
+// MARK: - Inspector provenance
+
+enum ArtifactProvenanceRelation: Equatable {
+    case currentDocument
+    case currentPage
+    case descendantPage
+    case linkedDocument
+}
+
+struct ArtifactProvenanceDisplay: Equatable {
+    let sourceDocumentId: String
+    let sourceLabel: String
+    let pageLabel: String?
+    let relation: ArtifactProvenanceRelation
+    let workflowLabel: String?
+    let providerLabel: String?
+
+    var rowSubtitle: String? {
+        let parts = [sourceLabel, workflowLabel, providerLabel]
+            .compactMap { value in
+                let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+                return trimmed.isEmpty ? nil : trimmed
+            }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+}
+
+enum ArtifactProvenance {
+    static func display(
+        for artifact: Artifact,
+        inspectedDocument: Document,
+        documentsById: [String: Document]
+    ) -> ArtifactProvenanceDisplay {
+        let sourceDocument = documentsById[artifact.documentId]
+        let pageLabel = sourceDocument?.pageThumbnailLabel
+
+        let relation: ArtifactProvenanceRelation
+        let sourceLabel: String
+        if artifact.documentId == inspectedDocument.id {
+            if inspectedDocument.docType == .page {
+                relation = .currentPage
+                sourceLabel = "This page"
+            } else {
+                relation = .currentDocument
+                sourceLabel = "This document"
+            }
+        } else if sourceDocument?.docType == .page {
+            relation = .descendantPage
+            sourceLabel = pageLabel.map { "Page \($0)" } ?? "Child page"
+        } else if let sourceDocument,
+                  !sourceDocument.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            relation = .linkedDocument
+            sourceLabel = sourceDocument.name
+        } else {
+            relation = .linkedDocument
+            sourceLabel = "Linked document"
+        }
+
+        let workflowLabel = normalized(artifact.stepName)
+        let providerLabel = [normalized(artifact.provider), normalized(artifact.model)]
+            .compactMap { $0 }
+            .joined(separator: " · ")
+
+        return ArtifactProvenanceDisplay(
+            sourceDocumentId: artifact.documentId,
+            sourceLabel: sourceLabel,
+            pageLabel: pageLabel,
+            relation: relation,
+            workflowLabel: workflowLabel,
+            providerLabel: providerLabel.isEmpty ? nil : providerLabel
+        )
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/fichero/fichero/Views/ContentView+State.swift
+++ b/fichero/fichero/Views/ContentView+State.swift
@@ -848,9 +848,9 @@ extension ContentView {
         }
     }
 
-    /// Handles `.onReceive` of `.ficheroEntitySearchRequested`.
+    /// Handles typed entity-search requests from inspector/KG lozenges.
     /// Fires the toolbar search for an entity-lozenge click.
-    func handleEntitySearchRequested(_ note: Notification) {
+    func handleEntitySearchRequested() {
         // Click on a blue entity lozenge anywhere in the UI fires the
         // toolbar search for that name. Same code path as typing in
         // the toolbar — creates a saved search, switches to search
@@ -862,9 +862,9 @@ extension ContentView {
         // artifact type — exactly the docs the user is asking about.
         // Free-text fallback when the type isn't tagged so older
         // call sites still work.
-        guard let name = note.userInfo?["name"] as? String,
+        guard let name = entitySearchState.requestedName,
               !name.trimmingCharacters(in: .whitespaces).isEmpty else { return }
-        let entityType = note.userInfo?["entityType"] as? String
+        let entityType = entitySearchState.requestedEntityType
         let query: String
         if let entityType, !entityType.isEmpty {
             let needsQuoting = name.contains(" ")

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -99,6 +99,7 @@ struct ContentView: View {
     // Runtime state - full objects for use in views
     @State var viewMode: AppViewMode = .library(nil)
     @State var detailDocument: Document?
+    @State var entitySearchState = EntitySearchState.shared
     /// Drives the distraction-free full-window reading overlay (#2520).
     @State private var isImmersiveReading = false
     @State private var focusedDocument = FocusedDocument.shared
@@ -565,8 +566,8 @@ struct ContentView: View {
                 }
             }
             #endif
-            .onReceive(NotificationCenter.default.publisher(for: .ficheroEntitySearchRequested)) { note in
-                handleEntitySearchRequested(note)
+            .onChange(of: entitySearchState.requestID) { _, _ in
+                handleEntitySearchRequested()
             }
             .onReceive(NotificationCenter.default.publisher(for: .ficheroOpenClaimSource)) { note in
                 handleOpenClaimSource(note)

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/ClaimSummaryCard+Details.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/ClaimSummaryCard+Details.swift
@@ -192,11 +192,7 @@ extension ClaimSummaryCard {
         let name = rawName.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !name.isEmpty else { return }
         guard let library = LibraryManager.shared.globalLibrary else {
-            NotificationCenter.default.post(
-                name: .ficheroEntitySearchRequested,
-                object: nil,
-                userInfo: ["name": name]
-            )
+            EntitySearchState.shared.request(name: name, entityType: nil)
             return
         }
         do {
@@ -214,11 +210,7 @@ extension ClaimSummaryCard {
         } catch {
             // Fallback to text search below.
         }
-        NotificationCenter.default.post(
-            name: .ficheroEntitySearchRequested,
-            object: nil,
-            userInfo: ["name": name]
-        )
+        EntitySearchState.shared.request(name: name, entityType: nil)
     }
 
     /// Post ficheroOpenClaimSource for the explicit sourceLine button.

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView.swift
@@ -213,13 +213,9 @@ struct EntityDetailView: View {
         } else {
             Button {
                 // #882 — tap canonical name to run a scoped library search.
-                NotificationCenter.default.post(
-                    name: .ficheroEntitySearchRequested,
-                    object: nil,
-                    userInfo: [
-                        "name": displayName,
-                        "entityType": entitySearchScope
-                    ]
+                EntitySearchState.shared.request(
+                    name: displayName,
+                    entityType: entitySearchScope
                 )
             } label: {
                 Text(displayName)

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
@@ -29,6 +29,33 @@ extension View {
     }
 }
 
+/// Shared bottom mini-toolbar shell for list-style inspector panes (#3414).
+/// Keeps the glass treatment, fixed height, and left-status / right-actions
+/// rhythm consistent while letting each pane supply its own native controls.
+struct InspectorBottomMiniToolbar<Actions: View>: View {
+    let statusText: String
+    let actions: Actions
+
+    init(statusText: String, @ViewBuilder actions: () -> Actions) {
+        self.statusText = statusText
+        self.actions = actions()
+    }
+
+    var body: some View {
+        MiniToolbar {
+            Text(statusText)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            actions
+        } trailing: {
+            EmptyView()
+        }
+    }
+}
+
 /// Inspector panel showing document metadata and details
 struct DocumentInspector: View {
     let document: Document?

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -894,13 +894,9 @@ struct DocumentInspectorEntitiesTab: View {
         for entity: Components.Schemas.KnowledgeEntity,
         kind: EntityKind
     ) {
-        NotificationCenter.default.post(
-            name: .ficheroEntitySearchRequested,
-            object: nil,
-            userInfo: [
-                "name": entity.canonicalName,
-                "entityType": kind.searchScope
-            ]
+        EntitySearchState.shared.request(
+            name: entity.canonicalName,
+            entityType: kind.searchScope
         )
     }
 }

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -239,13 +239,7 @@ struct DocumentInspectorEntitiesTab: View {
     }
 
     private var entitiesMiniToolbar: some View {
-        MiniToolbar {
-            Text(entitiesToolbarStatusText)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            Spacer()
-
+        InspectorBottomMiniToolbar(statusText: entitiesToolbarStatusText) {
             filterMenu
 
             Button {

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift
@@ -7,7 +7,7 @@ import SwiftUI
 
 /// One row inside an EntityKindBlock. The **name** is tappable —
 /// clicking fires a scoped entity search (e.g. `person:"…"`) via the
-/// `.ficheroEntitySearchRequested` notification, same path Keyword
+/// typed `EntitySearchState` request, same path Keyword
 /// lozenges use. Aliases / page reference / context render as plain
 /// selectable text below for ⌘C. (#882)
 struct EntityKindRow: View {
@@ -285,11 +285,7 @@ struct EntityKindRow: View {
                excerpt != context,
                excerpt != item.displayName {
                 Button {
-                    NotificationCenter.default.post(
-                        name: .ficheroEntitySearchRequested,
-                        object: nil,
-                        userInfo: ["name": excerpt]
-                    )
+                    EntitySearchState.shared.request(name: excerpt, entityType: nil)
                 } label: {
                     Text("\u{201C}\(excerpt)\u{201D}")
                         .font(secondaryTextFont)

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift
@@ -87,9 +87,6 @@ extension Notification.Name {
     /// the library grid. object = source document id String. (#833)
     static let ficheroOpenClaimSource = Notification.Name("ficheroOpenClaimSource")
 
-    /// Posted when a KG/inspector row asks the app to navigate to entity search.
-    static let ficheroEntitySearchRequested = Notification.Name("ficheroEntitySearchRequested")
-
     /// Forwarded from `ficheroOpenClaimSource` after ContentView
     /// has resolved the source-doc id to a page number. Received by the
     /// PDF canvas so it can jump to the right page. (#833)

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift
@@ -28,22 +28,7 @@ struct EntityLozenge: View {
 
     var body: some View {
         Button {
-            // Lozenge tap → fire a global entity-search request. ContentView
-            // listens and routes the name into runToolbarSearch so we get
-            // the same path as typing into the toolbar (creates a saved
-            // search, switches sidebar to search mode, runs the query).
-            // NotificationCenter avoids prop-drilling a closure through
-            // ArtifactEntitiesView → MailStyleRow → LibraryView →
-            // ContentView (5 levels deep).
-            var userInfo: [String: Any] = ["name": name]
-            if let entityType {
-                userInfo["entityType"] = entityType
-            }
-            NotificationCenter.default.post(
-                name: .ficheroEntitySearchRequested,
-                object: nil,
-                userInfo: userInfo
-            )
+            EntitySearchState.shared.request(name: name, entityType: entityType)
         } label: {
             Text(name)
                 .font(.caption2)
@@ -68,17 +53,27 @@ struct EntityLozenge: View {
     }
 }
 
+@Observable
+@MainActor
+final class EntitySearchState {
+    static let shared = EntitySearchState()
+
+    private(set) var requestID: Int = 0
+    private(set) var requestedName: String?
+    private(set) var requestedEntityType: String?
+
+    func request(name: String, entityType: String?) {
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+        requestedName = trimmedName
+        requestedEntityType = entityType?.trimmingCharacters(in: .whitespacesAndNewlines)
+        requestID &+= 1
+    }
+}
+
 // MARK: - Notification names
 
 extension Notification.Name {
-    /// Posted when the user taps an entity lozenge anywhere in the UI.
-    /// ContentView listens for this and routes through `runToolbarSearch`,
-    /// creating a saved search exactly the way typing in the toolbar would.
-    /// userInfo keys: "name" (String), optional "entityType" (String, e.g. "people").
-    static let ficheroEntitySearchRequested = Notification.Name(
-        "ficheroEntitySearchRequested"
-    )
-
     // The claim/entity *data-mutation* notifications (`.ficheroClaimDeleted`,
     // `.ficheroClaimUpdated`, `.ficheroEntityUpdated`) were retired in #1862.
     // Claim/entity mutations now flow through ClaimStore/EntityStore and the
@@ -91,6 +86,9 @@ extension Notification.Name {
     /// opens the source document in the reading pane or navigates to it in
     /// the library grid. object = source document id String. (#833)
     static let ficheroOpenClaimSource = Notification.Name("ficheroOpenClaimSource")
+
+    /// Posted when a KG/inspector row asks the app to navigate to entity search.
+    static let ficheroEntitySearchRequested = Notification.Name("ficheroEntitySearchRequested")
 
     /// Forwarded from `ficheroOpenClaimSource` after ContentView
     /// has resolved the source-doc id to a page number. Received by the

--- a/fichero/fichero/Views/Library/Inspector/ArtifactDetailView.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactDetailView.swift
@@ -17,38 +17,50 @@ import SwiftUI
 struct ArtifactDetailView: View {
     /// The artifact to render. `nil` shows the empty state (nothing selected).
     let artifact: Artifact?
+    var provenance: ArtifactProvenanceDisplay? = nil
+    var onOpenSource: (() -> Void)? = nil
 
     /// Persist edited content. `nil` → read-only (the `AttributedTextEditor`
     /// becomes non-editable, matching `ArtifactPanel`'s `onSave == nil` path).
-    var onSave: ((Artifact, String) async -> Void)?
+    var onSave: ((Artifact, String) async -> Void)? = nil
 
     /// Delete this artifact. `nil` hides the trash affordance.
-    var onDelete: ((Artifact) -> Void)?
+    var onDelete: ((Artifact) -> Void)? = nil
 
     var body: some View {
         Group {
             if let artifact {
-                // #2495: the selected artifact's text must fill the full
-                // available inspector height — not sit at intrinsic height in a
-                // scroll view (the old "small bottom strip" whose size tracked
-                // panel content). `fillsHeight` makes the editor claim all
-                // remaining vertical space; every content path (editor /
-                // read-only Text / structured JSON) already scrolls internally,
-                // so no outer ScrollView is needed — and a nested ScrollView
-                // wrapping a maxHeight:.infinity editor would fight over height.
-                ArtifactPanel(
-                    kind: .artifact(artifact),
-                    // The detail always shows its body — there's no sibling
-                    // competing for height, so default to expanded.
-                    defaultExpanded: true,
-                    fillsHeight: true,
-                    onDelete: onDelete.map { delete in { delete(artifact) } },
-                    onSave: onSave.map { save in
-                        { content in await save(artifact, content) }
+                VStack(spacing: 0) {
+                    if let provenance {
+                        ArtifactProvenanceSection(
+                            provenance: provenance,
+                            onOpenSource: onOpenSource
+                        )
+                        Divider()
                     }
-                )
-                .padding(.horizontal, 4)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+
+                    // #2495: the selected artifact's text must fill the full
+                    // available inspector height — not sit at intrinsic height in a
+                    // scroll view (the old "small bottom strip" whose size tracked
+                    // panel content). `fillsHeight` makes the editor claim all
+                    // remaining vertical space; every content path (editor /
+                    // read-only Text / structured JSON) already scrolls internally,
+                    // so no outer ScrollView is needed — and a nested ScrollView
+                    // wrapping a maxHeight:.infinity editor would fight over height.
+                    ArtifactPanel(
+                        kind: .artifact(artifact),
+                        // The detail always shows its body — there's no sibling
+                        // competing for height, so default to expanded.
+                        defaultExpanded: true,
+                        fillsHeight: true,
+                        onDelete: onDelete.map { delete in { delete(artifact) } },
+                        onSave: onSave.map { save in
+                            { content in await save(artifact, content) }
+                        }
+                    )
+                    .padding(.horizontal, 4)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+                }
             } else {
                 emptyState
             }
@@ -71,5 +83,46 @@ struct ArtifactDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .padding(.vertical, 32)
+    }
+}
+
+private struct ArtifactProvenanceSection: View {
+    let provenance: ArtifactProvenanceDisplay
+    var onOpenSource: (() -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            LabeledContent("Source") {
+                if let onOpenSource {
+                    Button(action: onOpenSource) {
+                        Text(provenance.sourceLabel)
+                    }
+                    .buttonStyle(.link)
+                    .accessibilityLabel("Open artifact source")
+                } else {
+                    Text(provenance.sourceLabel)
+                        .textSelection(.enabled)
+                }
+            }
+
+            if let workflowLabel = provenance.workflowLabel {
+                LabeledContent("Workflow") {
+                    Text(workflowLabel)
+                        .textSelection(.enabled)
+                }
+            }
+
+            if let providerLabel = provenance.providerLabel {
+                LabeledContent("Provider") {
+                    Text(providerLabel)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+        .font(.caption)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.quaternary.opacity(0.35))
     }
 }

--- a/fichero/fichero/Views/Library/Inspector/ArtifactListView.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactListView.swift
@@ -21,6 +21,8 @@ struct ArtifactListView: View {
     /// The reactive data source — the document-scoped store (#1997). The list
     /// reads `store.items`; it never fetches independently.
     let store: ArtifactStore
+    let inspectedDocument: Document
+    let documentsById: [String: Document]
 
     /// Shared selection holder the rows write to.
     @Bindable var focused: FocusedArtifact
@@ -119,7 +121,14 @@ struct ArtifactListView: View {
     /// stays cheap for the type-checker.
     @ViewBuilder
     private func row(for artifact: Artifact) -> some View {
-        ArtifactRow(artifact: artifact)
+        ArtifactRow(
+            artifact: artifact,
+            provenance: ArtifactProvenance.display(
+                for: artifact,
+                inspectedDocument: inspectedDocument,
+                documentsById: documentsById
+            )
+        )
             .tag(artifact.id)
             .contentShape(Rectangle())
             .onTapGesture(count: 2) {
@@ -212,6 +221,7 @@ enum ArtifactSelection {
 /// detail's job), so a long document's many artifacts stay scannable.
 private struct ArtifactRow: View {
     let artifact: Artifact
+    let provenance: ArtifactProvenanceDisplay
 
     var body: some View {
         HStack(spacing: 8) {
@@ -273,9 +283,6 @@ private struct ArtifactRow: View {
     }
 
     private var subtitle: String? {
-        var parts: [String] = []
-        if let provider = artifact.provider, !provider.isEmpty { parts.append(provider) }
-        if let model = artifact.model, !model.isEmpty { parts.append(model) }
-        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+        provenance.rowSubtitle
     }
 }

--- a/fichero/fichero/Views/Library/Inspector/ArtifactsInspectorPane.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactsInspectorPane.swift
@@ -86,6 +86,26 @@ struct ArtifactsInspectorPane: View {
         focused.id.flatMap { id in store.items.first { $0.id == id } }
     }
 
+    private var knownDocumentsById: [String: Document] {
+        (
+            documentStore.collections
+                + documentStore.currentDocuments
+                + documentStore.sidebarDocuments
+                + [document]
+        ).reduce(into: [String: Document]()) { result, item in
+            result[item.id] = item
+        }
+    }
+
+    private var selectedProvenance: ArtifactProvenanceDisplay? {
+        guard let selectedArtifact else { return nil }
+        return ArtifactProvenance.display(
+            for: selectedArtifact,
+            inspectedDocument: document,
+            documentsById: knownDocumentsById
+        )
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if let actionError {
@@ -94,6 +114,8 @@ struct ArtifactsInspectorPane: View {
             VStack(spacing: 0) {
                 ArtifactListView(
                     store: store,
+                    inspectedDocument: document,
+                    documentsById: knownDocumentsById,
                     focused: focused,
                     onOpenInWindow: openDetailWindow
                 )
@@ -103,6 +125,8 @@ struct ArtifactsInspectorPane: View {
 
                 ArtifactDetailView(
                     artifact: selectedArtifact,
+                    provenance: selectedProvenance,
+                    onOpenSource: openSelectedArtifactSource,
                     onSave: { artifact, content in
                         await saveArtifact(artifact, content: content)
                     },
@@ -185,6 +209,24 @@ struct ArtifactsInspectorPane: View {
         // Make sure the snapshot is current before the window reads it.
         focused.resolve(in: store.items)
         openWindow(id: "artifact-detail")
+    }
+
+    private func openSelectedArtifactSource() {
+        guard let selectedArtifact else { return }
+        let provenance = ArtifactProvenance.display(
+            for: selectedArtifact,
+            inspectedDocument: document,
+            documentsById: knownDocumentsById
+        )
+        var info: [String: Any] = ["documentId": provenance.sourceDocumentId]
+        if let pageLabel = provenance.pageLabel {
+            info["pageLabel"] = pageLabel
+        }
+        NotificationCenter.default.post(
+            name: .ficheroOpenClaimSource,
+            object: nil,
+            userInfo: info
+        )
     }
 
     // MARK: - Mutations

--- a/fichero/fichero/Views/Library/Inspector/ArtifactsInspectorPane.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactsInspectorPane.swift
@@ -179,7 +179,7 @@ struct ArtifactsInspectorPane: View {
             focused.documentName = document.name
             await store.setScope(
                 documentId: document.id,
-                includeDescendants: includesDescendantArtifacts,
+                includeDescendants: false,
                 force: true
             )
             focused.resolve(in: store.items)
@@ -190,15 +190,6 @@ struct ArtifactsInspectorPane: View {
         .onChange(of: executionObserver.workflowCompletedCount) { _, _ in
             Task { await store.reload() }
         }
-    }
-
-    /// A parent PDF's extractor workflows write per-page entity artifacts to its
-    /// page children, so this pane must surface those descendant outputs — the
-    /// behavior the old `DocumentInspectorContentV2(mode: .artifactsOnly)` had via
-    /// `shouldIncludeDescendantArtifacts` and that was dropped when this pane took
-    /// over (#3186). Restored now that `ArtifactStore` carries the scope flag.
-    private var includesDescendantArtifacts: Bool {
-        document.docType == .file && document.fileType == .pdf
     }
 
     private func openDetailWindow() {

--- a/scripts/check_shell_chrome.py
+++ b/scripts/check_shell_chrome.py
@@ -53,7 +53,6 @@ RULES = (("notif", _NC_APP_RE), ("shared", _SHARED_RE))
 
 # Grandfathered offenders (hash -> human location). Seed with --generate (#3040).
 KNOWN_VIOLATIONS: dict[str, str] = {
-    "ca362056aacf": '[notif] fichero/fichero/Views/ContentView.swift:536: .onReceive(NotificationCenter.default.publisher(for: .ficheroEntitySearchRequested)) { not',
     "666c9a648422": '[notif] fichero/fichero/Views/ContentView.swift:539: .onReceive(NotificationCenter.default.publisher(for: .ficheroOpenClaimSource)) { note in',
     "9ea6545b396b": '[notif] fichero/fichero/Views/ContentView.swift:542: .onReceive(NotificationCenter.default.publisher(for: .ficheroSelectDocumentRequested)) { n',
     "745fa9e2e206": '[notif] fichero/fichero/Views/ContentView.swift:545: .onReceive(NotificationCenter.default.publisher(for: .ficheroShowPanelRequested)) { note i',


### PR DESCRIPTION
## Summary
- show artifact provenance in the inspector
- keep PDF/folder artifact lists own-only unless a broader selection asks otherwise
- add the shared document-inspector mini-toolbar path
- replace the inspector entity-search notification bus with typed state and shrink the shell-chrome baseline

## Verification
- source /Users/danieltubb/code/fichero/.venv/bin/activate && bash scripts/verify_all.sh --fast
- xcodebuild -quiet -project fichero/fichero.xcodeproj -scheme "Fichero (Dev Local)" -destination "platform=macOS" -skipPackagePluginValidation build

Issues: #3417 #2305 #3414 #3193