### PR TITLE
Inspector: round out foundation + UX test coverage (#3456/#3457)

### DIFF
--- a/fichero/fichero-tests/DocumentInspectorTests.swift
+++ b/fichero/fichero-tests/DocumentInspectorTests.swift
@@ -336,6 +336,22 @@ final class DocumentInspectorTests: XCTestCase {
         XCTAssertNil(SourceOutlineNode.navigationRequest(for: noDoc))
     }
 
+    // MARK: - UX hooks for the switcher + provenance (#3457)
+
+    func testSwitcherAndProvenanceUIHooksArePresent() throws {
+        let inspector = try Self.appSource("Views/Library/DocumentInspector/DocumentInspector.swift")
+        // Top-icon-row switcher exposes per-section + bar XCUITest hooks (#3457).
+        XCTAssertTrue(inspector.contains("accessibilityIdentifier(section.accessibilityIdentifier)"))
+        XCTAssertTrue(inspector.contains("\"inspectorSectionBar\""))
+
+        // Provenance quick-look popover is wired on KG claim rows (#3449/#3457).
+        let claimRow = try Self.appSource(
+            "Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntityKindRow.swift"
+        )
+        XCTAssertTrue(claimRow.contains("SourceProvenanceCard("))
+        XCTAssertTrue(claimRow.contains(".onHover"))
+    }
+
     // MARK: - Interpretation inspector on the injected store (#3429)
 
     func testInterpretationSectionUsesInjectedStoreNotGlobalLibrary() throws {

--- a/fichero/fichero-tests/InspectorSectionTests.swift
+++ b/fichero/fichero-tests/InspectorSectionTests.swift
@@ -51,4 +51,18 @@ final class InspectorSectionTests: XCTestCase {
         // a tab of their own.
         XCTAssertEqual(InspectorSection.section(for: .citations), .knowledge)
     }
+
+    // MARK: - XCUITest a11y hook contract (#3456/#3457)
+
+    func testAccessibilityIdentifierIsStableAndUniquePerSection() {
+        // The top-icon-row switcher exposes one stable per-section id that the
+        // UX/XCUITest layer targets — locking the format guards those tests.
+        XCTAssertEqual(InspectorSection.source.accessibilityIdentifier, "inspectorSection-Source")
+        XCTAssertEqual(InspectorSection.artifacts.accessibilityIdentifier, "inspectorSection-Artifacts")
+        XCTAssertEqual(InspectorSection.knowledge.accessibilityIdentifier, "inspectorSection-Knowledge")
+        XCTAssertEqual(InspectorSection.notes.accessibilityIdentifier, "inspectorSection-Notes")
+
+        let ids = InspectorSection.allCases.map(\.accessibilityIdentifier)
+        XCTAssertEqual(Set(ids).count, InspectorSection.allCases.count, "each section needs a unique hook")
+    }
 }


### PR DESCRIPTION
Focused unit + UX tests for the 4-tab foundation (stores, source-nav, scope) and UX (switcher, selection, provenance). TEST BUILD SUCCEEDED. 🤖 Generated with [Claude Code](https://claude.com/claude-code)