### PR TITLE
fix: reduce inspector annotation and citation store coupling

### DIFF
--- a/fichero/fichero-tests/AnnotationServiceTests.swift
+++ b/fichero/fichero-tests/AnnotationServiceTests.swift
@@ -93,6 +93,26 @@ final class AnnotationServiceTests: XCTestCase {
         XCTAssertTrue(source.contains("await annotationStore.loadAnnotations(for: annotationScope, force: true)"))
     }
 
+    func testAnnotationStoreFiltersChangeEventsByLoadedScope() throws {
+        let source = try Self.appSource("Models/AnnotationStore.swift")
+
+        XCTAssertTrue(source.contains("guard eventTouchesLoadedScope(event) else { return }"))
+        XCTAssertTrue(source.contains("case .document(let id), .page(let id), .folder(let id):"))
+        XCTAssertTrue(source.contains("return ids.contains(id)"))
+    }
+
+    func testReaderSurfacesDoNotForceReloadAfterAddNote() throws {
+        let documentReader = try Self.appSource("Views/Library/Reading/DocumentTextReader.swift")
+        let pageContent = try Self.appSource("Views/Library/Reading/PageContentPane.swift")
+        let pdfToolbar = try Self.appSource("Views/Library/Reading/PDFPageWithToolbar.swift")
+        let imageViewer = try Self.appSource("Views/Library/ImageViewer/ImageViewerComponents.swift")
+
+        XCTAssertFalse(documentReader.contains("await annotationStore.loadAnnotations(for: .document(document.id), force: true)"))
+        XCTAssertFalse(pageContent.contains("await annotationStore.loadAnnotations(for: .page(doc.id), force: true)"))
+        XCTAssertFalse(pdfToolbar.contains("await annotationStore.loadAnnotations(for: .document(documentId), force: true)"))
+        XCTAssertFalse(imageViewer.contains("await annotationStore.loadAnnotations(for: .document(documentId), force: true)"))
+    }
+
     func testFolderScopedAnnotationsHideRevealDependentActions() throws {
         // Reveal/hide logic lives in AnnotationListView after the store migration.
         let source = try Self.appSource("Views/Library/Inspector/AnnotationListView.swift")

--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -82,6 +82,16 @@ final class DocumentInspectorTests: XCTestCase {
         XCTAssertFalse(sharedSource.contains("ficheroEntitySearchRequested"))
     }
 
+    func testLegacyCitationInfoPanelsUseEnvironmentStores() throws {
+        let citationsSource = try Self.appSource("Views/Library/DocumentInspector/DocumentInspectorInfoTab+Citations.swift")
+        let bibliographySource = try Self.appSource("Views/Library/DocumentInspector/DocumentInspectorInfoTab+Bibliography.swift")
+
+        XCTAssertTrue(citationsSource.contains("@Environment(CitationStore.self)"))
+        XCTAssertFalse(citationsSource.contains("LibraryManager.shared.globalLibrary?.citationStore"))
+        XCTAssertTrue(bibliographySource.contains("@Environment(ReferenceStore.self)"))
+        XCTAssertFalse(bibliographySource.contains("LibraryManager.shared.globalLibrary?.referenceStore"))
+    }
+
     func testFocusedEntityRoutesToEntitiesTabInsteadOfReplacingInspector() throws {
         let source = try Self.appSource("Views/Library/DocumentInspector/DocumentInspector.swift")
 

--- a/fichero/fichero/Models/AnnotationStore.swift
+++ b/fichero/fichero/Models/AnnotationStore.swift
@@ -148,6 +148,7 @@ final class AnnotationStore: ObservableDomainStore {
     nonisolated var changeDomain: String { "annotation" }
 
     func apply(_ event: ChangeEvent) {
+        guard eventTouchesLoadedScope(event) else { return }
         changeToken &+= 1
         switch event.verb {
         case "created", "updated", "deleted":
@@ -161,4 +162,14 @@ final class AnnotationStore: ObservableDomainStore {
     /// (called above for create/update/delete) and `resync()` are provided by the
     /// `ObservableDomainStore` extension — no per-store copies.
     let reloadDebouncer = ReloadDebouncer()
+
+    private func eventTouchesLoadedScope(_ event: ChangeEvent) -> Bool {
+        guard let loadedScope else { return false }
+        let ids = Set(event.documentIds)
+        if ids.isEmpty { return true }
+        switch loadedScope {
+        case .document(let id), .page(let id), .folder(let id):
+            return ids.contains(id)
+        }
+    }
 }

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab+Bibliography.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab+Bibliography.swift
@@ -44,6 +44,35 @@ struct DocumentBibliographyPanel: View {
         return parts.joined(separator: "\n\n")
     }
 
+    private var deleteDialogTitle: String {
+        pendingDelete.map { "Delete \"\(referenceTitle($0))\"?" } ?? "Delete reference?"
+    }
+
+    private var deleteErrorMessage: String { deleteError ?? "" }
+    private var extractErrorMessage: String { extractError ?? "" }
+    private var resolveErrorMessage: String { resolveError ?? "" }
+
+    private var isShowingDeleteError: Binding<Bool> {
+        Binding(
+            get: { deleteError != nil },
+            set: { if !$0 { deleteError = nil } }
+        )
+    }
+
+    private var isShowingExtractError: Binding<Bool> {
+        Binding(
+            get: { extractError != nil },
+            set: { if !$0 { extractError = nil } }
+        )
+    }
+
+    private var isShowingResolveError: Binding<Bool> {
+        Binding(
+            get: { resolveError != nil },
+            set: { if !$0 { resolveError = nil } }
+        )
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             if isLoading && references.isEmpty && loadError == nil {
@@ -124,7 +153,7 @@ struct DocumentBibliographyPanel: View {
         }
         .task(id: documentId) { await store.setScope(documentId: documentId) }
         .confirmationDialog(
-            pendingDelete.map { "Delete \"\(referenceTitle($0))\"?" } ?? "Delete reference?",
+            deleteDialogTitle,
             isPresented: Binding(
                 get: { pendingDelete != nil },
                 set: { if !$0 { pendingDelete = nil } }
@@ -147,40 +176,31 @@ struct DocumentBibliographyPanel: View {
         }
         .alert(
             "Couldn't delete reference",
-            isPresented: Binding(
-                get: { deleteError != nil },
-                set: { if !$0 { deleteError = nil } }
-            )
+            isPresented: isShowingDeleteError
         ) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text(deleteError ?? "")
+            Text(deleteErrorMessage)
         }
         .alert(
             "Couldn't extract bibliography",
-            isPresented: Binding(
-                get: { extractError != nil },
-                set: { if !$0 { extractError = nil } }
-            )
+            isPresented: isShowingExtractError
         ) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text(extractError ?? "")
+            Text(extractErrorMessage)
         }
         .alert(
             "Couldn't resolve reference",
-            isPresented: Binding(
-                get: { resolveError != nil },
-                set: { if !$0 { resolveError = nil } }
-            )
+            isPresented: isShowingResolveError
         ) {
             Button("OK", role: .cancel) {}
         } message: {
-            Text(resolveError ?? "")
+            Text(resolveErrorMessage)
         }
         .sheet(item: $editing) { editing in
             ReferenceEditSheet(reference: editing.ref) { patch in
-                try await store?.patchReference(editing.id, patch: patch)
+                try await store.patchReference(editing.id, patch: patch)
             }
         }
     }

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab+Bibliography.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab+Bibliography.swift
@@ -14,15 +14,15 @@ import SwiftUI
 /// graph); this shows the bibliography inside the document itself.
 struct DocumentBibliographyPanel: View {
     let documentId: String
+    @Environment(ReferenceStore.self) private var store
 
     // Live-refresh via the per-document ReferenceStore (#1999): the store owns
     // the fetch + the `reference.*` change-stream reactions. Reading the store's
     // properties in `body` registers the @Observable dependency.
-    private var store: ReferenceStore? { LibraryManager.shared.globalLibrary?.referenceStore }
-    private var references: [Components.Schemas.Reference] { store?.references ?? [] }
-    private var selfRef: Components.Schemas.Reference? { store?.selfRef }
-    private var isLoading: Bool { store?.isLoading ?? false }
-    private var loadError: String? { store?.loadError }
+    private var references: [Components.Schemas.Reference] { store.references }
+    private var selfRef: Components.Schemas.Reference? { store.selfRef }
+    private var isLoading: Bool { store.isLoading }
+    private var loadError: String? { store.loadError }
     @State private var copiedAll = false
     // Reference pending a confirmed delete (#3258 — surfaces the undoable
     // reference delete the action layer already backs).
@@ -59,7 +59,7 @@ struct DocumentBibliographyPanel: View {
                         .font(.caption).foregroundStyle(.secondary)
                     Spacer(minLength: 0)
                     Button("Retry") {
-                        Task { await store?.setScope(documentId: documentId, force: true) }
+                        Task { await store.setScope(documentId: documentId, force: true) }
                     }
                         .font(.caption2).buttonStyle(.borderless)
                 }
@@ -122,7 +122,7 @@ struct DocumentBibliographyPanel: View {
                 }
             }
         }
-        .task(id: documentId) { await store?.setScope(documentId: documentId) }
+        .task(id: documentId) { await store.setScope(documentId: documentId) }
         .confirmationDialog(
             pendingDelete.map { "Delete \"\(referenceTitle($0))\"?" } ?? "Delete reference?",
             isPresented: Binding(
@@ -135,7 +135,7 @@ struct DocumentBibliographyPanel: View {
                 guard let id = ref.id else { return }
                 Task {
                     do {
-                        try await store?.deleteReference(id)
+                        try await store.deleteReference(id)
                     } catch {
                         deleteError = error.localizedDescription
                     }
@@ -195,7 +195,7 @@ struct DocumentBibliographyPanel: View {
         Task { @MainActor in
             defer { isExtracting = false }
             do {
-                try await store?.runExtractor()
+                try await store.runExtractor()
             } catch {
                 extractError = error.localizedDescription
             }
@@ -208,7 +208,7 @@ struct DocumentBibliographyPanel: View {
         Task { @MainActor in
             defer { resolvingIds.remove(id) }
             do {
-                try await store?.resolveReference(doi: ref.doi, isbn: ref.isbn)
+                try await store.resolveReference(doi: ref.doi, isbn: ref.isbn)
             } catch {
                 resolveError = error.localizedDescription
             }

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab+Citations.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorInfoTab+Citations.swift
@@ -10,17 +10,17 @@ import SwiftUI
 /// italic resolved doc name for outbound, source-doc name for inbound.
 struct CitationGraphPanel: View {
     let documentId: String
+    @Environment(CitationStore.self) private var store
 
     // Live-refresh via the per-document CitationStore (#1998): the store owns
     // the fetch + the `citation.*` change-stream reactions, so an edit in any
     // window updates this panel in place. Reading the store's properties in
     // `body` registers the @Observable dependency.
-    private var store: CitationStore? { LibraryManager.shared.globalLibrary?.citationStore }
-    private var inbound: [Components.Schemas.DocumentCitation] { store?.inbound ?? [] }
-    private var outbound: [Components.Schemas.DocumentCitation] { store?.outbound ?? [] }
-    private var citationUsages: [EntityCitationUsage] { store?.usages ?? [] }
-    private var isLoading: Bool { store?.isLoading ?? false }
-    private var errorMessage: String? { store?.loadError }
+    private var inbound: [Components.Schemas.DocumentCitation] { store.inbound }
+    private var outbound: [Components.Schemas.DocumentCitation] { store.outbound }
+    private var citationUsages: [EntityCitationUsage] { store.usages }
+    private var isLoading: Bool { store.isLoading }
+    private var errorMessage: String? { store.loadError }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -54,7 +54,7 @@ struct CitationGraphPanel: View {
                 }
             }
         }
-        .task(id: documentId) { await store?.setScope(documentId: documentId) }
+        .task(id: documentId) { await store.setScope(documentId: documentId) }
     }
 
     @ViewBuilder

--- a/fichero/fichero/Views/Library/ImageViewer/ImageViewerComponents.swift
+++ b/fichero/fichero/Views/Library/ImageViewer/ImageViewerComponents.swift
@@ -76,7 +76,6 @@ struct ZoomableImagePreview: View {
                 bbox: box,
                 kind: kind
             )
-            await annotationStore.loadAnnotations(for: .document(documentId), force: true)
         }
     }
 

--- a/fichero/fichero/Views/Library/Reading/DocumentTextReader.swift
+++ b/fichero/fichero/Views/Library/Reading/DocumentTextReader.swift
@@ -157,7 +157,6 @@ struct DocumentTextReader: View {
                 charEnd: range.upperBound,
                 kind: .highlight
             )
-            await annotationStore.loadAnnotations(for: .document(document.id), force: true)
         }
     }
 
@@ -179,7 +178,6 @@ struct DocumentTextReader: View {
                 charEnd: range?.upperBound,
                 kind: .note
             )
-            await annotationStore.loadAnnotations(for: .document(document.id), force: true)
         }
     }
 

--- a/fichero/fichero/Views/Library/Reading/PDFPageWithToolbar.swift
+++ b/fichero/fichero/Views/Library/Reading/PDFPageWithToolbar.swift
@@ -156,7 +156,6 @@ struct PDFPageWithToolbar: View {
                 pageIndex: pageIndex,
                 kind: kind
             )
-            await annotationStore.loadAnnotations(for: .document(documentId), force: true)
         }
     }
 

--- a/fichero/fichero/Views/Library/Reading/PageContentPane.swift
+++ b/fichero/fichero/Views/Library/Reading/PageContentPane.swift
@@ -345,7 +345,6 @@ extension PageContentPane {
                 charEnd: range.upperBound,
                 kind: .highlight
             )
-            await annotationStore.loadAnnotations(for: .page(doc.id), force: true)
         }
     }
 
@@ -368,7 +367,6 @@ extension PageContentPane {
                 charEnd: range?.upperBound,
                 kind: .note
             )
-            await annotationStore.loadAnnotations(for: .page(doc.id), force: true)
         }
     }
 


### PR DESCRIPTION
## Summary
- reduce annotation reload fan-out by relying on scoped change events
- inject citation/bibliography inspector panels through stores instead of global library access
- repair the bibliography inspector Swift build by simplifying alert bindings and using the non-optional store

## Verification
- source /Users/danieltubb/code/fichero/.venv/bin/activate && bash scripts/verify_all.sh --fast
- xcodebuild -quiet -project fichero/fichero.xcodeproj -scheme "Fichero (Dev Local)" -destination "platform=macOS" -skipPackagePluginValidation build

Issues: #3265 #3258