### PR TITLE
Inspector visual-polish batch #3461 (build-gated a8570470c)

### DIFF
--- a/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
+++ b/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
@@ -884,6 +884,37 @@ final class KnowledgeGraphInspectorSectionTests: XCTestCase {
             mergedIntoId: nil
         )
     }
+
+    // MARK: - Source provenance anchor (#3449, item 12)
+
+    func testKGClaimBuildsSourceNavigationRequestWhenSourced() {
+        let claim = Components.Schemas.KnowledgeClaim(
+            id: "claim-1",
+            text: "Ada wrote the notes",
+            sourceDocumentId: "doc-9",
+            sourcePageLabel: "page 4",
+            sourceExcerpt: "the verbatim quote"
+        )
+
+        let request = ClaimSummaryCard.openClaimSourceRequest(for: claim)
+
+        XCTAssertNotNil(request, "A claim with a source document should yield a provenance anchor")
+        XCTAssertEqual(request?.documentId, "doc-9")
+        XCTAssertEqual(request?.pageLabel, "page 4")
+        XCTAssertEqual(request?.claimText, "the verbatim quote")
+        XCTAssertEqual(request?.claimId, "claim-1")
+    }
+
+    func testKGClaimWithoutSourceDocumentHasNoProvenanceAnchor() {
+        // No sourceDocumentId → no anchor, so the row shows no provenance popover
+        // (rather than a broken empty one).
+        let claim = Components.Schemas.KnowledgeClaim(
+            id: "claim-2",
+            text: "Unsourced assertion"
+        )
+
+        XCTAssertNil(ClaimSummaryCard.openClaimSourceRequest(for: claim))
+    }
 }
 
 private func makeKnowledgeClaim(

--- a/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
+++ b/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
@@ -932,6 +932,18 @@ final class KnowledgeGraphInspectorSectionTests: XCTestCase {
         XCTAssertTrue(source.contains(".onChange(of: claimSelection)"))
     }
 
+    func testKGListWiresSpaceKeySourceQuickLook() throws {
+        let source = try Self.appSource(
+            "Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift"
+        )
+
+        // Space on a selected claim opens the source quick-look popover, reusing
+        // the shared SourceProvenanceCard (#3449 item-12 extension).
+        XCTAssertTrue(source.contains(".onKeyPress(.space)"))
+        XCTAssertTrue(source.contains("spaceQuickLookClaimId"))
+        XCTAssertTrue(source.contains("SourceProvenanceCard("))
+    }
+
     func testKGClaimRowDefersSingleClickSelectionToTheList() throws {
         let source = try Self.appSource(
             "Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift"

--- a/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
+++ b/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
@@ -915,6 +915,33 @@ final class KnowledgeGraphInspectorSectionTests: XCTestCase {
 
         XCTAssertNil(ClaimSummaryCard.openClaimSourceRequest(for: claim))
     }
+
+    // MARK: - Native List conversion (#3425, item 14)
+
+    func testKGListModeUsesNativeListSelectionWithKindSections() throws {
+        let source = try Self.appSource(
+            "Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift"
+        )
+
+        // List mode is a native List(selection:) so it gets arrow-key nav +
+        // multi-select for free, grouped into per-kind Sections, with a
+        // focus-on-single-selection seam replacing the old click reducer.
+        XCTAssertTrue(source.contains("List(selection: $claimSelection)"))
+        XCTAssertTrue(source.contains(".tag(item.claimId)"))
+        XCTAssertTrue(source.contains("focusSingleSelectedClaim"))
+        XCTAssertTrue(source.contains(".onChange(of: claimSelection)"))
+    }
+
+    func testKGClaimRowDefersSingleClickSelectionToTheList() throws {
+        let source = try Self.appSource(
+            "Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift"
+        )
+
+        // The row no longer owns single-click selection (the List does); it keeps
+        // the double-click-to-open gesture.
+        XCTAssertFalse(source.contains(".onTapGesture"))
+        XCTAssertTrue(source.contains("TapGesture(count: 2)"))
+    }
 }
 
 private func makeKnowledgeClaim(

--- a/fichero/fichero/Models/Platform/PlatformAliases.swift
+++ b/fichero/fichero/Models/Platform/PlatformAliases.swift
@@ -112,3 +112,33 @@ struct PlatformVSplitView<Content: View>: View {
 }
 
 #endif
+
+/// Vertical **list-over-detail** layout shared by every inspector pane
+/// (#3434 4-section inspector, #3458). The top list defaults to ~1/3 of the
+/// available height and the detail fills the remaining ~2/3.
+///
+/// Why not `VSplitView` directly: a SwiftUI `List` is infinitely greedy
+/// vertically, so inside a `VSplitView` the top list ballooned to ~3/4 and
+/// squished the detail. A fixed fraction of the container height pins the list
+/// short regardless of the List's greed — the same behaviour on macOS and iOS.
+struct InspectorListDetailSplit<TopList: View, Detail: View>: View {
+    /// Fraction of the container height given to the top list; detail takes the rest.
+    var listFraction: CGFloat = 1.0 / 3.0
+    @ViewBuilder var list: () -> TopList
+    @ViewBuilder var detail: () -> Detail
+
+    var body: some View {
+        GeometryReader { proxy in
+            VStack(spacing: 0) {
+                list()
+                    // ponytail: fixed fraction, not a draggable divider — the ask
+                    // was a 1/3 default. Swap in a resizable+remembered split if a
+                    // user actually wants to drag it.
+                    .frame(height: max(120, proxy.size.height * listFraction))
+                Divider()
+                detail()
+                    .frame(maxHeight: .infinity)
+            }
+        }
+    }
+}

--- a/fichero/fichero/Views/KnowledgeGraph/EntityDigestView.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/EntityDigestView.swift
@@ -223,7 +223,7 @@ struct EntityDigestContent: View {
     let entityService: EntityServiceGenerated
 
     @State private var claims: [Components.Schemas.KnowledgeClaim] = []
-    @State private var selectedClaimIds: Set<String> = []
+    @State private var selectedClaimRowId: String?
     @State private var isLoading = false
 
     var body: some View {
@@ -309,12 +309,19 @@ struct EntityDigestContent: View {
                 let grouped = Dictionary(grouping: claims, by: { $0.sourceDocumentId ?? "" })
                 let sortedDocIds = grouped.keys.sorted()
 
-                List(selection: $selectedClaimIds) {
+                // Single-selection List with STABLE, non-optional tags. The old
+                // `.tag(claim.id)` was `String?` while the selection was
+                // `Set<String>` — the type mismatch collapsed identity so
+                // clicking one row highlighted them all. A `String?` selection
+                // matched by non-optional `String` tags fixes it, and
+                // `inspectorListRowTarget()` makes the whole row the hit target.
+                List(selection: $selectedClaimRowId) {
                     ForEach(sortedDocIds, id: \.self) { docId in
                         Section(header: Label(docName(for: docId), systemImage: "doc.text")) {
-                            ForEach(grouped[docId] ?? [], id: \.id) { claim in
+                            ForEach(Array((grouped[docId] ?? []).enumerated()), id: \.offset) { index, claim in
                                 provenanceRow(claim)
-                                    .tag(claim.id)
+                                    .inspectorListRowTarget()
+                                    .tag(claim.id ?? "\(docId)#\(index)")
                                     .listRowSeparator(.hidden)
                             }
                         }
@@ -348,9 +355,15 @@ struct EntityDigestContent: View {
         .padding(.vertical, 2)
     }
 
+    /// Human-readable name for a source document id. Searches every store the
+    /// app has loaded — current page/folder, collections, and the sidebar — not
+    /// just `currentDocuments`, so an off-page source resolves to its title
+    /// instead of a raw hash. Falls back to the id only when the document isn't
+    /// in any store (that residual case needs a title on the claim payload).
     private func docName(for docId: String) -> String {
-        LibraryManager.shared.globalLibrary?.documentStore
-            .currentDocuments.first(where: { $0.id == docId })?.name ?? docId
+        guard let store = LibraryManager.shared.globalLibrary?.documentStore else { return docId }
+        let all = store.currentDocuments + store.collections + store.sidebarDocuments
+        return all.first(where: { $0.id == docId })?.name ?? docId
     }
 
     private func provenanceSummary(for claim: Components.Schemas.KnowledgeClaim) -> String {
@@ -417,15 +430,15 @@ struct EntityDigestContent: View {
         defer { isLoading = false }
         guard let entityId = entity.id else {
             claims = []
-            selectedClaimIds.removeAll()
+            selectedClaimRowId = nil
             return
         }
         do {
             claims = try await entityService.listClaims(entityId: entityId, limit: 500)
-            selectedClaimIds.removeAll()
+            selectedClaimRowId = nil
         } catch {
             claims = []
-            selectedClaimIds.removeAll()
+            selectedClaimRowId = nil
         }
     }
 }

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
@@ -322,31 +322,30 @@ struct DocumentInspector: View {
 
     @ViewBuilder
     private func knowledgeGraphTab(for doc: Document) -> some View {
-        ScrollView {
-            KnowledgeGraphInspectorSection(
-                documentId: doc.id,
-                documentScope: doc.docType == .page ? .page : .folder,
-                entityService: entityService,
-                artifactService: artifactService,
-                kgCurationService: kgCurationService,
-                onNavigateToSource: onNavigateToSource,
-                onClaimSelect: { claimId, claimText, sourceDocId, pageLabel, charStart, charEnd in
-                    // Direct observable call — no NotificationCenter round-trip
-                    // (#3034). Passes the full payload the old .claimSelectedInInspector
-                    // bus carried but the ContentView handler dropped (it forwarded
-                    // only claimId), so the other panes now get text/source/range too.
-                    claimFocusState.selectClaim(
-                        claimId: claimId,
-                        claimText: claimText,
-                        sourceDocumentId: sourceDocId,
-                        pageLabel: pageLabel,
-                        charStart: charStart,
-                        charEnd: charEnd
-                    )
-                }
-            )
-            .padding()
-        }
+        // No outer ScrollView — KnowledgeGraphInspectorSection owns its own
+        // scroll + pinned bottom mini-toolbar (#3461).
+        KnowledgeGraphInspectorSection(
+            documentId: doc.id,
+            documentScope: doc.docType == .page ? .page : .folder,
+            entityService: entityService,
+            artifactService: artifactService,
+            kgCurationService: kgCurationService,
+            onNavigateToSource: onNavigateToSource,
+            onClaimSelect: { claimId, claimText, sourceDocId, pageLabel, charStart, charEnd in
+                // Direct observable call — no NotificationCenter round-trip
+                // (#3034). Passes the full payload the old .claimSelectedInInspector
+                // bus carried but the ContentView handler dropped (it forwarded
+                // only claimId), so the other panes now get text/source/range too.
+                claimFocusState.selectClaim(
+                    claimId: claimId,
+                    claimText: claimText,
+                    sourceDocumentId: sourceDocId,
+                    pageLabel: pageLabel,
+                    charStart: charStart,
+                    charEnd: charEnd
+                )
+            }
+        )
     }
 
     @ViewBuilder

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
@@ -159,8 +159,8 @@ struct DocumentInspector: View {
                     } label: {
                         Label(section.rawValue, systemImage: section.icon)
                             .labelStyle(.iconOnly)
-                            .font(.body)
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                            .font(.title3)
+                            .frame(maxWidth: .infinity, minHeight: 30)
                             .contentShape(Rectangle())
                     }
                     .accessibilityLabel(section.rawValue)
@@ -178,11 +178,6 @@ struct DocumentInspector: View {
                     .accessibilityIdentifier(section.accessibilityIdentifier)
                 }
             }
-            Text(activeSection.rawValue)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-                .padding(.horizontal, 6)
         }
         .frame(maxWidth: .infinity)
         .inspectorGlassStrip()

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -104,12 +104,8 @@ struct DocumentInspectorEntitiesTab: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            header
-                .padding(.horizontal)
-            if entitySelection.count > 1 {
-                bulkActionBar
-                    .padding(.horizontal)
-            }
+            // Top of the tab is just content — the count, filter, refresh, and
+            // selection actions all live in the bottom mini-toolbar (#3461).
             if let actionMessage {
                 Text(actionMessage)
                     .font(.caption)
@@ -222,24 +218,6 @@ struct DocumentInspectorEntitiesTab: View {
         }
     }
 
-    private var header: some View {
-        HStack(spacing: 8) {
-            Text("\(scopedEntities.count) entities")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Spacer()
-            filterMenu
-            Button {
-                Task { await entityStore.loadEntities(forDocument: documentId, force: true) }
-            } label: {
-                Image(systemName: "arrow.clockwise")
-            }
-            .buttonStyle(.plain)
-            .help("Reload entities")
-            .accessibilityLabel("Reload entities")
-        }
-    }
-
     private var entitiesMiniToolbar: some View {
         InspectorBottomMiniToolbar(statusText: entitiesToolbarStatusText) {
             filterMenu
@@ -264,9 +242,6 @@ struct DocumentInspectorEntitiesTab: View {
     }
 
     private var entitiesToolbarStatusText: String {
-        if entitySelection.count > 1 {
-            return "\(entitySelection.count) selected"
-        }
         if let selectedEntity {
             return selectedEntity.canonicalName
         }
@@ -293,26 +268,6 @@ struct DocumentInspectorEntitiesTab: View {
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-    }
-
-    private var bulkActionBar: some View {
-        HStack(spacing: 8) {
-            Text("\(entitySelection.count) selected")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Spacer()
-            bulkActionMenu(title: "Approve", systemImage: "checkmark.circle", action: .approve)
-            bulkActionMenu(title: "Reject", systemImage: "xmark.circle", action: .reject)
-            bulkActionMenu(title: "Suppress", systemImage: "eye.slash", action: .suppress)
-            mergeActionMenu(targetEntities: selectedEntities, menuTitle: "Merge")
-            deleteActionButton(targetEntities: selectedEntities)
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color.secondary.opacity(0.08))
-        )
     }
 
     @ViewBuilder

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -461,23 +461,20 @@ struct DocumentInspectorEntitiesTab: View {
                 #endif
                 .onAppear { renameFieldFocused = true }
         } else {
-            Button {
-                postSearch(
-                    for: entity,
-                    kind: EntityKind(apiType: entity.entityType) ?? .other
+            // Plain, readable name — no link styling. The accent-underlined
+            // button was unreadable when the row highlight inverted, and its
+            // single-click search intercepted the row's hit target so only a
+            // narrow strip selected. The name is now plain text: the whole row
+            // selects (List + tag), double-click renames, and "Find in Library"
+            // moved to the context menu.
+            Text(entity.canonicalName)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundStyle(.primary)
+                .help("Double-click to rename \"\(entity.canonicalName)\"")
+                .simultaneousGesture(
+                    TapGesture(count: 2).onEnded { beginRename(entity) }
                 )
-            } label: {
-                Text(entity.canonicalName)
-                    .font(.caption)
-                    .fontWeight(.semibold)
-                    .foregroundStyle(Color.accentColor)
-                    .underline()
-            }
-            .buttonStyle(.plain)
-            .help("Search the library for \"\(entity.canonicalName)\" — double-click to rename")
-            .simultaneousGesture(
-                TapGesture(count: 2).onEnded { beginRename(entity) }
-            )
         }
     }
 
@@ -531,6 +528,9 @@ struct DocumentInspectorEntitiesTab: View {
 
         Button("Rename") { beginRename(entity) }
             .disabled(entity.id == nil)
+        Button("Find in Library") {
+            postSearch(for: entity, kind: EntityKind(apiType: entity.entityType) ?? .other)
+        }
         Divider()
 
         Menu("Approve") {

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -135,17 +135,15 @@ struct DocumentInspectorEntitiesTab: View {
                 emptyVisibleGroupsState
             } else {
                 VStack(spacing: 0) {
-                    PlatformVSplitView {
+                    InspectorListDetailSplit {
                         List(selection: $entitySelection) {
                             ForEach(grouped, id: \.0) { kind, items in
                                 entityKindSection(kind: kind, entities: items)
                             }
                         }
                         .listStyle(.inset)
-                        .frame(minHeight: 140, idealHeight: 180)
-
+                    } detail: {
                         entityDetailPane
-                            .frame(minHeight: 240, idealHeight: 360)
                     }
                     Divider()
                     entitiesMiniToolbar

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -486,6 +486,14 @@ struct DocumentInspectorEntitiesTab: View {
         Button("Find in Library") {
             postSearch(for: entity, kind: EntityKind(apiType: entity.entityType) ?? .other)
         }
+        // Row text can't use .textSelection (it fights row selection), so Copy
+        // is the always-available copy-paste path for a selectable row (#3461).
+        Button("Copy Name") {
+            #if canImport(AppKit)
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(entity.canonicalName, forType: .string)
+            #endif
+        }
         Divider()
 
         Menu("Approve") {

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift
@@ -36,9 +36,15 @@ struct EntityKindRow: View {
 
     @Environment(ClaimFocusState.self) private var claimFocusState
     @Environment(KGFocusState.self) private var kgFocusState
+    /// Crop fetch seam for the source-provenance quick-look (#3449). Optional so
+    /// the popover is a safe no-op if a host hasn't injected the store — the
+    /// crop just resolves to "No source region" instead of crashing.
+    @Environment(AnnotationStore.self) private var annotationStore: AnnotationStore?
     @AppStorage("editor.fontSize") private var defaultFontSize: Double = 13
     @State private var claimForEditing: Components.Schemas.KnowledgeClaim?
     @State private var rowError: String?
+    /// Presents the source-provenance quick-look popover for the primary claim.
+    @State private var isSourcePreviewPresented = false
 
     private var bodyTextFont: Font {
         .system(size: CGFloat(defaultFontSize))
@@ -261,7 +267,14 @@ struct EntityKindRow: View {
 
                 if isPrimary,
                    let sourceDocumentId,
-                   let navigate = onNavigateToSource {
+                   let navigate = onNavigateToSource,
+                   let request = sourceNavigationRequest(
+                       claimId: claimId,
+                       claim: claim,
+                       sourceDocumentId: sourceDocumentId,
+                       sourcePageLabel: sourcePageLabel,
+                       sourceExcerpt: sourceExcerpt
+                   ) {
                     Button {
                         navigate(sourceDocumentId)
                     } label: {
@@ -270,7 +283,27 @@ struct EntityKindRow: View {
                             .foregroundStyle(Color.accentColor)
                     }
                     .buttonStyle(.plain)
-                    .help("Go to source")
+                    .help("Go to source — hover to preview")
+                    // Source-provenance quick-look (#3449/#2105): hovering the
+                    // arrow previews the cropped source region + verbatim span in
+                    // a popover (reusing SourceProvenanceCard → SourceSnippet); the
+                    // popover's Reveal — or clicking the arrow — drives the Preview
+                    // pane to the page. Full keyboard (Space) preview lands with the
+                    // native-List conversion in #3425.
+                    .onHover { hovering in
+                        if hovering { isSourcePreviewPresented = true }
+                    }
+                    .popover(isPresented: $isSourcePreviewPresented, arrowEdge: .trailing) {
+                        SourceProvenanceCard(
+                            request: request,
+                            attribution: claim.map(ClaimAttribution.init(claim:)),
+                            fetch: { try await annotationStore?.cropRegion($0) ?? nil },
+                            onReveal: {
+                                isSourcePreviewPresented = false
+                                navigate(sourceDocumentId)
+                            }
+                        )
+                    }
                 }
             }
 
@@ -336,6 +369,28 @@ struct EntityKindRow: View {
         }
     }
     // swiftlint:enable function_body_length cyclomatic_complexity function_parameter_count
+
+    /// Build the source anchor for the provenance popover / reveal. Prefer the
+    /// full claim (it carries char range + bbox); fall back to the grouped
+    /// item's coarser fields. Reuses `ClaimSummaryCard.openClaimSourceRequest`
+    /// so every "show me the source" surface shares one anchor builder (#2105).
+    private func sourceNavigationRequest(
+        claimId: String,
+        claim: Components.Schemas.KnowledgeClaim?,
+        sourceDocumentId: String,
+        sourcePageLabel: String?,
+        sourceExcerpt: String?
+    ) -> ClaimSourceNavigationRequest? {
+        if let claim {
+            return ClaimSummaryCard.openClaimSourceRequest(for: claim)
+        }
+        return ClaimSummaryCard.openClaimSourceRequest(
+            documentId: sourceDocumentId,
+            pageLabel: sourcePageLabel,
+            claimId: claimId,
+            excerpt: sourceExcerpt
+        )
+    }
 
     private func handleClaimTap(_ claim: Components.Schemas.KnowledgeClaim) {
         if let onClaimTap {

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift
@@ -185,7 +185,6 @@ struct EntityKindRow: View {
         isPrimary: Bool
     ) -> some View {
         let claim = claimById[claimId]
-        let isSelected = selectedClaimIds.contains(claimId)
         let isFocused = claimFocusState.isClaimSelected(claimId)
 
         VStack(alignment: .leading, spacing: 0) {
@@ -336,19 +335,10 @@ struct EntityKindRow: View {
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 4)
-        .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(isSelected ? Color.accentColor.opacity(0.16) : Color.clear)
-        )
         .contentShape(Rectangle())
-        .onTapGesture {
-            if let claim {
-                handleClaimTap(claim)
-            }
-        }
-        // Single-click selects (above); double-click opens — focus the
-        // claim and jump to its source page, Finder-style. Matches the
-        // Entities-tab interaction. (#1864/#1865)
+        // Single-click selection + arrow-key nav are owned by the enclosing
+        // native List(selection:) (#3425). Double-click still opens — focus the
+        // claim and jump to its source page, Finder-style. (#1864/#1865)
         .simultaneousGesture(
             TapGesture(count: 2).onEnded {
                 openClaim(claimId: claimId, sourceDocumentId: sourceDocumentId)

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift
@@ -248,58 +248,65 @@ struct KnowledgeGraphInspectorSection: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sectionHeader
-            if claimSelection.count > 1 {
-                claimBulkActionBar
-            }
-            if let claimActionMessage {
-                Text(claimActionMessage)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
+        // Self-contained: own ScrollView for the digest + a pinned bottom
+        // mini-toolbar holding prune / filter / view-mode / refresh and the
+        // on-selection claim actions (#3461). The top of the tab is content
+        // only; the hosts no longer wrap this in a ScrollView.
+        VStack(spacing: 0) {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    if let claimActionMessage {
+                        Text(claimActionMessage)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
 
-            if isLoading {
-                ProgressView().padding(.vertical, 8)
-            } else if let err = loadError {
-                Label(err, systemImage: "exclamationmark.triangle")
-                    .font(.caption)
-                    .foregroundStyle(.orange)
-            } else if grouped.isEmpty {
-                Text("No knowledge-graph entries for this document yet.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            } else if displayMode == .text {
-                textDigestView
-            } else {
-                ForEach(grouped, id: \.0) { kind, items in
-                    EntityKindBlock(
-                        kind: kind,
-                        items: items,
-                        claimById: claimsById,
-                        selectedClaimIds: claimSelection,
-                        claimScopeLabel: documentScopeLabel,
-                        claimContextMenuTarget: contextMenuTargetClaims(for:),
-                        onClaimTap: handleClaimTap(_:),
-                        applyClaimBulkAction: applyBulkAction,
-                        requestClaimMergeAction: requestMergeAction(plan:),
-                        requestClaimDeleteAction: requestDeleteAction(for:),
-                        requestPruneTrivialAction: requestPruneTrivialAction,
-                        onNavigateToSource: onNavigateToSource,
-                        onClaimSelect: onClaimSelect
-                    )
+                    if isLoading {
+                        ProgressView().padding(.vertical, 8)
+                    } else if let err = loadError {
+                        Label(err, systemImage: "exclamationmark.triangle")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    } else if grouped.isEmpty {
+                        Text("No knowledge-graph entries for this document yet.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else if displayMode == .text {
+                        textDigestView
+                    } else {
+                        ForEach(grouped, id: \.0) { kind, items in
+                            EntityKindBlock(
+                                kind: kind,
+                                items: items,
+                                claimById: claimsById,
+                                selectedClaimIds: claimSelection,
+                                claimScopeLabel: documentScopeLabel,
+                                claimContextMenuTarget: contextMenuTargetClaims(for:),
+                                onClaimTap: handleClaimTap(_:),
+                                applyClaimBulkAction: applyBulkAction,
+                                requestClaimMergeAction: requestMergeAction(plan:),
+                                requestClaimDeleteAction: requestDeleteAction(for:),
+                                requestPruneTrivialAction: requestPruneTrivialAction,
+                                onNavigateToSource: onNavigateToSource,
+                                onClaimSelect: onClaimSelect
+                            )
+                        }
+                    }
+
+                    Divider()
+                        .padding(.vertical, 4)
+                    KGCurationHistorySection(entityService: entityService)
+                    // Interpretations (the user's own reading) deliberately do NOT live
+                    // here — the KG tab shows ontology + hermeneutic facts (what the AI
+                    // and the sources say), never the user's interpretation presented as
+                    // fact (AI-integrity north star). They now render in the Notes tab
+                    // ("Notes-adjacent", per Daniel) via DocumentInterpretationsSection.
+                    // #2470.
                 }
+                .padding()
             }
-
             Divider()
-                .padding(.vertical, 4)
-            KGCurationHistorySection(entityService: entityService)
-            // Interpretations (the user's own reading) deliberately do NOT live
-            // here — the KG tab shows ontology + hermeneutic facts (what the AI
-            // and the sources say), never the user's interpretation presented as
-            // fact (AI-integrity north star). They now render in the Notes tab
-            // ("Notes-adjacent", per Daniel) via DocumentInterpretationsSection.
-            // #2470.
+            kgMiniToolbar
         }
         .task(id: documentId) { await loadStatements() }
         // Resync when any claim mutates anywhere — ClaimStore bumps its
@@ -364,92 +371,25 @@ struct KnowledgeGraphInspectorSection: View {
         }
     }
 
-    private var claimBulkActionBar: some View {
-        HStack(spacing: 8) {
-            Text("\(claimSelection.count) selected")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            Spacer()
-            claimBulkActionMenu(title: "Approve", systemImage: "checkmark.circle", action: .approve)
-            claimBulkActionMenu(title: "Reject", systemImage: "xmark.circle", action: .reject)
-            claimBulkActionMenu(title: "Suppress", systemImage: "eye.slash", action: .suppress)
-            claimMergeActionMenu(targetClaims: selectedClaims, menuTitle: "Merge")
-            deleteActionButton(targetClaims: selectedClaims)
-        }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 8)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(Color.secondary.opacity(0.08))
-        )
+    private var kgToolbarStatusText: String {
+        let count = grouped.reduce(0) { $0 + $1.1.count }
+        return "\(count) entit\(count == 1 ? "y" : "ies")"
     }
 
-    private var sectionHeader: some View {
-        // No "Knowledge Graph" title/icon — the inspector tab already names
-        // this surface, so the in-pane label was redundant (#1244). The header
-        // is now just the filter + view-mode + reload controls, right-aligned.
-        HStack(spacing: 8) {
-            Spacer()
+    /// Pinned bottom mini-toolbar — the single home for the KG tab's controls
+    /// (prune / filter / view-mode / refresh) plus the on-selection claim
+    /// actions, matching the other inspector panes (#3461).
+    private var kgMiniToolbar: some View {
+        InspectorBottomMiniToolbar(statusText: kgToolbarStatusText) {
             Menu("Prune trivial") {
                 pruneTrivialScopeButtons()
             }
-            .disabled(isMutatingClaims)
-            // Filter Menu — Tinderbox-style "displayed attributes" picker.
-            // Each entity kind has its own checkbox; persistence lives in
-            // @AppStorage so the choice survives restarts and applies to
-            // every doc the user inspects.
-            Menu {
-                Section("Scope") {
-                    Button {
-                        includeChildren = false
-                    } label: {
-                        HStack {
-                            Text("This item only")
-                            Spacer(minLength: 0)
-                            if !includeChildren {
-                                Image(systemName: "checkmark")
-                            }
-                        }
-                    }
-                    Button {
-                        includeChildren = true
-                    } label: {
-                        HStack {
-                            Text("Include children")
-                            Spacer(minLength: 0)
-                            if includeChildren {
-                                Image(systemName: "checkmark")
-                            }
-                        }
-                    }
-                }
-                ForEach(EntityKind.displayOrder, id: \.self) { kind in
-                    let isHidden = hiddenKinds.contains(kind)
-                    Button {
-                        setHidden(kind, hidden: !isHidden)
-                    } label: {
-                        Label(kind.label, systemImage: isHidden ? "" : "checkmark")
-                    }
-                }
-                Divider()
-                Button("Show all") { hiddenKindsCSV = "" }
-                Button("Hide all") {
-                    hiddenKindsCSV = EntityKind.displayOrder
-                        .map(\.rawValue)
-                        .sorted()
-                        .joined(separator: ",")
-                }
-            } label: {
-                Image(systemName: hiddenKinds.isEmpty
-                        ? "line.3.horizontal.decrease.circle"
-                        : "line.3.horizontal.decrease.circle.fill")
-            }
             .menuStyle(.borderlessButton)
-            .menuIndicator(.hidden)
             .fixedSize()
-            .help("Filter — choose which entity kinds (people, places, organizations…) appear in this list")
-            .accessibilityLabel("Filter entity kinds")
-            // Text / List mode toggle
+            .disabled(isMutatingClaims)
+
+            kgFilterMenu
+
             Button {
                 displayMode = .text
             } label: {
@@ -459,6 +399,7 @@ struct KnowledgeGraphInspectorSection: View {
             .foregroundStyle(displayMode == .text ? Color.accentColor : Color.secondary)
             .help("Text digest — entities as a dense prose summary, one paragraph per kind")
             .accessibilityLabel("Text digest")
+
             Button {
                 displayMode = .list
             } label: {
@@ -468,6 +409,7 @@ struct KnowledgeGraphInspectorSection: View {
             .foregroundStyle(displayMode == .list ? Color.accentColor : Color.secondary)
             .help("List view — entities as grouped, expandable rows you can click through to the source")
             .accessibilityLabel("List view")
+
             Button {
                 Task { await loadStatements() }
             } label: {
@@ -476,8 +418,72 @@ struct KnowledgeGraphInspectorSection: View {
             .buttonStyle(.plain)
             .help("Reload — re-fetch the knowledge-graph entities for this document")
             .accessibilityLabel("Reload entities")
+
+            if claimSelection.count > 1 {
+                claimBulkActionMenu(title: "Approve", systemImage: "checkmark.circle", action: .approve)
+                claimBulkActionMenu(title: "Reject", systemImage: "xmark.circle", action: .reject)
+                claimBulkActionMenu(title: "Suppress", systemImage: "eye.slash", action: .suppress)
+                claimMergeActionMenu(targetClaims: selectedClaims, menuTitle: "Merge")
+                deleteActionButton(targetClaims: selectedClaims)
+            }
         }
-        .foregroundStyle(.primary)
+    }
+
+    // Filter Menu — Tinderbox-style "displayed attributes" picker. Each entity
+    // kind has its own checkbox; persistence lives in @AppStorage so the choice
+    // survives restarts and applies to every doc the user inspects.
+    private var kgFilterMenu: some View {
+        Menu {
+            Section("Scope") {
+                Button {
+                    includeChildren = false
+                } label: {
+                    HStack {
+                        Text("This item only")
+                        Spacer(minLength: 0)
+                        if !includeChildren {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+                Button {
+                    includeChildren = true
+                } label: {
+                    HStack {
+                        Text("Include children")
+                        Spacer(minLength: 0)
+                        if includeChildren {
+                            Image(systemName: "checkmark")
+                        }
+                    }
+                }
+            }
+            ForEach(EntityKind.displayOrder, id: \.self) { kind in
+                let isHidden = hiddenKinds.contains(kind)
+                Button {
+                    setHidden(kind, hidden: !isHidden)
+                } label: {
+                    Label(kind.label, systemImage: isHidden ? "" : "checkmark")
+                }
+            }
+            Divider()
+            Button("Show all") { hiddenKindsCSV = "" }
+            Button("Hide all") {
+                hiddenKindsCSV = EntityKind.displayOrder
+                    .map(\.rawValue)
+                    .sorted()
+                    .joined(separator: ",")
+            }
+        } label: {
+            Image(systemName: hiddenKinds.isEmpty
+                    ? "line.3.horizontal.decrease.circle"
+                    : "line.3.horizontal.decrease.circle.fill")
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Filter — choose which entity kinds (people, places, organizations…) appear in this list")
+        .accessibilityLabel("Filter entity kinds")
     }
 
     private func claimBulkActionMenu(

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift
@@ -215,6 +215,9 @@ struct KnowledgeGraphInspectorSection: View {
 
     @ViewBuilder
     private var textDigestView: some View {
+        // Prose digest is always copy-pastable (#3461/#3463). textSelection on
+        // the container propagates to every descendant Text; it is safe here
+        // (no List row to fight for the click) unlike the selectable rows.
         VStack(alignment: .leading, spacing: 10) {
             if textDigest.isEmpty {
                 Text("No knowledge-graph entries for this document yet.")
@@ -245,6 +248,7 @@ struct KnowledgeGraphInspectorSection: View {
                 }
             }
         }
+        .textSelection(.enabled)
     }
 
     var body: some View {

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift
@@ -41,9 +41,14 @@ struct KnowledgeGraphInspectorSection: View {
     /// section's resync. Replaces the retired `.ficheroClaim*` NotificationCenter
     /// bus; the inspector still owns its grouped KG read (iterate, never replace).
     @Environment(ClaimStore.self) private var claimStore
+    /// Crop fetch seam for the Space-key source quick-look (#3449/#3425). Optional
+    /// so the preview is a safe no-op if a host hasn't injected the store.
+    @Environment(AnnotationStore.self) private var annotationStore: AnnotationStore?
     @State private var loadState = KnowledgeGraphInspectorLoadState()
     @State private var claimSelection: Set<String> = []
     @State private var claimSelectionAnchor: String?
+    /// The claim whose source is shown in the Space-key quick-look popover.
+    @State private var spaceQuickLookClaimId: String?
     @State private var isApplyingBulkAction = false
     @State private var isPruningTrivialClaims = false
     @State private var pendingMergePlan: InspectorClaimBulkSelection.MergePlan?
@@ -404,6 +409,46 @@ struct KnowledgeGraphInspectorSection: View {
         .listStyle(.inset)
         .onChange(of: claimSelection) { _, selection in
             focusSingleSelectedClaim(selection)
+        }
+        // Quick Look: Space on the selected claim previews its source region,
+        // Xcode-console style (#3449 item 12 extension). Only fires when the
+        // claim has a resolvable source anchor, else Space falls through.
+        .onKeyPress(.space) {
+            guard claimSelection.count == 1,
+                  let id = claimSelection.first,
+                  let claim = claimsById[id],
+                  ClaimSummaryCard.openClaimSourceRequest(for: claim) != nil else {
+                return .ignored
+            }
+            spaceQuickLookClaimId = id
+            return .handled
+        }
+        .popover(isPresented: Binding(
+            get: { spaceQuickLookClaimId != nil },
+            set: { if !$0 { spaceQuickLookClaimId = nil } }
+        )) {
+            spaceQuickLookPopover
+        }
+    }
+
+    /// Source quick-look popover for the Space-selected claim — reuses the same
+    /// SourceProvenanceCard as the hover affordance; Reveal drives the Preview.
+    @ViewBuilder
+    private var spaceQuickLookPopover: some View {
+        if let id = spaceQuickLookClaimId,
+           let claim = claimsById[id],
+           let request = ClaimSummaryCard.openClaimSourceRequest(for: claim) {
+            SourceProvenanceCard(
+                request: request,
+                attribution: ClaimAttribution(claim: claim),
+                fetch: { try await annotationStore?.cropRegion($0) ?? nil },
+                onReveal: {
+                    spaceQuickLookClaimId = nil
+                    if let docId = claim.sourceDocumentId {
+                        onNavigateToSource?(docId)
+                    }
+                }
+            )
         }
     }
 

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift
@@ -257,58 +257,15 @@ struct KnowledgeGraphInspectorSection: View {
         // on-selection claim actions (#3461). The top of the tab is content
         // only; the hosts no longer wrap this in a ScrollView.
         VStack(spacing: 0) {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 12) {
-                    if let claimActionMessage {
-                        Text(claimActionMessage)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    if isLoading {
-                        ProgressView().padding(.vertical, 8)
-                    } else if let err = loadError {
-                        Label(err, systemImage: "exclamationmark.triangle")
-                            .font(.caption)
-                            .foregroundStyle(.orange)
-                    } else if grouped.isEmpty {
-                        Text("No knowledge-graph entries for this document yet.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                    } else if displayMode == .text {
-                        textDigestView
-                    } else {
-                        ForEach(grouped, id: \.0) { kind, items in
-                            EntityKindBlock(
-                                kind: kind,
-                                items: items,
-                                claimById: claimsById,
-                                selectedClaimIds: claimSelection,
-                                claimScopeLabel: documentScopeLabel,
-                                claimContextMenuTarget: contextMenuTargetClaims(for:),
-                                onClaimTap: handleClaimTap(_:),
-                                applyClaimBulkAction: applyBulkAction,
-                                requestClaimMergeAction: requestMergeAction(plan:),
-                                requestClaimDeleteAction: requestDeleteAction(for:),
-                                requestPruneTrivialAction: requestPruneTrivialAction,
-                                onNavigateToSource: onNavigateToSource,
-                                onClaimSelect: onClaimSelect
-                            )
-                        }
-                    }
-
-                    Divider()
-                        .padding(.vertical, 4)
-                    KGCurationHistorySection(entityService: entityService)
-                    // Interpretations (the user's own reading) deliberately do NOT live
-                    // here — the KG tab shows ontology + hermeneutic facts (what the AI
-                    // and the sources say), never the user's interpretation presented as
-                    // fact (AI-integrity north star). They now render in the Notes tab
-                    // ("Notes-adjacent", per Daniel) via DocumentInterpretationsSection.
-                    // #2470.
-                }
-                .padding()
+            if let claimActionMessage {
+                Text(claimActionMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal)
+                    .padding(.top, 8)
             }
+            kgContent
             Divider()
             kgMiniToolbar
         }
@@ -373,6 +330,109 @@ struct KnowledgeGraphInspectorSection: View {
         } message: { pending in
             Text(pending.message)
         }
+    }
+
+    /// Content region: a native List (keyboard nav + multi-select) in list
+    /// mode; a ScrollView for the text digest / loading / empty states.
+    @ViewBuilder
+    private var kgContent: some View {
+        if isLoading {
+            ProgressView()
+                .padding(.vertical, 8)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let err = loadError {
+            Label(err, systemImage: "exclamationmark.triangle")
+                .font(.caption)
+                .foregroundStyle(.orange)
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        } else if grouped.isEmpty {
+            Text("No knowledge-graph entries for this document yet.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        } else if displayMode == .text {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 12) {
+                    textDigestView
+                    Divider().padding(.vertical, 4)
+                    KGCurationHistorySection(entityService: entityService)
+                }
+                .padding()
+            }
+        } else {
+            kgClaimList
+        }
+    }
+
+    /// Native List of claims in per-kind sections (#3425). The List owns
+    /// selection, so it provides arrow-key navigation and native multi-select
+    /// for free; selecting a single claim focuses/highlights it in Preview.
+    /// Keywords (.concept) still render as wrapping lozenges in their section.
+    /// Per-kind expand/collapse is deferred (a later enhancement).
+    private var kgClaimList: some View {
+        List(selection: $claimSelection) {
+            ForEach(grouped, id: \.0) { kind, items in
+                Section {
+                    if kind == .concept {
+                        FlowLayout(spacing: 4) {
+                            ForEach(items) { item in
+                                EntityLozenge(name: item.displayName, entityType: "keywords")
+                            }
+                        }
+                    } else {
+                        ForEach(items) { item in
+                            kgClaimRow(kind: kind, item: item)
+                                .tag(item.claimId)
+                        }
+                    }
+                } header: {
+                    Label("\(kind.label) (\(items.count))", systemImage: kind.systemImage)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.secondary)
+                }
+            }
+            // Curation history stays a trailing section so it scrolls with the
+            // claims. Interpretations deliberately stay OUT (AI-integrity: the KG
+            // shows ontological facts, never the user's reading as fact) — they
+            // render in the Notes tab via DocumentInterpretationsSection (#2470).
+            Section {
+                KGCurationHistorySection(entityService: entityService)
+            }
+        }
+        .listStyle(.inset)
+        .onChange(of: claimSelection) { _, selection in
+            focusSingleSelectedClaim(selection)
+        }
+    }
+
+    private func kgClaimRow(kind: EntityKind, item: GroupedItem) -> some View {
+        EntityKindRow(
+            item: item,
+            kind: kind,
+            claimById: claimsById,
+            selectedClaimIds: claimSelection,
+            claimScopeLabel: documentScopeLabel,
+            claimContextMenuTarget: contextMenuTargetClaims(for:),
+            onClaimTap: nil,
+            applyClaimBulkAction: applyBulkAction,
+            requestClaimMergeAction: requestMergeAction(plan:),
+            requestClaimDeleteAction: requestDeleteAction(for:),
+            requestPruneTrivialAction: requestPruneTrivialAction,
+            onNavigateToSource: onNavigateToSource,
+            onClaimSelect: onClaimSelect
+        )
+    }
+
+    /// Focus + highlight the claim when exactly one row is selected — the native
+    /// equivalent of the old single-click-focus. Multi-select stays quiet so the
+    /// bulk actions operate on the whole set.
+    private func focusSingleSelectedClaim(_ selection: Set<String>) {
+        guard selection.count == 1,
+              let claimId = selection.first,
+              let claim = claimsById[claimId] else { return }
+        focusClaim(claim)
     }
 
     private var kgToolbarStatusText: String {
@@ -604,32 +664,10 @@ struct KnowledgeGraphInspectorSection: View {
         pendingDeleteConfirmation = PendingClaimDeleteConfirmation(claims: targetClaims)
     }
 
-    private func handleClaimTap(_ claim: Components.Schemas.KnowledgeClaim) {
-        guard let claimId = claim.id else {
-            focusClaim(claim)
-            return
-        }
-
-        let modifiers: InspectorEntitySelectionModifiers = {
-            #if os(macOS)
-            return InspectorEntitySelectionModifiers(nsEventFlags: NSEvent.modifierFlags)
-            #else
-            return InspectorEntitySelectionModifiers()
-            #endif
-        }()
-        let reduced = InspectorEntityBulkSelection.reduceTap(
-            tappedId: claimId,
-            orderedIds: orderedClaimIds,
-            selection: claimSelection,
-            anchor: claimSelectionAnchor,
-            modifiers: modifiers
-        )
-        claimSelection = reduced.selection
-        claimSelectionAnchor = reduced.anchor
-
-        guard modifiers.isEmpty else { return }
-        focusClaim(claim)
-    }
+    // The old modifier-key selection reducer (handleClaimTap) was retired with
+    // the native-List conversion (#3425): List(selection:) owns single-click,
+    // cmd/shift multi-select, and arrow-key navigation. Focus now flows from
+    // focusSingleSelectedClaim on selection change.
 
     private func focusClaim(_ claim: Components.Schemas.KnowledgeClaim) {
         guard let claimId = claim.id else { return }

--- a/fichero/fichero/Views/Library/DocumentKGSurface.swift
+++ b/fichero/fichero/Views/Library/DocumentKGSurface.swift
@@ -220,23 +220,22 @@ struct DocumentKGSurface: View {
         case .transcript, .digest, .graph, .timeline, .map:
             EmptyView()
         case .claims:
-            ScrollView {
-                KnowledgeGraphInspectorSection(
-                    documentId: documentId,
-                    documentScope: documentScope,
-                    entityService: entityService,
-                    artifactService: artifactService,
-                    kgCurationService: kgCurationService,
-                    onClaimSelect: { claimId, _, sourceDocId, pageLabel, _, _ in
-                        kgFocusState.focusClaim(
-                            claimId: claimId,
-                            sourceDocumentId: sourceDocId,
-                            sourcePageLabel: pageLabel
-                        )
-                    }
-                )
-                .padding()
-            }
+            // No outer ScrollView — KnowledgeGraphInspectorSection owns its own
+            // scroll + pinned bottom mini-toolbar (#3461).
+            KnowledgeGraphInspectorSection(
+                documentId: documentId,
+                documentScope: documentScope,
+                entityService: entityService,
+                artifactService: artifactService,
+                kgCurationService: kgCurationService,
+                onClaimSelect: { claimId, _, sourceDocId, pageLabel, _, _ in
+                    kgFocusState.focusClaim(
+                        claimId: claimId,
+                        sourceDocumentId: sourceDocId,
+                        sourcePageLabel: pageLabel
+                    )
+                }
+            )
         }
     }
 

--- a/fichero/fichero/Views/Library/Inspector/AnnotationsInspectorPane.swift
+++ b/fichero/fichero/Views/Library/Inspector/AnnotationsInspectorPane.swift
@@ -26,16 +26,13 @@ struct AnnotationsInspectorPane: View {
             if let loadError = annotationStore.loadError {
                 errorBox(loadError)
             }
-            PlatformVSplitView {
+            InspectorListDetailSplit {
                 AnnotationListView(
                     annotations: annotations,
                     focused: focused,
                     onOpenInWindow: openDetailWindow
                 )
-                .frame(minHeight: 140, idealHeight: 180)
-
-                Divider()
-
+            } detail: {
                 AnnotationDetailView(
                     annotation: selectedAnnotation,
                     onSave: { annotation, text in
@@ -54,7 +51,6 @@ struct AnnotationsInspectorPane: View {
                         reveal(annotation)
                     }
                 )
-                .frame(minHeight: 240, idealHeight: 360)
             }
             Divider()
             InspectorBottomMiniToolbar(statusText: annotationsToolbarStatusText) {

--- a/fichero/fichero/Views/Library/Inspector/ArtifactListView.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactListView.swift
@@ -31,6 +31,11 @@ struct ArtifactListView: View {
     /// the affordance (e.g. if a host doesn't support the detached scene).
     var onOpenInWindow: (() -> Void)?
 
+    /// Translate the inspected document into a language, from the row context
+    /// menu (#3426). `nil` hides the affordance. Document-scoped, not per-artifact
+    /// — the menu is labelled "Translate Document" to make that clear.
+    var onTranslate: ((TranslationLanguage) -> Void)?
+
     /// Native multi-selection set the `List` drives (#2519). Single-click selects
     /// one (and the detail follows via `focused`); ⇧/⌘-click extend; ⌫ / the
     /// context-menu "Delete" remove the whole selection. Kept in sync with the
@@ -151,7 +156,23 @@ struct ArtifactListView: View {
                         : [artifact]
                     confirmDelete(targets)
                 }
+                translateMenuItems()
             }
+    }
+
+    /// The "Translate Document" contextual submenu (#3426). Shared by the row
+    /// context menu and the empty-state, so a document with zero artifacts can
+    /// still be translated (that is exactly when you translate to CREATE one).
+    @ViewBuilder
+    private func translateMenuItems() -> some View {
+        if let onTranslate {
+            Divider()
+            Menu("Translate Document") {
+                ForEach(TranslationLanguage.common) { lang in
+                    Button(lang.name) { onTranslate(lang) }
+                }
+            }
+        }
     }
 
     // MARK: - Multi-select delete (#2519)
@@ -192,6 +213,9 @@ struct ArtifactListView: View {
             systemImage: "sparkles",
             description: Text("Run a workflow to generate transcriptions, catalogues, or summaries.")
         )
+        // Right-click still offers Translate so an artifact-less document can be
+        // translated to create its first artifact (#3426).
+        .contextMenu { translateMenuItems() }
     }
 }
 

--- a/fichero/fichero/Views/Library/Inspector/ArtifactsInspectorPane.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactsInspectorPane.swift
@@ -174,16 +174,9 @@ struct ArtifactsInspectorPane: View {
                 .disabled(focused.id == nil)
             }
         }
-        .toolbar {
-            ToolbarItem(placement: .automatic) {
-                // #2254 §E: the gated, reusable detach affordance. Absent where a
-                // second window can't exist (iPhone), so the floating placement is
-                // a true macOS / multi-scene opt-in.
-                DetachInspectorButton(isEnabled: focused.id != nil) {
-                    openDetailWindow()
-                }
-            }
-        }
+        // The top-toolbar detach button was removed (#3461): the bottom
+        // mini-toolbar's "Open in window" button is the single detach affordance,
+        // keeping the top of the inspector as just the section switcher.
         .task(id: document.id) {
             // Preserve a same-document artifact selection when another pane
             // (e.g. Content / outline) routes into Artifacts; otherwise the tab

--- a/fichero/fichero/Views/Library/Inspector/ArtifactsInspectorPane.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactsInspectorPane.swift
@@ -126,7 +126,8 @@ struct ArtifactsInspectorPane: View {
                     inspectedDocument: document,
                     documentsById: knownDocumentsById,
                     focused: focused,
-                    onOpenInWindow: openDetailWindow
+                    onOpenInWindow: openDetailWindow,
+                    onTranslate: { translate(to: $0) }
                 )
             } detail: {
                 ArtifactDetailView(
@@ -143,7 +144,6 @@ struct ArtifactsInspectorPane: View {
             }
             Divider()
             InspectorBottomMiniToolbar(statusText: artifactsToolbarStatusText) {
-                translateMenu
                 Button {
                     Task { await store.reload() }
                 } label: {
@@ -209,22 +209,6 @@ struct ArtifactsInspectorPane: View {
             return inspectorArtifactTitle(selectedArtifact)
         }
         return "\(store.items.count) artifacts"
-    }
-
-    private var translateMenu: some View {
-        Menu {
-            ForEach(TranslationLanguage.common) { lang in
-                Button(lang.name) { translate(to: lang) }
-            }
-        } label: {
-            if isTranslating {
-                ProgressView().controlSize(.small)
-            } else {
-                Label("Translate", systemImage: "character.book.closed")
-            }
-        }
-        .disabled(isTranslating)
-        .help("Translate this document into another language")
     }
 
     private func openDetailWindow() {

--- a/fichero/fichero/Views/Library/Inspector/ArtifactsInspectorPane.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactsInspectorPane.swift
@@ -120,7 +120,7 @@ struct ArtifactsInspectorPane: View {
             if let actionError {
                 errorBox(actionError)
             }
-            PlatformVSplitView {
+            InspectorListDetailSplit {
                 ArtifactListView(
                     store: store,
                     inspectedDocument: document,
@@ -128,10 +128,7 @@ struct ArtifactsInspectorPane: View {
                     focused: focused,
                     onOpenInWindow: openDetailWindow
                 )
-                .frame(minHeight: 140, idealHeight: 180)
-
-                Divider()
-
+            } detail: {
                 ArtifactDetailView(
                     artifact: selectedArtifact,
                     provenance: selectedProvenance,
@@ -143,7 +140,6 @@ struct ArtifactsInspectorPane: View {
                         Task { await deleteArtifact(artifact) }
                     }
                 )
-                .frame(minHeight: 240, idealHeight: 360)
             }
             Divider()
             InspectorBottomMiniToolbar(statusText: artifactsToolbarStatusText) {

--- a/fichero/fichero/Views/Library/Inspector/CitationsInspectorPane.swift
+++ b/fichero/fichero/Views/Library/Inspector/CitationsInspectorPane.swift
@@ -35,18 +35,14 @@ struct CitationsInspectorPane: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            PlatformVSplitView {
+            InspectorListDetailSplit {
                 CitationListView(
                     store: store,
                     focused: focused,
                     onOpenInWindow: openDetailWindow
                 )
-                .frame(minHeight: 140, idealHeight: 180)
-
-                Divider()
-
+            } detail: {
                 CitationDetailView(item: selectedItem, usages: store.usages)
-                    .frame(minHeight: 240, idealHeight: 360)
             }
             Divider()
             InspectorBottomMiniToolbar(statusText: citationsToolbarStatusText) {

--- a/fichero/fichero/Views/Notes/NotesInspectorPane.swift
+++ b/fichero/fichero/Views/Notes/NotesInspectorPane.swift
@@ -26,16 +26,13 @@ struct NotesInspectorPane: View {
             if let loadError = noteStore.loadError {
                 errorBox(loadError)
             }
-            PlatformVSplitView {
+            InspectorListDetailSplit {
                 NoteListView(
                     notes: notes,
                     focused: focused,
                     onOpenInWindow: openDetailWindow
                 )
-                .frame(minHeight: 140, idealHeight: 180)
-
-                Divider()
-
+            } detail: {
                 NoteDetailView(
                     item: selectedNote,
                     onSave: { item, body in
@@ -48,7 +45,6 @@ struct NotesInspectorPane: View {
                         try? await noteStore.links(for: noteId)
                     }
                 )
-                .frame(minHeight: 240, idealHeight: 360)
             }
             Divider()
             InspectorBottomMiniToolbar(statusText: notesToolbarStatusText) {


### PR DESCRIPTION
Inspector visual-polish batch (#3461) — build-gated **BUILD SUCCEEDED** on a8570470c (worker xcodebuild, own DerivedData; disjoint Swift over the merged engine fixes).

## Landed (all tabs)
- List/detail split → 1/3 default; full-row selection everywhere (#3424); readable selection + dead-link fix.
- All chrome consolidated into the bottom mini-toolbar (count/filter/refresh/actions); dropped duplicate top toolbars, "N selected" label, redundant tab-name label; widened switcher icons.
- Source Annotations → single-select + human doc names.
- KG claims: native List (keyboard nav + multi-select, #3425), source-provenance quick-look + Space-key Quick Look (#3449/#2105), copy-pastable text (#3463).
- Translate → contextual menu (#3426).

Disjoint from engine (Python). Follow-up features tracked separately (#3463 inline SVO edit, #3466 configurable metadata, #3447 full PyKEEN wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)