### PR TITLE
Tests: cover content representation revision error routes

### DIFF
--- a/fichero-engine/tests/unit/test_content_representations.py
+++ b/fichero-engine/tests/unit/test_content_representations.py
@@ -56,3 +56,13 @@ def test_representation_read_routes(client, db):
     response = client.get(f"/api/content-representations/document/{representation.document_id}")
     assert response.status_code == 200
     assert response.json()[0]["id"] == representation.id
+
+
+def test_revision_routes_reject_missing_representation_and_empty_content(client):
+    missing = client.get("/api/content-representations/missing/revisions")
+    empty = client.post(
+        "/api/content-representations/missing/revisions", json={"content": ""}
+    )
+
+    assert missing.status_code == 404
+    assert empty.status_code == 422


### PR DESCRIPTION
Hardening pass — focused error-path coverage for content-representation revision routes. test_content_representations.py 4 passed. Python-only, additive. 🤖 Generated with [Claude Code](https://claude.com/claude-code)