### PR TITLE
Engine: persist annotation ink + OCR provenance (#3438)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/annotations.py
+++ b/fichero-engine/src/fichero/api/routes/annotations.py
@@ -47,6 +47,12 @@ class AnnotationCreateRequest(BaseModel):
     bbox: list[float] | None = None
     anchor_kind: str | None = None
     paragraph_index: int | None = None
+    ink_payload: str | None = None
+    ocr_text: str | None = None
+    ocr_provider: str | None = None
+    ocr_model: str | None = None
+    ocr_confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    ocr_recorded_at: datetime | None = None
     text: str | None = None
     rating: int | None = Field(default=None, ge=1, le=5)
     color: str | None = None
@@ -248,6 +254,13 @@ class AnnotationPatchRequest(BaseModel):
     char_end: int | None = None
     bbox: list[float] | None = None
     anchor_kind: str | None = None
+    paragraph_index: int | None = None
+    ink_payload: str | None = None
+    ocr_text: str | None = None
+    ocr_provider: str | None = None
+    ocr_model: str | None = None
+    ocr_confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    ocr_recorded_at: datetime | None = None
     paragraph_index: int | None = None
     metadata: dict[str, Any] | None = None
 

--- a/fichero-engine/src/fichero/knowledge/knowledge_models.py
+++ b/fichero-engine/src/fichero/knowledge/knowledge_models.py
@@ -1348,6 +1348,12 @@ class Annotation(BaseModel):
     # 0-indexed paragraph within the page, set when anchor_kind == "paragraph"
     # (paragraph checkmarks). Resolved against page_content paragraph offsets.
     paragraph_index: int | None = None
+    ink_payload: str | None = None
+    ocr_text: str | None = None
+    ocr_provider: str | None = None
+    ocr_model: str | None = None
+    ocr_confidence: float | None = Field(default=None, ge=0.0, le=1.0)
+    ocr_recorded_at: datetime | None = None
 
     kind: AnnotationKind
     text: str | None = None  # note body / comment text / bookmark label

--- a/fichero-engine/tests/unit/test_routes_annotations_actions.py
+++ b/fichero-engine/tests/unit/test_routes_annotations_actions.py
@@ -381,6 +381,26 @@ class TestAnnotationDeleteRestoreActions:
 
 
 class TestAnnotationRoutesWriteActionAudit:
+    def test_create_round_trips_ink_and_ocr_provenance(self, client, db):
+        doc = _mk_doc(db)
+        response = client.post(
+            "/api/annotations",
+            json={
+                "document_id": doc.id,
+                "kind": "note",
+                "anchor_kind": "paragraph",
+                "paragraph_index": 2,
+                "ink_payload": "pencilkit-data",
+                "ocr_text": "marginal note",
+                "ocr_provider": "apple",
+                "ocr_model": "vision",
+                "ocr_confidence": 0.9,
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["ink_payload"] == "pencilkit-data"
+        assert response.json()["ocr_text"] == "marginal note"
+
     def test_create_patch_delete_routes_write_action_audit(self, client, db):
         doc = _mk_doc(db)
 


### PR DESCRIPTION
Annotations API persists editable ink + OCR provenance + anchors. Gate: test_routes_annotations_actions.py **29 passed**. Python-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)