### PR TITLE
Regen: OpenAPI + Swift client for #3318 reconciliation endpoint

### DIFF
--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -22897,6 +22897,30 @@
               "default": true,
               "title": "Same Type Only"
             }
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "library",
+                "folder"
+              ],
+              "type": "string",
+              "default": "library",
+              "title": "Scope"
+            }
+          },
+          {
+            "name": "folder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Folder Id"
+            }
           }
         ],
         "responses": {

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -6386,16 +6386,20 @@ def register_generated_openapi_commands(
     @target_app.command("graph-context-merge-candidates-jaccard-over-co-occurrence-neighborhoods")
     def kg_graph_context_merge_candidates_jaccard_over_co_occurrence_neighborhoods_get(
         ctx: typer.Context,
+        folder_id: Optional[str] = typer.Option(None, "--folder-id", help="Query parameter: folder_id."),
         min_jaccard: Optional[float] = typer.Option(None, "--min-jaccard", help="Query parameter: min_jaccard."),
         same_type_only: Optional[bool] = typer.Option(None, "--same-type-only/--no-same-type-only", help="Query parameter: same_type_only."),
+        scope: Optional[str] = typer.Option(None, "--scope", help="Query parameter: scope."),
         top_k: Optional[int] = typer.Option(None, "--top-k", help="Query parameter: top_k."),
     ) -> None:
         """Graph-context merge candidates (Jaccard over co-occurrence neighborhoods) (GET /api/kg/entity-curation/candidates)."""
         def op_call(client: FicheroClient) -> Any:
             endpoint_path = "/api/kg/entity-curation/candidates"
             params = {
+                "folder_id": folder_id,
                 "min_jaccard": min_jaccard,
                 "same_type_only": same_type_only,
+                "scope": scope,
                 "top_k": top_k,
             }
             return client.request("GET", endpoint_path, params=params)

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -4421,6 +4421,11 @@
         "path_params": [],
         "query_params": [
           {
+            "name": "folder_id",
+            "required": false,
+            "type": "string"
+          },
+          {
             "name": "min_jaccard",
             "required": false,
             "type": "number"
@@ -4429,6 +4434,11 @@
             "name": "same_type_only",
             "required": false,
             "type": "boolean"
+          },
+          {
+            "name": "scope",
+            "required": false,
+            "type": "string"
           },
           {
             "name": "top_k",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -22897,6 +22897,30 @@
               "default": true,
               "title": "Same Type Only"
             }
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "library",
+                "folder"
+              ],
+              "type": "string",
+              "default": "library",
+              "title": "Scope"
+            }
+          },
+          {
+            "name": "folder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Folder Id"
+            }
           }
         ],
         "responses": {

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -22897,6 +22897,30 @@
               "default": true,
               "title": "Same Type Only"
             }
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "library",
+                "folder"
+              ],
+              "type": "string",
+              "default": "library",
+              "title": "Scope"
+            }
+          },
+          {
+            "name": "folder_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Folder Id"
+            }
           }
         ],
         "responses": {


### PR DESCRIPTION
Regenerates openapi.json + Swift client for the /api/kg/entity-curation scoped-candidates endpoint (#3318). Generated artifacts only. Verified by f_inspector rebuild post-merge. 🤖 Generated with [Claude Code](https://claude.com/claude-code)