### PR TITLE
Inspector: native document outline (structure) + folder-aggregation test (#3440/#3456)

### DIFF
--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -277,4 +277,31 @@ final class DocumentInspectorTests: XCTestCase {
         // switcher clamps to Source rather than showing a dead segment.
         XCTAssertEqual(DocumentInspector.section(for: .edits, in: nil), .source)
     }
+
+    // MARK: - Source outline tree fold (#3440)
+
+    private func outlineRow(_ id: String, depth: Int) -> Components.Schemas.DocumentOutlineRow {
+        Components.Schemas.DocumentOutlineRow(id: id, depth: depth, kind: "section", label: id, count: 0)
+    }
+
+    func testSourceOutlineTreeFoldsFlatDepthRowsIntoHierarchy() {
+        // Flat depth-first rows: doc(0) → [ pageA(1) → [ chunk(2) ], pageB(1) ].
+        let rows = [
+            outlineRow("doc", depth: 0),
+            outlineRow("pageA", depth: 1),
+            outlineRow("chunk", depth: 2),
+            outlineRow("pageB", depth: 1)
+        ]
+        let tree = SourceOutlineNode.tree(from: rows)
+
+        XCTAssertEqual(tree.map(\.id), ["doc"])
+        XCTAssertEqual(tree.first?.children?.map(\.id), ["pageA", "pageB"])
+        XCTAssertEqual(tree.first?.children?.first?.children?.map(\.id), ["chunk"])
+        // A leaf has nil children (so the outline shows no empty disclosure).
+        XCTAssertNil(tree.first?.children?.last?.children)
+    }
+
+    func testSourceOutlineTreeEmptyForNoRows() {
+        XCTAssertTrue(SourceOutlineNode.tree(from: []).isEmpty)
+    }
 }

--- a/fichero/fichero-tests/EntityStoreTests.swift
+++ b/fichero/fichero-tests/EntityStoreTests.swift
@@ -506,4 +506,10 @@ final class EntityStoreTests: XCTestCase {
         ])
         XCTAssertEqual(merged.map(\.canonicalName), ["Ada", "Grace"])
     }
+
+    func testAggregationKeyPrefersIdThenTypeNameFallback() {
+        XCTAssertEqual(EntityStore.aggregationKey(for: aggEntity(id: "e1", name: "Ada")), "e1")
+        // No id → stable type:name key (aggEntity uses .person).
+        XCTAssertEqual(EntityStore.aggregationKey(for: aggEntity(id: nil, name: "Ada")), "person:Ada")
+    }
 }

--- a/fichero/fichero/Services/DocumentServiceGenerated.swift
+++ b/fichero/fichero/Services/DocumentServiceGenerated.swift
@@ -178,6 +178,28 @@ class DocumentServiceGenerated {
         }
     }
 
+    /// Hierarchical source outline for a document (#3440). Flat depth-ordered
+    /// rows (id/depth/kind/label/count) the inspector folds into a native
+    /// OutlineView. Typed OpenAPI op — no hand-rolled URL. Source anchors for
+    /// reveal are added by #3441.
+    func documentOutline(_ id: String) async throws -> [Components.Schemas.DocumentOutlineRow] {
+        logger.info("Fetching outline for document: \(id)")
+
+        let response = try await client.api.documentOutlineApiDocumentsDocumentIdOutlineGet(.init(
+            path: .init(documentId: id)
+        ))
+
+        switch response {
+        case .ok(let ok):
+            return try ok.body.json.rows
+        case .unprocessableContent(let error):
+            let detail = try? error.body.json
+            throw DocumentServiceError.serverError(detail?.detail?.description ?? "Validation error")
+        default:
+            throw DocumentServiceError.unexpectedResponse
+        }
+    }
+
     /// Export the library (or a subtree) as an Eleventy (11ty) static site
     /// (#3055 / #2755 remnant). Routed through the generated, tokened client with
     /// typed errors (no hand-rolled URLSession).

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
@@ -300,12 +300,9 @@ struct DocumentInspector: View {
 
     @ViewBuilder
     private func contentTab(for doc: Document) -> some View {
-        VStack(spacing: 0) {
-            DisplayAttributesStrip(document: doc)
-            Divider()
-            DocumentInspectorContentV2(document: doc, mode: .pageContentOnly)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
+        // Source section = a Content / Outline mode toggle (#3440). The native
+        // document Outline is a hierarchy mode within Source, not a new tab.
+        SourceSectionView(document: doc)
     }
 
     @ViewBuilder

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorContentV2.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorContentV2.swift
@@ -1,3 +1,4 @@
+import FicheroAPIClient
 import SwiftUI
 
 /// V2 inspector Content tab. Tinderbox-style layout:
@@ -347,4 +348,207 @@ func persistPageContent(
     return await documentStore.savePageContent(documentId: id) {
         try await documentService.updateDocument(id, pageContent: content)
     }
+}
+
+// MARK: - Source outline (#3440)
+
+/// Document-scoped observable store for the generated source outline (#3440).
+///
+/// Wraps `GET /api/documents/{id}/outline` through the injected
+/// `DocumentServiceGenerated` — no hand-rolled URL, no view-owned fetch. Holds
+/// the flat, depth-ordered rows; the view folds them into a hierarchy.
+///
+/// Source **anchors** for reveal-in-Preview are engine work (#3441): today the
+/// rows carry only id / depth / kind / label / count, so this is a native
+/// hierarchy/drill-down mode, and rows do not pretend to be source anchors.
+@MainActor
+@Observable
+final class DocumentOutlineStore {
+    private(set) var rows: [Components.Schemas.DocumentOutlineRow] = []
+    private(set) var isLoading = false
+    private(set) var loadError: String?
+    private(set) var loadedDocumentId: String?
+
+    func load(
+        documentId: String,
+        using service: DocumentServiceGenerated,
+        force: Bool = false
+    ) async {
+        if !force, loadedDocumentId == documentId, loadError == nil { return }
+        isLoading = true
+        loadError = nil
+        defer { isLoading = false }
+        do {
+            rows = try await service.documentOutline(documentId)
+            loadedDocumentId = documentId
+        } catch is CancellationError {
+            // Superseded by a newer selection — keep current state.
+        } catch {
+            rows = []
+            loadError = error.localizedDescription
+            loadedDocumentId = nil
+        }
+    }
+}
+
+/// One node in the source-outline tree — the flat depth-list folded into a
+/// hierarchy for the native `OutlineGroup` (#3440).
+struct SourceOutlineNode: Identifiable, Hashable {
+    let row: Components.Schemas.DocumentOutlineRow
+    var children: [SourceOutlineNode]?
+
+    var id: String { row.id }
+
+    /// Fold a flat, depth-ordered row list into a tree. Rows arrive depth-first
+    /// (a parent immediately followed by its deeper descendants), with `depth`
+    /// giving the level, so a recursive descent reconstructs the hierarchy.
+    /// `children` is `nil` (not `[]`) for leaves, so the native outline shows a
+    /// disclosure triangle only where there is something to expand. Pure + testable.
+    static func tree(
+        from rows: [Components.Schemas.DocumentOutlineRow]
+    ) -> [SourceOutlineNode] {
+        guard let minDepth = rows.map(\.depth).min() else { return [] }
+        var index = 0
+
+        func parse(atDepth depth: Int) -> [SourceOutlineNode] {
+            var nodes: [SourceOutlineNode] = []
+            while index < rows.count, rows[index].depth == depth {
+                let row = rows[index]
+                index += 1
+                let children: [SourceOutlineNode]?
+                if index < rows.count, rows[index].depth > depth {
+                    children = parse(atDepth: depth + 1)
+                } else {
+                    children = nil
+                }
+                nodes.append(SourceOutlineNode(row: row, children: children))
+            }
+            return nodes
+        }
+
+        return parse(atDepth: minDepth)
+    }
+}
+
+/// Native document outline (#3440): the generated source hierarchy rendered as a
+/// SwiftUI `List` with disclosure, so keyboard navigation, VoiceOver, and
+/// full-row selection come from the platform. A deliberate hierarchy MODE inside
+/// the Source section (see ``SourceSectionView``), not a permanent tab.
+///
+/// Source reveal for page/structural rows lands with #3441 (stable anchors);
+/// until then this is drill-down/overview only.
+struct SourceOutlineView: View {
+    let documentId: String
+
+    @Environment(DocumentServiceGenerated.self) private var documentService
+    @State private var store = DocumentOutlineStore()
+    @State private var selection: String?
+
+    var body: some View {
+        Group {
+            if store.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if let loadError = store.loadError {
+                ContentUnavailableView {
+                    Label("Couldn’t load outline", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(loadError)
+                } actions: {
+                    Button("Retry") {
+                        Task { await store.load(documentId: documentId, using: documentService, force: true) }
+                    }
+                }
+            } else if store.rows.isEmpty {
+                ContentUnavailableView(
+                    "No outline",
+                    systemImage: "list.bullet.indent",
+                    description: Text("This document has no structural outline yet.")
+                )
+            } else {
+                List(
+                    SourceOutlineNode.tree(from: store.rows),
+                    children: \.children,
+                    selection: $selection
+                ) { node in
+                    outlineRow(node.row)
+                }
+                .listStyle(.inset)
+            }
+        }
+        .task(id: documentId) {
+            await store.load(documentId: documentId, using: documentService)
+        }
+    }
+
+    private func outlineRow(_ row: Components.Schemas.DocumentOutlineRow) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: Self.icon(forKind: row.kind))
+                .foregroundStyle(.secondary)
+                .font(.caption)
+            Text(row.label)
+                .lineLimit(1)
+            Spacer(minLength: 4)
+            if row.count > 0 {
+                Text("\(row.count)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .inspectorListRowTarget()
+        .help(row.label)
+    }
+
+    /// SF Symbol for an outline row kind. Falls back to a generic marker so a new
+    /// backend kind still renders (rather than a blank row).
+    static func icon(forKind kind: String) -> String {
+        switch kind.lowercased() {
+        case "document", "file": return "doc.text"
+        case "folder", "collection": return "folder"
+        case "page": return "doc"
+        case "section", "chunk": return "text.alignleft"
+        case "entity", "person", "place", "organization": return "person.crop.circle"
+        case "claim": return "quote.bubble"
+        default: return "circle.fill"
+        }
+    }
+}
+
+/// The Source section body: a deliberate **mode** toggle between the page
+/// Content view and the native document Outline (#3440) — Outline is a hierarchy
+/// mode within Source, not another permanent inspector tab.
+struct SourceSectionView: View {
+    let document: Document
+
+    @SceneStorage("inspector.source.mode") private var mode: SourceSectionMode = .content
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Picker("Source view", selection: $mode) {
+                Text("Content").tag(SourceSectionMode.content)
+                Text("Outline").tag(SourceSectionMode.outline)
+            }
+            .pickerStyle(.segmented)
+            .labelsHidden()
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            Divider()
+
+            switch mode {
+            case .content:
+                DisplayAttributesStrip(document: document)
+                Divider()
+                DocumentInspectorContentV2(document: document, mode: .pageContentOnly)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case .outline:
+                SourceOutlineView(documentId: document.id)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+        }
+    }
+}
+
+enum SourceSectionMode: String, CaseIterable {
+    case content
+    case outline
 }


### PR DESCRIPTION
Native OutlineView document outline (structure-only; source-anchor wiring follows now that engine #3441 landed) + folder-aggregation key-fallback test. TEST BUILD SUCCEEDED. 🤖 Generated with [Claude Code](https://claude.com/claude-code)