### PR TITLE
Engine: typed content representations + revisions + API (#3443)

### DIFF
--- a/fichero-engine/src/fichero/api/main.py
+++ b/fichero-engine/src/fichero/api/main.py
@@ -1315,6 +1315,7 @@ from fichero.api.routes import (  # noqa: E402
     citation_usages,
     citation_rendering,
     citations,
+    content_representations,
     claim_curation,
     claim_links,
     claims,
@@ -1394,6 +1395,7 @@ _CORE_ROUTE_SPECS: list[RouteSpec] = [
     # unconditionally.
     (changes.router, "/api", ["changes"]),
     (annotations.router, "/api", ["annotations"]),
+    (content_representations.router, "/api", ["content-representations"]),
     (notes.router, "/api", ["notes"]),
     (projects.router, "/api", ["projects"]),
     (artifacts.router, "/api/artifacts", ["artifacts"]),

--- a/fichero-engine/src/fichero/api/routes/content_representations.py
+++ b/fichero-engine/src/fichero/api/routes/content_representations.py
@@ -1,0 +1,48 @@
+"""Audited content-representation revision actions (#3443)."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+from fichero.actions.registry import ActionContext, ChangeSpec, action
+from fichero.db import Database
+from fichero.models import ContentRepresentation, ContentRepresentationRevision
+
+
+class RepresentationRevisionParams(BaseModel):
+    representation_id: str
+    content: str = Field(min_length=1)
+    decision: str | None = None
+
+
+@action(
+    "representation.revise",
+    RepresentationRevisionParams,
+    domains=["representation"],
+    undoable=False,
+)
+def revise_representation(
+    db: Database,
+    params: RepresentationRevisionParams,
+    ctx: ActionContext,
+) -> tuple[dict, ChangeSpec]:
+    """Create a user revision without changing the source representation."""
+    representation = db.get(ContentRepresentation, params.representation_id)
+    if representation is None:
+        raise LookupError(f"Content representation not found: {params.representation_id}")
+    revision = ContentRepresentationRevision(
+        representation_id=representation.id,
+        content=params.content,
+        reviewer=ctx.actor,
+        decision=params.decision,
+    )
+    db.save(revision)
+    snapshot = revision.model_dump(mode="json")
+    return snapshot, ChangeSpec(
+        domains=["representation"],
+        target_ids=[representation.id, revision.id],
+        before=None,
+        after=snapshot,
+        emit_type="representation.revised",
+        document_ids=[representation.document_id],
+    )

--- a/fichero-engine/src/fichero/api/routes/content_representations.py
+++ b/fichero-engine/src/fichero/api/routes/content_representations.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 from pydantic import BaseModel, Field
+from fastapi import APIRouter, Depends, HTTPException
 
-from fichero.actions.registry import ActionContext, ChangeSpec, action
+from fichero.actions.registry import ActionContext, ChangeSpec, action, registry
+from fichero.api.auth import action_context
+from fichero.api.main import get_library_database, get_library_database_for_write
 from fichero.db import Database
 from fichero.models import ContentRepresentation, ContentRepresentationRevision
+
+router = APIRouter(prefix="/content-representations")
 
 
 class RepresentationRevisionParams(BaseModel):
@@ -46,3 +51,37 @@ def revise_representation(
         emit_type="representation.revised",
         document_ids=[representation.document_id],
     )
+
+
+@router.get("/document/{document_id}", response_model=list[ContentRepresentation])
+async def list_representations(
+    document_id: str,
+    db: Database = Depends(get_library_database),
+) -> list[ContentRepresentation]:
+    return db.query(ContentRepresentation, document_id=document_id)
+
+
+@router.get("/{representation_id}/revisions", response_model=list[ContentRepresentationRevision])
+async def list_revisions(
+    representation_id: str,
+    db: Database = Depends(get_library_database),
+) -> list[ContentRepresentationRevision]:
+    if db.get(ContentRepresentation, representation_id) is None:
+        raise HTTPException(404, f"Content representation not found: {representation_id}")
+    return db.query(ContentRepresentationRevision, representation_id=representation_id)
+
+
+@router.post("/{representation_id}/revisions", response_model=ContentRepresentationRevision)
+async def create_revision(
+    representation_id: str,
+    payload: RepresentationRevisionParams,
+    db: Database = Depends(get_library_database_for_write),
+    ctx: ActionContext = Depends(action_context),
+) -> ContentRepresentationRevision:
+    result = registry.invoke(
+        db,
+        "representation.revise",
+        {**payload.model_dump(), "representation_id": representation_id},
+        ctx,
+    )
+    return ContentRepresentationRevision.model_validate(result.result)

--- a/fichero-engine/src/fichero/models.py
+++ b/fichero-engine/src/fichero/models.py
@@ -614,6 +614,64 @@ class Artifact(BaseModel):
         return None
 
 
+class ContentRepresentationKind(str, Enum):
+    transcription = "transcription"
+    normalized_text = "normalized_text"
+    translation = "translation"
+    transliteration = "transliteration"
+    markdown = "markdown"
+    html = "html"
+    svg = "svg"
+
+
+class ContentReviewState(str, Enum):
+    source = "source"
+    draft = "draft"
+    reviewed = "reviewed"
+
+
+class ContentSourceAnchor(BaseModel):
+    document_id: str
+    page_id: str | None = None
+    char_start: int | None = None
+    char_end: int | None = None
+    bbox: list[float] | None = None
+
+
+class ContentRepresentation(BaseModel):
+    """Immutable source-linked content representation (#3443 slice 1)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str = Field(default_factory=_new_id)
+    document_id: str
+    kind: ContentRepresentationKind
+    content: str
+    language: str | None = None
+    script: str | None = None
+    source_anchor: ContentSourceAnchor
+    parent_representation_id: str | None = None
+    derived_from_representation_id: str | None = None
+    producer_run_id: str | None = None
+    producer_tool: str | None = None
+    producer_model: str | None = None
+    review_state: ContentReviewState = ContentReviewState.source
+    created_at: datetime = Field(default_factory=datetime.now)
+
+
+class ContentRepresentationRevision(BaseModel):
+    """A user-authored revision linked to an immutable representation."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str = Field(default_factory=_new_id)
+    representation_id: str
+    content: str
+    reviewer: str = "human"
+    decision: str | None = None
+    created_at: datetime = Field(default_factory=datetime.now)
+
+
 # =============================================================================
 # Workflow - Pipeline Definition
 # =============================================================================

--- a/fichero-engine/tests/unit/test_content_representations.py
+++ b/fichero-engine/tests/unit/test_content_representations.py
@@ -43,3 +43,16 @@ def test_revision_action_preserves_source_representation(db):
     revision = db.get(ContentRepresentationRevision, result.result["id"])
     assert revision.reviewer == "reviewer"
     assert db.get(ContentRepresentation, representation.id).content == "immutable source"
+
+
+def test_representation_read_routes(client, db):
+    representation = ContentRepresentation(
+        document_id="doc-api",
+        kind=ContentRepresentationKind.markdown,
+        content="# source",
+        source_anchor=ContentSourceAnchor(document_id="doc-api"),
+    )
+    db.save(representation)
+    response = client.get(f"/api/content-representations/document/{representation.document_id}")
+    assert response.status_code == 200
+    assert response.json()[0]["id"] == representation.id

--- a/fichero-engine/tests/unit/test_content_representations.py
+++ b/fichero-engine/tests/unit/test_content_representations.py
@@ -4,6 +4,8 @@ from fichero.models import (
     ContentRepresentationRevision,
     ContentSourceAnchor,
 )
+from fichero.actions.registry import ActionContext, registry
+import fichero.api.routes.content_representations  # noqa: F401
 
 
 def test_representation_and_revision_persist(db):
@@ -22,3 +24,22 @@ def test_representation_and_revision_persist(db):
 
     assert db.get(ContentRepresentation, representation.id).source_anchor.page_id == "page-1"
     assert db.get(ContentRepresentationRevision, revision.id).representation_id == representation.id
+
+
+def test_revision_action_preserves_source_representation(db):
+    representation = ContentRepresentation(
+        document_id="doc-1",
+        kind=ContentRepresentationKind.transcription,
+        content="immutable source",
+        source_anchor=ContentSourceAnchor(document_id="doc-1"),
+    )
+    db.save(representation)
+    result = registry.invoke(
+        db,
+        "representation.revise",
+        {"representation_id": representation.id, "content": "reader correction"},
+        ActionContext(actor="reviewer"),
+    )
+    revision = db.get(ContentRepresentationRevision, result.result["id"])
+    assert revision.reviewer == "reviewer"
+    assert db.get(ContentRepresentation, representation.id).content == "immutable source"

--- a/fichero-engine/tests/unit/test_content_representations.py
+++ b/fichero-engine/tests/unit/test_content_representations.py
@@ -1,0 +1,24 @@
+from fichero.models import (
+    ContentRepresentation,
+    ContentRepresentationKind,
+    ContentRepresentationRevision,
+    ContentSourceAnchor,
+)
+
+
+def test_representation_and_revision_persist(db):
+    representation = ContentRepresentation(
+        document_id="doc-1",
+        kind=ContentRepresentationKind.transcription,
+        content="diplomatic source",
+        source_anchor=ContentSourceAnchor(document_id="doc-1", page_id="page-1", char_start=2, char_end=8),
+    )
+    db.save(representation)
+    revision = ContentRepresentationRevision(
+        representation_id=representation.id,
+        content="reader correction",
+    )
+    db.save(revision)
+
+    assert db.get(ContentRepresentation, representation.id).source_anchor.page_id == "page-1"
+    assert db.get(ContentRepresentationRevision, revision.id).representation_id == representation.id


### PR DESCRIPTION
Content inspector engine — typed representation persistence models, audited immutable-source revisions, and read API. Built in 3 committable slices (models→revisions→API). Gate: test_content_representations.py **3 passed**. Python-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)