### PR TITLE
Engine: persist extraction source bounding boxes (#3459)

### DIFF
--- a/fichero-engine/src/fichero/workflows/tools/extractors.py
+++ b/fichero-engine/src/fichero/workflows/tools/extractors.py
@@ -2408,6 +2408,7 @@ def _write_kg_rows(
         # on disk + page number.
         char_start: int | None = None
         char_end: int | None = None
+        source_bbox = item.get("source_bbox")
         if source_text and page_excerpt:
             idx = page_excerpt.find(source_text)
             if idx >= 0:
@@ -2674,6 +2675,7 @@ def _write_kg_rows(
             source_page_label=page_label,
             source_char_start=char_start,
             source_char_end=char_end,
+            source_bbox=source_bbox,
             claim_type=ctype or ClaimType.fact,
             metadata=meta,
             epistemic_status=epistemic,

--- a/fichero-engine/tests/unit/workflows/test_extractor_kg_edge_cases.py
+++ b/fichero-engine/tests/unit/workflows/test_extractor_kg_edge_cases.py
@@ -896,3 +896,18 @@ def test_claim_writer_cleans_escaped_text_and_deletion_markers(db, container_doc
 
     claim = db.query(KnowledgeClaim, source_document_id=container_doc.id)[0]
     assert claim.text == 'Rosario contains La parte "limpia".'
+
+
+def test_claim_writer_preserves_source_bbox(db, container_doc):
+    from fichero.knowledge_models import KnowledgeClaim
+    from fichero.workflows.tools.extractors import _SECTIONS, _write_kg_rows
+
+    section = next(s for s in _SECTIONS if s["name"] == "places_extract")
+    _write_kg_rows(
+        db,
+        section,
+        [{"name": "Rosario", "verb": "is", "object": "a street", "source_bbox": [0.1, 0.2, 0.3, 0.4]}],
+        container_doc.id,
+    )
+    claim = db.query(KnowledgeClaim, source_document_id=container_doc.id)[0]
+    assert claim.source_bbox == [0.1, 0.2, 0.3, 0.4]


### PR DESCRIPTION
Engine — records source_bbox during extraction so the inspector provenance crops/highlights light up (was the data-dependency behind #2105/#3449).
- Gate: `test_extractor_kg_edge_cases.py` **31 passed** (worker + manager-verified, PYTHONPATH pinned).
- Python-only, disjoint from Swift.
🤖 Generated with [Claude Code](https://claude.com/claude-code)