### PR TITLE
Reader Knowledge: force-graph + Timeline/Map sub-modes (#3503)

### DIFF
--- a/fichero/fichero-tests/InspectorLayoutTests.swift
+++ b/fichero/fichero-tests/InspectorLayoutTests.swift
@@ -513,16 +513,17 @@ struct KGSurfaceTabTests {
         #expect(KGSurfaceTab.map.title == "Map")
     }
 
-    @Test("Timeline and Map tabs stay inside the shared WebKit pane")
+    @Test("Timeline and Map stay WebKit; Entities/Claims/Graph render natively")
     func webKitTabs() {
         #expect(KGSurfaceTab.transcript.usesWebKit)
         #expect(KGSurfaceTab.digest.usesWebKit)
-        #expect(KGSurfaceTab.graph.usesWebKit)
         #expect(KGSurfaceTab.timeline.usesWebKit)
         #expect(KGSurfaceTab.map.usesWebKit)
         #expect(!KGSurfaceTab.claims.usesWebKit)
-        // Entities render natively (inspector list), not in the WebKit pane (#3503).
+        // Entities (inspector list) + Graph (OntologyBrowser force graph) render
+        // natively, not in the WebKit pane (#3503).
         #expect(!KGSurfaceTab.entities.usesWebKit)
+        #expect(!KGSurfaceTab.graph.usesWebKit)
     }
 
     @Test("Every KGSurfaceTab has a non-empty SF Symbol")

--- a/fichero/fichero-tests/InspectorLayoutTests.swift
+++ b/fichero/fichero-tests/InspectorLayoutTests.swift
@@ -513,17 +513,18 @@ struct KGSurfaceTabTests {
         #expect(KGSurfaceTab.map.title == "Map")
     }
 
-    @Test("Timeline and Map stay WebKit; Entities/Claims/Graph render natively")
+    @Test("Only transcript + digest stay WebKit; all KG visualizations are native")
     func webKitTabs() {
+        // Transcript + the digest summary remain WebKit HTML.
         #expect(KGSurfaceTab.transcript.usesWebKit)
         #expect(KGSurfaceTab.digest.usesWebKit)
-        #expect(KGSurfaceTab.timeline.usesWebKit)
-        #expect(KGSurfaceTab.map.usesWebKit)
+        // Entities/Claims (inspector lists) + Graph/Timeline/Map (OntologyBrowser
+        // components) render natively, not in the WebKit pane (#3503).
         #expect(!KGSurfaceTab.claims.usesWebKit)
-        // Entities (inspector list) + Graph (OntologyBrowser force graph) render
-        // natively, not in the WebKit pane (#3503).
         #expect(!KGSurfaceTab.entities.usesWebKit)
         #expect(!KGSurfaceTab.graph.usesWebKit)
+        #expect(!KGSurfaceTab.timeline.usesWebKit)
+        #expect(!KGSurfaceTab.map.usesWebKit)
     }
 
     @Test("Every KGSurfaceTab has a non-empty SF Symbol")

--- a/fichero/fichero/Views/Library/DocumentKGSurface.swift
+++ b/fichero/fichero/Views/Library/DocumentKGSurface.swift
@@ -1,3 +1,4 @@
+import FicheroAPIClient
 import Observation
 import SwiftUI
 
@@ -110,12 +111,13 @@ enum KGSurfaceTab: String, CaseIterable, Identifiable {
         }
     }
 
-    /// True for tabs rendered inside the shared WKWebView (#1346). Entities and
-    /// claims render natively (inspector components), so the WebKit pane hides.
+    /// True for tabs rendered inside the shared WKWebView (#1346). Entities,
+    /// claims, and the force graph render natively (inspector / OntologyBrowser
+    /// components), so the WebKit pane hides for them.
     var usesWebKit: Bool {
         switch self {
-        case .transcript, .digest, .graph, .timeline, .map: return true
-        case .claims, .entities: return false
+        case .transcript, .digest, .timeline, .map: return true
+        case .claims, .entities, .graph: return false
         }
     }
 }
@@ -183,6 +185,24 @@ struct DocumentKGSurface: View {
     // For resolving the Document the native Entities sub-mode needs (#3503) when
     // the caller doesn't supply one via `document`.
     @Environment(DocumentStore.self) private var documentStore
+    // Document-scoped entities feed the native Graph/Timeline/Map sub-modes (#3503).
+    @Environment(EntityStore.self) private var entityStore
+
+    /// The document's entities for the native KG visualizations.
+    private var documentEntities: [Components.Schemas.KnowledgeEntity] {
+        entityStore.entitiesByDocumentId[documentId] ?? []
+    }
+
+    /// Entity selection bound to KG focus so picking a node drives the shared
+    /// highlight (the same focus the transcript / claims views observe).
+    private var selectedEntityBinding: Binding<String?> {
+        Binding(
+            get: { selectedEntityId },
+            set: { newId in
+                if let id = newId { kgFocusState.focusEntity(entityId: id) }
+            }
+        )
+    }
 
     var body: some View {
         // The representation switcher (Transcript/Digest/Graph/Claims/Timeline/
@@ -255,13 +275,26 @@ struct DocumentKGSurface: View {
         .onChange(of: activeTab.usesWebKit) { _, usesWebKit in
             if usesWebKit { everShownWebKit = true }
         }
+        // Load the document's entities for the native Graph/Timeline/Map
+        // sub-modes (idempotent + cached in the store). (#3503)
+        .task(id: documentId) {
+            await entityStore.loadEntities(forDocument: documentId)
+        }
     }
 
     @ViewBuilder
     private var nativeTabContent: some View {
         switch activeTab {
-        case .transcript, .digest, .graph, .timeline, .map:
+        case .transcript, .digest, .timeline, .map:
             EmptyView()
+        case .graph:
+            // Native force-directed graph (OntologyBrowser component) over the
+            // document's entities — no WebKit (#3503). Nodes are entities, edges
+            // their claim co-occurrence; selecting a node drives KG focus.
+            ForceDirectedGraphView(
+                entities: documentEntities,
+                selectedEntityId: selectedEntityBinding
+            )
         case .claims:
             // No outer ScrollView — KnowledgeGraphInspectorSection owns its own
             // scroll + pinned bottom mini-toolbar (#3461).

--- a/fichero/fichero/Views/Library/DocumentKGSurface.swift
+++ b/fichero/fichero/Views/Library/DocumentKGSurface.swift
@@ -111,13 +111,14 @@ enum KGSurfaceTab: String, CaseIterable, Identifiable {
         }
     }
 
-    /// True for tabs rendered inside the shared WKWebView (#1346). Entities,
-    /// claims, and the force graph render natively (inspector / OntologyBrowser
-    /// components), so the WebKit pane hides for them.
+    /// True for tabs rendered inside the shared WKWebView (#1346). The KG
+    /// visualizations (Entities, Claims, Graph, Timeline, Map) render natively
+    /// via inspector / OntologyBrowser components; only the transcript and the
+    /// digest summary remain WebKit HTML.
     var usesWebKit: Bool {
         switch self {
-        case .transcript, .digest, .timeline, .map: return true
-        case .claims, .entities, .graph: return false
+        case .transcript, .digest: return true
+        case .claims, .entities, .graph, .timeline, .map: return false
         }
     }
 }
@@ -285,13 +286,27 @@ struct DocumentKGSurface: View {
     @ViewBuilder
     private var nativeTabContent: some View {
         switch activeTab {
-        case .transcript, .digest, .timeline, .map:
+        case .transcript, .digest:
             EmptyView()
         case .graph:
             // Native force-directed graph (OntologyBrowser component) over the
             // document's entities — no WebKit (#3503). Nodes are entities, edges
             // their claim co-occurrence; selecting a node drives KG focus.
             ForceDirectedGraphView(
+                entities: documentEntities,
+                selectedEntityId: selectedEntityBinding
+            )
+        case .timeline:
+            // Native timeline (OntologyBrowser component): the document's
+            // entities' dated claims on a time axis (#3503).
+            KGTimelineView(
+                entities: documentEntities,
+                selectedEntityId: selectedEntityBinding
+            )
+        case .map:
+            // Native map (OntologyBrowser component): the document's entities'
+            // geo-located claims (#3503).
+            KGMapView(
                 entities: documentEntities,
                 selectedEntityId: selectedEntityBinding
             )


### PR DESCRIPTION
Reader Knowledge tab now hosts the native force-directed graph + Timeline + Map sub-modes with real data. BUILD SUCCEEDED. Completes the Knowledge sub-mode wiring for #3503. 🤖 Generated with [Claude Code](https://claude.com/claude-code)