### PR TITLE
Inspector follow-ups: drag semantics, inline SVO edit, configurable metadata, graph link-out

### DIFF
--- a/fichero/fichero-tests/KGFocusStateTests.swift
+++ b/fichero/fichero-tests/KGFocusStateTests.swift
@@ -80,4 +80,29 @@ final class KGFocusStateTests: XCTestCase {
         state.syncPushedEntity("e-2")
         XCTAssertEqual(state.focusedEntityId, "e-2")
     }
+
+    // MARK: - Graph reveal request (#3452)
+
+    /// "Show in Graph" focuses the entity and bumps the reveal token so
+    /// ContentView switches into the force graph.
+    func testRequestGraphRevealFocusesEntityAndBumpsToken() {
+        let state = KGFocusState()
+        let before = state.graphRevealRequestToken
+
+        state.requestGraphReveal(entityId: "e-9")
+
+        XCTAssertEqual(state.focusedEntityId, "e-9")
+        XCTAssertEqual(state.graphRevealRequestToken, before + 1)
+    }
+
+    /// Revealing the SAME entity twice still bumps the token, so a repeat
+    /// "Show in Graph" re-triggers the mode switch.
+    func testRepeatGraphRevealStillBumpsToken() {
+        let state = KGFocusState()
+        state.requestGraphReveal(entityId: "e-1")
+        let afterFirst = state.graphRevealRequestToken
+
+        state.requestGraphReveal(entityId: "e-1")
+        XCTAssertEqual(state.graphRevealRequestToken, afterFirst + 1)
+    }
 }

--- a/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
+++ b/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
@@ -916,6 +916,20 @@ final class KnowledgeGraphInspectorSectionTests: XCTestCase {
         XCTAssertNil(ClaimSummaryCard.openClaimSourceRequest(for: claim))
     }
 
+    // MARK: - Inline S/V/O editing (#3463)
+
+    func testKGClaimRowEditsSVOInlineNotInASheet() throws {
+        let source = try Self.appSource(
+            "Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift"
+        )
+
+        // "Edit S/V/O…" expands the row into the inline editor (reusing
+        // InlineClaimEditor); the old EditClaimSheet presentation is gone.
+        XCTAssertTrue(source.contains("InlineClaimEditor("))
+        XCTAssertTrue(source.contains("inlineEditingClaimId"))
+        XCTAssertFalse(source.contains("EditClaimSheet("))
+    }
+
     // MARK: - Cross-target drag payload (#3425)
 
     func testInspectorEntityDragPayloadRoundTripsAcrossTargets() throws {

--- a/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
+++ b/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
@@ -916,6 +916,18 @@ final class KnowledgeGraphInspectorSectionTests: XCTestCase {
         XCTAssertNil(ClaimSummaryCard.openClaimSourceRequest(for: claim))
     }
 
+    // MARK: - Cross-target drag payload (#3425)
+
+    func testInspectorEntityDragPayloadRoundTripsAcrossTargets() throws {
+        // The structured JSON representation must survive serialization so the
+        // entity drag carries its full identity across app targets/scenes.
+        let payload = InspectorEntityDragID(id: "e-1", text: "Ada Lovelace")
+        let data = try JSONEncoder().encode(payload)
+        let decoded = try JSONDecoder().decode(InspectorEntityDragID.self, from: data)
+        XCTAssertEqual(decoded.id, "e-1")
+        XCTAssertEqual(decoded.text, "Ada Lovelace")
+    }
+
     // MARK: - Native List conversion (#3425, item 14)
 
     func testKGListModeUsesNativeListSelectionWithKindSections() throws {

--- a/fichero/fichero/Models/KGFocusState.swift
+++ b/fichero/fichero/Models/KGFocusState.swift
@@ -16,6 +16,19 @@ final class KGFocusState {
     var sourceDocumentId: String?
     var sourcePageLabel: String?
 
+    /// A request to reveal an entity in the full Knowledge Graph force graph
+    /// (#3452). Inspector "Show in Graph" affordances call ``requestGraphReveal``;
+    /// ContentView watches ``graphRevealRequestToken`` and switches to the
+    /// Knowledge Graph mode focused on ``focusedEntityId``. The token makes
+    /// repeat reveals of the same entity still fire.
+    private(set) var graphRevealRequestToken = 0
+
+    /// Focus `entityId` and ask the shell to switch into the force-graph view.
+    func requestGraphReveal(entityId: String) {
+        focusEntity(entityId: entityId)
+        graphRevealRequestToken &+= 1
+    }
+
     func focusEntity(
         entityId: String?,
         sourceDocumentId: String? = nil,

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -590,6 +590,12 @@ struct ContentView: View {
             .onChange(of: kgFocusState.sourcePageLabel) { _, _ in
                 handleKGFocusChanged()
             }
+            // "Show in Graph" from the inspector switches to the Knowledge Graph
+            // force graph, focused on the requested entity (#3452). The focus is
+            // already set by requestGraphReveal; we just flip the mode.
+            .onChange(of: kgFocusState.graphRevealRequestToken) { _, _ in
+                sidebarMode = .knowledgeGraph
+            }
             .onChange(of: viewDisplayMode) { _, newMode in
                 handleViewDisplayModeChange(newMode)
             }

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -5,6 +5,7 @@ import AppKit
 import FicheroAPIClient
 import OSLog
 import SwiftUI
+import UniformTypeIdentifiers
 
 // MARK: - Document Entities Tab
 
@@ -384,7 +385,7 @@ struct DocumentInspectorEntitiesTab: View {
         .background(dropTargetHighlight(for: entity))
         .inspectorListRowTarget()
         .tag(entity.stableInspectorId)
-        .draggable(InspectorEntityDragID(id: entity.stableInspectorId))
+        .draggable(InspectorEntityDragID(id: entity.stableInspectorId, text: entity.canonicalName))
         .dropDestination(
             for: InspectorEntityDragID.self,
             action: { payloads, _ in
@@ -890,12 +891,21 @@ extension Components.Schemas.KnowledgeEntity {
     }
 }
 
-struct InspectorEntityDragID: Transferable {
+/// The drag payload for an inspector entity (#3425). Carries the stable id (for
+/// in-app entity merge / reclassify drops) plus the canonical name, and defines
+/// cross-target pasteboard semantics so a dragged entity behaves natively no
+/// matter where it lands:
+///   - a structured JSON representation that survives across the app's targets
+///     and scenes (the in-app drop destinations decode this), and
+///   - a plain-text representation (the entity name) so dragging an entity into
+///     a text field, note, or another app pastes something meaningful.
+struct InspectorEntityDragID: Codable, Transferable {
     let id: String
+    var text: String = ""
 
     static var transferRepresentation: some TransferRepresentation {
-        ProxyRepresentation(exporting: \.id)
-            .visibility(.ownProcess)
+        CodableRepresentation(contentType: .json)
+        ProxyRepresentation(exporting: \.text)
     }
 }
 

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -28,6 +28,8 @@ struct DocumentInspectorEntitiesTab: View {
     @Environment(EntityServiceGenerated.self) private var entityService
     /// Per-window entity-search bus (#3437).
     @Environment(EntitySearchState.self) private var entitySearchState: EntitySearchState?
+    /// Cross-view KG focus — drives "Show in Graph" (#3452).
+    @Environment(KGFocusState.self) private var kgFocusState
 
     @State private var entitySelection: Set<String> = []
     @State private var isApplyingBulkAction = false
@@ -493,6 +495,11 @@ struct DocumentInspectorEntitiesTab: View {
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(entity.canonicalName, forType: .string)
             #endif
+        }
+        if let entityId = entity.id {
+            Button("Show in Graph") {
+                kgFocusState.requestGraphReveal(entityId: entityId)
+            }
         }
         Divider()
 

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift
@@ -41,6 +41,12 @@ struct EntityKindRow: View {
     /// crop just resolves to "No source region" instead of crashing.
     @Environment(AnnotationStore.self) private var annotationStore: AnnotationStore?
     @AppStorage("editor.fontSize") private var defaultFontSize: Double = 13
+    // Configurable row metadata (#3466), Xcode-console-style — the mini-toolbar's
+    // "Row Detail" menu flips these, persisted so the choice sticks across docs.
+    @AppStorage("inspector.kg.row.showConfidence") private var showConfidence = true
+    @AppStorage("inspector.kg.row.showPageRef") private var showPageRef = true
+    @AppStorage("inspector.kg.row.showContext") private var showContext = true
+    @AppStorage("inspector.kg.row.showExcerpt") private var showExcerpt = true
     @State private var claimForEditing: Components.Schemas.KnowledgeClaim?
     @State private var rowError: String?
     /// Presents the source-provenance quick-look popover for the primary claim.
@@ -135,7 +141,7 @@ struct EntityKindRow: View {
     /// sitting beside the tappable name on line 1.
     private var trailingText: Text {
         let aliasesText = item.aliases.isEmpty ? "" : " (aka \(item.aliases.joined(separator: ", ")))"
-        let pageRefText = pageReference.map { "  (\($0))" } ?? ""
+        let pageRefText = (showPageRef ? pageReference : nil).map { "  (\($0))" } ?? ""
         if !item.aliases.isEmpty {
             return Text("\(aliasesText)\(pageRefText)")
                 .font(secondaryTextFont)
@@ -219,7 +225,7 @@ struct EntityKindRow: View {
                     ClaimCurationBadge(state: curationState)
                 }
 
-                if let confidence {
+                if showConfidence, let confidence {
                     Text(String(format: "%.2f", confidence))
                         .font(.caption2.monospacedDigit())
                         .foregroundStyle(.secondary)
@@ -306,7 +312,8 @@ struct EntityKindRow: View {
                 }
             }
 
-            if !context.isEmpty,
+            if showContext,
+               !context.isEmpty,
                context != item.displayName,
                !item.displayName.contains(context) {
                 Text(context)
@@ -315,7 +322,8 @@ struct EntityKindRow: View {
                     .textSelection(.enabled)
             }
 
-            if let excerpt = sourceExcerpt,
+            if showExcerpt,
+               let excerpt = sourceExcerpt,
                !excerpt.isEmpty,
                excerpt != context,
                excerpt != item.displayName {

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift
@@ -363,6 +363,11 @@ struct EntityKindRow: View {
                 Button("Edit claim…") {
                     loadClaimForEditing()
                 }
+                if let entityId = item.entityId {
+                    Button("Show in Graph") {
+                        kgFocusState.requestGraphReveal(entityId: entityId)
+                    }
+                }
             }
         }
     }

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift
@@ -47,8 +47,8 @@ struct EntityKindRow: View {
     @AppStorage("inspector.kg.row.showPageRef") private var showPageRef = true
     @AppStorage("inspector.kg.row.showContext") private var showContext = true
     @AppStorage("inspector.kg.row.showExcerpt") private var showExcerpt = true
-    @State private var claimForEditing: Components.Schemas.KnowledgeClaim?
-    @State private var rowError: String?
+    /// The claim currently expanded into the inline S/V/O editor (#3463).
+    @State private var inlineEditingClaimId: String?
     /// Presents the source-provenance quick-look popover for the primary claim.
     @State private var isSourcePreviewPresented = false
 
@@ -101,27 +101,9 @@ struct EntityKindRow: View {
                 .padding(.leading, 8)
             }
 
-            if let rowError {
-                Text(rowError)
-                    .font(.caption2)
-                    .foregroundStyle(.red)
-            }
         }
         .padding(.vertical, 2)
         .contentShape(Rectangle())
-        .sheet(isPresented: Binding(
-            get: { claimForEditing != nil },
-            set: { if !$0 { claimForEditing = nil } }
-        )) {
-            if let claimForEditing {
-                // EditClaimSheet persists via PATCH; the backend emits
-                // `claim.updated`, the change-stream bumps ClaimStore.changeToken,
-                // and the KG section resyncs — no NotificationCenter nudge (#1862).
-                EditClaimSheet(claim: claimForEditing) { _ in
-                    self.claimForEditing = nil
-                }
-            }
-        }
     }
 
     private func focusPrimaryClaim() {
@@ -165,18 +147,6 @@ struct EntityKindRow: View {
             return "p. \(numericPart)"
         }
         return raw
-    }
-
-    private func loadClaimForEditing() {
-        guard let library = LibraryManager.shared.globalLibrary else { return }
-        rowError = nil
-        Task {
-            do {
-                claimForEditing = try await library.entityService.getClaim(item.claimId)
-            } catch {
-                rowError = error.localizedDescription
-            }
-        }
     }
 
     // swiftlint:disable function_body_length cyclomatic_complexity function_parameter_count
@@ -340,6 +310,19 @@ struct EntityKindRow: View {
                 .buttonStyle(.plain)
                 .help("Search the library for this quote")
             }
+
+            // Inline S/V/O editor (#3463): "Edit S/V/O…" expands the row in place
+            // into editable subject / verb / object fields (reusing the shared
+            // InlineClaimEditor, which persists via the claim.patch action; the
+            // change stream refreshes the list). Primary claim only.
+            if isPrimary, inlineEditingClaimId == claimId, let claim {
+                InlineClaimEditor(
+                    claim: claim,
+                    onCancel: { inlineEditingClaimId = nil },
+                    onSave: { _ in inlineEditingClaimId = nil }
+                )
+                .padding(.top, 4)
+            }
         }
         .padding(.horizontal, 6)
         .padding(.vertical, 4)
@@ -360,8 +343,8 @@ struct EntityKindRow: View {
                 }
             }
             if isPrimary {
-                Button("Edit claim…") {
-                    loadClaimForEditing()
+                Button(inlineEditingClaimId == claimId ? "Done Editing" : "Edit S/V/O…") {
+                    inlineEditingClaimId = (inlineEditingClaimId == claimId) ? nil : claimId
                 }
                 if let entityId = item.entityId {
                     Button("Show in Graph") {

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+KGSection.swift
@@ -83,6 +83,12 @@ struct KnowledgeGraphInspectorSection: View {
     /// "Include children" scope toggle and badged ("Includes children") when on.
     @AppStorage("inspector.scope.includeChildren") private var includeChildren: Bool = false
     @AppStorage("editor.fontSize") private var defaultFontSize: Double = 13
+    // Configurable per-row metadata (#3466). Shared keys with EntityKindRow so the
+    // "Row Detail" menu below toggles exactly what each row renders.
+    @AppStorage("inspector.kg.row.showConfidence") private var rowShowConfidence = true
+    @AppStorage("inspector.kg.row.showPageRef") private var rowShowPageRef = true
+    @AppStorage("inspector.kg.row.showContext") private var rowShowContext = true
+    @AppStorage("inspector.kg.row.showExcerpt") private var rowShowExcerpt = true
 
     private var bodyTextFont: Font {
         .system(size: CGFloat(defaultFontSize))
@@ -519,6 +525,10 @@ struct KnowledgeGraphInspectorSection: View {
             .help("List view — entities as grouped, expandable rows you can click through to the source")
             .accessibilityLabel("List view")
 
+            if displayMode == .list {
+                rowDetailMenu
+            }
+
             Button {
                 Task { await loadStatements() }
             } label: {
@@ -536,6 +546,24 @@ struct KnowledgeGraphInspectorSection: View {
                 deleteActionButton(targetClaims: selectedClaims)
             }
         }
+    }
+
+    /// "Row Detail" menu (#3466), Xcode-console-style: toggle which metadata each
+    /// claim row renders. Persisted via @AppStorage (shared keys with EntityKindRow).
+    private var rowDetailMenu: some View {
+        Menu {
+            Toggle("Confidence", isOn: $rowShowConfidence)
+            Toggle("Page reference", isOn: $rowShowPageRef)
+            Toggle("Context", isOn: $rowShowContext)
+            Toggle("Source excerpt", isOn: $rowShowExcerpt)
+        } label: {
+            Image(systemName: "slider.horizontal.3")
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help("Row detail — choose which metadata each claim row shows")
+        .accessibilityLabel("Row detail")
     }
 
     // Filter Menu — Tinderbox-style "displayed attributes" picker. Each entity


### PR DESCRIPTION
Inspector Swift follow-ups — build-gated **BUILD SUCCEEDED** (bab0b6c76, worker xcodebuild in worktree).
- #3425 defined cross-target drag semantics for entities
- #3452 "Show in Graph" — link out to the force graph (OntologyBrowser)
- #3466 configurable KG row metadata (Row Detail menu)
- #3463 inline S/V/O editing on KG claim rows
🤖 Generated with [Claude Code](https://claude.com/claude-code)