### PR TITLE
Reader Knowledge: native Entities sub-mode (#3503)

### DIFF
--- a/fichero/fichero-tests/InspectorLayoutTests.swift
+++ b/fichero/fichero-tests/InspectorLayoutTests.swift
@@ -478,10 +478,10 @@ struct PageContentPaneEditStateTests {
 
 struct KGSurfaceTabTests {
 
-    @Test("KGSurfaceTab has transcript, digest, graph, claims, timeline, map in order")
+    @Test("KGSurfaceTab has transcript, digest, graph, claims, timeline, map, entities in order")
     func orderingAndCount() {
         // Order drives the native toolbar's left-to-right button layout.
-        #expect(KGSurfaceTab.allCases == [.transcript, .digest, .graph, .claims, .timeline, .map])
+        #expect(KGSurfaceTab.allCases == [.transcript, .digest, .graph, .claims, .timeline, .map, .entities])
     }
 
     @Test("KGSurfaceTab rawValues match the JS tab ids in document_view.html")
@@ -521,6 +521,8 @@ struct KGSurfaceTabTests {
         #expect(KGSurfaceTab.timeline.usesWebKit)
         #expect(KGSurfaceTab.map.usesWebKit)
         #expect(!KGSurfaceTab.claims.usesWebKit)
+        // Entities render natively (inspector list), not in the WebKit pane (#3503).
+        #expect(!KGSurfaceTab.entities.usesWebKit)
     }
 
     @Test("Every KGSurfaceTab has a non-empty SF Symbol")

--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -274,27 +274,27 @@ private struct ReadingPaneView: View {
     }
 
     /// The KG exploration sub-modes in the Knowledge tab. Transcript is a Page
-    /// concern; Digest is a separate section (below). Graph/Claims/Timeline/Map
-    /// are the "what we know" visualization views.
-    private static let knowledgeVizModes: [KGSurfaceTab] = [.graph, .claims, .timeline, .map]
+    /// concern; Digest is a separate section (below). Entities/Claims are native
+    /// lists; Graph/Timeline/Map are the WebKit visualization views (#3503).
+    private static let knowledgeVizModes: [KGSurfaceTab] = [.entities, .claims, .graph, .timeline, .map]
 
     /// Binds the exploration sub-mode picker to `activeTab`. When the Digest
     /// section is active (`activeTab == .digest`) the selection is nil so no viz
-    /// segment is highlighted; any stale non-knowledge value clamps to Graph.
+    /// segment is highlighted; any stale non-knowledge value clamps to Entities.
     private var knowledgeVizBinding: Binding<KGSurfaceTab?> {
         Binding(
             get: {
                 if Self.knowledgeVizModes.contains(activeTab) { return activeTab }
-                return activeTab == .digest ? nil : .graph
+                return activeTab == .digest ? nil : .entities
             },
             set: { if let mode = $0 { activeTab = mode } }
         )
     }
 
     /// The KG tab actually shown: a valid viz sub-mode or the digest section;
-    /// anything else (e.g. a stale `.transcript`) falls back to Graph.
+    /// anything else (e.g. a stale `.transcript`) falls back to Entities.
     private var effectiveKnowledgeTab: KGSurfaceTab {
-        (Self.knowledgeVizModes.contains(activeTab) || activeTab == .digest) ? activeTab : .graph
+        (Self.knowledgeVizModes.contains(activeTab) || activeTab == .digest) ? activeTab : .entities
     }
 
     /// Page tab — read the source. A source/split/transcript toggle (#3502) lays
@@ -465,7 +465,8 @@ private struct ReadingPaneView: View {
                 scrollSync: scrollSync,
                 zoom: webZoom,
                 externalActiveTab: effectiveKnowledgeTab,
-                onTabSelected: { activeTab = $0 }
+                onTabSelected: { activeTab = $0 },
+                document: doc
             )
         } else {
             Text("No selection")

--- a/fichero/fichero/Views/Library/DocumentKGSurface.swift
+++ b/fichero/fichero/Views/Library/DocumentKGSurface.swift
@@ -52,6 +52,7 @@ enum KGSurfaceTab: String, CaseIterable, Identifiable {
     case claims
     case timeline
     case map
+    case entities
 
     var id: String { rawValue }
 
@@ -64,6 +65,7 @@ enum KGSurfaceTab: String, CaseIterable, Identifiable {
         case .claims: return "Claims"
         case .timeline: return "Timeline"
         case .map: return "Map"
+        case .entities: return "Entities"
         }
     }
 
@@ -76,6 +78,7 @@ enum KGSurfaceTab: String, CaseIterable, Identifiable {
         case .claims: return "quote.bubble"
         case .timeline: return "calendar.badge.clock"
         case .map: return "map"
+        case .entities: return "circle.grid.2x2"
         }
     }
 
@@ -88,6 +91,7 @@ enum KGSurfaceTab: String, CaseIterable, Identifiable {
         case .claims: return "Claims — statements extracted from the document, grouped by source"
         case .timeline: return "Timeline — dated entities and events in chronological order"
         case .map: return "Map — entities laid out on a visual canvas"
+        case .entities: return "Entities — the people, places, and things named in the document"
         }
     }
 
@@ -102,14 +106,16 @@ enum KGSurfaceTab: String, CaseIterable, Identifiable {
         case .claims: return "4"
         case .timeline: return "5"
         case .map: return "6"
+        case .entities: return "7"
         }
     }
 
-    /// True for tabs rendered inside the shared WKWebView (#1346).
+    /// True for tabs rendered inside the shared WKWebView (#1346). Entities and
+    /// claims render natively (inspector components), so the WebKit pane hides.
     var usesWebKit: Bool {
         switch self {
         case .transcript, .digest, .graph, .timeline, .map: return true
-        case .claims: return false
+        case .claims, .entities: return false
         }
     }
 }
@@ -154,6 +160,10 @@ struct DocumentKGSurface: View {
     /// `= nil` is load-bearing: KnowledgeSurface call site omits these args.
     var externalActiveTab: KGSurfaceTab? = nil // swiftlint:disable:this implicit_optional_initialization
     var onTabSelected: ((KGSurfaceTab) -> Void)? = nil // swiftlint:disable:this implicit_optional_initialization
+    /// The full Document, supplied by callers that expose the native Entities
+    /// sub-mode (#3503). When nil the surface resolves it from the DocumentStore.
+    /// `= nil` is load-bearing: the KnowledgeSurface call site omits it.
+    var document: Document? = nil // swiftlint:disable:this implicit_optional_initialization
 
     @State private var internalActiveTab: KGSurfaceTab = .transcript
     private var activeTab: KGSurfaceTab { externalActiveTab ?? internalActiveTab }
@@ -170,6 +180,9 @@ struct DocumentKGSurface: View {
     @Environment(EntityServiceGenerated.self) private var entityService
     @Environment(ArtifactServiceGenerated.self) private var artifactService
     @Environment(KGCurationServiceGenerated.self) private var kgCurationService
+    // For resolving the Document the native Entities sub-mode needs (#3503) when
+    // the caller doesn't supply one via `document`.
+    @Environment(DocumentStore.self) private var documentStore
 
     var body: some View {
         // The representation switcher (Transcript/Digest/Graph/Claims/Timeline/
@@ -266,6 +279,23 @@ struct DocumentKGSurface: View {
                     )
                 }
             )
+        case .entities:
+            // Native document-scoped entity list, reusing the inspector's
+            // entities surface (#3503). Selecting an entity drives KG focus so
+            // the graph / transcript highlight follows.
+            if let doc = document ?? documentStore.currentDocuments.first(where: { $0.id == documentId }) {
+                DocumentInspectorEntitiesTab(
+                    document: doc,
+                    documentId: documentId,
+                    selectedEntityId: selectedEntityId,
+                    onEntitySelect: { entityId in kgFocusState.focusEntity(entityId: entityId) }
+                )
+            } else {
+                Text("Select a document to see its entities.")
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
         }
     }
 


### PR DESCRIPTION
Reader Knowledge tab now hosts the native Entities sub-mode (real entity content). BUILD SUCCEEDED. Part of #3503 (Claims/Graph/timeline-map sub-modes to follow). 🤖 Generated with [Claude Code](https://claude.com/claude-code)