### PR TITLE
Engine: stable document-outline hierarchy + source anchors (#3441)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/document_inspector.py
+++ b/fichero-engine/src/fichero/api/routes/document_inspector.py
@@ -58,6 +58,10 @@ class DocumentOutlineRow(BaseModel):
     kind: str
     label: str
     count: int
+    parent_id: str | None = None
+    source_document_id: str | None = None
+    page_label: str | None = None
+    source_capability: str = "reveal"
 
 
 class DocumentOutlineResponse(BaseModel):
@@ -255,6 +259,9 @@ async def document_outline(
                     + artifact_count_by_doc.get(page.id, 0)
                     + citation_count_by_doc.get(page.id, 0)
                 ),
+                parent_id=document_id,
+                source_document_id=page.id,
+                page_label=str(page.sequence) if page.sequence is not None else None,
             )
         )
 
@@ -271,6 +278,8 @@ async def document_outline(
                     + artifact_count_by_doc.get(chunk.id, 0)
                     + citation_count_by_doc.get(chunk.id, 0)
                 ),
+                parent_id=chunk.parent_id,
+                source_document_id=chunk.parent_id or document_id,
             )
         )
 
@@ -292,6 +301,7 @@ async def document_outline(
                 kind=node.kind,
                 label=node.title,
                 count=sum(claim_count_by_doc.get(pid, 0) for pid in in_range_doc_ids),
+                source_document_id=document_id,
             )
         )
 
@@ -312,6 +322,8 @@ async def document_outline(
             kind="annotation-group",
             label="Annotations",
             count=len(annotations),
+            parent_id=document_id,
+            source_capability="group",
         )
     )
     rows.append(
@@ -321,6 +333,8 @@ async def document_outline(
             kind="entity-group",
             label="Entities",
             count=len(entities),
+            parent_id=document_id,
+            source_capability="group",
         )
     )
 

--- a/fichero-engine/tests/unit/kg/test_inspector_aggregates.py
+++ b/fichero-engine/tests/unit/kg/test_inspector_aggregates.py
@@ -343,6 +343,11 @@ class TestDocumentOutline:
         assert result.document_id == doc.id
         kinds = {row.kind for row in result.rows}
         assert {"page", "chapter", "section", "chunk", "annotation-group", "entity-group"} <= kinds
+        rows = {row.id: row for row in result.rows}
+        assert rows[page1.id].parent_id == doc.id
+        assert rows[page1.id].source_document_id == page1.id
+        assert rows[chunk.id].parent_id == page1.id
+        assert rows[f"{doc.id}:annotations"].source_capability == "group"
         chapter_row = next(row for row in result.rows if row.kind == "chapter")
         assert chapter_row.label == "Chapter 1"
         assert chapter_row.depth == 1


### PR DESCRIPTION
Stable parent hierarchy + source provenance anchors for the document outline — unblocks the inspector outline (#3440) anchor-wiring. Gate: test_inspector_aggregates.py **21 passed** (file scope). Python-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)