### PR TITLE
Reader: RTF plain-text decode + iOS lazy WKWebView (#2317/#2409)

### DIFF
--- a/fichero/fichero-tests/ArtifactRichTextCodecTests.swift
+++ b/fichero/fichero-tests/ArtifactRichTextCodecTests.swift
@@ -92,6 +92,29 @@ final class ArtifactRichTextCodecTests: XCTestCase {
         XCTAssertEqual(String(decoded.characters), "the user typed a fresh sentence")
     }
 
+    // MARK: - Plain-text projection (#2317)
+
+    /// THE #2317 bug: page content stored as RTF must render as resolved text in
+    /// the native reader — accented escapes (`\'e1` → á, `\'f1` → ñ) resolved and
+    /// no stray control words / backslashes leaking through.
+    func testPlainTextResolvesRTFEscapes() {
+        let rtf = "{\\rtf1\\ansi C\\'e1rmen se\\'f1or Jos\\'e9}"
+        let plain = ArtifactRichTextCodec.plainText(rtf)
+        XCTAssertTrue(plain.contains("Cármen"), "\\'e1 must resolve to á")
+        XCTAssertTrue(plain.contains("señor"), "\\'f1 must resolve to ñ")
+        XCTAssertTrue(plain.contains("José"), "\\'e9 must resolve to é")
+        XCTAssertFalse(plain.contains("\\'"), "no raw escape codes may leak")
+        XCTAssertFalse(plain.contains("\\rtf"), "no RTF control words may leak")
+    }
+
+    /// Plain text short-circuits unchanged — the common (non-RTF) case pays no
+    /// decode cost and is returned verbatim, backslashes and all.
+    func testPlainTextPassesNonRTFThrough() {
+        let plain = "just plain text with a \\ backslash and no rtf header"
+        XCTAssertEqual(ArtifactRichTextCodec.plainText(plain), plain)
+        XCTAssertEqual(ArtifactRichTextCodec.plainText(""), "")
+    }
+
     // MARK: - Save path (stubbed service)
 
     /// An edit fires the save with the *encoded* content, and that encoded

--- a/fichero/fichero/Views/Library/ArtifactRichTextCodec.swift
+++ b/fichero/fichero/Views/Library/ArtifactRichTextCodec.swift
@@ -93,6 +93,18 @@ enum ArtifactRichTextCodec {
         return html
     }
 
+    // MARK: - Plain-text boundary (#2317)
+
+    /// Plain-text projection of stored content for native readers that render
+    /// selectable plain text (`PageContentPane`, `DocumentTextReader`) and must
+    /// not leak raw RTF. RTF source (`{\rtf` prefix) is decoded so control words
+    /// and `\'xx` escapes resolve to real characters (`\'e1` → á); plain text
+    /// short-circuits unchanged so the common case pays no decode cost (#2317).
+    static func plainText(_ content: String) -> String {
+        guard content.hasPrefix("{\\rtf") else { return content }
+        return decode(content).string
+    }
+
     // MARK: - AttributedString boundary (#2453)
 
     /// Decode stored content into a SwiftUI-native `AttributedString` for the

--- a/fichero/fichero/Views/Library/DocumentKGSurface.swift
+++ b/fichero/fichero/Views/Library/DocumentKGSurface.swift
@@ -157,6 +157,15 @@ struct DocumentKGSurface: View {
 
     @State private var internalActiveTab: KGSurfaceTab = .transcript
     private var activeTab: KGSurfaceTab { externalActiveTab ?? internalActiveTab }
+
+    // Lazy-host latches for the heavy WKWebView on iOS (#2409). `hasAppeared`
+    // gates the pane off the first paint so the 6–8s WebContent/GPU/Networking
+    // helper-process launch doesn't block the reader's initial layout;
+    // `everShownWebKit` keeps a session that stays on the native claims tab from
+    // ever spawning the web processes at all. On macOS both are ignored — the
+    // pane is cheap and stays alive to preserve scroll (#1346).
+    @State private var hasAppeared = false
+    @State private var everShownWebKit = false
     @Environment(KGFocusState.self) private var kgFocusState
     @Environment(EntityServiceGenerated.self) private var entityService
     @Environment(ArtifactServiceGenerated.self) private var artifactService
@@ -187,30 +196,51 @@ struct DocumentKGSurface: View {
         }
     }
 
+    /// Whether to host the WKWebView pane this pass. macOS always hosts it (cheap,
+    /// preserves scroll, #1346); iOS defers until after first paint and only once
+    /// a WebKit tab has been requested, so the heavy helper-process launch never
+    /// blocks initial layout and a claims-only session skips it entirely (#2409).
+    private var shouldHostWebPane: Bool {
+        #if os(iOS)
+        return hasAppeared && everShownWebKit
+        #else
+        return true
+        #endif
+    }
+
     @ViewBuilder
     private var content: some View {
         // Keep the WKWebView alive across tab switches via ZStack + opacity
         // so scroll position survives when the user moves between transcript/
         // digest/graph/timeline/map and the native claims tab. (#1346)
         ZStack {
-            DocumentKGWebPane(
-                documentId: documentId,
-                libraryPath: libraryPath,
-                selectedEntityId: selectedEntityId,
-                selectedClaimId: selectedClaimId,
-                activeTab: activeTab.rawValue,
-                activePageNumber: activePageNumber,
-                pageCount: pageCount,
-                onPageSelected: onPageSelected,
-                scrollSync: scrollSync,
-                zoom: zoom
-            )
-            .opacity(activeTab.usesWebKit ? 1 : 0)
-            .allowsHitTesting(activeTab.usesWebKit)
+            if shouldHostWebPane {
+                DocumentKGWebPane(
+                    documentId: documentId,
+                    libraryPath: libraryPath,
+                    selectedEntityId: selectedEntityId,
+                    selectedClaimId: selectedClaimId,
+                    activeTab: activeTab.rawValue,
+                    activePageNumber: activePageNumber,
+                    pageCount: pageCount,
+                    onPageSelected: onPageSelected,
+                    scrollSync: scrollSync,
+                    zoom: zoom
+                )
+                .opacity(activeTab.usesWebKit ? 1 : 0)
+                .allowsHitTesting(activeTab.usesWebKit)
+            }
 
             if !activeTab.usesWebKit {
                 nativeTabContent
             }
+        }
+        .onAppear {
+            hasAppeared = true
+            if activeTab.usesWebKit { everShownWebKit = true }
+        }
+        .onChange(of: activeTab.usesWebKit) { _, usesWebKit in
+            if usesWebKit { everShownWebKit = true }
         }
     }
 

--- a/fichero/fichero/Views/Library/Reading/DocumentTextReader.swift
+++ b/fichero/fichero/Views/Library/Reading/DocumentTextReader.swift
@@ -95,10 +95,17 @@ struct DocumentTextReader: View {
     @State private var isComposingNote = false
     @State private var noteDraft = ""
 
+    /// Decoded, display-ready text — RTF source resolves to plain text so the
+    /// reader never shows raw escape codes (#2317). Annotation ranges and
+    /// selection all index into this same decoded string.
+    private var displayText: String {
+        ArtifactRichTextCodec.plainText(content)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             AnnotatableTextView(
-                text: content,
+                text: displayText,
                 highlights: highlightRanges,
                 selection: $selectionRange
             )
@@ -131,7 +138,7 @@ struct DocumentTextReader: View {
     private var highlightRanges: [Range<Int>] {
         AnnotationHighlight.ranges(
             for: documentAnnotations,
-            inUTF16Count: (content as NSString).length
+            inUTF16Count: (displayText as NSString).length
         )
     }
 
@@ -140,7 +147,7 @@ struct DocumentTextReader: View {
     }
 
     private func selectedText(_ range: Range<Int>) -> String {
-        let nsContent = content as NSString
+        let nsContent = displayText as NSString
         let nsRange = NSRange(location: range.lowerBound, length: range.count)
         guard NSMaxRange(nsRange) <= nsContent.length else { return "" }
         return nsContent.substring(with: nsRange)

--- a/fichero/fichero/Views/Library/Reading/PageContentPane.swift
+++ b/fichero/fichero/Views/Library/Reading/PageContentPane.swift
@@ -30,8 +30,12 @@ struct PageContentPane: View { // swiftlint:disable:this type_body_length
         return doc
     }
 
+    /// Decoded, display-ready page text. RTF source is resolved to plain text so
+    /// the reader never shows raw `\'e1`/control-word escapes (#2317); everything
+    /// downstream (edit draft, highlight ranges, claim matching) works off this
+    /// same decoded string so offsets stay consistent.
     private var pageContent: String {
-        pageDoc?.pageContent ?? ""
+        ArtifactRichTextCodec.plainText(pageDoc?.pageContent ?? "")
     }
 
     var body: some View {
@@ -50,8 +54,8 @@ struct PageContentPane: View { // swiftlint:disable:this type_body_length
                                 commitDraft(exitAfterSave: false)
                             }
                         }
-                } else if let content = doc.pageContent, !content.isEmpty {
-                    pageContentScroll(content)
+                } else if !pageContent.isEmpty {
+                    pageContentScroll(pageContent)
                 } else {
                     emptyState(
                         title: "No content",
@@ -235,13 +239,13 @@ struct PageContentPane: View { // swiftlint:disable:this type_body_length
     }
 
     private func toggleEditing() {
-        guard let doc = pageDoc else { return }
+        guard pageDoc != nil else { return }
         saveError = nil
 
         if editState.isEditing {
             commitDraft(exitAfterSave: true)
         } else {
-            editState.beginEditing(from: doc.pageContent ?? "")
+            editState.beginEditing(from: pageContent)
             isEditorFocused = true
         }
     }


### PR DESCRIPTION
#2317 RTF page content decoded to plain text in native readers (was raw escape codes). #2409 KG/transcript WKWebView lazy-hosted on iOS (was slow spawn + jank). BUILD SUCCEEDED. 🤖 Generated with [Claude Code](https://claude.com/claude-code)