### PR TITLE
Tests: cover missing PyKEEN review decision path

### DIFF
--- a/fichero-engine/tests/unit/test_routes_kg_pykeen_reviews.py
+++ b/fichero-engine/tests/unit/test_routes_kg_pykeen_reviews.py
@@ -21,3 +21,12 @@ def test_prediction_review_persists_and_transitions(client, db):
     assert decided.status_code == 200
     assert decided.json()["state"] == "accepted"
     assert db.get(KnowledgePredictionReview, review_id).resulting_claim_id == "claim-1"
+
+
+def test_prediction_review_rejects_unknown_id(client):
+    response = client.patch(
+        "/api/kg/pykeen/reviews/missing", json={"state": "rejected", "note": "duplicate"}
+    )
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"]


### PR DESCRIPTION
Hardening — error/edge coverage for the PyKEEN review decision route. test_routes_kg_pykeen_reviews.py 2 passed. Python-only, additive. 🤖 Generated with [Claude Code](https://claude.com/claude-code)