### PR TITLE
Reader: wire Page/Knowledge/Notes tabs into the reading pane (#3501)

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		3D3445F0B90D093149C9A7D6 /* DocumentInspectorContentTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36234E44A7E494963A441CDC /* DocumentInspectorContentTab.swift */; };
 		4016BD3CF245BCA932D3D1D5 /* InviteAccountSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6337F0388FCB9CD46ACFEE95 /* InviteAccountSection.swift */; };
 		40B4487F9C8C03F6518A8988 /* PageImageGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753C4D174F9A42A6593BECC6 /* PageImageGrid.swift */; };
+		FEEDDEAD0000000000000002 /* ReaderTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000001 /* ReaderTabBar.swift */; };
 		417694AF6ACC5AEEF6E2E4B9 /* ClaimSummaryCard+Provenance.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CE0962968DEE7EAB60E454 /* ClaimSummaryCard+Provenance.swift */; };
 		44088B69B036974D72906372 /* ShareSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FF20EF84262D15A268246D /* ShareSettingsView.swift */; };
 		441627D26C9932352CE1FDF1 /* CanvasItemStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5921F26A97AF84B80B4DCD29 /* CanvasItemStore.swift */; };
@@ -881,6 +882,7 @@
 		74ECCAE0282E67AA4A150871 /* CoalescingSaveRunner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoalescingSaveRunner.swift; sourceTree = "<group>"; };
 		75371C597B1E4689B6E1803F /* TriggerEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerEditorView.swift; sourceTree = "<group>"; };
 		753C4D174F9A42A6593BECC6 /* PageImageGrid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PageImageGrid.swift; sourceTree = "<group>"; };
+		FEEDDEAD0000000000000001 /* ReaderTabBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReaderTabBar.swift; sourceTree = "<group>"; };
 		75558D1F0B1D0F65CEFF577C /* PDFReadingView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFReadingView.swift; sourceTree = "<group>"; };
 		772A6A57C4986C2765A174EE /* PlatformPasteboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlatformPasteboard.swift; sourceTree = "<group>"; };
 		79192DB989A34D1DBEEF3E34 /* CitationExportButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CitationExportButton.swift; sourceTree = "<group>"; };
@@ -2231,6 +2233,7 @@
 				D32974474262617AAAE4A322 /* PageContentPane.swift */,
 				C7E92E864B4AF4383634E221 /* ImmersiveReaderView.swift */,
 				753C4D174F9A42A6593BECC6 /* PageImageGrid.swift */,
+				FEEDDEAD0000000000000001 /* ReaderTabBar.swift */,
 			);
 			path = Reading;
 			sourceTree = "<group>";
@@ -3048,6 +3051,7 @@
 				669E5960825CCF224C5297A1 /* BackendWorkPill.swift in Sources */,
 				527561D7A2B768C662B2D74E /* PaneVisibility.swift in Sources */,
 				40B4487F9C8C03F6518A8988 /* PageImageGrid.swift in Sources */,
+				FEEDDEAD0000000000000002 /* ReaderTabBar.swift in Sources */,
 				2FA0C9F98B2B1A0A35107B07 /* ChainStore.swift in Sources */,
 				9DD32C9E1B17D298CF3138F1 /* SourceSnippet.swift in Sources */,
 				451693E6DEA7C6AEEB8C8183 /* InspectorSection.swift in Sources */,

--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -28,6 +28,15 @@ private struct ReadingPaneView: View {
     @State private var pinnedPageCount: Int?
     @State private var webZoom: Double = 1.0
     @State private var activeTab: KGSurfaceTab = .transcript
+    /// The reader's top-level tab (Page/Knowledge/Notes) — the reader IA fold
+    /// (2026-07-11 design). Per-window via @SceneStorage. Defaults to Knowledge
+    /// so this pane's long-standing default (the WebKit knowledge surface) is
+    /// unchanged; Page and Notes are now reachable as native top tabs.
+    @SceneStorage("reader.topTab") private var readerTabRaw = ReaderTab.knowledge.rawValue
+    private var readerTab: ReaderTab { ReaderTab(rawValue: readerTabRaw) ?? .knowledge }
+    private var readerTabBinding: Binding<ReaderTab> {
+        Binding(get: { readerTab }, set: { readerTabRaw = $0.rawValue })
+    }
 
     private var effectiveDocument: Document? { isPinned ? pinnedDocument : liveDocument }
     private var effectivePageNumber: Int? { isPinned ? pinnedActivePageNumber : liveActivePageNumber }
@@ -46,7 +55,14 @@ private struct ReadingPaneView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            surfaceView
+            // Native top tabs (Page/Knowledge/Notes) — fixed chrome over the
+            // WebKit/native content beneath (reader IA fold, 2026-07-11).
+            ReaderTabBar(selection: readerTabBinding)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 6)
+            Divider()
+
+            readerTabContent
 
             PaneFilterBar { Spacer(minLength: 0) }
 
@@ -164,6 +180,66 @@ private struct ReadingPaneView: View {
         .menuStyle(.borderlessButton)
         .menuIndicator(.hidden)
         .fixedSize()
+    }
+
+    /// Routes the selected reader tab to its content, native chrome over the
+    /// WebKit/native surfaces (reader IA fold). Page = read the source (image /
+    /// PDF with loupe #2419 / transcript); Knowledge = the WebKit KG surface;
+    /// Notes = the reading layer (highlights/notes/bookmarks).
+    @ViewBuilder
+    private var readerTabContent: some View {
+        switch readerTab {
+        case .page:
+            pageTabContent
+        case .knowledge:
+            surfaceView
+        case .notes:
+            notesTabContent
+        }
+    }
+
+    /// Page tab — the source. A PDF (or a page of one) renders in the native
+    /// `PDFPageWithToolbar`, which carries the bottom loupe control (#2419) and
+    /// page navigation; an image renders through `DocumentCanvas` (storage
+    /// HTTP, never a local path); anything else falls back to the transcript.
+    /// The image↔transcript side-by-side toggle is the #3502 follow-up.
+    @ViewBuilder
+    private var pageTabContent: some View {
+        if let doc = effectiveDocument {
+            if doc.docType == .page, let parentId = doc.parentId {
+                PDFPageWithToolbar(documentId: parentId, pageIndex: max(0, (doc.sequence ?? 1) - 1))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if doc.fileType == .pdf {
+                PDFPageWithToolbar(documentId: doc.id, pageIndex: 0)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else if doc.fileType == .image {
+                DocumentCanvas(content: .imageStorageDisplay(documentId: doc.id))
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                PageContentPane(document: doc)
+            }
+        } else {
+            readerEmptyState
+        }
+    }
+
+    /// Notes tab — the human reading layer (highlights / notes / bookmarks
+    /// anchored to the page), via the existing document notes surface.
+    @ViewBuilder
+    private var notesTabContent: some View {
+        if let doc = effectiveDocument {
+            DocumentNotesTab(document: doc)
+        } else {
+            readerEmptyState
+        }
+    }
+
+    private var readerEmptyState: some View {
+        Text("No selection")
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(.textBackgroundColor))
     }
 
     @ViewBuilder


### PR DESCRIPTION
Wires the native Page/Knowledge/Notes tabs into the reading pane. BUILD SUCCEEDED. 🤖 Generated with [Claude Code](https://claude.com/claude-code)