### PR TITLE
Reader: Notes tab Marks/Notes sub-mode toggle (#3513)

### DIFF
--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -25,6 +25,12 @@ private struct ReadingPaneView: View {
     @Environment(\.splitAxisActions) private var splitAxisActions
     /// Shared annotation focus for the Notes tab's list ↔ detail selection.
     @State private var focusedAnnotation = FocusedAnnotation.shared
+    /// Notes-tab sub-mode: anchored marks vs free-text notes (#3513). Per-window.
+    @SceneStorage("reader.notes.mode") private var notesModeRaw = ReaderNotesMode.annotations.rawValue
+    private var notesMode: ReaderNotesMode { ReaderNotesMode(rawValue: notesModeRaw) ?? .annotations }
+    private var notesModeBinding: Binding<ReaderNotesMode> {
+        Binding(get: { notesMode }, set: { notesModeRaw = $0.rawValue })
+    }
 
     @State private var isPinned = false
     @State private var pinnedDocument: Document?
@@ -368,20 +374,44 @@ private struct ReadingPaneView: View {
         }
     }
 
-    /// Notes tab — the human reading layer: highlights / notes / bookmarks
-    /// anchored to the page, via the shared `AnnotationsInspectorPane`
-    /// (AnnotationStore-backed, list + detail, reveal-in-source, promote-to-claim).
-    /// The parent loads the document-scoped slice; the pane owns the mutations.
+    /// Notes tab — the human reading layer. A sub-mode toggle (#3513) switches
+    /// between anchored **Marks** (highlights / notes / bookmarks via the shared
+    /// `AnnotationsInspectorPane`) and free-text document **Notes** (NoteStore
+    /// via `DocumentNotesTab`), so both loose notes and page-anchored marks live
+    /// under one tab.
     @ViewBuilder
     private var notesTabContent: some View {
         if let doc = effectiveDocument {
-            AnnotationsInspectorPane(
-                document: doc,
-                annotations: annotationStore.annotations,
-                focused: focusedAnnotation
-            )
-            .task(id: doc.id) {
-                await annotationStore.loadAnnotations(for: annotationScope(for: doc), force: true)
+            VStack(spacing: 0) {
+                Picker("Notes mode", selection: notesModeBinding) {
+                    ForEach(ReaderNotesMode.allCases) { mode in
+                        Label(mode.title, systemImage: mode.icon)
+                            .help(mode.help)
+                            .tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .labelStyle(.titleAndIcon)
+                .fixedSize()
+                .padding(.horizontal, 8)
+                .padding(.vertical, 4)
+                .accessibilityIdentifier("readerNotesMode")
+
+                Divider()
+
+                switch notesMode {
+                case .annotations:
+                    AnnotationsInspectorPane(
+                        document: doc,
+                        annotations: annotationStore.annotations,
+                        focused: focusedAnnotation
+                    )
+                    .task(id: doc.id) {
+                        await annotationStore.loadAnnotations(for: annotationScope(for: doc), force: true)
+                    }
+                case .notes:
+                    DocumentNotesTab(document: doc)
+                }
             }
         } else {
             readerEmptyState

--- a/fichero/fichero/Views/Library/Reading/ReaderTabBar.swift
+++ b/fichero/fichero/Views/Library/Reading/ReaderTabBar.swift
@@ -86,6 +86,37 @@ enum ReaderPageLayout: String, CaseIterable, Identifiable {
     }
 }
 
+/// Notes-tab sub-mode (#3513): the anchored reading marks (highlights / notes /
+/// bookmarks) or free-text document notes. Both live under Notes so the reading
+/// layer and loose notes share one tab.
+enum ReaderNotesMode: String, CaseIterable, Identifiable {
+    case annotations
+    case notes
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .annotations: return "Marks"
+        case .notes: return "Notes"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .annotations: return "highlighter"
+        case .notes: return "note.text"
+        }
+    }
+
+    var help: String {
+        switch self {
+        case .annotations: return "Highlights, notes, and bookmarks anchored to the page"
+        case .notes: return "Free-text notes about this document"
+        }
+    }
+}
+
 /// Native top-tab switcher for the Reader. The reader is the center pane with
 /// room to spare, and top tabs read well — the DECIDED switcher style (Daniel
 /// 2026-07-11): native chrome over the WebKit/native content beneath. A


### PR DESCRIPTION
Reader Notes tab — toggle between source-anchored Marks (annotations) and free-text document Notes. BUILD SUCCEEDED. 🤖 Generated with [Claude Code](https://claude.com/claude-code)