### PR TITLE
Notes inspector: route mutations through stores + typed source-nav (#3428/#3430/#3432)

### DIFF
--- a/fichero/fichero-tests/AnnotationServiceTests.swift
+++ b/fichero/fichero-tests/AnnotationServiceTests.swift
@@ -164,4 +164,31 @@ final class AnnotationServiceTests: XCTestCase {
         )
         XCTAssertFalse(AnnotationService.matchesSearch(annotation, query: "mining"))
     }
+
+    // MARK: - Source-navigation mapping (#3432)
+
+    func testAnnotationSourceNavigationMapsFullAnchor() throws {
+        let annotation = DocumentAnnotation(
+            id: "a1",
+            documentId: "doc-9",
+            pageLabel: "p. 4",
+            charStart: 10,
+            charEnd: 25,
+            bbox: [0.1, 0.2, 0.3, 0.4]
+        )
+
+        let request = try XCTUnwrap(AnnotationSourceNavigation.request(for: annotation))
+        XCTAssertEqual(request.documentId, "doc-9")
+        XCTAssertEqual(request.pageLabel, "p. 4")
+        XCTAssertEqual(request.charStart, 10)
+        XCTAssertEqual(request.charEnd, 25)
+        XCTAssertEqual(request.bbox, [0.1, 0.2, 0.3, 0.4])
+    }
+
+    func testAnnotationSourceNavigationNilWithoutDocumentAnchor() {
+        // No document id → no anchor, so selection/reveal is a safe no-op rather
+        // than routing an unresolvable request.
+        let annotation = DocumentAnnotation(id: "a2", pageLabel: "p. 1")
+        XCTAssertNil(AnnotationSourceNavigation.request(for: annotation))
+    }
 }

--- a/fichero/fichero/Views/Library/Inspector/AnnotationListView.swift
+++ b/fichero/fichero/Views/Library/Inspector/AnnotationListView.swift
@@ -1,9 +1,25 @@
 import FicheroAPIClient
 import SwiftUI
 
-extension Notification.Name {
-    /// Posted when the user selects an annotation in the inspector.
-    static let annotationSelectedInInspector = Notification.Name("annotationSelectedInInspector")
+/// Maps an annotation to the shared typed source-navigation request (#3432),
+/// replacing the unconsumed `annotationSelectedInInspector` NotificationCenter
+/// bus. Pure + testable: resolves document id, page label, bbox, and character
+/// range into the `ClaimSourceNavigationRequest` that ContentView/the reader
+/// already consume. Returns nil when there's no document anchor to navigate to.
+enum AnnotationSourceNavigation {
+    static func request(for annotation: DocumentAnnotation) -> ClaimSourceNavigationRequest? {
+        guard let documentId = annotation.documentId,
+              !documentId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return ClaimSourceNavigationRequest(
+            documentId: documentId,
+            pageLabel: annotation.pageLabel,
+            charStart: annotation.charStart,
+            charEnd: annotation.charEnd,
+            bbox: annotation.bbox
+        )
+    }
 }
 
 /// A native `List(selection:)` of annotations.
@@ -15,6 +31,10 @@ struct AnnotationListView: View {
     let annotations: [DocumentAnnotation]
 
     @Bindable var focused: FocusedAnnotation
+
+    /// Per-window typed source-navigation bus (#3437/#3432); optional so a host
+    /// that hasn't injected it safely no-ops instead of posting into the void.
+    @Environment(ClaimSourceNavigationState.self) private var claimSourceNavigationState: ClaimSourceNavigationState?
 
     var onOpenInWindow: (() -> Void)?
 
@@ -54,7 +74,7 @@ struct AnnotationListView: View {
             }
             focused.resolve(in: annotations)
             guard let annotation = annotations.first(where: { $0.id == newId }) else { return }
-            postRevealNotification(for: annotation)
+            navigateToSource(of: annotation)
         }
         .onChange(of: annotations) { _, items in
             focused.resolve(in: items)
@@ -77,18 +97,9 @@ struct AnnotationListView: View {
         )
     }
 
-    private func postRevealNotification(for annotation: DocumentAnnotation) {
-        guard let documentId = annotation.documentId else { return }
-        var info: [String: Any] = ["documentId": documentId]
-        if let pageLabel = annotation.pageLabel { info["pageLabel"] = pageLabel }
-        if let bbox = annotation.bbox { info["bbox"] = bbox }
-        if let charStart = annotation.charStart { info["charStart"] = charStart }
-        if let charEnd = annotation.charEnd { info["charEnd"] = charEnd }
-        NotificationCenter.default.post(
-            name: .annotationSelectedInInspector,
-            object: nil,
-            userInfo: info
-        )
+    private func navigateToSource(of annotation: DocumentAnnotation) {
+        guard let request = AnnotationSourceNavigation.request(for: annotation) else { return }
+        claimSourceNavigationState?.request(request)
     }
 }
 

--- a/fichero/fichero/Views/Library/Inspector/AnnotationsInspectorPane.swift
+++ b/fichero/fichero/Views/Library/Inspector/AnnotationsInspectorPane.swift
@@ -10,6 +10,8 @@ struct AnnotationsInspectorPane: View {
     let annotations: [DocumentAnnotation]
 
     @Environment(AnnotationStore.self) private var annotationStore
+    /// Per-window typed source-navigation bus (#3437/#3432).
+    @Environment(ClaimSourceNavigationState.self) private var claimSourceNavigationState: ClaimSourceNavigationState?
     @Environment(\.openWindow) private var openWindow
     @Environment(\.supportsMultipleWindows) private var supportsMultipleWindows
 
@@ -160,17 +162,10 @@ struct AnnotationsInspectorPane: View {
     }
 
     private func reveal(_ annotation: DocumentAnnotation) {
-        guard let documentId = annotation.documentId else { return }
-        var info: [String: Any] = ["documentId": documentId]
-        if let pageLabel = annotation.pageLabel { info["pageLabel"] = pageLabel }
-        if let bbox = annotation.bbox { info["bbox"] = bbox }
-        if let charStart = annotation.charStart { info["charStart"] = charStart }
-        if let charEnd = annotation.charEnd { info["charEnd"] = charEnd }
-        NotificationCenter.default.post(
-            name: .annotationSelectedInInspector,
-            object: nil,
-            userInfo: info
-        )
+        // Route through the typed source-navigation bus ContentView consumes
+        // (#3432), not the dead annotationSelectedInInspector notification.
+        guard let request = AnnotationSourceNavigation.request(for: annotation) else { return }
+        claimSourceNavigationState?.request(request)
     }
 
     @ViewBuilder

--- a/fichero/fichero/Views/Library/Inspector/AnnotationsInspectorPane.swift
+++ b/fichero/fichero/Views/Library/Inspector/AnnotationsInspectorPane.swift
@@ -10,8 +10,6 @@ struct AnnotationsInspectorPane: View {
     let annotations: [DocumentAnnotation]
 
     @Environment(AnnotationStore.self) private var annotationStore
-    @Environment(LibraryManager.self) private var libraryManager
-    @Environment(WindowState.self) private var windowState
     @Environment(\.openWindow) private var openWindow
     @Environment(\.supportsMultipleWindows) private var supportsMultipleWindows
 
@@ -125,37 +123,30 @@ struct AnnotationsInspectorPane: View {
         }
     }
 
+    // Mutations route through the injected AnnotationStore — the sanctioned
+    // observable data layer — instead of resolving an action service through
+    // LibraryManager + WindowState (#3428). The store updates its published
+    // `annotations` in place, so the list/detail refresh without a full reload.
     private func saveAnnotation(_ annotation: DocumentAnnotation, text: String) async throws {
-        guard let library = currentLibrary else { return }
-        var update = Components.Schemas.AnnotationPatchRequest()
-        update.text = text
-        _ = try await library.actionsService.invokeAction(
-            name: "annotation.update",
-            params: AnnotationUpdateActionParams(annotationId: annotation.id, update: update)
-        )
-        await annotationStore.reload()
+        guard await annotationStore.updateText(id: annotation.id, text: text) != nil else {
+            throw AnnotationInspectorActionError.failed
+        }
         focused.resolve(in: annotationStore.annotations)
     }
 
     private func deleteAnnotation(_ annotation: DocumentAnnotation) async throws {
-        guard let library = currentLibrary else { return }
-        _ = try await library.actionsService.invokeAction(
-            name: "annotation.delete",
-            params: AnnotationDeleteActionParams(annotationId: annotation.id)
-        )
+        guard await annotationStore.delete(id: annotation.id) else {
+            throw AnnotationInspectorActionError.failed
+        }
         if focused.id == annotation.id {
             focused.clear()
         }
-        await annotationStore.reload()
     }
 
     private func promoteAnnotation(_ annotation: DocumentAnnotation) async throws {
-        guard let library = currentLibrary else { return }
-        _ = try await library.actionsService.invokeAction(
-            name: "annotation.promote_to_claim",
-            params: AnnotationPromoteActionParams(annotationId: annotation.id)
-        )
-        await annotationStore.reload()
+        guard await annotationStore.promoteToClaim(id: annotation.id) else {
+            throw AnnotationInspectorActionError.failed
+        }
         focused.resolve(in: annotationStore.annotations)
     }
 
@@ -166,10 +157,6 @@ struct AnnotationsInspectorPane: View {
             return
         }
         PlatformPasteboard.writeString(text)
-    }
-
-    private var currentLibrary: LibraryManager.LibraryReference? {
-        libraryManager.getLibrary(id: windowState.libraryId)
     }
 
     private func reveal(_ annotation: DocumentAnnotation) {
@@ -207,6 +194,12 @@ struct AnnotationsInspectorPane: View {
         .padding(.vertical, 8)
         .background(.orange.opacity(0.1))
     }
+}
+
+/// Raised when a store-routed annotation mutation reports failure, so the
+/// detail view's existing error handling still fires (#3428).
+enum AnnotationInspectorActionError: Error {
+    case failed
 }
 
 /// The torn-off annotation-detail window.

--- a/fichero/fichero/Views/Notes/NotesInspectorPane.swift
+++ b/fichero/fichero/Views/Notes/NotesInspectorPane.swift
@@ -9,9 +9,7 @@ struct NotesInspectorPane: View {
     let selectionResetToken: String
     let documentName: String?
 
-    @Environment(LibraryManager.self) private var libraryManager
     @Environment(NoteStore.self) private var noteStore
-    @Environment(WindowState.self) private var windowState
     @Environment(\.openWindow) private var openWindow
     @Environment(\.supportsMultipleWindows) private var supportsMultipleWindows
 
@@ -103,34 +101,21 @@ struct NotesInspectorPane: View {
         openWindow(id: "note-detail")
     }
 
+    // Mutations route through the injected NoteStore — the sanctioned observable
+    // data layer — instead of resolving an action service through LibraryManager
+    // + WindowState (#3430). The store reloads its published `notes` internally.
     private func saveNote(_ item: NoteSelectionItem, body: String) async throws {
-        guard let noteId = item.note.id,
-              let library = currentLibrary else { return }
-        var update = Components.Schemas.NotePatchRequest()
-        update.body = body
-        _ = try await library.actionsService.invokeAction(
-            name: "note.update",
-            params: NoteUpdateActionParams(noteId: noteId, update: update)
-        )
-        await noteStore.reload()
+        guard let noteId = item.note.id else { return }
+        _ = try await noteStore.update(noteId: noteId, body: body)
         focused.resolve(in: noteStore.notes.map(NoteSelectionItem.init))
     }
 
     private func deleteNote(_ item: NoteSelectionItem) async throws {
-        guard let noteId = item.note.id,
-              let library = currentLibrary else { return }
-        _ = try await library.actionsService.invokeAction(
-            name: "note.delete",
-            params: NoteDeleteActionParams(noteId: noteId)
-        )
+        guard let noteId = item.note.id else { return }
+        try await noteStore.delete(noteId: noteId)
         if focused.id == item.id {
             focused.clear()
         }
-        await noteStore.reload()
-    }
-
-    private var currentLibrary: LibraryManager.LibraryReference? {
-        libraryManager.getLibrary(id: windowState.libraryId)
     }
 
     @ViewBuilder


### PR DESCRIPTION
Notes/annotation store-injection + dead-nav-bus removal — build-verified BUILD SUCCEEDED (Swift; rebased over disjoint engine #3460).
- #3428 annotation mutations through the store
- #3430 note mutations through the store
- #3432 annotation reveal through the typed source-nav bus (off the unconsumed NotificationCenter)
🤖 Generated with [Claude Code](https://claude.com/claude-code)