### PR TITLE
Reader: don't expose engine token to page JS — seal window.fetch (#3223)

### DIFF
--- a/fichero/fichero-tests/DocumentKGPaneRouteTests.swift
+++ b/fichero/fichero-tests/DocumentKGPaneRouteTests.swift
@@ -138,6 +138,17 @@ final class DocumentKGPaneRouteTests: XCTestCase {
         XCTAssertFalse(script.contains("window.ficheroToken = 'secret-token'"))
     }
 
+    func testBootstrapScriptSealsFetchSoItCannotBeRewrapped() {
+        // #3223 hardening: the fetch override is sealed non-writable/non-configurable
+        // so a later page script (or an XSS in the reader templates) can't re-wrap
+        // window.fetch to capture the real token swapped into proxied requests.
+        let script = DocumentKGPaneRoute.bootstrapScript(token: "secret-token", libraryPath: "/tmp/library")
+
+        XCTAssertTrue(script.contains("Object.defineProperty(window, 'fetch'"))
+        XCTAssertTrue(script.contains("writable: false"))
+        XCTAssertTrue(script.contains("configurable: false"))
+    }
+
     func testReaderPaneCachesBootstrapScriptBetweenUpdates() throws {
         let source = try String(
             contentsOf: URL(fileURLWithPath: #filePath)

--- a/fichero/fichero/Views/Library/DocumentKGWebPane.swift
+++ b/fichero/fichero/Views/Library/DocumentKGWebPane.swift
@@ -104,6 +104,23 @@ enum DocumentKGPaneRoute {
                 }
                 return nativeFetch(input, nextInit);
             };
+            // Seal the override so a later page script (or an XSS via document
+            // names / OCR / entity names in the templates) can't re-wrap
+            // window.fetch to capture the real token swapped into proxied
+            // requests (#3223). window.ficheroToken already exposes only a
+            // non-functional sentinel; this closes the remaining exfil path.
+            // (Complete defense-in-depth — preventing an XSS from *using* the
+            // API — needs a read-only library-scoped view token from the engine.)
+            try {
+                Object.defineProperty(window, 'fetch', {
+                    value: window.fetch,
+                    writable: false,
+                    configurable: false
+                });
+            } catch (sealError) {
+                // Older WebKit that rejects redefining fetch: the override still
+                // applies, it just stays re-wrappable. Non-fatal.
+            }
         })();
         """
     }


### PR DESCRIPTION
Reader WebKit security — engine Bearer token no longer re-wrappable from page JavaScript (sealed window.fetch). Build-verified against the regenerated OpenAPI client (BUILD SUCCEEDED). 🤖 Generated with [Claude Code](https://claude.com/claude-code)