### PR TITLE
Engine: expose artifact lineage in inspector responses (#3420)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/artifacts.py
+++ b/fichero-engine/src/fichero/api/routes/artifacts.py
@@ -36,6 +36,10 @@ class ArtifactResponse(BaseModel):
     model: Optional[str] = None
     confidence: Optional[float] = None
     reviewed: bool
+    source_artifact_id: Optional[str] = None
+    source_document_id: Optional[str] = None
+    run_id: Optional[str] = None
+    step_name: Optional[str] = None
     created_at: str
 
 
@@ -95,6 +99,10 @@ def _artifact_response(artifact: Artifact) -> ArtifactResponse:
         model=artifact.model,
         confidence=artifact.confidence,
         reviewed=artifact.reviewed,
+        source_artifact_id=artifact.source_artifact_id,
+        source_document_id=artifact.source_document_id,
+        run_id=artifact.run_id,
+        step_name=artifact.step_name,
         created_at=artifact.created_at.isoformat() if artifact.created_at else "",
     )
 

--- a/fichero-engine/tests/unit/test_routes_artifacts.py
+++ b/fichero-engine/tests/unit/test_routes_artifacts.py
@@ -330,6 +330,24 @@ class TestListDocumentArtifacts:
 
 
 class TestGetArtifact:
+    def test_returns_lineage_fields(self, client, db):
+        doc = Document(name="source")
+        db.save(doc)
+        artifact = Artifact(
+            document_id=doc.id,
+            artifact_type="summary",
+            source_artifact_id="upstream",
+            source_document_id="original",
+            run_id="run-1",
+            step_name="summarize",
+        )
+        db.save(artifact)
+
+        response = client.get(f"/api/artifacts/{artifact.id}")
+        assert response.status_code == 200
+        assert response.json()["step_name"] == "summarize"
+        assert response.json()["source_artifact_id"] == "upstream"
+
     def test_returns_artifact_by_id(self, client, db):
         doc = _make_doc(db)
         a = _make_artifact(db, doc.id)


### PR DESCRIPTION
Exposes artifact lineage/derivation fields for inspector provenance. Gate: test_translation_embedding.py + test_routes_artifacts.py **47 passed** at file scope. (A broad -k 'lineage or artifact' filter shows 3 failures from PRE-EXISTING test-isolation contamination — identical at origin/main baseline — tracked separately, not caused by this change.) Python-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)