### PR TITLE
Inspector: wire document outline to source anchors (#3440 completion)

### DIFF
--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -20660,6 +20660,140 @@
         }
       }
     },
+    "/api/kg/pykeen/reviews": {
+      "post": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Create Prediction Review",
+        "operationId": "create_prediction_review_api_kg_pykeen_reviews_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KnowledgePredictionReview"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgePredictionReview"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "List Prediction Reviews",
+        "operationId": "list_prediction_reviews_api_kg_pykeen_reviews_get",
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/PredictionReviewState",
+              "nullable": true,
+              "title": "State"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PykeenListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/pykeen/reviews/{review_id}": {
+      "patch": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Decide Prediction Review",
+        "operationId": "decide_prediction_review_api_kg_pykeen_reviews__review_id__patch",
+        "parameters": [
+          {
+            "name": "review_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Review Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictionReviewDecision"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgePredictionReview"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/kg/pykeen/training-jobs": {
       "get": {
         "tags": [
@@ -34118,6 +34252,26 @@
             "type": "boolean",
             "title": "Reviewed"
           },
+          "source_artifact_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Source Artifact Id"
+          },
+          "source_document_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Source Document Id"
+          },
+          "run_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Run Id"
+          },
+          "step_name": {
+            "type": "string",
+            "nullable": true,
+            "title": "Step Name"
+          },
           "created_at": {
             "type": "string",
             "title": "Created At"
@@ -40398,6 +40552,26 @@
           "count": {
             "type": "integer",
             "title": "Count"
+          },
+          "parent_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Parent Id"
+          },
+          "source_document_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Source Document Id"
+          },
+          "page_label": {
+            "type": "string",
+            "nullable": true,
+            "title": "Page Label"
+          },
+          "source_capability": {
+            "type": "string",
+            "title": "Source Capability",
+            "default": "reveal"
           }
         },
         "type": "object",
@@ -45719,6 +45893,85 @@
           "target_id"
         ],
         "title": "KnowledgeGraphInclusion"
+      },
+      "KnowledgePredictionReview": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "run_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Run Id"
+          },
+          "source_entity_id": {
+            "type": "string",
+            "title": "Source Entity Id"
+          },
+          "relation": {
+            "type": "string",
+            "title": "Relation"
+          },
+          "target_entity_id": {
+            "type": "string",
+            "title": "Target Entity Id"
+          },
+          "score": {
+            "type": "number",
+            "title": "Score"
+          },
+          "rank": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Rank"
+          },
+          "model_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Model Id"
+          },
+          "model_config_snapshot": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Model Config Snapshot"
+          },
+          "state": {
+            "$ref": "#/components/schemas/PredictionReviewState",
+            "default": "pending"
+          },
+          "decision_note": {
+            "type": "string",
+            "nullable": true,
+            "title": "Decision Note"
+          },
+          "resulting_claim_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Resulting Claim Id"
+          },
+          "reviewed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Reviewed At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "source_entity_id",
+          "relation",
+          "target_entity_id",
+          "score"
+        ],
+        "title": "KnowledgePredictionReview",
+        "description": "Persisted, library-scoped human review of one predicted edge."
       },
       "KnownLibrary": {
         "properties": {
@@ -51351,6 +51604,38 @@
         ],
         "title": "PredictionResult",
         "description": "Single link prediction result."
+      },
+      "PredictionReviewDecision": {
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/PredictionReviewState"
+          },
+          "note": {
+            "type": "string",
+            "nullable": true,
+            "title": "Note"
+          },
+          "resulting_claim_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Resulting Claim Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "title": "PredictionReviewDecision"
+      },
+      "PredictionReviewState": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "accepted",
+          "rejected",
+          "deferred"
+        ],
+        "title": "PredictionReviewState"
       },
       "PredictionType": {
         "type": "string",

--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -304,4 +304,35 @@ final class DocumentInspectorTests: XCTestCase {
     func testSourceOutlineTreeEmptyForNoRows() {
         XCTAssertTrue(SourceOutlineNode.tree(from: []).isEmpty)
     }
+
+    // MARK: - Source outline reveal anchor (#3440 + #3441)
+
+    func testOutlineNavigationRequestForRevealCapableRow() {
+        let row = Components.Schemas.DocumentOutlineRow(
+            id: "p1",
+            depth: 1,
+            kind: "page",
+            label: "Page 1",
+            count: 0,
+            sourceDocumentId: "doc-9",
+            pageLabel: "p. 1",
+            sourceCapability: "reveal"
+        )
+        let request = SourceOutlineNode.navigationRequest(for: row)
+        XCTAssertEqual(request?.documentId, "doc-9")
+        XCTAssertEqual(request?.pageLabel, "p. 1")
+    }
+
+    func testOutlineNavigationRequestNilForGroupOrAnchorlessRow() {
+        // Group/structural row without a source anchor must NOT fake one.
+        let group = Components.Schemas.DocumentOutlineRow(
+            id: "g", depth: 0, kind: "entities", label: "Entities", count: 5
+        )
+        XCTAssertNil(SourceOutlineNode.navigationRequest(for: group))
+        // Reveal capability but no document id → still nil.
+        let noDoc = Components.Schemas.DocumentOutlineRow(
+            id: "x", depth: 1, kind: "page", label: "P", count: 0, sourceCapability: "reveal"
+        )
+        XCTAssertNil(SourceOutlineNode.navigationRequest(for: noDoc))
+    }
 }

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorContentV2.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorContentV2.swift
@@ -428,6 +428,22 @@ struct SourceOutlineNode: Identifiable, Hashable {
 
         return parse(atDepth: minDepth)
     }
+
+    /// The source anchor for an outline row, or nil for a group/structural row
+    /// that isn't a source anchor (#3440 + #3441). Page/structural rows the
+    /// engine marks reveal-capable (`sourceCapability == "reveal"`) with a
+    /// document id route through the shared source-navigation contract; group
+    /// rows (no anchor) deliberately return nil rather than fake one. Pure +
+    /// testable.
+    static func navigationRequest(
+        for row: Components.Schemas.DocumentOutlineRow
+    ) -> ClaimSourceNavigationRequest? {
+        guard row.sourceCapability == "reveal",
+              let documentId = row.sourceDocumentId,
+              !documentId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else { return nil }
+        return ClaimSourceNavigationRequest(documentId: documentId, pageLabel: row.pageLabel)
+    }
 }
 
 /// Native document outline (#3440): the generated source hierarchy rendered as a
@@ -441,6 +457,9 @@ struct SourceOutlineView: View {
     let documentId: String
 
     @Environment(DocumentServiceGenerated.self) private var documentService
+    /// Per-window typed source-navigation bus (#3437) — reveal-capable outline
+    /// rows route their source anchor through it, same contract as claims (#3440).
+    @Environment(ClaimSourceNavigationState.self) private var claimSourceNavigationState: ClaimSourceNavigationState?
     @State private var store = DocumentOutlineStore()
     @State private var selection: String?
 
@@ -478,6 +497,14 @@ struct SourceOutlineView: View {
         }
         .task(id: documentId) {
             await store.load(documentId: documentId, using: documentService)
+        }
+        // Selecting a reveal-capable page/structural row drives the reader to its
+        // source via the shared contract (#3440/#3441); group rows no-op.
+        .onChange(of: selection) { _, newSelection in
+            guard let newSelection,
+                  let row = store.rows.first(where: { $0.id == newSelection }),
+                  let request = SourceOutlineNode.navigationRequest(for: row) else { return }
+            claimSourceNavigationState?.request(request)
         }
     }
 


### PR DESCRIPTION
Completes #3440 — outline rows now navigate to source anchors (engine #3441). TEST BUILD SUCCEEDED. 🤖 Generated with [Claude Code](https://claude.com/claude-code)