### PR TITLE
Engine: hermeneutics SVO extraction stage (#3460)

### DIFF
--- a/fichero-engine/src/fichero/workflows/tools/extractors.py
+++ b/fichero-engine/src/fichero/workflows/tools/extractors.py
@@ -384,6 +384,22 @@ _SECTIONS: list[dict[str, Any]] = [
         ),
     },
     {
+        "name": "hermeneutics_extract",
+        "display": "Extract Interpretations",
+        "artifact": "hermeneutics",
+        "entity_type": EntityType.concept,
+        "icon": "text.quote",
+        "color": "purple",
+        "schema_key": "hermeneutics",
+        "item_shape": '{"name": "...", "verb": "...", "object": "..."}',
+        "instruction": (
+            "Extract only interpretive claims the document itself supports. "
+            "Name the interpreted theme, practice, or concept; split the "
+            "interpretation into verb and object; include the shortest "
+            "supporting source_text. Do not turn unstated speculation into fact."
+        ),
+    },
+    {
         "name": "quotes_extract",
         "display": "Extract Quotes",
         "artifact": "quotes",
@@ -877,6 +893,7 @@ _SECTION_SCHEMAS: dict[str, type[BaseModel]] = {
     "properties": _make_section_schema(_SectionProperty, "properties"),
     "legal_references": _make_section_schema(_SectionLegalReference, "legal_references"),
     "citation_usages": _make_section_schema(_SectionCitationUsage, "citation_usages"),
+    "hermeneutics": _make_section_schema(_SectionLegalReference, "hermeneutics"),
     "quotes": _make_section_schema(_SectionQuote, "quotes"),
 }
 

--- a/fichero-engine/tests/unit/workflows/test_extractor_kg_edge_cases.py
+++ b/fichero-engine/tests/unit/workflows/test_extractor_kg_edge_cases.py
@@ -911,3 +911,20 @@ def test_claim_writer_preserves_source_bbox(db, container_doc):
     )
     claim = db.query(KnowledgeClaim, source_document_id=container_doc.id)[0]
     assert claim.source_bbox == [0.1, 0.2, 0.3, 0.4]
+
+
+def test_hermeneutics_stage_persists_svo_claim(db, container_doc):
+    from fichero.knowledge_models import KnowledgeClaim
+    from fichero.workflows.tools.extractors import _SECTIONS, _write_kg_rows
+
+    section = next(s for s in _SECTIONS if s["name"] == "hermeneutics_extract")
+    _write_kg_rows(
+        db,
+        section,
+        [{"name": "Land tenure", "verb": "reveals", "object": "colonial power", "source_text": "The deed reveals colonial power."}],
+        container_doc.id,
+    )
+    claim = db.query(KnowledgeClaim, source_document_id=container_doc.id)[0]
+    assert (claim.subject_canonical, claim.predicate_verb, claim.object_phrase) == (
+        "Land tenure", "reveals", "colonial power"
+    )

--- a/fichero-engine/tests/unit/workflows/test_extractors.py
+++ b/fichero-engine/tests/unit/workflows/test_extractors.py
@@ -26,6 +26,7 @@ EXTRACTOR_NAMES = [
     "properties_extract",
     "legal_references_extract",
     "citation_usage_extract",
+    "hermeneutics_extract",
     "keywords_extract",
     "quotes_extract",
 ]
@@ -234,6 +235,6 @@ class TestSectionConfig:
         # Artifact types must match what DocumentInspectorArtifactsTab renders.
         known = {"people", "places", "organizations", "dates", "rivers",
                  "events", "mines", "properties", "legal_references",
-                 "citation_usages", "keywords", "quotes"}
+                 "citation_usages", "hermeneutics", "keywords", "quotes"}
         for section in _SECTIONS:
             assert section["artifact"] in known


### PR DESCRIPTION
Adds the missing hermeneutics SVO extraction stage to the catalogue workflow (citation-SVO already existed). Gate: hermeneutics/SVO tests **25 passed**. Python-only, disjoint from Swift. 🤖 Generated with [Claude Code](https://claude.com/claude-code)