### PR TITLE
Engine: scoped entity-reconciliation candidates endpoint (#3318)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/kg_entity_curation.py
+++ b/fichero-engine/src/fichero/api/routes/kg_entity_curation.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from pydantic import BaseModel, Field
@@ -586,6 +586,8 @@ async def candidate_pairs(
     min_jaccard: float = Query(default=0.5, ge=0.0, le=1.0),
     top_k: int = Query(default=20, ge=1, le=200),
     same_type_only: bool = Query(default=True),
+    scope: Literal["library", "folder"] = Query(default="library"),
+    folder_id: str | None = Query(default=None),
     db: Database = Depends(get_library_database),
 ) -> KGGraphListResponse:
     """Compute Jaccard similarity over the co-occurrence graph between
@@ -596,6 +598,19 @@ async def candidate_pairs(
     from fichero.kg.graph import build_full_cooccurrence
 
     graph = build_full_cooccurrence(db)
+    if scope == "folder":
+        if not folder_id:
+            raise HTTPException(status_code=422, detail="folder_id is required for folder scope")
+        from fichero.api.routes.claims import _descendant_doc_ids
+
+        doc_ids = _descendant_doc_ids(db, folder_id)
+        entity_ids = {
+            entity_id
+            for claim in db.query_in(KnowledgeClaim, "source_document_id", doc_ids)
+            for entity_id in (claim.entity_ids or [])
+        }
+        entity_ids.update(db.knowledge_entity_ids_scoped_to_documents(doc_ids))
+        graph = graph.subgraph(entity_ids).copy()
     if graph.number_of_nodes() < 2:
         return KGGraphListResponse(items=[], count=0)
     by_id: dict[str, KnowledgeEntity] = {e.id: e for e in db.query(KnowledgeEntity)}

--- a/fichero-engine/tests/unit/test_routes_entity_curation_scope.py
+++ b/fichero-engine/tests/unit/test_routes_entity_curation_scope.py
@@ -1,0 +1,15 @@
+"""Scoped entity-reconciliation candidate route coverage (#3318)."""
+
+
+def test_folder_scope_requires_folder_id(client):
+    response = client.get("/api/kg/entity-curation/candidates?scope=folder")
+
+    assert response.status_code == 422
+    assert "folder_id is required" in response.json()["detail"]
+
+
+def test_library_scope_is_the_default(client):
+    response = client.get("/api/kg/entity-curation/candidates")
+
+    assert response.status_code == 200
+    assert response.json() == {"items": [], "count": 0}


### PR DESCRIPTION
/api/kg/entity-curation candidates scoped by folder|library (reuse #3317 candidate logic + audited merge) for the reconciliation UI. Gate: test_routes_entity_curation_scope.py 2 passed. Python-only. Adds an endpoint → OpenAPI regen follows. 🤖 Generated with [Claude Code](https://claude.com/claude-code)