### PR TITLE
Reader: native Page/Knowledge/Notes tab foundation (4-tab IA fold)

### DIFF
--- a/fichero/fichero-tests/InspectorLayoutTests.swift
+++ b/fichero/fichero-tests/InspectorLayoutTests.swift
@@ -531,6 +531,39 @@ struct KGSurfaceTabTests {
     }
 }
 
+// MARK: - Reader Tab Tests (reader IA fold 2026-07-11)
+
+struct ReaderTabTests {
+
+    @Test("ReaderTab folds the reader into Page, Knowledge, Notes in order")
+    func orderingAndCount() {
+        // Order drives the native top tab bar's left-to-right layout.
+        #expect(ReaderTab.allCases == [.page, .knowledge, .notes])
+    }
+
+    @Test("ReaderTab id equals rawValue")
+    func idEqualsRawValue() {
+        for tab in ReaderTab.allCases {
+            #expect(tab.id == tab.rawValue)
+        }
+    }
+
+    @Test("ReaderTab titles are the approved human-readable labels")
+    func titles() {
+        #expect(ReaderTab.page.title == "Page")
+        #expect(ReaderTab.knowledge.title == "Knowledge")
+        #expect(ReaderTab.notes.title == "Notes")
+    }
+
+    @Test("Every ReaderTab has a non-empty SF Symbol and help text")
+    func iconsAndHelp() {
+        for tab in ReaderTab.allCases {
+            #expect(!tab.icon.isEmpty, "\(tab.rawValue) should have an icon")
+            #expect(!tab.help.isEmpty, "\(tab.rawValue) should have help text")
+        }
+    }
+}
+
 // MARK: - PDF Loupe Tracking-Area Selector Guard (#1228)
 
 @MainActor

--- a/fichero/fichero/Views/Library/Reading/ReaderTabBar.swift
+++ b/fichero/fichero/Views/Library/Reading/ReaderTabBar.swift
@@ -1,0 +1,74 @@
+import SwiftUI
+
+/// The Reader's three top-level tabs — the 2026-07-11 reader IA fold
+/// (`docs/superpowers/specs/2026-07-11-reader-ia-design.md`, REVIEWED +
+/// APPROVED). The reader collapses ~10 WebKit modes into **Page / Knowledge /
+/// Notes**, native chrome over WebKit content, mirroring the Inspector's 10→4
+/// fold:
+///
+/// - **Page** — read the source. Absorbs WebKit-PDF/Document, the transcript,
+///   the page image/grid, loupe, page-turn, and image edits.
+/// - **Knowledge** — explore what we know. Absorbs Entities, Claims, Graph, KG,
+///   plus Timeline & Map (as sub-modes) and Digest + Sources (as a section) —
+///   the existing `DocumentKGSurface` / `KGSurfaceTab` surface.
+/// - **Notes** — the human reading layer: highlights, notes, bookmarks anchored
+///   to the page.
+///
+/// Preview stays a SEPARATE quick-look surface (Q3) and Canvas/Spatial stay
+/// Library view modes — neither folds in here.
+enum ReaderTab: String, CaseIterable, Identifiable {
+    case page
+    case knowledge
+    case notes
+
+    var id: String { rawValue }
+
+    /// Human-readable label shown on the native top tab.
+    var title: String {
+        switch self {
+        case .page: return "Page"
+        case .knowledge: return "Knowledge"
+        case .notes: return "Notes"
+        }
+    }
+
+    /// SF Symbol mirroring the Inspector tab-bar visual language.
+    var icon: String {
+        switch self {
+        case .page: return "doc.text.image"
+        case .knowledge: return "point.3.connected.trianglepath.dotted"
+        case .notes: return "note.text"
+        }
+    }
+
+    /// Tooltip: what the tab shows. (Mirrors `KGSurfaceTab.helpText`.)
+    var help: String {
+        switch self {
+        case .page: return "Page — read the source: image, transcript, loupe, page-turn"
+        case .knowledge: return "Knowledge — explore entities, claims, graph, timeline, map, and the digest"
+        case .notes: return "Notes — your highlights, notes, and bookmarks anchored to the page"
+        }
+    }
+}
+
+/// Native top-tab switcher for the Reader. The reader is the center pane with
+/// room to spare, and top tabs read well — the DECIDED switcher style (Daniel
+/// 2026-07-11): native chrome over the WebKit/native content beneath. A
+/// segmented `Picker` is the native, keyboard- and accessibility-friendly
+/// top-tab control; it never scrolls with the content (fixed chrome).
+struct ReaderTabBar: View {
+    @Binding var selection: ReaderTab
+
+    var body: some View {
+        Picker("Reader view", selection: $selection) {
+            ForEach(ReaderTab.allCases) { tab in
+                Label(tab.title, systemImage: tab.icon)
+                    .help(tab.help)
+                    .tag(tab)
+            }
+        }
+        .pickerStyle(.segmented)
+        .labelStyle(.titleAndIcon)
+        .accessibilityIdentifier("readerTabBar")
+    }
+}


### PR DESCRIPTION
Reader 4-tab restructure foundation — native top tabs Page/Knowledge/Notes (native chrome over WebKit content), per the approved Reader IA. BUILD SUCCEEDED. 🤖 Generated with [Claude Code](https://claude.com/claude-code)