### PR TITLE
Inspector: repo-clean, folder aggregation, multi-level undo, focused tests (#3453/#3450/#3444/#3457)

### DIFF
--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -255,4 +255,26 @@ final class DocumentInspectorTests: XCTestCase {
         XCTAssertNil(AuditStore.nextUndoable(in: []))
         XCTAssertNil(AuditStore.nextUndoable(in: [auditEntry("z", undone: true)]))
     }
+
+    // MARK: - Switcher section mapping (#3457)
+
+    func testSwitcherMapsEachTabToItsSection() {
+        // doc = nil → all tabs available, so this is the pure section mapping the
+        // top-icon-row switcher uses (no doc-type clamping).
+        XCTAssertEqual(DocumentInspector.section(for: .content, in: nil), .source)
+        XCTAssertEqual(DocumentInspector.section(for: .info, in: nil), .source)
+        XCTAssertEqual(DocumentInspector.section(for: .artifacts, in: nil), .artifacts)
+        XCTAssertEqual(DocumentInspector.section(for: .entities, in: nil), .knowledge)
+        XCTAssertEqual(DocumentInspector.section(for: .knowledgeGraph, in: nil), .knowledge)
+        XCTAssertEqual(DocumentInspector.section(for: .citations, in: nil), .knowledge)
+        XCTAssertEqual(DocumentInspector.section(for: .notes, in: nil), .notes)
+        XCTAssertEqual(DocumentInspector.section(for: .annotations, in: nil), .notes)
+        XCTAssertEqual(DocumentInspector.section(for: .interpretations, in: nil), .notes)
+    }
+
+    func testSwitcherFallsBackToSourceForEdits() {
+        // Edits left the inspector (#3434), so it maps to no section and the
+        // switcher clamps to Source rather than showing a dead segment.
+        XCTAssertEqual(DocumentInspector.section(for: .edits, in: nil), .source)
+    }
 }

--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -1,4 +1,5 @@
 @testable import Fichero
+import FicheroAPIClient
 import XCTest
 
 @MainActor
@@ -211,5 +212,47 @@ final class DocumentInspectorTests: XCTestCase {
 
         XCTAssertFalse(source.contains("SourceOutlineView(documentId: doc.id)"))
         XCTAssertFalse(source.contains(".outline"))
+    }
+
+    // MARK: - Multi-level undo walk (#3444)
+
+    private func auditEntry(
+        _ id: String,
+        undone: Bool = false,
+        inverseOf: String? = nil,
+        undoable: Bool = true
+    ) -> Components.Schemas.AuditLogEntry {
+        Components.Schemas.AuditLogEntry(
+            id: id,
+            actionName: "entity.merge",
+            actor: "human",
+            targetIds: [],
+            createdAt: "t",
+            undone: undone,
+            inverseOf: inverseOf,
+            undoable: undoable
+        )
+    }
+
+    func testNextUndoableWalksToMostRecentForwardUndoableAction() {
+        // Newest-first: an inverse (redo target), an already-undone action, then
+        // two live forward actions. The walk targets the newest live forward one.
+        let entries = [
+            auditEntry("inv", inverseOf: "c"),   // skip — an inverse/redo row
+            auditEntry("c", undone: true),        // skip — already undone
+            auditEntry("b"),                      // <- next undo target
+            auditEntry("a")
+        ]
+        XCTAssertEqual(AuditStore.nextUndoable(in: entries)?.id, "b")
+    }
+
+    func testNextUndoableSkipsNonUndoableRows() {
+        let entries = [auditEntry("x", undoable: false), auditEntry("y")]
+        XCTAssertEqual(AuditStore.nextUndoable(in: entries)?.id, "y")
+    }
+
+    func testNextUndoableNilWhenNothingReversible() {
+        XCTAssertNil(AuditStore.nextUndoable(in: []))
+        XCTAssertNil(AuditStore.nextUndoable(in: [auditEntry("z", undone: true)]))
     }
 }

--- a/fichero/fichero-tests/EntityStoreTests.swift
+++ b/fichero/fichero-tests/EntityStoreTests.swift
@@ -471,4 +471,39 @@ final class EntityStoreTests: XCTestCase {
     private func jsonData(_ object: Any) -> Data {
         (try? JSONSerialization.data(withJSONObject: object)) ?? Data()
     }
+
+    // MARK: - Folder aggregation union (#3450)
+
+    private func aggEntity(id: String?, name: String) -> Components.Schemas.KnowledgeEntity {
+        Components.Schemas.KnowledgeEntity(
+            id: id,
+            canonicalName: name,
+            entityType: .person,
+            aliases: nil,
+            description: nil,
+            language: nil,
+            metadata: nil,
+            mergedIntoId: nil
+        )
+    }
+
+    func testUnionDedupesByEntityIdPreservingFirstSeenOrder() {
+        let folder = [aggEntity(id: "e1", name: "Ada"), aggEntity(id: "e2", name: "Grace")]
+        let childA = [aggEntity(id: "e2", name: "Grace"), aggEntity(id: "e3", name: "Alan")]
+        let childB = [aggEntity(id: "e1", name: "Ada")]
+
+        let merged = EntityStore.union([folder, childA, childB])
+
+        // e1, e2, e3 — each once, in first-seen order across the folder + children.
+        XCTAssertEqual(merged.map(\.id), ["e1", "e2", "e3"])
+    }
+
+    func testUnionFallsBackToTypeNameKeyForIdlessEntities() {
+        // Two not-yet-persisted entities with the same type+name collapse to one.
+        let merged = EntityStore.union([
+            [aggEntity(id: nil, name: "Ada")],
+            [aggEntity(id: nil, name: "Ada"), aggEntity(id: nil, name: "Grace")]
+        ])
+        XCTAssertEqual(merged.map(\.canonicalName), ["Ada", "Grace"])
+    }
 }

--- a/fichero/fichero/Models/AuditStore.swift
+++ b/fichero/fichero/Models/AuditStore.swift
@@ -106,4 +106,37 @@ final class AuditStore {
     func canUndo(_ entry: Components.Schemas.AuditLogEntry) -> Bool {
         entry.undoable && !entry.undone
     }
+
+    // MARK: - Multi-level undo (#3444)
+
+    /// The next target for a multi-level ⌘Z that walks the audit log: the
+    /// most-recent *forward* action that can still be reversed. Entries are
+    /// newest-first, so this steps backward one action per undo. Rows that are
+    /// themselves inverses (`inverseOf` set) are skipped — those are redo
+    /// targets, not further undos — as are already-undone rows.
+    var nextUndoableEntry: Components.Schemas.AuditLogEntry? {
+        entries.first { $0.undoable && !$0.undone && $0.inverseOf == nil }
+    }
+
+    /// Pure walk helper (testable without the network): the newest forward,
+    /// still-undoable entry in a given list.
+    static func nextUndoable(
+        in entries: [Components.Schemas.AuditLogEntry]
+    ) -> Components.Schemas.AuditLogEntry? {
+        entries.first { $0.undoable && !$0.undone && $0.inverseOf == nil }
+    }
+
+    /// Undo the most-recent still-undoable forward action, walking the audit log
+    /// (#3444 multi-level undo). Loads the log first if it hasn't been fetched,
+    /// so ⌘Z works without the Audit History view being open. `undo(_:)` reloads
+    /// afterwards, so a repeated call naturally steps one action further back.
+    @discardableResult
+    func undoLast() async -> Bool {
+        if entries.isEmpty { await load() }
+        guard let entry = nextUndoableEntry else {
+            statusMessage = "Nothing to undo"
+            return false
+        }
+        return await undo(entry.id)
+    }
 }

--- a/fichero/fichero/Models/EntityStore.swift
+++ b/fichero/fichero/Models/EntityStore.swift
@@ -123,6 +123,60 @@ final class EntityStore: ObservableDomainStore {
         }
     }
 
+    /// Aggregate entities across a folder's children in memory (#3450). Fetches
+    /// the folder's own inspector entities plus each child's and unions them by
+    /// stable identity, so the folder view can review/filter/merge/split/delete
+    /// across children. Published under the folder's own id scope, so
+    /// `entities(forDocument: folderId)` returns the aggregate and the list
+    /// updates in place (stable ids, no wholesale re-render).
+    ///
+    /// Client-side: fine for review-scale folders. A server-side aggregation
+    /// endpoint is the scale path — see the deferred successor noted on #3450.
+    func loadAggregatedEntities(
+        forFolder folderId: String,
+        childDocumentIds: [String],
+        force: Bool = false
+    ) async {
+        if !force, loadedDocumentIds.contains(folderId), loadErrorsByDocumentId[folderId] == nil {
+            syncLegacyScope(documentId: folderId)
+            return
+        }
+
+        lastLoadedDocumentId = folderId
+        loadingDocumentIds.insert(folderId)
+        loadErrorsByDocumentId[folderId] = nil
+        syncLegacyScope(documentId: folderId)
+        defer {
+            loadingDocumentIds.remove(folderId)
+            syncLegacyScope(documentId: folderId)
+        }
+
+        // Folder-level entities first, then each child — union preserves that order.
+        let scopeIds = [folderId] + childDocumentIds
+        var lists: [[Components.Schemas.KnowledgeEntity]] = []
+        var lastError: Error?
+        for docId in scopeIds {
+            do {
+                lists.append(try await entityService.listInspectorEntitiesForDocument(documentId: docId))
+            } catch is CancellationError {
+                return  // superseded by a newer selection — keep current state
+            } catch {
+                lastError = error  // partial aggregation beats none; remember for the all-failed case
+            }
+        }
+
+        if lists.isEmpty, let lastError {
+            entitiesByDocumentId[folderId] = []
+            loadErrorsByDocumentId[folderId] = "Couldn't load entities: \(lastError.localizedDescription)"
+            loadedDocumentIds.remove(folderId)
+        } else {
+            entitiesByDocumentId[folderId] = EntityStore.union(lists)
+            loadErrorsByDocumentId.removeValue(forKey: folderId)
+            loadedDocumentIds.insert(folderId)
+        }
+        syncLegacyScope(documentId: folderId)
+    }
+
     /// Re-fetch the current document scope (post-mutation / reconnect resync).
     func reload() async {
         let documentIds = loadedDocumentIds.isEmpty
@@ -135,6 +189,30 @@ final class EntityStore: ObservableDomainStore {
 
     func entities(forDocument documentId: String) -> [Components.Schemas.KnowledgeEntity] {
         entitiesByDocumentId[documentId] ?? []
+    }
+
+    /// Union entity lists (folder's own + each child's) preserving first-seen
+    /// order, deduped by stable identity so the same entity referenced by
+    /// multiple children collapses to one row (#3450). Pure + testable.
+    static func union(
+        _ lists: [[Components.Schemas.KnowledgeEntity]]
+    ) -> [Components.Schemas.KnowledgeEntity] {
+        var merged: [String: Components.Schemas.KnowledgeEntity] = [:]
+        var order: [String] = []
+        for list in lists {
+            for entity in list {
+                let key = aggregationKey(for: entity)
+                if merged[key] == nil { order.append(key) }
+                merged[key] = entity
+            }
+        }
+        return order.compactMap { merged[$0] }
+    }
+
+    /// Dedup key for aggregation: the global entity id, else a type:name fallback
+    /// for not-yet-persisted entities (mirrors the row's stable identity).
+    static func aggregationKey(for entity: Components.Schemas.KnowledgeEntity) -> String {
+        entity.id ?? "\(entity.entityType?.rawValue ?? "other"):\(entity.canonicalName)"
     }
 
     func isLoading(forDocument documentId: String) -> Bool {

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -31,6 +31,10 @@ struct DocumentInspectorEntitiesTab: View {
     @Environment(EntitySearchState.self) private var entitySearchState: EntitySearchState?
     /// Cross-view KG focus — drives "Show in Graph" (#3452).
     @Environment(KGFocusState.self) private var kgFocusState
+    /// Document tree — supplies a folder's children for aggregation (#3450).
+    @Environment(DocumentStore.self) private var documentStore
+    /// Shared with the KG tab: aggregate across a folder's children when on.
+    @AppStorage("inspector.scope.includeChildren") private var includeChildren = false
 
     @State private var entitySelection: Set<String> = []
     @State private var isApplyingBulkAction = false
@@ -93,6 +97,28 @@ struct DocumentInspectorEntitiesTab: View {
         entityStore.entities(forDocument: documentId)
     }
 
+    private var isFolder: Bool { document.docType == .folder }
+
+    /// Aggregate across children when a folder is inspected and the scope toggle
+    /// is on (#3450); otherwise the entities are just this document's.
+    private var aggregatingChildren: Bool { isFolder && includeChildren }
+
+    /// Load entities for the current scope: a folder's aggregated children, or a
+    /// single document. Published under `documentId`, so `scopedEntities` reads
+    /// the right set either way.
+    private func loadScopedEntities(force: Bool = false) async {
+        if aggregatingChildren {
+            let childIds = await documentStore.children(of: documentId).map(\.id)
+            await entityStore.loadAggregatedEntities(
+                forFolder: documentId,
+                childDocumentIds: childIds,
+                force: force
+            )
+        } else {
+            await entityStore.loadEntities(forDocument: documentId, force: force)
+        }
+    }
+
     private var scopedLoadError: String? {
         entityStore.loadError(forDocument: documentId)
     }
@@ -152,8 +178,9 @@ struct DocumentInspectorEntitiesTab: View {
             }
         }
         .padding(.top)
-        // The store owns fetching; the view just scopes it to this document.
-        .task(id: documentId) { await entityStore.loadEntities(forDocument: documentId) }
+        // The store owns fetching; the view just scopes it to this document
+        // (or the folder's aggregated children when the scope toggle is on).
+        .task(id: "\(documentId)-\(includeChildren)") { await loadScopedEntities() }
         .onAppear { recomputeGrouped() }
         .onChange(of: scopedEntities) { _, _ in
             recomputeGrouped()
@@ -226,7 +253,7 @@ struct DocumentInspectorEntitiesTab: View {
             filterMenu
 
             Button {
-                Task { await entityStore.loadEntities(forDocument: documentId, force: true) }
+                Task { await loadScopedEntities(force: true) }
             } label: {
                 Image(systemName: "arrow.clockwise")
             }
@@ -309,6 +336,29 @@ struct DocumentInspectorEntitiesTab: View {
 
     private var filterMenu: some View {
         Menu {
+            // Folder aggregation scope (#3450) — only meaningful for a folder.
+            if isFolder {
+                Section("Scope") {
+                    Button {
+                        includeChildren = false
+                    } label: {
+                        HStack {
+                            Text("This folder only")
+                            Spacer(minLength: 0)
+                            if !includeChildren { Image(systemName: "checkmark") }
+                        }
+                    }
+                    Button {
+                        includeChildren = true
+                    } label: {
+                        HStack {
+                            Text("Include children")
+                            Spacer(minLength: 0)
+                            if includeChildren { Image(systemName: "checkmark") }
+                        }
+                    }
+                }
+            }
             ForEach(EntityKind.displayOrder, id: \.self) { kind in
                 let isHidden = hiddenKinds.contains(kind)
                 Button {

--- a/fichero/fichero/Views/Library/Inspector/AnnotationDetailView.swift
+++ b/fichero/fichero/Views/Library/Inspector/AnnotationDetailView.swift
@@ -1,32 +1,6 @@
 import FicheroAPIClient
 import SwiftUI
 
-struct AnnotationUpdateActionParams: Encodable {
-    let annotationId: String
-    let update: Components.Schemas.AnnotationPatchRequest
-
-    enum CodingKeys: String, CodingKey {
-        case annotationId = "annotation_id"
-        case update
-    }
-}
-
-struct AnnotationDeleteActionParams: Encodable {
-    let annotationId: String
-
-    enum CodingKeys: String, CodingKey {
-        case annotationId = "annotation_id"
-    }
-}
-
-struct AnnotationPromoteActionParams: Encodable {
-    let annotationId: String
-
-    enum CodingKeys: String, CodingKey {
-        case annotationId = "annotation_id"
-    }
-}
-
 /// The shared renderer for one annotation.
 ///
 /// Reuses the existing row-style presentation, then layers the edit / delete /

--- a/fichero/fichero/Views/Menu/FocusedCommandButtons.swift
+++ b/fichero/fichero/Views/Menu/FocusedCommandButtons.swift
@@ -368,6 +368,12 @@ struct UndoLastActionButton: View {
     private var lastAction: LastAction? {
         LibraryManager.shared.globalLibrary?.actionsService.lastAction
     }
+    /// The active library's audit log — the source of truth for multi-level undo
+    /// (#3444). ⌘Z walks it row by row instead of only reversing the single
+    /// last-recorded action.
+    private var auditStore: AuditStore? {
+        LibraryManager.shared.globalLibrary?.auditStore
+    }
     @FocusedValue(\.navigationUndoAction) private var navigationUndoAction
 
     private var logger: Logger {
@@ -382,17 +388,22 @@ struct UndoLastActionButton: View {
         .disabled(!isEnabled)
     }
 
-    /// "Undo Merge" when an action is recorded, plain "Undo" otherwise.
+    /// "Undo Merge" when the next undoable action is known, plain "Undo"
+    /// otherwise. Prefers the audit log's next target (multi-level, #3444);
+    /// falls back to the last-recorded action before the log has loaded.
     private var undoTitle: String {
         if navigationUndoAction != nil {
             return "Undo"
         }
-        guard let name = lastAction?.actionName else { return "Undo" }
+        let name = auditStore?.nextUndoableEntry?.actionName ?? lastAction?.actionName
+        guard let name else { return "Undo" }
         return "Undo \(Self.menuLabel(for: name))"
     }
 
     private var isEnabled: Bool {
-        navigationUndoAction?.isEnabled == true || lastAction?.auditId != nil
+        navigationUndoAction?.isEnabled == true
+            || auditStore?.nextUndoableEntry != nil
+            || lastAction?.auditId != nil
     }
 
     /// `"entity.merge"` → `"Merge"`. Falls back to the raw name if unverbed.
@@ -407,26 +418,35 @@ struct UndoLastActionButton: View {
             navigationUndoAction.run()
             return
         }
-        guard let lastAction,
-              let auditId = lastAction.auditId,
-              let service = LibraryManager.shared.globalLibrary?.actionsService else { return }
-        let previousActionName = lastAction.actionName
-        // Clear up front so a second ⌘Z can't replay the inverse of the same row
-        // (single-level undo). Re-records nothing: redo is a follow-up.
-        lastAction.auditId = nil
-        lastAction.actionName = nil
+        guard let auditStore else { return }
         Task {
-            do {
-                _ = try await service.undoAction(auditId: auditId)
-                logger.info("⌘Z undo of audit \(auditId) succeeded")
-            } catch {
-                // A failed undo must not leave the user with nothing undone AND
-                // Undo silently disabled (#3302 / raise-not-silent). Restore the
-                // holder so ⌘Z can retry, and surface the failure.
-                lastAction.auditId = auditId
-                lastAction.actionName = previousActionName
-                logger.error("⌘Z undo of audit \(auditId) failed: \(error.localizedDescription)")
-                presentUndoError(error)
+            // Multi-level: walk the audit log and reverse the most-recent
+            // still-undoable forward action. `undoLast()` loads the log if
+            // needed and reloads after, so a repeated ⌘Z steps further back.
+            let didUndo = await auditStore.undoLast()
+            if didUndo {
+                logger.info("⌘Z multi-level undo succeeded")
+                // Keep the single-level signal in sync: once the log has no more
+                // undoable forward actions, drop it so Undo disables cleanly.
+                if auditStore.nextUndoableEntry == nil {
+                    lastAction?.auditId = nil
+                    lastAction?.actionName = nil
+                }
+            } else {
+                // Nothing left to undo, or the reversal failed — clear the signal
+                // and surface any message (raise-not-silent, #3302).
+                lastAction?.auditId = nil
+                lastAction?.actionName = nil
+                logger.error("⌘Z undo found nothing to reverse or failed")
+                if let message = auditStore.statusMessage, message != "Nothing to undo" {
+                    presentUndoError(
+                        NSError(
+                            domain: "app.fichero.undo",
+                            code: 0,
+                            userInfo: [NSLocalizedDescriptionKey: message]
+                        )
+                    )
+                }
             }
         }
     }

--- a/fichero/fichero/Views/Notes/NoteDetailView.swift
+++ b/fichero/fichero/Views/Notes/NoteDetailView.swift
@@ -1,24 +1,6 @@
 import FicheroAPIClient
 import SwiftUI
 
-struct NoteUpdateActionParams: Encodable {
-    let noteId: String
-    let update: Components.Schemas.NotePatchRequest
-
-    enum CodingKeys: String, CodingKey {
-        case noteId = "note_id"
-        case update
-    }
-}
-
-struct NoteDeleteActionParams: Encodable {
-    let noteId: String
-
-    enum CodingKeys: String, CodingKey {
-        case noteId = "note_id"
-    }
-}
-
 /// Shared renderer for one note.
 struct NoteDetailView: View {
     let item: NoteSelectionItem?


### PR DESCRIPTION
Build-verified (TEST BUILD SUCCEEDED; rebased over disjoint engine).
- #3453 remove dead action-param structs
- #3450 client-side aggregate entities across a folder's children
- #3444 multi-level undo walking the audit log
- #3457 focused switcher-mapping tests
🤖 Generated with [Claude Code](https://claude.com/claude-code)