### PR TITLE
Engine: honest hermeneutics /suggestions (#3296)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/hermeneutics.py
+++ b/fichero-engine/src/fichero/api/routes/hermeneutics.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 
 from fichero.api.main import get_library_database, get_library_database_for_write
@@ -14,7 +14,6 @@ from fichero.hermeneutics_models import (
     CircleNavigationDirection,
     FrameworkType,
     HermeneuticCircleState,
-    HermesSuggestion,
     HermesSuggestionRequest,
     Interpretation,
     InterpretiveActType,
@@ -164,11 +163,6 @@ class PatternListResponse(BaseModel):
 
 class CircleStateListResponse(BaseModel):
     items: list[HermeneuticCircleState]
-    count: int
-
-
-class HermesSuggestionListResponse(BaseModel):
-    items: list[HermesSuggestion]
     count: int
 
 
@@ -745,59 +739,19 @@ async def backtrack_circle(
 
 
 # ─────────────────────────────────────────────────────────────────────────────
-# AI Interpretation Suggestions (placeholder — requires LLM provider integration)
+# AI Interpretation Suggestions
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-@router.post("/suggestions", response_model=HermesSuggestionListResponse)
+@router.post("/suggestions", status_code=status.HTTP_501_NOT_IMPLEMENTED)
 async def suggest_interpretations(
     request: HermesSuggestionRequest,
-    db: Database = Depends(get_library_database),
-) -> HermesSuggestionListResponse:
-    """Generate AI interpretation suggestions for claims.
-
-    Uses the configured LLM providers (via LangChain) to suggest how
-    frameworks might be applied to the given claims. Returns ranked
-    suggestions.
-    """
-    if request.num_suggestions < 1 or request.num_suggestions > 10:
-        raise HTTPException(
-            status_code=400, detail="num_suggestions must be between 1 and 10"
-        )
-
-    # Load requested frameworks (or all active if none specified)
-    if request.framework_ids:
-        frameworks = [
-            db.get(InterpretiveFramework, fid) for fid in request.framework_ids
-        ]
-        frameworks = [f for f in frameworks if f and f.is_active]
-    else:
-        frameworks = [f for f in db.all(InterpretiveFramework) if f.is_active]
-
-    if not frameworks:
-        raise HTTPException(status_code=400, detail="No active frameworks available")
-
-    suggestions: list[HermesSuggestion] = []
-
-    for framework in frameworks[: request.num_suggestions]:
-        suggestion = HermesSuggestion(
-            framework_id=framework.id,
-            framework_name=framework.name,
-            interpretation_text=(
-                f"Apply {framework.name} ({framework.framework_type.value}) framework: "
-                f"{framework.description[:200]}..."
-            ),
-            confidence=0.5,
-            reasoning=(
-                f"Framework '{framework.name}' is relevant based on its "
-                f"core questions: {'; '.join(framework.core_questions[:2])}"
-            ),
-            act=InterpretiveActType.contextualizing,
-            key_insights=framework.key_concepts[:3],
-        )
-        suggestions.append(suggestion)
-
-    return HermesSuggestionListResponse(items=suggestions, count=len(suggestions))
+) -> None:
+    """Report that grounded interpretation suggestions are not available yet."""
+    raise HTTPException(
+        status_code=status.HTTP_501_NOT_IMPLEMENTED,
+        detail="Grounded AI interpretation suggestions are not implemented.",
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/fichero-engine/src/fichero/mcp_kg_tools.py
+++ b/fichero-engine/src/fichero/mcp_kg_tools.py
@@ -479,7 +479,7 @@ TOOLS: list[types.Tool] = [
     ),
     types.Tool(
         name="fichero_hm_suggest_interpretations",
-        description="Get AI-suggested interpretations for claims using available frameworks",
+        description="Reserved for grounded AI interpretation suggestions; currently unavailable",
         inputSchema={
             "type": "object",
             "properties": {

--- a/fichero-engine/tests/unit/test_hermeneutics_api.py
+++ b/fichero-engine/tests/unit/test_hermeneutics_api.py
@@ -271,7 +271,7 @@ def test_circle_state_not_found(client):
 
 
 def test_interpretation_suggestions(client, db):
-    """AI interpretation suggestions return framework-based recommendations."""
+    """Suggestions are unavailable until a grounded LLM path exists."""
     # Create a framework
     fw_resp = client.post(
         "/api/hermeneutics/frameworks",
@@ -297,15 +297,12 @@ def test_interpretation_suggestions(client, db):
             "num_suggestions": 3,
         },
     )
-    assert sugg_resp.status_code == 200
-    suggestions = sugg_resp.json()
-    assert suggestions["count"] >= 1
-    assert suggestions["items"][0]["framework_id"] == fw["id"]
-    assert suggestions["items"][0]["framework_name"] == "Annales School"
+    assert sugg_resp.status_code == 501
+    assert sugg_resp.json()["detail"] == "Grounded AI interpretation suggestions are not implemented."
 
 
-def test_interpretation_suggestions_no_frameworks(client, db):
-    """Suggestions fails gracefully when no active frameworks exist."""
+def test_interpretation_suggestions_is_unavailable_without_frameworks(client, db):
+    """Unsupported suggestions never fabricate output based on framework state."""
     resp = client.post(
         "/api/hermeneutics/suggestions",
         json={
@@ -313,8 +310,8 @@ def test_interpretation_suggestions_no_frameworks(client, db):
             "num_suggestions": 3,
         },
     )
-    assert resp.status_code == 400
-    assert "No active frameworks" in resp.json()["detail"]
+    assert resp.status_code == 501
+    assert resp.json()["detail"] == "Grounded AI interpretation suggestions are not implemented."
 
 
 def test_interpretation_suggestions_invalid_num(client, db):

--- a/fichero-engine/tests/unit/test_hermeneutics_security.py
+++ b/fichero-engine/tests/unit/test_hermeneutics_security.py
@@ -1,13 +1,8 @@
 """Security tests for Phase 2 Hermeneutics components.
 
-These tests verify that hermeneutics endpoints are secure and document
-future LLM injection risks when LiteLLM integration is added.
+These tests verify that hermeneutics endpoints are secure and do not fabricate
+LLM output.
 """
-
-import re
-from unittest.mock import MagicMock, patch
-
-import pytest
 
 
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -70,14 +65,10 @@ class TestFrameworkSecurity:
 
 
 class TestLLMInjectionFutureRisk:
-    """Test future LLM injection risks (placeholder code)."""
+    """Test the unavailable suggestion path and future prompt inputs."""
 
-    def test_suggestions_endpoint_is_placeholder(self, client):
-        """MEDIUM-1: /suggestions should be placeholder (no live LLM).
-
-        Verifies that the suggestions endpoint returns mock data
-        rather than calling an actual LLM.
-        """
+    def test_suggestions_endpoint_is_explicitly_unavailable(self, client):
+        """MEDIUM-1: /suggestions does not present placeholder text as AI output."""
         from fichero.hermeneutics_models import HermesSuggestionRequest
 
         # Create a framework first
@@ -102,11 +93,8 @@ class TestLLMInjectionFutureRisk:
             ).model_dump(),
         )
 
-        assert resp.status_code == 200
-        suggestions = resp.json()
-
-        # Should return suggestions (mock data currently)
-        assert len(suggestions) >= 0
+        assert resp.status_code == 501
+        assert resp.json()["detail"] == "Grounded AI interpretation suggestions are not implemented."
 
     def test_framework_injection_markers_detected(self):
         """MEDIUM-1: Framework fields could contain injection markers.
@@ -136,18 +124,3 @@ class TestLLMInjectionFutureRisk:
             # Should store without modification
             # Future: should sanitize before LLM prompt
             assert pattern in framework.name or pattern in framework.description
-
-    def test_suggestions_need_sanitization_when_llm_added(self):
-        """MEDIUM-1: Future LLM integration requires prompt sanitization.
-
-        This test documents the requirement for prompt sanitization
-        when LiteLLM is integrated into /suggestions.
-        """
-        # Document required sanitization patterns
-        required_sanitization = [
-            r"ignore\s+(previous|all|prior)\s+instructions",
-            r"system\s+prompt",
-            r"you\s+are\s+now",
-            r"disregard",
-            r"<",
-        ]

--- a/fichero-engine/tests/unit/test_openapi_response_models.py
+++ b/fichero-engine/tests/unit/test_openapi_response_models.py
@@ -60,9 +60,3 @@ def test_hermeneutics_list_routes_have_typed_item_envelopes() -> None:
     for path, (envelope, item) in cases.items():
         assert _response_schema("get", path)["$ref"].endswith(envelope)
         assert schemas[envelope]["properties"]["items"]["items"]["$ref"].endswith(item)
-    assert _response_schema("post", "/api/hermeneutics/suggestions")["$ref"].endswith(
-        "HermesSuggestionListResponse"
-    )
-    assert schemas["HermesSuggestionListResponse"]["properties"]["items"]["items"]["$ref"].endswith(
-        "HermesSuggestion"
-    )


### PR DESCRIPTION
/suggestions no longer fabricates template text + hardcoded 0.5 confidence — returns an honest unavailable/unsupported response. Gate: test_hermeneutics_api.py 12 passed. Python-only. 🤖 Generated with [Claude Code](https://claude.com/claude-code)