### PR TITLE
Reader: compact-width tab bar + reveal-source→Page anchor (#3522/#3521)

### DIFF
--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -23,6 +23,9 @@ private struct ReadingPaneView: View {
     @Environment(ClaimFocusState.self) private var claimFocusState
     @Environment(AnnotationStore.self) private var annotationStore
     @Environment(\.splitAxisActions) private var splitAxisActions
+    /// Per-window source-navigation bus (#2105/#3437). A reveal brings the reader
+    /// to the Page tab so the highlighted source is visible (#3521).
+    @Environment(ClaimSourceNavigationState.self) private var claimSourceNavigationState: ClaimSourceNavigationState?
     /// Shared annotation focus for the Notes tab's list ↔ detail selection.
     @State private var focusedAnnotation = FocusedAnnotation.shared
     /// Notes-tab sub-mode: anchored marks vs free-text notes (#3513). Per-window.
@@ -158,6 +161,22 @@ private struct ReadingPaneView: View {
                 .help(isPinned ? "Unpin — follow current selection" : "Pin to current document")
             })
         }
+        // A source reveal (#2105) brings the reader to the Page tab so the
+        // highlighted / scrolled-to source is actually visible (#3521).
+        .onChange(of: claimSourceNavigationState?.requestID) { _, newID in
+            if newID != nil { revealSourceInPageTab() }
+        }
+    }
+
+    /// Switch the reader to the Page tab and, if it's showing only the source,
+    /// split in the transcript — so a revealed claim/entity source shows with
+    /// its highlight + scroll-to-anchor. The transcript highlight and scroll
+    /// come from PageContentPane observing ClaimFocusState (#3511 on appear,
+    /// #3226 anchor); the PDF page scroll comes from the reveal's
+    /// `.ficheroNavigateToPage`.
+    private func revealSourceInPageTab() {
+        if readerTab != .page { readerTabRaw = ReaderTab.page.rawValue }
+        if pageLayout == .source { pageLayoutRaw = ReaderPageLayout.split.rawValue }
     }
 
     @ViewBuilder

--- a/fichero/fichero/Views/Library/Reading/ReaderTabBar.swift
+++ b/fichero/fichero/Views/Library/Reading/ReaderTabBar.swift
@@ -124,9 +124,14 @@ enum ReaderNotesMode: String, CaseIterable, Identifiable {
 /// top-tab control; it never scrolls with the content (fixed chrome).
 struct ReaderTabBar: View {
     @Binding var selection: ReaderTab
+    /// On compact width (iPhone / narrow iPad) the segmented tabs show icons
+    /// only so all three stay reachable without clipping; regular width keeps
+    /// the labelled tabs (#3522). macOS reports `.regular`.
+    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+    private var isCompact: Bool { horizontalSizeClass == .compact }
 
     var body: some View {
-        Picker("Reader view", selection: $selection) {
+        let picker = Picker("Reader view", selection: $selection) {
             ForEach(ReaderTab.allCases) { tab in
                 Label(tab.title, systemImage: tab.icon)
                     .help(tab.help)
@@ -134,7 +139,14 @@ struct ReaderTabBar: View {
             }
         }
         .pickerStyle(.segmented)
-        .labelStyle(.titleAndIcon)
         .accessibilityIdentifier("readerTabBar")
+
+        // Distinct label styles are distinct types, so branch rather than
+        // ternary; the style propagates to the segment Labels via environment.
+        if isCompact {
+            picker.labelStyle(.iconOnly)
+        } else {
+            picker.labelStyle(.titleAndIcon)
+        }
     }
 }


### PR DESCRIPTION
#3522 top tab bar adapts to compact width (iPhone). #3521 revealing a claim/entity source switches the reader to the Page tab and scrolls to the source anchor. BUILD SUCCEEDED. Final Reader polish. 🤖 Generated with [Claude Code](https://claude.com/claude-code)