### PR TITLE
Engine: typed annotation list response schema (#3435)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/annotations.py
+++ b/fichero-engine/src/fichero/api/routes/annotations.py
@@ -28,11 +28,18 @@ from fichero.knowledge_models import (
     validate_annotation_color,
 )
 from fichero.utf16_offsets import utf16_range_to_codepoint_range
-from fichero.models import AnnotationListResponse, DocType, Document
+from fichero.models import DocType, Document
 from fichero.storage import resolve_source
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/annotations")
+
+
+class AnnotationListResponse(BaseModel):
+    """Typed annotation list envelope for the OpenAPI client."""
+
+    items: list[Annotation]
+    count: int
 
 
 class AnnotationCreateRequest(BaseModel):

--- a/fichero-engine/tests/unit/test_annotation_list_schema.py
+++ b/fichero-engine/tests/unit/test_annotation_list_schema.py
@@ -1,0 +1,6 @@
+from fichero.api.routes.annotations import AnnotationListResponse
+
+
+def test_annotation_list_schema_has_typed_items():
+    items = AnnotationListResponse.model_json_schema()["properties"]["items"]
+    assert items["items"]["$ref"].endswith("/Annotation")


### PR DESCRIPTION
Annotation list items now a typed OpenAPI schema (was list[Any]). Gate: test_annotation_list_schema.py 1 passed. Python-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)