### PR TITLE
Reader: apply claim-source highlight on Page transcript (#3511)

### DIFF
--- a/fichero/fichero/Views/Library/Reading/PageContentPane.swift
+++ b/fichero/fichero/Views/Library/Reading/PageContentPane.swift
@@ -124,6 +124,10 @@ struct PageContentPane: View { // swiftlint:disable:this type_body_length
         .onAppear {
             editState.synchronize(with: pageContent)
             loadAnnotations()
+            // Apply any already-selected claim's source highlight on appear, not
+            // only on change — so switching to the Page transcript after picking
+            // a claim in the Knowledge tab reveals the highlight (#3511).
+            syncSourceHighlightFromClaimFocus()
         }
         .onChange(of: pageDoc?.id ?? "") { _, _ in
             isSaving = false


### PR DESCRIPTION
Knowledge overlay — claim-source highlights applied on the Page transcript when it appears. BUILD SUCCEEDED. 🤖 Generated with [Claude Code](https://claude.com/claude-code)