### PR TITLE
fix: improve inspector entity routing and KG cap feedback

### DIFF
--- a/fichero/fichero-tests/ClaimSummaryCardTests.swift
+++ b/fichero/fichero-tests/ClaimSummaryCardTests.swift
@@ -16,8 +16,8 @@ final class ClaimSummaryCardTests: XCTestCase {
         return try String(contentsOf: url, encoding: .utf8)
     }
 
-    func testOpenClaimSourceUserInfoIncludesProvenanceFields() {
-        let info = ClaimSummaryCard.openClaimSourceUserInfo(
+    func testOpenClaimSourceRequestIncludesProvenanceFields() {
+        let request = ClaimSummaryCard.openClaimSourceRequest(
             documentId: "doc-9",
             pageLabel: " 12 ",
             charStart: 101,
@@ -26,18 +26,16 @@ final class ClaimSummaryCardTests: XCTestCase {
             excerpt: " Paris is the capital of France. "
         )
 
-        XCTAssertEqual(info?["documentId"] as? String, "doc-9")
-        XCTAssertEqual(info?["pageLabel"] as? String, "12")
-        let charStart = (info?["charStart"] as? Int) ?? (info?["charStart"] as? NSNumber)?.intValue
-        let charEnd = (info?["charEnd"] as? Int) ?? (info?["charEnd"] as? NSNumber)?.intValue
-        XCTAssertEqual(charStart, 101)
-        XCTAssertEqual(charEnd, 127)
-        XCTAssertEqual(info?["claimId"] as? String, "claim-42")
-        XCTAssertEqual(info?["excerpt"] as? String, "Paris is the capital of France.")
+        XCTAssertEqual(request?.documentId, "doc-9")
+        XCTAssertEqual(request?.pageLabel, "12")
+        XCTAssertEqual(request?.charStart, 101)
+        XCTAssertEqual(request?.charEnd, 127)
+        XCTAssertEqual(request?.claimId, "claim-42")
+        XCTAssertEqual(request?.claimText, "Paris is the capital of France.")
     }
 
-    func testOpenClaimSourceUserInfoRejectsEmptyDocumentId() {
-        let info = ClaimSummaryCard.openClaimSourceUserInfo(
+    func testOpenClaimSourceRequestRejectsEmptyDocumentId() {
+        let request = ClaimSummaryCard.openClaimSourceRequest(
             documentId: "",
             pageLabel: "12",
             charStart: 101,
@@ -46,7 +44,7 @@ final class ClaimSummaryCardTests: XCTestCase {
             excerpt: "Paris is the capital of France."
         )
 
-        XCTAssertNil(info)
+        XCTAssertNil(request)
     }
 
     func testPageContentClaimSourceHighlightMatchesCharRange() {

--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -82,6 +82,16 @@ final class DocumentInspectorTests: XCTestCase {
         XCTAssertFalse(sharedSource.contains("ficheroEntitySearchRequested"))
     }
 
+    func testEntityListNameUsesSearchClickWithDoubleClickRename() throws {
+        let entitiesSource = try Self.appSource("Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift")
+
+        XCTAssertTrue(entitiesSource.contains("Button {"))
+        XCTAssertTrue(entitiesSource.contains("postSearch("))
+        XCTAssertTrue(entitiesSource.contains("Search the library for"))
+        XCTAssertTrue(entitiesSource.contains(".simultaneousGesture("))
+        XCTAssertTrue(entitiesSource.contains("TapGesture(count: 2).onEnded { beginRename(entity) }"))
+    }
+
     func testLegacyCitationInfoPanelsUseEnvironmentStores() throws {
         let citationsSource = try Self.appSource("Views/Library/DocumentInspector/DocumentInspectorInfoTab+Citations.swift")
         let bibliographySource = try Self.appSource("Views/Library/DocumentInspector/DocumentInspectorInfoTab+Bibliography.swift")

--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -51,8 +51,8 @@ final class DocumentInspectorTests: XCTestCase {
         let source = try Self.appSource("Views/Library/Inspector/ArtifactsInspectorPane.swift")
         let detailSource = try Self.appSource("Views/Library/Inspector/ArtifactDetailView.swift")
 
-        XCTAssertTrue(source.contains("NotificationCenter.default.post("))
-        XCTAssertTrue(source.contains("name: .ficheroOpenClaimSource"))
+        XCTAssertTrue(source.contains("ClaimSourceNavigationState.shared.request("))
+        XCTAssertTrue(source.contains("ClaimSourceNavigationRequest("))
         XCTAssertTrue(detailSource.contains("LabeledContent(\"Source\")"))
     }
 
@@ -80,6 +80,20 @@ final class DocumentInspectorTests: XCTestCase {
         XCTAssertTrue(contentSource.contains(".onChange(of: entitySearchState.requestID)"))
         XCTAssertTrue(entitiesSource.contains("EntitySearchState.shared.request("))
         XCTAssertFalse(sharedSource.contains("ficheroEntitySearchRequested"))
+    }
+
+    func testClaimSourceRoutingUsesTypedStateInsteadOfNotificationBus() throws {
+        let contentSource = try Self.appSource("Views/ContentView.swift")
+        let sharedSource = try Self.appSource("Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift")
+        let artifactsSource = try Self.appSource("Views/Library/Inspector/ArtifactsInspectorPane.swift")
+        let searchSource = try Self.appSource("Views/Search/SearchView+Helpers.swift")
+
+        XCTAssertTrue(sharedSource.contains("final class ClaimSourceNavigationState"))
+        XCTAssertTrue(contentSource.contains(".onChange(of: claimSourceNavigationState.requestID)"))
+        XCTAssertTrue(artifactsSource.contains("ClaimSourceNavigationState.shared.request("))
+        XCTAssertTrue(searchSource.contains("ClaimSourceNavigationState.shared.request(request)"))
+        XCTAssertFalse(contentSource.contains(".ficheroOpenClaimSource"))
+        XCTAssertFalse(sharedSource.contains("static let ficheroOpenClaimSource"))
     }
 
     func testEntityListNameUsesSearchClickWithDoubleClickRename() throws {

--- a/fichero/fichero-tests/OntologyBrowserFilterTests.swift
+++ b/fichero/fichero-tests/OntologyBrowserFilterTests.swift
@@ -113,6 +113,26 @@ final class OntologyBrowserFilterTests: XCTestCase {
         XCTAssertFalse(OntologyBrowser.isOcrGarbage("COVID-19"))
     }
 
+    // MARK: - Truncation warning
+
+    func testTruncationMessageHiddenBelowCap() {
+        XCTAssertNil(OntologyBrowser.truncationMessage(entityCount: 99, searchText: ""))
+    }
+
+    func testTruncationMessageWarnsForUnfilteredListAtCap() {
+        XCTAssertEqual(
+            OntologyBrowser.truncationMessage(entityCount: 100, searchText: ""),
+            "Showing the first 100 entities. Refine the list to narrow the graph."
+        )
+    }
+
+    func testTruncationMessageWarnsForSearchResultsAtCap() {
+        XCTAssertEqual(
+            OntologyBrowser.truncationMessage(entityCount: 100, searchText: "paris"),
+            "Showing the first 100 matching entities. Refine the search to narrow the list."
+        )
+    }
+
     // MARK: - EntityRow display-label fallback
 
     func testEntityRowFallbackForEmptyCanonicalName() {

--- a/fichero/fichero-tests/SearchResultRowFromAPITests.swift
+++ b/fichero/fichero-tests/SearchResultRowFromAPITests.swift
@@ -136,7 +136,7 @@ final class SearchResultRowFromAPITests: XCTestCase {
         XCTAssertEqual(row.preferredExcerptText, "Specific matched excerpt")
     }
 
-    func testNavigationUserInfoUsesMetadataWhenTranscriptExcerptMissing() {
+    func testNavigationRequestUsesMetadataWhenTranscriptExcerptMissing() {
         let result = makeResult(
             metadata: [
                 "source_excerpt": AnyCodable("Specific matched excerpt"),
@@ -146,12 +146,12 @@ final class SearchResultRowFromAPITests: XCTestCase {
             ]
         )
 
-        let info = SearchResultRowFromAPI.navigationUserInfo(for: result)
-        XCTAssertEqual(info?["documentId"] as? String, "doc-1")
-        XCTAssertEqual(info?["excerpt"] as? String, "Specific matched excerpt")
-        XCTAssertEqual(info?["pageLabel"] as? String, "12")
-        XCTAssertEqual(info?["charStart"] as? Int, 45)
-        XCTAssertEqual(info?["charEnd"] as? Int, 61)
+        let request = SearchResultRowFromAPI.navigationRequest(for: result)
+        XCTAssertEqual(request?.documentId, "doc-1")
+        XCTAssertEqual(request?.claimText, "Specific matched excerpt")
+        XCTAssertEqual(request?.pageLabel, "12")
+        XCTAssertEqual(request?.charStart, 45)
+        XCTAssertEqual(request?.charEnd, 61)
     }
 
     func testSearchServiceConversionPreservesTranscriptExcerptsWiring() throws {

--- a/fichero/fichero/Views/ContentView+State.swift
+++ b/fichero/fichero/Views/ContentView+State.swift
@@ -878,18 +878,18 @@ extension ContentView {
         runToolbarSearch(query)
     }
 
-    /// Handles `.onReceive` of `.ficheroOpenClaimSource`.
+    /// Handles typed source-open requests from inspector/KG/search surfaces.
     /// Navigates to a claim's source document with the page scrolled into view.
-    func handleOpenClaimSource(_ note: Notification) {
+    func handleOpenClaimSource() {
         // Claim card source-doc link → navigate to the document
-        // with the page scrolled into view. userInfo carries
+        // with the page scrolled into view. The typed request carries
         // documentId (required) + pageLabel / charStart / charEnd /
         // claimId (all optional). For now this lights up doc
         // selection + posts an internal navigation event the
         // PDF preview will consume to scroll to pageLabel. The
         // highlight-span overlay lands in a later phase (#995). (#978/#979/#982)
-        guard let info = note.userInfo,
-              let docId = info["documentId"] as? String else { return }
+        guard let request = claimSourceNavigationState.currentRequest else { return }
+        let docId = request.documentId
         // Switch to library view if we're in another mode (KG /
         // Activity / Workflow) — the source preview lives there.
         if sidebarMode != .library {
@@ -897,14 +897,14 @@ extension ContentView {
         }
         showInspectorSidebar = true
         focusedPane = .inspector
-        if let claimId = info["claimId"] as? String {
+        if let claimId = request.claimId {
             claimFocusState.selectClaim(
                 claimId: claimId,
-                claimText: (info["claimText"] as? String) ?? (info["excerpt"] as? String),
+                claimText: request.claimText,
                 sourceDocumentId: docId,
-                pageLabel: info["pageLabel"] as? String,
-                charStart: info["charStart"] as? Int,
-                charEnd: info["charEnd"] as? Int
+                pageLabel: request.pageLabel,
+                charStart: request.charStart,
+                charEnd: request.charEnd
             )
         }
         // Resolve page-child source documents to their parent file and
@@ -912,6 +912,11 @@ extension ContentView {
         // PDFPageView consumes for scrolling/highlighting.
         Task { @MainActor in
             await navigateToSourcePage(docId)
+            var info: [String: Any] = ["documentId": docId]
+            if let claimId = request.claimId { info["claimId"] = claimId }
+            if let pageLabel = request.pageLabel { info["pageLabel"] = pageLabel }
+            if let charStart = request.charStart { info["charStart"] = charStart }
+            if let charEnd = request.charEnd { info["charEnd"] = charEnd }
             NotificationCenter.default.post(
                 name: .ficheroNavigateToPage,
                 object: nil,

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -100,6 +100,7 @@ struct ContentView: View {
     @State var viewMode: AppViewMode = .library(nil)
     @State var detailDocument: Document?
     @State var entitySearchState = EntitySearchState.shared
+    @State var claimSourceNavigationState = ClaimSourceNavigationState.shared
     /// Drives the distraction-free full-window reading overlay (#2520).
     @State private var isImmersiveReading = false
     @State private var focusedDocument = FocusedDocument.shared
@@ -569,8 +570,8 @@ struct ContentView: View {
             .onChange(of: entitySearchState.requestID) { _, _ in
                 handleEntitySearchRequested()
             }
-            .onReceive(NotificationCenter.default.publisher(for: .ficheroOpenClaimSource)) { note in
-                handleOpenClaimSource(note)
+            .onChange(of: claimSourceNavigationState.requestID) { _, _ in
+                handleOpenClaimSource()
             }
             .onReceive(NotificationCenter.default.publisher(for: .ficheroSelectDocumentRequested)) { note in
                 handleAppleScriptSelectDocument(note)

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/ClaimSummaryCard+Details.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/ClaimSummaryCard+Details.swift
@@ -213,39 +213,36 @@ extension ClaimSummaryCard {
         EntitySearchState.shared.request(name: name, entityType: nil)
     }
 
-    /// Post ficheroOpenClaimSource for the explicit sourceLine button.
+    /// Route the explicit source-line button through the typed source-open state.
     func openClaimSource() {
         Self.postOpenClaimSource(for: claim)
     }
 
-    static func openClaimSourceUserInfo(
+    static func openClaimSourceRequest(
         documentId: String,
         pageLabel: String? = nil,
         charStart: Int? = nil,
         charEnd: Int? = nil,
         claimId: String? = nil,
         excerpt: String? = nil
-    ) -> [String: Any]? {
+    ) -> ClaimSourceNavigationRequest? {
         guard !documentId.isEmpty else { return nil }
-        var info: [String: Any] = ["documentId": documentId]
-        if let pageLabel = pageLabel?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !pageLabel.isEmpty {
-            info["pageLabel"] = pageLabel
-        }
-        if let charStart { info["charStart"] = charStart }
-        if let charEnd { info["charEnd"] = charEnd }
-        if let claimId { info["claimId"] = claimId }
-        if let excerpt = excerpt?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !excerpt.isEmpty {
-            info["excerpt"] = excerpt
-        }
-        return info
+        let cleanedPageLabel = pageLabel?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let cleanedExcerpt = excerpt?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return ClaimSourceNavigationRequest(
+            documentId: documentId,
+            claimId: claimId,
+            claimText: cleanedExcerpt?.isEmpty == false ? cleanedExcerpt : nil,
+            pageLabel: cleanedPageLabel?.isEmpty == false ? cleanedPageLabel : nil,
+            charStart: charStart,
+            charEnd: charEnd
+        )
     }
 
-    static func openClaimSourceUserInfo(
+    static func openClaimSourceRequest(
         for claim: Components.Schemas.KnowledgeClaim
-    ) -> [String: Any]? {
-        openClaimSourceUserInfo(
+    ) -> ClaimSourceNavigationRequest? {
+        openClaimSourceRequest(
             documentId: claim.sourceDocumentId ?? "",
             pageLabel: claim.sourcePageLabel,
             charStart: claim.sourceCharStart,
@@ -262,13 +259,9 @@ extension ClaimSummaryCard {
                 .documentStore
                 .currentDocuments
                 .contains(where: { $0.id == docId }) == true,
-              let info = openClaimSourceUserInfo(for: claim)
+              let request = openClaimSourceRequest(for: claim)
         else { return }
-        NotificationCenter.default.post(
-            name: .ficheroOpenClaimSource,
-            object: nil,
-            userInfo: info
-        )
+        ClaimSourceNavigationState.shared.request(request)
     }
 
     private func navigateToSource() {

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/OntologyBrowser+List.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/OntologyBrowser+List.swift
@@ -4,11 +4,38 @@ import SwiftUI
 // Entity list sidebar, search bar, list rows, and navigation for
 // OntologyBrowser (#1703).
 extension OntologyBrowser {
+    static let entityListLimit = 100
+
     // MARK: - Entity List Sidebar
+
+    static func truncationMessage(
+        entityCount: Int,
+        searchText: String,
+        limit: Int = entityListLimit
+    ) -> String? {
+        guard entityCount >= limit else { return nil }
+        if searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Showing the first \(limit) entities. Refine the list to narrow the graph."
+        }
+        return "Showing the first \(limit) matching entities. Refine the search to narrow the list."
+    }
+
+    var entityTruncationMessage: String? {
+        Self.truncationMessage(entityCount: entities.count, searchText: searchText)
+    }
 
     var entityListSidebar: some View {
         VStack(spacing: 0) {
             searchBar
+            if let entityTruncationMessage {
+                Divider()
+                Text(entityTruncationMessage)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 6)
+            }
             Divider()
             entityList
                 .frame(maxWidth: .infinity)  // fill the column, don't anchor left (#981)
@@ -209,7 +236,7 @@ extension OntologyBrowser {
         do {
             let library = LibraryManager.shared.globalLibrary!
             let service = library.entityService
-            async let entityList = service.listEntities(limit: 100)
+            async let entityList = service.listEntities(limit: Self.entityListLimit)
             async let counts = service.fetchClaimCounts()
             entities = try await entityList
             claimCounts = (try? await counts) ?? [:]
@@ -235,7 +262,7 @@ extension OntologyBrowser {
             // EntityServiceGenerated.listEntities supports a free-text
             // `query` filter — same as searching by canonical name or
             // alias. No need for a separate resolve-by-value API.
-            entities = try await service.listEntities(query: searchText, limit: 100)
+            entities = try await service.listEntities(query: searchText, limit: Self.entityListLimit)
         } catch {
             await loadEntities()
         }

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -459,13 +459,23 @@ struct DocumentInspectorEntitiesTab: View {
                 #endif
                 .onAppear { renameFieldFocused = true }
         } else {
-            Text(entity.canonicalName)
-                .font(.caption)
-                .fontWeight(.semibold)
-                .foregroundStyle(.primary)
-                .highPriorityGesture(
-                    TapGesture(count: 2).onEnded { beginRename(entity) }
+            Button {
+                postSearch(
+                    for: entity,
+                    kind: EntityKind(apiType: entity.entityType) ?? .other
                 )
+            } label: {
+                Text(entity.canonicalName)
+                    .font(.caption)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(Color.accentColor)
+                    .underline()
+            }
+            .buttonStyle(.plain)
+            .help("Search the library for \"\(entity.canonicalName)\" — double-click to rename")
+            .simultaneousGesture(
+                TapGesture(count: 2).onEnded { beginRename(entity) }
+            )
         }
     }
 

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift
@@ -71,6 +71,30 @@ final class EntitySearchState {
     }
 }
 
+struct ClaimSourceNavigationRequest: Equatable {
+    let documentId: String
+    var claimId: String?
+    var claimText: String?
+    var pageLabel: String?
+    var charStart: Int?
+    var charEnd: Int?
+}
+
+@Observable
+@MainActor
+final class ClaimSourceNavigationState {
+    static let shared = ClaimSourceNavigationState()
+
+    private(set) var requestID: Int = 0
+    private(set) var currentRequest: ClaimSourceNavigationRequest?
+
+    func request(_ request: ClaimSourceNavigationRequest) {
+        guard !request.documentId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        currentRequest = request
+        requestID &+= 1
+    }
+}
+
 // MARK: - Notification names
 
 extension Notification.Name {
@@ -81,13 +105,7 @@ extension Notification.Name {
     // to every window's stores. Only *navigation* signals remain — those are
     // not data mutations and stay out of the change-stream (spec §4.3).
 
-    /// Posted when the user taps a source-doc citation on a claim card
-    /// (the small arrow in EntityKindRow). ContentView listens and either
-    /// opens the source document in the reading pane or navigates to it in
-    /// the library grid. object = source document id String. (#833)
-    static let ficheroOpenClaimSource = Notification.Name("ficheroOpenClaimSource")
-
-    /// Forwarded from `ficheroOpenClaimSource` after ContentView
+    /// Forwarded from the typed source-open request after ContentView
     /// has resolved the source-doc id to a page number. Received by the
     /// PDF canvas so it can jump to the right page. (#833)
     static let ficheroNavigateToPage = Notification.Name("ficheroNavigateToPage")

--- a/fichero/fichero/Views/Library/DocumentKGWebPane.swift
+++ b/fichero/fichero/Views/Library/DocumentKGWebPane.swift
@@ -591,7 +591,7 @@ struct DocumentKGWebPane: NSViewRepresentable {
         private func postOpenClaimSource(
             sourceDocumentId: String, pageLabel: String?, entityId: String?, claimId: String?, body: [String: Any]
         ) {
-            guard var info = ClaimSummaryCard.openClaimSourceUserInfo(
+            guard let request = ClaimSummaryCard.openClaimSourceRequest(
                 documentId: sourceDocumentId,
                 pageLabel: pageLabel,
                 charStart: body["charStart"] as? Int,
@@ -599,10 +599,8 @@ struct DocumentKGWebPane: NSViewRepresentable {
                 claimId: claimId,
                 excerpt: body["excerpt"] as? String
             ) else { return }
-            if let entityId, !entityId.isEmpty {
-                info["entityId"] = entityId
-            }
-            NotificationCenter.default.post(name: .ficheroOpenClaimSource, object: nil, userInfo: info)
+            _ = entityId
+            ClaimSourceNavigationState.shared.request(request)
         }
 
         private func pageLabel(from body: [String: Any]) -> String? {
@@ -949,7 +947,7 @@ struct DocumentKGWebPane: UIViewRepresentable {
         private func postOpenClaimSource(
             sourceDocumentId: String, pageLabel: String?, entityId: String?, claimId: String?, body: [String: Any]
         ) {
-            guard var info = ClaimSummaryCard.openClaimSourceUserInfo(
+            guard let request = ClaimSummaryCard.openClaimSourceRequest(
                 documentId: sourceDocumentId,
                 pageLabel: pageLabel,
                 charStart: body["charStart"] as? Int,
@@ -957,10 +955,8 @@ struct DocumentKGWebPane: UIViewRepresentable {
                 claimId: claimId,
                 excerpt: body["excerpt"] as? String
             ) else { return }
-            if let entityId, !entityId.isEmpty {
-                info["entityId"] = entityId
-            }
-            NotificationCenter.default.post(name: .ficheroOpenClaimSource, object: nil, userInfo: info)
+            _ = entityId
+            ClaimSourceNavigationState.shared.request(request)
         }
 
         private func pageLabel(from body: [String: Any]) -> String? {

--- a/fichero/fichero/Views/Library/Inspector/ArtifactsInspectorPane.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactsInspectorPane.swift
@@ -209,14 +209,11 @@ struct ArtifactsInspectorPane: View {
             inspectedDocument: document,
             documentsById: knownDocumentsById
         )
-        var info: [String: Any] = ["documentId": provenance.sourceDocumentId]
-        if let pageLabel = provenance.pageLabel {
-            info["pageLabel"] = pageLabel
-        }
-        NotificationCenter.default.post(
-            name: .ficheroOpenClaimSource,
-            object: nil,
-            userInfo: info
+        ClaimSourceNavigationState.shared.request(
+            ClaimSourceNavigationRequest(
+                documentId: provenance.sourceDocumentId,
+                pageLabel: provenance.pageLabel
+            )
         )
     }
 

--- a/fichero/fichero/Views/Search/SearchResultRowFromAPI.swift
+++ b/fichero/fichero/Views/Search/SearchResultRowFromAPI.swift
@@ -183,14 +183,14 @@ struct SearchResultRowFromAPI: View {
         return nil
     }
 
-    static func navigationUserInfo(for result: SearchResult) -> [String: Any]? {
+    static func navigationRequest(for result: SearchResult) -> ClaimSourceNavigationRequest? {
         if let excerpt = result.transcriptExcerpts.first {
-            return [
-                "documentId": excerpt.anchor.documentId,
-                "excerpt": excerpt.text,
-                "charStart": excerpt.anchor.charStart,
-                "charEnd": excerpt.anchor.charEnd
-            ]
+            return ClaimSourceNavigationRequest(
+                documentId: excerpt.anchor.documentId,
+                claimText: excerpt.text,
+                charStart: excerpt.anchor.charStart,
+                charEnd: excerpt.anchor.charEnd
+            )
         }
 
         let excerpt = metadataString(
@@ -201,21 +201,13 @@ struct SearchResultRowFromAPI: View {
             return nil
         }
 
-        var info: [String: Any] = [
-            "documentId": result.documentId,
-            "excerpt": cleaned
-        ]
-
-        if let pageLabel = metadataString(from: result, keys: ["source_page_label", "page_label"]) {
-            info["pageLabel"] = pageLabel
-        }
-        if let charStart = metadataInt(from: result, keys: ["source_char_start", "char_start"]) {
-            info["charStart"] = charStart
-        }
-        if let charEnd = metadataInt(from: result, keys: ["source_char_end", "char_end"]) {
-            info["charEnd"] = charEnd
-        }
-        return info
+        return ClaimSourceNavigationRequest(
+            documentId: result.documentId,
+            claimText: cleaned,
+            pageLabel: metadataString(from: result, keys: ["source_page_label", "page_label"]),
+            charStart: metadataInt(from: result, keys: ["source_char_start", "char_start"]),
+            charEnd: metadataInt(from: result, keys: ["source_char_end", "char_end"])
+        )
     }
 
     /// Build an AttributedString with `**...**` spans highlighted.

--- a/fichero/fichero/Views/Search/SearchView+Helpers.swift
+++ b/fichero/fichero/Views/Search/SearchView+Helpers.swift
@@ -178,15 +178,11 @@ extension SearchView {
     }
 
     func openExcerpt(_ result: SearchResult) {
-        guard let info = SearchResultRowFromAPI.navigationUserInfo(for: result) else {
+        guard let request = SearchResultRowFromAPI.navigationRequest(for: result) else {
             loadDocument(result.documentId)
             return
         }
 
-        NotificationCenter.default.post(
-            name: .ficheroOpenClaimSource,
-            object: nil,
-            userInfo: info
-        )
+        ClaimSourceNavigationState.shared.request(request)
     }
 }

--- a/scripts/check_shell_chrome.py
+++ b/scripts/check_shell_chrome.py
@@ -53,10 +53,8 @@ RULES = (("notif", _NC_APP_RE), ("shared", _SHARED_RE))
 
 # Grandfathered offenders (hash -> human location). Seed with --generate (#3040).
 KNOWN_VIOLATIONS: dict[str, str] = {
-    "666c9a648422": '[notif] fichero/fichero/Views/ContentView.swift:539: .onReceive(NotificationCenter.default.publisher(for: .ficheroOpenClaimSource)) { note in',
     "9ea6545b396b": '[notif] fichero/fichero/Views/ContentView.swift:542: .onReceive(NotificationCenter.default.publisher(for: .ficheroSelectDocumentRequested)) { n',
     "745fa9e2e206": '[notif] fichero/fichero/Views/ContentView.swift:545: .onReceive(NotificationCenter.default.publisher(for: .ficheroShowPanelRequested)) { note i',
-    "ee7aad6e9825": '[notif] fichero/fichero/Views/Library/DocumentKGWebPane.swift:861: NotificationCenter.default.post(name: .ficheroOpenClaimSource, object: nil, userInfo: info',
     "0fbc3922252c": '[shared] fichero/fichero/Views/Library/LibraryView.swift:105: @ObservedObject var featureManager = FeatureManager.shared',
     "881489cff539": '[shared] fichero/fichero/Views/Menu/AddItemMenu.swift:10: @ObservedObject var featureManager = FeatureManager.shared',
     "178cfaef2a1f": '[shared] fichero/fichero/Views/Menu/FocusedCommandButtons.swift:520: @ObservedObject var featureManager = FeatureManager.shared',


### PR DESCRIPTION
## Summary
- route inspector entity names into library search
- replace claim-source NotificationCenter routing with typed focus state
- show an ontology-browser warning when entity cap truncates results
- shrink the shell-chrome guardrail allowlist for the removed notification routes

## Verification
- `source /Users/danieltubb/code/fichero/.venv/bin/activate && bash scripts/verify_all.sh --fast`
- `xcodebuild -quiet -project fichero/fichero.xcodeproj -scheme "Fichero (Dev Local)" -destination "platform=macOS" -skipPackagePluginValidation build`

Issues: #1789 #3193 #3294