### PR TITLE
Regen: OpenAPI spec + client contract for merged inspector endpoints (#3442)

### DIFF
--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Fichero API",
     "description": "Document processing and search API",
-    "version": "0.1.0.dev1"
+    "version": "2026.7.3b1"
   },
   "paths": {
     "/api/health": {
@@ -2495,6 +2495,158 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PromoteResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content-representations/document/{document_id}": {
+      "get": {
+        "tags": [
+          "content-representations"
+        ],
+        "summary": "List Representations",
+        "operationId": "list_representations_api_content_representations_document__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContentRepresentation"
+                  },
+                  "title": "Response List Representations Api Content Representations Document  Document Id  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content-representations/{representation_id}/revisions": {
+      "get": {
+        "tags": [
+          "content-representations"
+        ],
+        "summary": "List Revisions",
+        "operationId": "list_revisions_api_content_representations__representation_id__revisions_get",
+        "parameters": [
+          {
+            "name": "representation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Representation Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContentRepresentationRevision"
+                  },
+                  "title": "Response List Revisions Api Content Representations  Representation Id  Revisions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "content-representations"
+        ],
+        "summary": "Create Revision",
+        "operationId": "create_revision_api_content_representations__representation_id__revisions_post",
+        "parameters": [
+          {
+            "name": "representation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Representation Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepresentationRevisionParams"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentRepresentationRevision"
                 }
               }
             }
@@ -20469,6 +20621,16 @@
               "type": "string",
               "title": "Entity Id"
             }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
           }
         ],
         "responses": {
@@ -20643,6 +20805,140 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/KGGraphListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/pykeen/reviews": {
+      "post": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Create Prediction Review",
+        "operationId": "create_prediction_review_api_kg_pykeen_reviews_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KnowledgePredictionReview"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgePredictionReview"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "List Prediction Reviews",
+        "operationId": "list_prediction_reviews_api_kg_pykeen_reviews_get",
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/PredictionReviewState",
+              "nullable": true,
+              "title": "State"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PykeenListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/pykeen/reviews/{review_id}": {
+      "patch": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Decide Prediction Review",
+        "operationId": "decide_prediction_review_api_kg_pykeen_reviews__review_id__patch",
+        "parameters": [
+          {
+            "name": "review_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Review Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictionReviewDecision"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgePredictionReview"
                 }
               }
             }
@@ -23888,7 +24184,7 @@
           "knowledge-graph"
         ],
         "summary": "Suggest Interpretations",
-        "description": "Generate AI interpretation suggestions for claims.\n\nUses the configured LLM providers (via LangChain) to suggest how\nframeworks might be applied to the given claims. Returns ranked\nsuggestions.",
+        "description": "Report that grounded interpretation suggestions are not available yet.",
         "operationId": "suggest_interpretations_api_hermeneutics_suggestions_post",
         "requestBody": {
           "content": {
@@ -23901,13 +24197,11 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "501": {
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HermesSuggestionListResponse"
-                }
+                "schema": {}
               }
             }
           },
@@ -24960,7 +25254,7 @@
           "knowledge-graph"
         ],
         "summary": "Suggest Interpretations",
-        "description": "Generate AI interpretation suggestions for claims.\n\nUses the configured LLM providers (via LangChain) to suggest how\nframeworks might be applied to the given claims. Returns ranked\nsuggestions.",
+        "description": "Report that grounded interpretation suggestions are not available yet.",
         "operationId": "suggest_interpretations_api_kg_interpretations_suggestions_post",
         "requestBody": {
           "content": {
@@ -24973,13 +25267,11 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "501": {
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HermesSuggestionListResponse"
-                }
+                "schema": {}
               }
             }
           },
@@ -33327,6 +33619,39 @@
             "nullable": true,
             "title": "Paragraph Index"
           },
+          "ink_payload": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ink Payload"
+          },
+          "ocr_text": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Text"
+          },
+          "ocr_provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Provider"
+          },
+          "ocr_model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Model"
+          },
+          "ocr_confidence": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "nullable": true,
+            "title": "Ocr Confidence"
+          },
+          "ocr_recorded_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Ocr Recorded At"
+          },
           "kind": {
             "$ref": "#/components/schemas/AnnotationKind"
           },
@@ -33463,6 +33788,39 @@
             "nullable": true,
             "title": "Paragraph Index"
           },
+          "ink_payload": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ink Payload"
+          },
+          "ocr_text": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Text"
+          },
+          "ocr_provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Provider"
+          },
+          "ocr_model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Model"
+          },
+          "ocr_confidence": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "nullable": true,
+            "title": "Ocr Confidence"
+          },
+          "ocr_recorded_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Ocr Recorded At"
+          },
           "text": {
             "type": "string",
             "nullable": true,
@@ -33540,7 +33898,9 @@
       "AnnotationListResponse": {
         "properties": {
           "items": {
-            "items": {},
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            },
             "type": "array",
             "title": "Items"
           },
@@ -33555,7 +33915,7 @@
           "count"
         ],
         "title": "AnnotationListResponse",
-        "description": "Standardized envelope for GET /api/annotations list endpoints."
+        "description": "Typed annotation list envelope for the OpenAPI client."
       },
       "AnnotationPatchRequest": {
         "properties": {
@@ -33650,6 +34010,39 @@
             "type": "integer",
             "nullable": true,
             "title": "Paragraph Index"
+          },
+          "ink_payload": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ink Payload"
+          },
+          "ocr_text": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Text"
+          },
+          "ocr_provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Provider"
+          },
+          "ocr_model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Model"
+          },
+          "ocr_confidence": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "nullable": true,
+            "title": "Ocr Confidence"
+          },
+          "ocr_recorded_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Ocr Recorded At"
           },
           "metadata": {
             "additionalProperties": true,
@@ -34117,6 +34510,26 @@
           "reviewed": {
             "type": "boolean",
             "title": "Reviewed"
+          },
+          "source_artifact_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Source Artifact Id"
+          },
+          "source_document_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Source Document Id"
+          },
+          "run_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Run Id"
+          },
+          "step_name": {
+            "type": "string",
+            "nullable": true,
+            "title": "Step Name"
           },
           "created_at": {
             "type": "string",
@@ -38296,6 +38709,177 @@
         "title": "ConnectionTestResponse",
         "description": "Result of a provider connection test."
       },
+      "ContentRepresentation": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "document_id": {
+            "type": "string",
+            "title": "Document Id"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/ContentRepresentationKind"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "language": {
+            "type": "string",
+            "nullable": true,
+            "title": "Language"
+          },
+          "script": {
+            "type": "string",
+            "nullable": true,
+            "title": "Script"
+          },
+          "source_anchor": {
+            "$ref": "#/components/schemas/ContentSourceAnchor"
+          },
+          "parent_representation_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Parent Representation Id"
+          },
+          "derived_from_representation_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Derived From Representation Id"
+          },
+          "producer_run_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Producer Run Id"
+          },
+          "producer_tool": {
+            "type": "string",
+            "nullable": true,
+            "title": "Producer Tool"
+          },
+          "producer_model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Producer Model"
+          },
+          "review_state": {
+            "$ref": "#/components/schemas/ContentReviewState",
+            "default": "source"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id",
+          "kind",
+          "content",
+          "source_anchor"
+        ],
+        "title": "ContentRepresentation",
+        "description": "Immutable source-linked content representation (#3443 slice 1)."
+      },
+      "ContentRepresentationKind": {
+        "type": "string",
+        "enum": [
+          "transcription",
+          "normalized_text",
+          "translation",
+          "transliteration",
+          "markdown",
+          "html",
+          "svg"
+        ],
+        "title": "ContentRepresentationKind"
+      },
+      "ContentRepresentationRevision": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "representation_id": {
+            "type": "string",
+            "title": "Representation Id"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "reviewer": {
+            "type": "string",
+            "title": "Reviewer",
+            "default": "human"
+          },
+          "decision": {
+            "type": "string",
+            "nullable": true,
+            "title": "Decision"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "representation_id",
+          "content"
+        ],
+        "title": "ContentRepresentationRevision",
+        "description": "A user-authored revision linked to an immutable representation."
+      },
+      "ContentReviewState": {
+        "type": "string",
+        "enum": [
+          "source",
+          "draft",
+          "reviewed"
+        ],
+        "title": "ContentReviewState"
+      },
+      "ContentSourceAnchor": {
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "title": "Document Id"
+          },
+          "page_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Page Id"
+          },
+          "char_start": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Char Start"
+          },
+          "char_end": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Char End"
+          },
+          "bbox": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "nullable": true,
+            "title": "Bbox"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id"
+        ],
+        "title": "ContentSourceAnchor"
+      },
       "ContradictionEvidence": {
         "properties": {
           "claim_id": {
@@ -40398,6 +40982,26 @@
           "count": {
             "type": "integer",
             "title": "Count"
+          },
+          "parent_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Parent Id"
+          },
+          "source_document_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Source Document Id"
+          },
+          "page_label": {
+            "type": "string",
+            "nullable": true,
+            "title": "Page Label"
+          },
+          "source_capability": {
+            "type": "string",
+            "title": "Source Capability",
+            "default": "reveal"
           }
         },
         "type": "object",
@@ -43277,72 +43881,6 @@
         "title": "HermeneuticCircleState",
         "description": "Tracks navigation between parts and wholes in interpretive analysis.\n\nThe hermeneutic circle describes the iterative process of understanding:\nunderstanding parts through wholes, and wholes through parts.\nThis model tracks where the analyst is in that navigation."
       },
-      "HermesSuggestion": {
-        "properties": {
-          "framework_id": {
-            "type": "string",
-            "title": "Framework Id"
-          },
-          "framework_name": {
-            "type": "string",
-            "title": "Framework Name"
-          },
-          "interpretation_text": {
-            "type": "string",
-            "title": "Interpretation Text"
-          },
-          "confidence": {
-            "type": "number",
-            "title": "Confidence"
-          },
-          "reasoning": {
-            "type": "string",
-            "title": "Reasoning"
-          },
-          "act": {
-            "$ref": "#/components/schemas/InterpretiveActType"
-          },
-          "key_insights": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Key Insights"
-          }
-        },
-        "type": "object",
-        "required": [
-          "framework_id",
-          "framework_name",
-          "interpretation_text",
-          "confidence",
-          "reasoning",
-          "act"
-        ],
-        "title": "HermesSuggestion",
-        "description": "A single AI-generated interpretation suggestion."
-      },
-      "HermesSuggestionListResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/HermesSuggestion"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "count"
-        ],
-        "title": "HermesSuggestionListResponse"
-      },
       "HermesSuggestionRequest": {
         "properties": {
           "claim_ids": {
@@ -45719,6 +46257,85 @@
           "target_id"
         ],
         "title": "KnowledgeGraphInclusion"
+      },
+      "KnowledgePredictionReview": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "run_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Run Id"
+          },
+          "source_entity_id": {
+            "type": "string",
+            "title": "Source Entity Id"
+          },
+          "relation": {
+            "type": "string",
+            "title": "Relation"
+          },
+          "target_entity_id": {
+            "type": "string",
+            "title": "Target Entity Id"
+          },
+          "score": {
+            "type": "number",
+            "title": "Score"
+          },
+          "rank": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Rank"
+          },
+          "model_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Model Id"
+          },
+          "model_config_snapshot": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Model Config Snapshot"
+          },
+          "state": {
+            "$ref": "#/components/schemas/PredictionReviewState",
+            "default": "pending"
+          },
+          "decision_note": {
+            "type": "string",
+            "nullable": true,
+            "title": "Decision Note"
+          },
+          "resulting_claim_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Resulting Claim Id"
+          },
+          "reviewed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Reviewed At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "source_entity_id",
+          "relation",
+          "target_entity_id",
+          "score"
+        ],
+        "title": "KnowledgePredictionReview",
+        "description": "Persisted, library-scoped human review of one predicted edge."
       },
       "KnownLibrary": {
         "properties": {
@@ -51352,6 +51969,38 @@
         "title": "PredictionResult",
         "description": "Single link prediction result."
       },
+      "PredictionReviewDecision": {
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/PredictionReviewState"
+          },
+          "note": {
+            "type": "string",
+            "nullable": true,
+            "title": "Note"
+          },
+          "resulting_claim_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Resulting Claim Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "title": "PredictionReviewDecision"
+      },
+      "PredictionReviewState": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "accepted",
+          "rejected",
+          "deferred"
+        ],
+        "title": "PredictionReviewState"
+      },
       "PredictionType": {
         "type": "string",
         "enum": [
@@ -53340,6 +53989,30 @@
           "count"
         ],
         "title": "ReorderResponse"
+      },
+      "RepresentationRevisionParams": {
+        "properties": {
+          "representation_id": {
+            "type": "string",
+            "title": "Representation Id"
+          },
+          "content": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Content"
+          },
+          "decision": {
+            "type": "string",
+            "nullable": true,
+            "title": "Decision"
+          }
+        },
+        "type": "object",
+        "required": [
+          "representation_id",
+          "content"
+        ],
+        "title": "RepresentationRevisionParams"
       },
       "ResearchChecklist": {
         "properties": {

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -968,11 +968,17 @@ def register_generated_openapi_commands(
         color: Optional[str] = typer.Option(None, "--color", help="Request field: color."),
         document_id: Optional[str] = typer.Option(None, "--document-id", help="Request field: document_id."),
         folder_id: Optional[str] = typer.Option(None, "--folder-id", help="Request field: folder_id."),
+        ink_payload: Optional[str] = typer.Option(None, "--ink-payload", help="Request field: ink_payload."),
         kind: str = typer.Option(..., "--kind", help="Request field: kind."),
         linked_claim_ids: Optional[str] = typer.Option(None, "--linked-claim-ids", help="Request field: linked_claim_ids."),
         linked_entity_ids: Optional[str] = typer.Option(None, "--linked-entity-ids", help="Request field: linked_entity_ids."),
         linked_note_ids: Optional[str] = typer.Option(None, "--linked-note-ids", help="Request field: linked_note_ids."),
         metadata: Optional[str] = typer.Option(None, "--metadata", help="Request field: metadata."),
+        ocr_confidence: Optional[float] = typer.Option(None, "--ocr-confidence", help="Request field: ocr_confidence."),
+        ocr_model: Optional[str] = typer.Option(None, "--ocr-model", help="Request field: ocr_model."),
+        ocr_provider: Optional[str] = typer.Option(None, "--ocr-provider", help="Request field: ocr_provider."),
+        ocr_recorded_at: Optional[str] = typer.Option(None, "--ocr-recorded-at", help="Request field: ocr_recorded_at."),
+        ocr_text: Optional[str] = typer.Option(None, "--ocr-text", help="Request field: ocr_text."),
         page_id: Optional[str] = typer.Option(None, "--page-id", help="Request field: page_id."),
         page_index: Optional[int] = typer.Option(None, "--page-index", help="Request field: page_index."),
         page_label: Optional[str] = typer.Option(None, "--page-label", help="Request field: page_label."),
@@ -993,11 +999,17 @@ def register_generated_openapi_commands(
                 "color": color,
                 "document_id": document_id,
                 "folder_id": folder_id,
+                "ink_payload": ink_payload,
                 "kind": kind,
                 "linked_claim_ids": linked_claim_ids,
                 "linked_entity_ids": linked_entity_ids,
                 "linked_note_ids": linked_note_ids,
                 "metadata": metadata,
+                "ocr_confidence": ocr_confidence,
+                "ocr_model": ocr_model,
+                "ocr_provider": ocr_provider,
+                "ocr_recorded_at": ocr_recorded_at,
+                "ocr_text": ocr_text,
                 "page_id": page_id,
                 "page_index": page_index,
                 "page_label": page_label,
@@ -1013,11 +1025,17 @@ def register_generated_openapi_commands(
                 "color": {'type': 'string', 'nullable': True, 'title': 'Color', 'x-cli-required': False},
                 "document_id": {'type': 'string', 'nullable': True, 'title': 'Document Id', 'x-cli-required': False},
                 "folder_id": {'type': 'string', 'nullable': True, 'title': 'Folder Id', 'x-cli-required': False},
+                "ink_payload": {'type': 'string', 'nullable': True, 'title': 'Ink Payload', 'x-cli-required': False},
                 "kind": {'type': 'string', 'enum': ['highlight', 'note', 'rating', 'bookmark', 'comment'], 'title': 'AnnotationKind', 'description': 'User annotation kinds (#914).\n\nEach kind has slightly different rendering + payload conventions:\n- highlight: coloured tint over a span; ``color`` + ``rating`` carry weight\n- note: margin/sticky note; ``text`` is the body\n- rating: 1-5 importance flag; ``rating`` carries weight\n- bookmark: navigation marker; ``text`` optional label\n- comment: threaded discussion (future); ``text`` is the body', 'x-cli-required': True},
                 "linked_claim_ids": {'items': {'type': 'string'}, 'type': 'array', 'title': 'Linked Claim Ids', 'default': [], 'x-cli-required': False},
                 "linked_entity_ids": {'items': {'type': 'string'}, 'type': 'array', 'title': 'Linked Entity Ids', 'default': [], 'x-cli-required': False},
                 "linked_note_ids": {'items': {'type': 'string'}, 'type': 'array', 'title': 'Linked Note Ids', 'default': [], 'x-cli-required': False},
                 "metadata": {'additionalProperties': True, 'type': 'object', 'title': 'Metadata', 'default': {}, 'x-cli-required': False},
+                "ocr_confidence": {'type': 'number', 'maximum': 1.0, 'minimum': 0.0, 'nullable': True, 'title': 'Ocr Confidence', 'x-cli-required': False},
+                "ocr_model": {'type': 'string', 'nullable': True, 'title': 'Ocr Model', 'x-cli-required': False},
+                "ocr_provider": {'type': 'string', 'nullable': True, 'title': 'Ocr Provider', 'x-cli-required': False},
+                "ocr_recorded_at": {'type': 'string', 'format': 'date-time', 'nullable': True, 'title': 'Ocr Recorded At', 'x-cli-required': False},
+                "ocr_text": {'type': 'string', 'nullable': True, 'title': 'Ocr Text', 'x-cli-required': False},
                 "page_id": {'type': 'string', 'nullable': True, 'title': 'Page Id', 'x-cli-required': False},
                 "page_index": {'type': 'integer', 'nullable': True, 'title': 'Page Index', 'x-cli-required': False},
                 "page_label": {'type': 'string', 'nullable': True, 'title': 'Page Label', 'x-cli-required': False},
@@ -1105,10 +1123,16 @@ def register_generated_openapi_commands(
         color: Optional[str] = typer.Option(None, "--color", help="Request field: color."),
         document_id: Optional[str] = typer.Option(None, "--document-id", help="Request field: document_id."),
         folder_id: Optional[str] = typer.Option(None, "--folder-id", help="Request field: folder_id."),
+        ink_payload: Optional[str] = typer.Option(None, "--ink-payload", help="Request field: ink_payload."),
         linked_claim_ids: Optional[str] = typer.Option(None, "--linked-claim-ids", help="Request field: linked_claim_ids."),
         linked_entity_ids: Optional[str] = typer.Option(None, "--linked-entity-ids", help="Request field: linked_entity_ids."),
         linked_note_ids: Optional[str] = typer.Option(None, "--linked-note-ids", help="Request field: linked_note_ids."),
         metadata: Optional[str] = typer.Option(None, "--metadata", help="Request field: metadata."),
+        ocr_confidence: Optional[float] = typer.Option(None, "--ocr-confidence", help="Request field: ocr_confidence."),
+        ocr_model: Optional[str] = typer.Option(None, "--ocr-model", help="Request field: ocr_model."),
+        ocr_provider: Optional[str] = typer.Option(None, "--ocr-provider", help="Request field: ocr_provider."),
+        ocr_recorded_at: Optional[str] = typer.Option(None, "--ocr-recorded-at", help="Request field: ocr_recorded_at."),
+        ocr_text: Optional[str] = typer.Option(None, "--ocr-text", help="Request field: ocr_text."),
         page_id: Optional[str] = typer.Option(None, "--page-id", help="Request field: page_id."),
         paragraph_index: Optional[int] = typer.Option(None, "--paragraph-index", help="Request field: paragraph_index."),
         rating: Optional[int] = typer.Option(None, "--rating", help="Request field: rating."),
@@ -1127,10 +1151,16 @@ def register_generated_openapi_commands(
                 "color": color,
                 "document_id": document_id,
                 "folder_id": folder_id,
+                "ink_payload": ink_payload,
                 "linked_claim_ids": linked_claim_ids,
                 "linked_entity_ids": linked_entity_ids,
                 "linked_note_ids": linked_note_ids,
                 "metadata": metadata,
+                "ocr_confidence": ocr_confidence,
+                "ocr_model": ocr_model,
+                "ocr_provider": ocr_provider,
+                "ocr_recorded_at": ocr_recorded_at,
+                "ocr_text": ocr_text,
                 "page_id": page_id,
                 "paragraph_index": paragraph_index,
                 "rating": rating,
@@ -1144,10 +1174,16 @@ def register_generated_openapi_commands(
                 "color": {'type': 'string', 'nullable': True, 'title': 'Color', 'x-cli-required': False},
                 "document_id": {'type': 'string', 'nullable': True, 'title': 'Document Id', 'x-cli-required': False},
                 "folder_id": {'type': 'string', 'nullable': True, 'title': 'Folder Id', 'x-cli-required': False},
+                "ink_payload": {'type': 'string', 'nullable': True, 'title': 'Ink Payload', 'x-cli-required': False},
                 "linked_claim_ids": {'items': {'type': 'string'}, 'type': 'array', 'nullable': True, 'title': 'Linked Claim Ids', 'x-cli-required': False},
                 "linked_entity_ids": {'items': {'type': 'string'}, 'type': 'array', 'nullable': True, 'title': 'Linked Entity Ids', 'x-cli-required': False},
                 "linked_note_ids": {'items': {'type': 'string'}, 'type': 'array', 'nullable': True, 'title': 'Linked Note Ids', 'x-cli-required': False},
                 "metadata": {'additionalProperties': True, 'type': 'object', 'nullable': True, 'title': 'Metadata', 'x-cli-required': False},
+                "ocr_confidence": {'type': 'number', 'maximum': 1.0, 'minimum': 0.0, 'nullable': True, 'title': 'Ocr Confidence', 'x-cli-required': False},
+                "ocr_model": {'type': 'string', 'nullable': True, 'title': 'Ocr Model', 'x-cli-required': False},
+                "ocr_provider": {'type': 'string', 'nullable': True, 'title': 'Ocr Provider', 'x-cli-required': False},
+                "ocr_recorded_at": {'type': 'string', 'format': 'date-time', 'nullable': True, 'title': 'Ocr Recorded At', 'x-cli-required': False},
+                "ocr_text": {'type': 'string', 'nullable': True, 'title': 'Ocr Text', 'x-cli-required': False},
                 "page_id": {'type': 'string', 'nullable': True, 'title': 'Page Id', 'x-cli-required': False},
                 "paragraph_index": {'type': 'integer', 'nullable': True, 'title': 'Paragraph Index', 'x-cli-required': False},
                 "rating": {'type': 'integer', 'maximum': 5.0, 'minimum': 1.0, 'nullable': True, 'title': 'Rating', 'x-cli-required': False},
@@ -3497,6 +3533,60 @@ def register_generated_openapi_commands(
                 "sort_order": {'type': 'integer', 'nullable': True, 'title': 'Sort Order', 'x-cli-required': False},
             }, required=True)
             return client.request("PATCH", endpoint_path, params=params, json=payload)
+        invoke(ctx, op_call)
+
+    target_app = existing_apps.get('content-representations')
+    if target_app is None:
+        target_app = typer.Typer(help='Generated OpenAPI commands for content-representations endpoints.', no_args_is_help=True)
+        root_app.add_typer(target_app, name='content-representations')
+        existing_apps['content-representations'] = target_app
+
+    @target_app.command("list")
+    def content_representations_list_get(
+        ctx: typer.Context,
+        document_id: str = typer.Argument(..., help="Path parameter: document_id."),
+    ) -> None:
+        """List Representations (GET /api/content-representations/document/{document_id})."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/content-representations/document/{document_id}"
+            params = None
+            return client.request("GET", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
+    @target_app.command("list-revisions")
+    def content_representations_list_revisions_get(
+        ctx: typer.Context,
+        representation_id: str = typer.Argument(..., help="Path parameter: representation_id."),
+    ) -> None:
+        """List Revisions (GET /api/content-representations/{representation_id}/revisions)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/content-representations/{representation_id}/revisions"
+            params = None
+            return client.request("GET", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
+    @target_app.command("create-revision")
+    def content_representations_create_revision_post(
+        ctx: typer.Context,
+        representation_id: str = typer.Argument(..., help="Path parameter: representation_id."),
+        content: str = typer.Option(..., "--content", help="Request field: content."),
+        decision: Optional[str] = typer.Option(None, "--decision", help="Request field: decision."),
+        representation_id_2: str = typer.Option(..., "--representation-id", help="Request field: representation_id."),
+    ) -> None:
+        """Create Revision (POST /api/content-representations/{representation_id}/revisions)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/content-representations/{representation_id}/revisions"
+            params = None
+            payload = _build_json_payload({
+                "content": content,
+                "decision": decision,
+                "representation_id": representation_id,
+            }, {
+                "content": {'type': 'string', 'minLength': 1, 'title': 'Content', 'x-cli-required': True},
+                "decision": {'type': 'string', 'nullable': True, 'title': 'Decision', 'x-cli-required': False},
+                "representation_id": {'type': 'string', 'title': 'Representation Id', 'x-cli-required': True},
+            }, required=True)
+            return client.request("POST", endpoint_path, params=params, json=payload)
         invoke(ctx, op_call)
 
     target_app = existing_apps.get('documents')
@@ -7264,6 +7354,100 @@ def register_generated_openapi_commands(
                 "top_k": top_k,
             }
             return client.request("GET", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
+    @target_app.command("list-prediction-reviews")
+    def kg_list_prediction_reviews_get(
+        ctx: typer.Context,
+        state: Optional[str] = typer.Option(None, "--state", help="Query parameter: state."),
+    ) -> None:
+        """List Prediction Reviews (GET /api/kg/pykeen/reviews)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/kg/pykeen/reviews"
+            params = {
+                "state": state,
+            }
+            return client.request("GET", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
+    @target_app.command("create-prediction-review")
+    def kg_create_prediction_review_post(
+        ctx: typer.Context,
+        created_at: Optional[str] = typer.Option(None, "--created-at", help="Request field: created_at."),
+        decision_note: Optional[str] = typer.Option(None, "--decision-note", help="Request field: decision_note."),
+        id: Optional[str] = typer.Option(None, "--id", help="Request field: id."),
+        model_config_snapshot: Optional[str] = typer.Option(None, "--model-config-snapshot", help="Request field: model_config_snapshot."),
+        model_id: Optional[str] = typer.Option(None, "--model-id", help="Request field: model_id."),
+        rank: Optional[int] = typer.Option(None, "--rank", help="Request field: rank."),
+        relation: str = typer.Option(..., "--relation", help="Request field: relation."),
+        resulting_claim_id: Optional[str] = typer.Option(None, "--resulting-claim-id", help="Request field: resulting_claim_id."),
+        reviewed_at: Optional[str] = typer.Option(None, "--reviewed-at", help="Request field: reviewed_at."),
+        run_id: Optional[str] = typer.Option(None, "--run-id", help="Request field: run_id."),
+        score: float = typer.Option(..., "--score", help="Request field: score."),
+        source_entity_id: str = typer.Option(..., "--source-entity-id", help="Request field: source_entity_id."),
+        state: Optional[str] = typer.Option(None, "--state", help="Request field: state."),
+        target_entity_id: str = typer.Option(..., "--target-entity-id", help="Request field: target_entity_id."),
+    ) -> None:
+        """Create Prediction Review (POST /api/kg/pykeen/reviews)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/kg/pykeen/reviews"
+            params = None
+            payload = _build_json_payload({
+                "created_at": created_at,
+                "decision_note": decision_note,
+                "id": id,
+                "model_config_snapshot": model_config_snapshot,
+                "model_id": model_id,
+                "rank": rank,
+                "relation": relation,
+                "resulting_claim_id": resulting_claim_id,
+                "reviewed_at": reviewed_at,
+                "run_id": run_id,
+                "score": score,
+                "source_entity_id": source_entity_id,
+                "state": state,
+                "target_entity_id": target_entity_id,
+            }, {
+                "created_at": {'type': 'string', 'format': 'date-time', 'title': 'Created At', 'x-cli-required': False},
+                "decision_note": {'type': 'string', 'nullable': True, 'title': 'Decision Note', 'x-cli-required': False},
+                "id": {'type': 'string', 'title': 'Id', 'x-cli-required': False},
+                "model_config_snapshot": {'additionalProperties': True, 'type': 'object', 'title': 'Model Config Snapshot', 'x-cli-required': False},
+                "model_id": {'type': 'string', 'nullable': True, 'title': 'Model Id', 'x-cli-required': False},
+                "rank": {'type': 'integer', 'nullable': True, 'title': 'Rank', 'x-cli-required': False},
+                "relation": {'type': 'string', 'title': 'Relation', 'x-cli-required': True},
+                "resulting_claim_id": {'type': 'string', 'nullable': True, 'title': 'Resulting Claim Id', 'x-cli-required': False},
+                "reviewed_at": {'type': 'string', 'format': 'date-time', 'nullable': True, 'title': 'Reviewed At', 'x-cli-required': False},
+                "run_id": {'type': 'string', 'nullable': True, 'title': 'Run Id', 'x-cli-required': False},
+                "score": {'type': 'number', 'title': 'Score', 'x-cli-required': True},
+                "source_entity_id": {'type': 'string', 'title': 'Source Entity Id', 'x-cli-required': True},
+                "state": {'type': 'string', 'enum': ['pending', 'accepted', 'rejected', 'deferred'], 'title': 'PredictionReviewState', 'x-cli-required': False},
+                "target_entity_id": {'type': 'string', 'title': 'Target Entity Id', 'x-cli-required': True},
+            }, required=True)
+            return client.request("POST", endpoint_path, params=params, json=payload)
+        invoke(ctx, op_call)
+
+    @target_app.command("decide-prediction-review")
+    def kg_decide_prediction_review_patch(
+        ctx: typer.Context,
+        review_id: str = typer.Argument(..., help="Path parameter: review_id."),
+        note: Optional[str] = typer.Option(None, "--note", help="Request field: note."),
+        resulting_claim_id: Optional[str] = typer.Option(None, "--resulting-claim-id", help="Request field: resulting_claim_id."),
+        state: str = typer.Option(..., "--state", help="Request field: state."),
+    ) -> None:
+        """Decide Prediction Review (PATCH /api/kg/pykeen/reviews/{review_id})."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/kg/pykeen/reviews/{review_id}"
+            params = None
+            payload = _build_json_payload({
+                "note": note,
+                "resulting_claim_id": resulting_claim_id,
+                "state": state,
+            }, {
+                "note": {'type': 'string', 'nullable': True, 'title': 'Note', 'x-cli-required': False},
+                "resulting_claim_id": {'type': 'string', 'nullable': True, 'title': 'Resulting Claim Id', 'x-cli-required': False},
+                "state": {'type': 'string', 'enum': ['pending', 'accepted', 'rejected', 'deferred'], 'title': 'PredictionReviewState', 'x-cli-required': True},
+            }, required=True)
+            return client.request("PATCH", endpoint_path, params=params, json=payload)
         invoke(ctx, op_call)
 
     @target_app.command("list-stored-predictions")

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -2394,6 +2394,44 @@
         "response_model": "ClassificationValue"
       }
     ],
+    "content-representations": [
+      {
+        "method": "GET",
+        "path": "/content-representations/document/{document_id}",
+        "operation_id": "list_representations_api_content_representations_document__document_id__get",
+        "summary": "List Representations",
+        "path_params": [
+          "document_id"
+        ],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "[ContentRepresentation]"
+      },
+      {
+        "method": "GET",
+        "path": "/content-representations/{representation_id}/revisions",
+        "operation_id": "list_revisions_api_content_representations__representation_id__revisions_get",
+        "summary": "List Revisions",
+        "path_params": [
+          "representation_id"
+        ],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "[ContentRepresentationRevision]"
+      },
+      {
+        "method": "POST",
+        "path": "/content-representations/{representation_id}/revisions",
+        "operation_id": "create_revision_api_content_representations__representation_id__revisions_post",
+        "summary": "Create Revision",
+        "path_params": [
+          "representation_id"
+        ],
+        "query_params": [],
+        "request_model": "RepresentationRevisionParams",
+        "response_model": "ContentRepresentationRevision"
+      }
+    ],
     "documents": [
       {
         "method": "GET",
@@ -3627,7 +3665,7 @@
         "path_params": [],
         "query_params": [],
         "request_model": "HermesSuggestionRequest",
-        "response_model": "HermesSuggestionListResponse"
+        "response_model": null
       },
       {
         "method": "GET",
@@ -4992,7 +5030,7 @@
         "path_params": [],
         "query_params": [],
         "request_model": "HermesSuggestionRequest",
-        "response_model": "HermesSuggestionListResponse"
+        "response_model": null
       },
       {
         "method": "GET",
@@ -5115,6 +5153,44 @@
         ],
         "request_model": null,
         "response_model": "KGGraphListResponse"
+      },
+      {
+        "method": "GET",
+        "path": "/kg/pykeen/reviews",
+        "operation_id": "list_prediction_reviews_api_kg_pykeen_reviews_get",
+        "summary": "List Prediction Reviews",
+        "path_params": [],
+        "query_params": [
+          {
+            "name": "state",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "request_model": null,
+        "response_model": "PykeenListResponse"
+      },
+      {
+        "method": "POST",
+        "path": "/kg/pykeen/reviews",
+        "operation_id": "create_prediction_review_api_kg_pykeen_reviews_post",
+        "summary": "Create Prediction Review",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "KnowledgePredictionReview",
+        "response_model": "KnowledgePredictionReview"
+      },
+      {
+        "method": "PATCH",
+        "path": "/kg/pykeen/reviews/{review_id}",
+        "operation_id": "decide_prediction_review_api_kg_pykeen_reviews__review_id__patch",
+        "summary": "Decide Prediction Review",
+        "path_params": [
+          "review_id"
+        ],
+        "query_params": [],
+        "request_model": "PredictionReviewDecision",
+        "response_model": "KnowledgePredictionReview"
       },
       {
         "method": "GET",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Fichero API",
     "description": "Document processing and search API",
-    "version": "0.1.0.dev1"
+    "version": "2026.7.3b1"
   },
   "paths": {
     "/api/health": {
@@ -2495,6 +2495,158 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PromoteResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content-representations/document/{document_id}": {
+      "get": {
+        "tags": [
+          "content-representations"
+        ],
+        "summary": "List Representations",
+        "operationId": "list_representations_api_content_representations_document__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContentRepresentation"
+                  },
+                  "title": "Response List Representations Api Content Representations Document  Document Id  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content-representations/{representation_id}/revisions": {
+      "get": {
+        "tags": [
+          "content-representations"
+        ],
+        "summary": "List Revisions",
+        "operationId": "list_revisions_api_content_representations__representation_id__revisions_get",
+        "parameters": [
+          {
+            "name": "representation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Representation Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContentRepresentationRevision"
+                  },
+                  "title": "Response List Revisions Api Content Representations  Representation Id  Revisions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "content-representations"
+        ],
+        "summary": "Create Revision",
+        "operationId": "create_revision_api_content_representations__representation_id__revisions_post",
+        "parameters": [
+          {
+            "name": "representation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Representation Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepresentationRevisionParams"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentRepresentationRevision"
                 }
               }
             }
@@ -20469,6 +20621,16 @@
               "type": "string",
               "title": "Entity Id"
             }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
           }
         ],
         "responses": {
@@ -20643,6 +20805,140 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/KGGraphListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/pykeen/reviews": {
+      "post": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Create Prediction Review",
+        "operationId": "create_prediction_review_api_kg_pykeen_reviews_post",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KnowledgePredictionReview"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgePredictionReview"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "List Prediction Reviews",
+        "operationId": "list_prediction_reviews_api_kg_pykeen_reviews_get",
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/PredictionReviewState",
+              "nullable": true,
+              "title": "State"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PykeenListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/pykeen/reviews/{review_id}": {
+      "patch": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Decide Prediction Review",
+        "operationId": "decide_prediction_review_api_kg_pykeen_reviews__review_id__patch",
+        "parameters": [
+          {
+            "name": "review_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Review Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PredictionReviewDecision"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KnowledgePredictionReview"
                 }
               }
             }
@@ -23888,7 +24184,7 @@
           "knowledge-graph"
         ],
         "summary": "Suggest Interpretations",
-        "description": "Generate AI interpretation suggestions for claims.\n\nUses the configured LLM providers (via LangChain) to suggest how\nframeworks might be applied to the given claims. Returns ranked\nsuggestions.",
+        "description": "Report that grounded interpretation suggestions are not available yet.",
         "operationId": "suggest_interpretations_api_hermeneutics_suggestions_post",
         "requestBody": {
           "content": {
@@ -23901,13 +24197,11 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "501": {
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HermesSuggestionListResponse"
-                }
+                "schema": {}
               }
             }
           },
@@ -24960,7 +25254,7 @@
           "knowledge-graph"
         ],
         "summary": "Suggest Interpretations",
-        "description": "Generate AI interpretation suggestions for claims.\n\nUses the configured LLM providers (via LangChain) to suggest how\nframeworks might be applied to the given claims. Returns ranked\nsuggestions.",
+        "description": "Report that grounded interpretation suggestions are not available yet.",
         "operationId": "suggest_interpretations_api_kg_interpretations_suggestions_post",
         "requestBody": {
           "content": {
@@ -24973,13 +25267,11 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "501": {
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HermesSuggestionListResponse"
-                }
+                "schema": {}
               }
             }
           },
@@ -33327,6 +33619,39 @@
             "nullable": true,
             "title": "Paragraph Index"
           },
+          "ink_payload": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ink Payload"
+          },
+          "ocr_text": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Text"
+          },
+          "ocr_provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Provider"
+          },
+          "ocr_model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Model"
+          },
+          "ocr_confidence": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "nullable": true,
+            "title": "Ocr Confidence"
+          },
+          "ocr_recorded_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Ocr Recorded At"
+          },
           "kind": {
             "$ref": "#/components/schemas/AnnotationKind"
           },
@@ -33463,6 +33788,39 @@
             "nullable": true,
             "title": "Paragraph Index"
           },
+          "ink_payload": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ink Payload"
+          },
+          "ocr_text": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Text"
+          },
+          "ocr_provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Provider"
+          },
+          "ocr_model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Model"
+          },
+          "ocr_confidence": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "nullable": true,
+            "title": "Ocr Confidence"
+          },
+          "ocr_recorded_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Ocr Recorded At"
+          },
           "text": {
             "type": "string",
             "nullable": true,
@@ -33540,7 +33898,9 @@
       "AnnotationListResponse": {
         "properties": {
           "items": {
-            "items": {},
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            },
             "type": "array",
             "title": "Items"
           },
@@ -33555,7 +33915,7 @@
           "count"
         ],
         "title": "AnnotationListResponse",
-        "description": "Standardized envelope for GET /api/annotations list endpoints."
+        "description": "Typed annotation list envelope for the OpenAPI client."
       },
       "AnnotationPatchRequest": {
         "properties": {
@@ -33650,6 +34010,39 @@
             "type": "integer",
             "nullable": true,
             "title": "Paragraph Index"
+          },
+          "ink_payload": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ink Payload"
+          },
+          "ocr_text": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Text"
+          },
+          "ocr_provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Provider"
+          },
+          "ocr_model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Model"
+          },
+          "ocr_confidence": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "nullable": true,
+            "title": "Ocr Confidence"
+          },
+          "ocr_recorded_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Ocr Recorded At"
           },
           "metadata": {
             "additionalProperties": true,
@@ -34117,6 +34510,26 @@
           "reviewed": {
             "type": "boolean",
             "title": "Reviewed"
+          },
+          "source_artifact_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Source Artifact Id"
+          },
+          "source_document_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Source Document Id"
+          },
+          "run_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Run Id"
+          },
+          "step_name": {
+            "type": "string",
+            "nullable": true,
+            "title": "Step Name"
           },
           "created_at": {
             "type": "string",
@@ -38296,6 +38709,177 @@
         "title": "ConnectionTestResponse",
         "description": "Result of a provider connection test."
       },
+      "ContentRepresentation": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "document_id": {
+            "type": "string",
+            "title": "Document Id"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/ContentRepresentationKind"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "language": {
+            "type": "string",
+            "nullable": true,
+            "title": "Language"
+          },
+          "script": {
+            "type": "string",
+            "nullable": true,
+            "title": "Script"
+          },
+          "source_anchor": {
+            "$ref": "#/components/schemas/ContentSourceAnchor"
+          },
+          "parent_representation_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Parent Representation Id"
+          },
+          "derived_from_representation_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Derived From Representation Id"
+          },
+          "producer_run_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Producer Run Id"
+          },
+          "producer_tool": {
+            "type": "string",
+            "nullable": true,
+            "title": "Producer Tool"
+          },
+          "producer_model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Producer Model"
+          },
+          "review_state": {
+            "$ref": "#/components/schemas/ContentReviewState",
+            "default": "source"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id",
+          "kind",
+          "content",
+          "source_anchor"
+        ],
+        "title": "ContentRepresentation",
+        "description": "Immutable source-linked content representation (#3443 slice 1)."
+      },
+      "ContentRepresentationKind": {
+        "type": "string",
+        "enum": [
+          "transcription",
+          "normalized_text",
+          "translation",
+          "transliteration",
+          "markdown",
+          "html",
+          "svg"
+        ],
+        "title": "ContentRepresentationKind"
+      },
+      "ContentRepresentationRevision": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "representation_id": {
+            "type": "string",
+            "title": "Representation Id"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "reviewer": {
+            "type": "string",
+            "title": "Reviewer",
+            "default": "human"
+          },
+          "decision": {
+            "type": "string",
+            "nullable": true,
+            "title": "Decision"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "representation_id",
+          "content"
+        ],
+        "title": "ContentRepresentationRevision",
+        "description": "A user-authored revision linked to an immutable representation."
+      },
+      "ContentReviewState": {
+        "type": "string",
+        "enum": [
+          "source",
+          "draft",
+          "reviewed"
+        ],
+        "title": "ContentReviewState"
+      },
+      "ContentSourceAnchor": {
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "title": "Document Id"
+          },
+          "page_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Page Id"
+          },
+          "char_start": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Char Start"
+          },
+          "char_end": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Char End"
+          },
+          "bbox": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "nullable": true,
+            "title": "Bbox"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id"
+        ],
+        "title": "ContentSourceAnchor"
+      },
       "ContradictionEvidence": {
         "properties": {
           "claim_id": {
@@ -40398,6 +40982,26 @@
           "count": {
             "type": "integer",
             "title": "Count"
+          },
+          "parent_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Parent Id"
+          },
+          "source_document_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Source Document Id"
+          },
+          "page_label": {
+            "type": "string",
+            "nullable": true,
+            "title": "Page Label"
+          },
+          "source_capability": {
+            "type": "string",
+            "title": "Source Capability",
+            "default": "reveal"
           }
         },
         "type": "object",
@@ -43277,72 +43881,6 @@
         "title": "HermeneuticCircleState",
         "description": "Tracks navigation between parts and wholes in interpretive analysis.\n\nThe hermeneutic circle describes the iterative process of understanding:\nunderstanding parts through wholes, and wholes through parts.\nThis model tracks where the analyst is in that navigation."
       },
-      "HermesSuggestion": {
-        "properties": {
-          "framework_id": {
-            "type": "string",
-            "title": "Framework Id"
-          },
-          "framework_name": {
-            "type": "string",
-            "title": "Framework Name"
-          },
-          "interpretation_text": {
-            "type": "string",
-            "title": "Interpretation Text"
-          },
-          "confidence": {
-            "type": "number",
-            "title": "Confidence"
-          },
-          "reasoning": {
-            "type": "string",
-            "title": "Reasoning"
-          },
-          "act": {
-            "$ref": "#/components/schemas/InterpretiveActType"
-          },
-          "key_insights": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Key Insights"
-          }
-        },
-        "type": "object",
-        "required": [
-          "framework_id",
-          "framework_name",
-          "interpretation_text",
-          "confidence",
-          "reasoning",
-          "act"
-        ],
-        "title": "HermesSuggestion",
-        "description": "A single AI-generated interpretation suggestion."
-      },
-      "HermesSuggestionListResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/HermesSuggestion"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "count"
-        ],
-        "title": "HermesSuggestionListResponse"
-      },
       "HermesSuggestionRequest": {
         "properties": {
           "claim_ids": {
@@ -45719,6 +46257,85 @@
           "target_id"
         ],
         "title": "KnowledgeGraphInclusion"
+      },
+      "KnowledgePredictionReview": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "run_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Run Id"
+          },
+          "source_entity_id": {
+            "type": "string",
+            "title": "Source Entity Id"
+          },
+          "relation": {
+            "type": "string",
+            "title": "Relation"
+          },
+          "target_entity_id": {
+            "type": "string",
+            "title": "Target Entity Id"
+          },
+          "score": {
+            "type": "number",
+            "title": "Score"
+          },
+          "rank": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Rank"
+          },
+          "model_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Model Id"
+          },
+          "model_config_snapshot": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Model Config Snapshot"
+          },
+          "state": {
+            "$ref": "#/components/schemas/PredictionReviewState",
+            "default": "pending"
+          },
+          "decision_note": {
+            "type": "string",
+            "nullable": true,
+            "title": "Decision Note"
+          },
+          "resulting_claim_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Resulting Claim Id"
+          },
+          "reviewed_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Reviewed At"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "additionalProperties": true,
+        "type": "object",
+        "required": [
+          "source_entity_id",
+          "relation",
+          "target_entity_id",
+          "score"
+        ],
+        "title": "KnowledgePredictionReview",
+        "description": "Persisted, library-scoped human review of one predicted edge."
       },
       "KnownLibrary": {
         "properties": {
@@ -51352,6 +51969,38 @@
         "title": "PredictionResult",
         "description": "Single link prediction result."
       },
+      "PredictionReviewDecision": {
+        "properties": {
+          "state": {
+            "$ref": "#/components/schemas/PredictionReviewState"
+          },
+          "note": {
+            "type": "string",
+            "nullable": true,
+            "title": "Note"
+          },
+          "resulting_claim_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Resulting Claim Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "title": "PredictionReviewDecision"
+      },
+      "PredictionReviewState": {
+        "type": "string",
+        "enum": [
+          "pending",
+          "accepted",
+          "rejected",
+          "deferred"
+        ],
+        "title": "PredictionReviewState"
+      },
       "PredictionType": {
         "type": "string",
         "enum": [
@@ -53340,6 +53989,30 @@
           "count"
         ],
         "title": "ReorderResponse"
+      },
+      "RepresentationRevisionParams": {
+        "properties": {
+          "representation_id": {
+            "type": "string",
+            "title": "Representation Id"
+          },
+          "content": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Content"
+          },
+          "decision": {
+            "type": "string",
+            "nullable": true,
+            "title": "Decision"
+          }
+        },
+        "type": "object",
+        "required": [
+          "representation_id",
+          "content"
+        ],
+        "title": "RepresentationRevisionParams"
       },
       "ResearchChecklist": {
         "properties": {

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Fichero API",
     "description": "Document processing and search API",
-    "version": "0.1.0.dev1"
+    "version": "2026.7.3b1"
   },
   "paths": {
     "/api/health": {
@@ -2495,6 +2495,158 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PromoteResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content-representations/document/{document_id}": {
+      "get": {
+        "tags": [
+          "content-representations"
+        ],
+        "summary": "List Representations",
+        "operationId": "list_representations_api_content_representations_document__document_id__get",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContentRepresentation"
+                  },
+                  "title": "Response List Representations Api Content Representations Document  Document Id  Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content-representations/{representation_id}/revisions": {
+      "get": {
+        "tags": [
+          "content-representations"
+        ],
+        "summary": "List Revisions",
+        "operationId": "list_revisions_api_content_representations__representation_id__revisions_get",
+        "parameters": [
+          {
+            "name": "representation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Representation Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ContentRepresentationRevision"
+                  },
+                  "title": "Response List Revisions Api Content Representations  Representation Id  Revisions Get"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "content-representations"
+        ],
+        "summary": "Create Revision",
+        "operationId": "create_revision_api_content_representations__representation_id__revisions_post",
+        "parameters": [
+          {
+            "name": "representation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Representation Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RepresentationRevisionParams"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContentRepresentationRevision"
                 }
               }
             }
@@ -20469,6 +20621,16 @@
               "type": "string",
               "title": "Entity Id"
             }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
           }
         ],
         "responses": {
@@ -24022,7 +24184,7 @@
           "knowledge-graph"
         ],
         "summary": "Suggest Interpretations",
-        "description": "Generate AI interpretation suggestions for claims.\n\nUses the configured LLM providers (via LangChain) to suggest how\nframeworks might be applied to the given claims. Returns ranked\nsuggestions.",
+        "description": "Report that grounded interpretation suggestions are not available yet.",
         "operationId": "suggest_interpretations_api_hermeneutics_suggestions_post",
         "requestBody": {
           "content": {
@@ -24035,13 +24197,11 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "501": {
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HermesSuggestionListResponse"
-                }
+                "schema": {}
               }
             }
           },
@@ -25094,7 +25254,7 @@
           "knowledge-graph"
         ],
         "summary": "Suggest Interpretations",
-        "description": "Generate AI interpretation suggestions for claims.\n\nUses the configured LLM providers (via LangChain) to suggest how\nframeworks might be applied to the given claims. Returns ranked\nsuggestions.",
+        "description": "Report that grounded interpretation suggestions are not available yet.",
         "operationId": "suggest_interpretations_api_kg_interpretations_suggestions_post",
         "requestBody": {
           "content": {
@@ -25107,13 +25267,11 @@
           "required": true
         },
         "responses": {
-          "200": {
+          "501": {
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HermesSuggestionListResponse"
-                }
+                "schema": {}
               }
             }
           },
@@ -33461,6 +33619,39 @@
             "nullable": true,
             "title": "Paragraph Index"
           },
+          "ink_payload": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ink Payload"
+          },
+          "ocr_text": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Text"
+          },
+          "ocr_provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Provider"
+          },
+          "ocr_model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Model"
+          },
+          "ocr_confidence": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "nullable": true,
+            "title": "Ocr Confidence"
+          },
+          "ocr_recorded_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Ocr Recorded At"
+          },
           "kind": {
             "$ref": "#/components/schemas/AnnotationKind"
           },
@@ -33597,6 +33788,39 @@
             "nullable": true,
             "title": "Paragraph Index"
           },
+          "ink_payload": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ink Payload"
+          },
+          "ocr_text": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Text"
+          },
+          "ocr_provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Provider"
+          },
+          "ocr_model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Model"
+          },
+          "ocr_confidence": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "nullable": true,
+            "title": "Ocr Confidence"
+          },
+          "ocr_recorded_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Ocr Recorded At"
+          },
           "text": {
             "type": "string",
             "nullable": true,
@@ -33674,7 +33898,9 @@
       "AnnotationListResponse": {
         "properties": {
           "items": {
-            "items": {},
+            "items": {
+              "$ref": "#/components/schemas/Annotation"
+            },
             "type": "array",
             "title": "Items"
           },
@@ -33689,7 +33915,7 @@
           "count"
         ],
         "title": "AnnotationListResponse",
-        "description": "Standardized envelope for GET /api/annotations list endpoints."
+        "description": "Typed annotation list envelope for the OpenAPI client."
       },
       "AnnotationPatchRequest": {
         "properties": {
@@ -33784,6 +34010,39 @@
             "type": "integer",
             "nullable": true,
             "title": "Paragraph Index"
+          },
+          "ink_payload": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ink Payload"
+          },
+          "ocr_text": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Text"
+          },
+          "ocr_provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Provider"
+          },
+          "ocr_model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Ocr Model"
+          },
+          "ocr_confidence": {
+            "type": "number",
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "nullable": true,
+            "title": "Ocr Confidence"
+          },
+          "ocr_recorded_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "title": "Ocr Recorded At"
           },
           "metadata": {
             "additionalProperties": true,
@@ -38449,6 +38708,177 @@
         ],
         "title": "ConnectionTestResponse",
         "description": "Result of a provider connection test."
+      },
+      "ContentRepresentation": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "document_id": {
+            "type": "string",
+            "title": "Document Id"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/ContentRepresentationKind"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "language": {
+            "type": "string",
+            "nullable": true,
+            "title": "Language"
+          },
+          "script": {
+            "type": "string",
+            "nullable": true,
+            "title": "Script"
+          },
+          "source_anchor": {
+            "$ref": "#/components/schemas/ContentSourceAnchor"
+          },
+          "parent_representation_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Parent Representation Id"
+          },
+          "derived_from_representation_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Derived From Representation Id"
+          },
+          "producer_run_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Producer Run Id"
+          },
+          "producer_tool": {
+            "type": "string",
+            "nullable": true,
+            "title": "Producer Tool"
+          },
+          "producer_model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Producer Model"
+          },
+          "review_state": {
+            "$ref": "#/components/schemas/ContentReviewState",
+            "default": "source"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id",
+          "kind",
+          "content",
+          "source_anchor"
+        ],
+        "title": "ContentRepresentation",
+        "description": "Immutable source-linked content representation (#3443 slice 1)."
+      },
+      "ContentRepresentationKind": {
+        "type": "string",
+        "enum": [
+          "transcription",
+          "normalized_text",
+          "translation",
+          "transliteration",
+          "markdown",
+          "html",
+          "svg"
+        ],
+        "title": "ContentRepresentationKind"
+      },
+      "ContentRepresentationRevision": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "representation_id": {
+            "type": "string",
+            "title": "Representation Id"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content"
+          },
+          "reviewer": {
+            "type": "string",
+            "title": "Reviewer",
+            "default": "human"
+          },
+          "decision": {
+            "type": "string",
+            "nullable": true,
+            "title": "Decision"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "representation_id",
+          "content"
+        ],
+        "title": "ContentRepresentationRevision",
+        "description": "A user-authored revision linked to an immutable representation."
+      },
+      "ContentReviewState": {
+        "type": "string",
+        "enum": [
+          "source",
+          "draft",
+          "reviewed"
+        ],
+        "title": "ContentReviewState"
+      },
+      "ContentSourceAnchor": {
+        "properties": {
+          "document_id": {
+            "type": "string",
+            "title": "Document Id"
+          },
+          "page_id": {
+            "type": "string",
+            "nullable": true,
+            "title": "Page Id"
+          },
+          "char_start": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Char Start"
+          },
+          "char_end": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Char End"
+          },
+          "bbox": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "nullable": true,
+            "title": "Bbox"
+          }
+        },
+        "type": "object",
+        "required": [
+          "document_id"
+        ],
+        "title": "ContentSourceAnchor"
       },
       "ContradictionEvidence": {
         "properties": {
@@ -43450,72 +43880,6 @@
         ],
         "title": "HermeneuticCircleState",
         "description": "Tracks navigation between parts and wholes in interpretive analysis.\n\nThe hermeneutic circle describes the iterative process of understanding:\nunderstanding parts through wholes, and wholes through parts.\nThis model tracks where the analyst is in that navigation."
-      },
-      "HermesSuggestion": {
-        "properties": {
-          "framework_id": {
-            "type": "string",
-            "title": "Framework Id"
-          },
-          "framework_name": {
-            "type": "string",
-            "title": "Framework Name"
-          },
-          "interpretation_text": {
-            "type": "string",
-            "title": "Interpretation Text"
-          },
-          "confidence": {
-            "type": "number",
-            "title": "Confidence"
-          },
-          "reasoning": {
-            "type": "string",
-            "title": "Reasoning"
-          },
-          "act": {
-            "$ref": "#/components/schemas/InterpretiveActType"
-          },
-          "key_insights": {
-            "items": {
-              "type": "string"
-            },
-            "type": "array",
-            "title": "Key Insights"
-          }
-        },
-        "type": "object",
-        "required": [
-          "framework_id",
-          "framework_name",
-          "interpretation_text",
-          "confidence",
-          "reasoning",
-          "act"
-        ],
-        "title": "HermesSuggestion",
-        "description": "A single AI-generated interpretation suggestion."
-      },
-      "HermesSuggestionListResponse": {
-        "properties": {
-          "items": {
-            "items": {
-              "$ref": "#/components/schemas/HermesSuggestion"
-            },
-            "type": "array",
-            "title": "Items"
-          },
-          "count": {
-            "type": "integer",
-            "title": "Count"
-          }
-        },
-        "type": "object",
-        "required": [
-          "items",
-          "count"
-        ],
-        "title": "HermesSuggestionListResponse"
       },
       "HermesSuggestionRequest": {
         "properties": {
@@ -53625,6 +53989,30 @@
           "count"
         ],
         "title": "ReorderResponse"
+      },
+      "RepresentationRevisionParams": {
+        "properties": {
+          "representation_id": {
+            "type": "string",
+            "title": "Representation Id"
+          },
+          "content": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Content"
+          },
+          "decision": {
+            "type": "string",
+            "nullable": true,
+            "title": "Decision"
+          }
+        },
+        "type": "object",
+        "required": [
+          "representation_id",
+          "content"
+        ],
+        "title": "RepresentationRevisionParams"
       },
       "ResearchChecklist": {
         "properties": {


### PR DESCRIPTION
Regenerates openapi.json (×3) + endpoints.json + generated surface for the endpoints added by #3438/#3441/#3443/#3445/#3435. Generated artifacts only — no source logic. Swift client regenerates from openapi.json at build (verified by f_inspector rebuild post-merge). 🤖 Generated with [Claude Code](https://claude.com/claude-code)