### PR TITLE
Reconciliation UI (#3318) + shared SurfaceTabBar extraction (#3530)

### DIFF
--- a/fichero/fichero-tests/InspectorLayoutTests.swift
+++ b/fichero/fichero-tests/InspectorLayoutTests.swift
@@ -568,6 +568,35 @@ struct ReaderTabTests {
     }
 }
 
+// MARK: - Shared SurfaceChrome (#3530)
+
+private enum SampleSurfaceTab: String, CaseIterable, Identifiable, SurfaceTab {
+    case alpha, beta
+    var id: String { rawValue }
+    var title: String { rawValue.capitalized }
+    var icon: String { "circle" }
+    var help: String { "\(title) help" }
+}
+
+struct SurfaceChromeTests {
+    @Test("SurfaceTab derives a default accessibility id from the title")
+    func defaultAccessibilityID() {
+        #expect(SampleSurfaceTab.alpha.accessibilityID == "surfaceTab-Alpha")
+    }
+
+    @Test("ReaderTab conforms to SurfaceTab with complete metadata")
+    func readerTabConformsToSurfaceTab() {
+        let tabs: [any SurfaceTab] = ReaderTab.allCases
+        #expect(tabs.count == 3)
+        for tab in ReaderTab.allCases {
+            #expect(!tab.title.isEmpty)
+            #expect(!tab.icon.isEmpty)
+            #expect(!tab.help.isEmpty)
+            #expect(!tab.accessibilityID.isEmpty)
+        }
+    }
+}
+
 // MARK: - PDF Loupe Tracking-Area Selector Guard (#1228)
 
 @MainActor

--- a/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
+++ b/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
@@ -1031,37 +1031,31 @@ private func makeKnowledgeClaim(
 // MARK: - Entity reconciliation grouping (#3318)
 
 final class EntityReconciliationTests: XCTestCase {
-    private func entity(_ id: String, _ name: String) -> Components.Schemas.KnowledgeEntity {
-        Components.Schemas.KnowledgeEntity(
-            id: id,
-            canonicalName: name,
-            entityType: .person,
-            aliases: nil,
-            description: nil,
-            language: nil,
-            metadata: nil,
-            mergedIntoId: nil
-        )
+    func testParsesCandidatePairsFromEngineEnvelope() throws {
+        // The /api/kg/entity-curation/candidates envelope: { items: [pairs], count }.
+        let json = Data("""
+        {"count": 2, "items": [
+          {"entity_a_id": "a", "entity_a_name": "Pedro", "entity_b_id": "b",
+           "entity_b_name": "Pedro de la Vega", "jaccard": 0.82, "shared_neighbors": 5,
+           "entity_type": "person"},
+          {"entity_a_id": "x", "entity_a_name": "x", "entity_b_id": "x",
+           "entity_b_name": "x", "jaccard": 0.9}
+        ]}
+        """.utf8)
+        let pairs = EntityStore.parseReconciliationCandidates(json)
+        // The self-pair (a==b) is dropped; the real pair is parsed.
+        XCTAssertEqual(pairs.count, 1)
+        let pair = try XCTUnwrap(pairs.first)
+        XCTAssertEqual(pair.entityAId, "a")
+        XCTAssertEqual(pair.entityBName, "Pedro de la Vega")
+        XCTAssertEqual(pair.jaccard, 0.82, accuracy: 0.001)
+        XCTAssertEqual(pair.entityType, "person")
+        XCTAssertEqual(pair.id, "a|b")
     }
 
-    func testGroupsNormalizedNameDuplicatesAndSkipsSingletons() {
-        let entities = [
-            entity("1", "Ada Lovelace"),
-            entity("2", "ada lovelace"),   // case variant → same group as 1
-            entity("3", "  Ada Lovelace "), // whitespace variant → same group
-            entity("4", "Charles Babbage")  // unique → no group
-        ]
-        let groups = EntityReconciliationSheet.groupDuplicates(entities)
-        XCTAssertEqual(groups.count, 1, "only the Ada Lovelace variants form a group")
-        XCTAssertEqual(groups.first?.entities.count, 3)
-        XCTAssertEqual(Set(groups.first?.entities.compactMap(\.id) ?? []), ["1", "2", "3"])
-    }
-
-    func testNormalizedKeyFoldsCaseAndWhitespace() {
-        XCTAssertEqual(
-            EntityReconciliationSheet.normalizedKey("  Popayán "),
-            EntityReconciliationSheet.normalizedKey("popayán")
-        )
+    func testParsesEmptyOrMalformedEnvelopeToNoPairs() {
+        XCTAssertTrue(EntityStore.parseReconciliationCandidates(Data("null".utf8)).isEmpty)
+        XCTAssertTrue(EntityStore.parseReconciliationCandidates(Data("{\"count\":0,\"items\":[]}".utf8)).isEmpty)
     }
 
     func testScopeAvailabilityMatchesTheShippedScopes() {

--- a/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
+++ b/fichero/fichero-tests/KnowledgeGraphInspectorSectionTests.swift
@@ -1028,4 +1028,50 @@ private func makeKnowledgeClaim(
         objectPhrase: object
     )
 }
+// MARK: - Entity reconciliation grouping (#3318)
+
+final class EntityReconciliationTests: XCTestCase {
+    private func entity(_ id: String, _ name: String) -> Components.Schemas.KnowledgeEntity {
+        Components.Schemas.KnowledgeEntity(
+            id: id,
+            canonicalName: name,
+            entityType: .person,
+            aliases: nil,
+            description: nil,
+            language: nil,
+            metadata: nil,
+            mergedIntoId: nil
+        )
+    }
+
+    func testGroupsNormalizedNameDuplicatesAndSkipsSingletons() {
+        let entities = [
+            entity("1", "Ada Lovelace"),
+            entity("2", "ada lovelace"),   // case variant → same group as 1
+            entity("3", "  Ada Lovelace "), // whitespace variant → same group
+            entity("4", "Charles Babbage")  // unique → no group
+        ]
+        let groups = EntityReconciliationSheet.groupDuplicates(entities)
+        XCTAssertEqual(groups.count, 1, "only the Ada Lovelace variants form a group")
+        XCTAssertEqual(groups.first?.entities.count, 3)
+        XCTAssertEqual(Set(groups.first?.entities.compactMap(\.id) ?? []), ["1", "2", "3"])
+    }
+
+    func testNormalizedKeyFoldsCaseAndWhitespace() {
+        XCTAssertEqual(
+            EntityReconciliationSheet.normalizedKey("  Popayán "),
+            EntityReconciliationSheet.normalizedKey("popayán")
+        )
+    }
+
+    func testScopeAvailabilityMatchesTheShippedScopes() {
+        // Folder + Library ship now; cross-library (#3527) + external (#3528) are
+        // deferred and must render disabled.
+        XCTAssertTrue(EntityReconciliationScope.folder.isAvailable)
+        XCTAssertTrue(EntityReconciliationScope.library.isAvailable)
+        XCTAssertFalse(EntityReconciliationScope.crossLibrary.isAvailable)
+        XCTAssertFalse(EntityReconciliationScope.external.isAvailable)
+    }
+}
+
 // swiftlint:enable file_length type_body_length

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -545,6 +545,7 @@
 		DC1FCDEE6B31AEA018C6F0DA /* ArtifactsInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C36D41D71387394E6AEB453 /* ArtifactsInspectorPane.swift */; };
 		DCC4D9C15886A018CBA1AA2E /* FocusedNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20829DBAC5757AEA6096835 /* FocusedNote.swift */; };
 		DCFC0B2C370966F9B57072A2 /* EntityMergeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB5DE35F2956544D2771C85 /* EntityMergeSheet.swift */; };
+		FEEDDEAD0000000000000004 /* EntityReconciliationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000003 /* EntityReconciliationSheet.swift */; };
 		DD1C07E557CD9392EF3C3BC5 /* PDFThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C59C2205AA2F446083A9C9 /* PDFThumbnailView.swift */; };
 		DDE8A1E95DE61B0723A40BC9 /* DynamicConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DA25B2C1FBB75B0B1CC643 /* DynamicConfigView.swift */; };
 		E03D3AB8185C98A43134F6EF /* DocumentInspectorInfoTab+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35793BBA8A74DAA0982CCFA4 /* DocumentInspectorInfoTab+Header.swift */; };
@@ -907,6 +908,7 @@
 		8C31EBD6243D124565257708 /* EngineConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EngineConfig.swift; sourceTree = "<group>"; };
 		8C61D10AF212650451E8C13B /* EditClaimSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EditClaimSheet.swift; sourceTree = "<group>"; };
 		8EB5DE35F2956544D2771C85 /* EntityMergeSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityMergeSheet.swift; sourceTree = "<group>"; };
+		FEEDDEAD0000000000000003 /* EntityReconciliationSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityReconciliationSheet.swift; sourceTree = "<group>"; };
 		8F9C3B5A53041FFAA09E0221 /* CitationsInspectorPane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CitationsInspectorPane.swift; sourceTree = "<group>"; };
 		902DF4705DA9730D76AF2C06 /* PDFPageWithToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFPageWithToolbar.swift; sourceTree = "<group>"; };
 		9037096857E2AE5F3339A8DC /* DocumentInspectorInfoTab+Workflow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentInspectorInfoTab+Workflow.swift"; sourceTree = "<group>"; };
@@ -1278,6 +1280,7 @@
 				BA39991F769A1DD42BB17F01 /* ClaimSummaryCard+Details.swift */,
 				8C61D10AF212650451E8C13B /* EditClaimSheet.swift */,
 				8EB5DE35F2956544D2771C85 /* EntityMergeSheet.swift */,
+				FEEDDEAD0000000000000003 /* EntityReconciliationSheet.swift */,
 				7F3FE2F360EADE051A3D2D51 /* EntitySplitSheet.swift */,
 				2F46B999D0208EA4C734535C /* ClaimReviewQueueSheet.swift */,
 				53458DC3387BC4C694EE3452 /* ContradictionTriageSheet.swift */,
@@ -2811,6 +2814,7 @@
 				D9D582D305FA54570A7F6093 /* UITestSupport.swift in Sources */,
 				FC38FF82492B7D35C486CF71 /* EditClaimSheet.swift in Sources */,
 				DCFC0B2C370966F9B57072A2 /* EntityMergeSheet.swift in Sources */,
+				FEEDDEAD0000000000000004 /* EntityReconciliationSheet.swift in Sources */,
 				1BD8C58F169EE984D4CF90A4 /* EntitySplitSheet.swift in Sources */,
 				0A667D33534B55BD383F4D55 /* KGMapView.swift in Sources */,
 				56DCD53ACD6483561CF542B3 /* KGTemporalSpatial.swift in Sources */,

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -276,6 +276,7 @@
 		78F8389F0A4A57F5A2D6F260 /* BackendActivityEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07BE5ECB91F929ADBD8595A /* BackendActivityEvent.swift */; };
 		7BC4AED0E0043218B6104F4A /* ScrollWheelZoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3080C713216B7BBD39725487 /* ScrollWheelZoom.swift */; };
 		7C874A46B0C0C85ACD9F23AA /* DocumentInspectorArtifactsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312845068CA928DA393E0468 /* DocumentInspectorArtifactsTab.swift */; };
+		FEEDDEAD0000000000000006 /* SurfaceTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000005 /* SurfaceTabBar.swift */; };
 		7D8F36CB01DB7346C305CA3C /* ContentView+ReadingLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6650E28284D750D9076B0612 /* ContentView+ReadingLayout.swift */; };
 		7DBC189DE3A7BC27C2B3BEFF /* LibraryOutlineNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453CA6ACF420E59AED37F906 /* LibraryOutlineNode.swift */; };
 		7ECBD1BC6380EBF38150DBAF /* DocumentInspectorInfoTab+RelatedClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0164BBC35A375AA74214F42 /* DocumentInspectorInfoTab+RelatedClaims.swift */; };
@@ -788,6 +789,7 @@
 		300A8405FFC476E5124372AE /* APIClient+Types.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "APIClient+Types.swift"; sourceTree = "<group>"; };
 		3080C713216B7BBD39725487 /* ScrollWheelZoom.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScrollWheelZoom.swift; sourceTree = "<group>"; };
 		312845068CA928DA393E0468 /* DocumentInspectorArtifactsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DocumentInspectorArtifactsTab.swift; path = fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab.swift; sourceTree = SOURCE_ROOT; };
+		FEEDDEAD0000000000000005 /* SurfaceTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SurfaceTabBar.swift; path = fichero/Views/SurfaceChrome/SurfaceTabBar.swift; sourceTree = SOURCE_ROOT; };
 		322ECCB87D28069C9539D009 /* FocusedAnnotation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FocusedAnnotation.swift; sourceTree = "<group>"; };
 		32F310DFF84C9557A77D4FDA /* NodePopover+Comparison.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NodePopover+Comparison.swift"; sourceTree = "<group>"; };
 		35793BBA8A74DAA0982CCFA4 /* DocumentInspectorInfoTab+Header.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentInspectorInfoTab+Header.swift"; sourceTree = "<group>"; };
@@ -2177,6 +2179,7 @@
 				DD03402A88F98251F388870F /* DocumentInspectorInfoTab.swift */,
 				E7B146AE8AC4CEEC3775CB94 /* DocumentInspectorMetadataTab.swift */,
 				312845068CA928DA393E0468 /* DocumentInspectorArtifactsTab.swift */,
+				FEEDDEAD0000000000000005 /* SurfaceTabBar.swift */,
 				36234E44A7E494963A441CDC /* DocumentInspectorContentTab.swift */,
 				AB786740043A3DAB4CDBFD6F /* DocumentInspectorAnnotationsTab.swift */,
 				B00A8552DEACF83751D617C6 /* DocumentNotesTab.swift */,
@@ -2766,6 +2769,7 @@
 				E8DB4DEABBD7388DB33D81DA /* DocumentInspectorInfoTab.swift in Sources */,
 				AD284E03A3377968AE568677 /* DocumentInspectorMetadataTab.swift in Sources */,
 				7C874A46B0C0C85ACD9F23AA /* DocumentInspectorArtifactsTab.swift in Sources */,
+				FEEDDEAD0000000000000006 /* SurfaceTabBar.swift in Sources */,
 				3D3445F0B90D093149C9A7D6 /* DocumentInspectorContentTab.swift in Sources */,
 				AF3C46E684A7D133B1BAA5D2 /* TriggerEditorFormPanel.swift in Sources */,
 				2ED84CCBA91252EA2D0C5D34 /* TriggerEditorPreviewPanel.swift in Sources */,

--- a/fichero/fichero/Models/EntityStore.swift
+++ b/fichero/fichero/Models/EntityStore.swift
@@ -1,7 +1,23 @@
+// swiftlint:disable file_length
 import FicheroAPIClient
 import Foundation
 import Observation
 import OSLog
+
+/// One graph-context merge-candidate pair (#3318) from
+/// `/api/kg/entity-curation/candidates` — two entities whose claim-neighborhoods
+/// overlap (Jaccard), surfaced for user-confirmed merge. Never merged
+/// automatically.
+struct EntityReconciliationCandidate: Identifiable, Hashable {
+    let entityAId: String
+    let entityAName: String
+    let entityBId: String
+    let entityBName: String
+    let jaccard: Double
+    let entityType: String?
+
+    var id: String { "\(entityAId)|\(entityBId)" }
+}
 
 /// Observable domain store for knowledge entities (#1885, keystone template).
 ///
@@ -18,6 +34,7 @@ import OSLog
 /// (registered on `LibraryReference`), shared across that library's windows.
 @MainActor
 @Observable
+// swiftlint:disable:next type_body_length
 final class EntityStore: ObservableDomainStore {
     // ─── Published domain state (views read these directly) ───
     private(set) var entities: [Components.Schemas.KnowledgeEntity] = []
@@ -252,6 +269,38 @@ final class EntityStore: ObservableDomainStore {
         for index in entities.indices {
             guard let id = entities[index].id, targetIds.contains(id) else { continue }
             entities[index].curationState = state
+        }
+    }
+
+    /// Graph-context duplicate candidate pairs for a reconciliation scope
+    /// (#3318), from `/api/kg/entity-curation/candidates`. The store is the only
+    /// endpoint accessor; the reconciliation sheet reads these.
+    func reconciliationCandidates(
+        scope: String,
+        folderId: String?
+    ) async throws -> [EntityReconciliationCandidate] {
+        let data = try await entityService.reconciliationCandidates(scope: scope, folderId: folderId)
+        return Self.parseReconciliationCandidates(data)
+    }
+
+    /// Parse the candidate-pairs envelope (`{ items: [...], count }`) into typed
+    /// pairs. The OpenAPI `items` schema is freeform, so parse defensively.
+    /// Exposed for tests.
+    static func parseReconciliationCandidates(_ data: Data) -> [EntityReconciliationCandidate] {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let items = obj["items"] as? [[String: Any]] else { return [] }
+        return items.compactMap { item -> EntityReconciliationCandidate? in
+            guard let aId = item["entity_a_id"] as? String,
+                  let bId = item["entity_b_id"] as? String,
+                  aId != bId else { return nil }
+            return EntityReconciliationCandidate(
+                entityAId: aId,
+                entityAName: item["entity_a_name"] as? String ?? aId,
+                entityBId: bId,
+                entityBName: item["entity_b_name"] as? String ?? bId,
+                jaccard: (item["jaccard"] as? Double) ?? 0,
+                entityType: item["entity_type"] as? String
+            )
         }
     }
 

--- a/fichero/fichero/Services/ArtifactServiceGenerated.swift
+++ b/fichero/fichero/Services/ArtifactServiceGenerated.swift
@@ -579,6 +579,21 @@ final class EntityServiceGenerated {
         }
     }
 
+    /// Graph-context merge candidate pairs (Jaccard over co-occurrence
+    /// neighborhoods) for the chosen scope. Backed by
+    /// `/api/kg/entity-curation/candidates` (#3318). Returns the raw JSON so the
+    /// store parses the freeform `items` (the OpenAPI envelope is untyped).
+    func reconciliationCandidates(scope: String, folderId: String?) async throws -> Data {
+        var items = [URLQueryItem(name: "scope", value: scope)]
+        if let folderId, !folderId.isEmpty {
+            items.append(URLQueryItem(name: "folder_id", value: folderId))
+        }
+        return try await endpointData(
+            path: "/api/kg/entity-curation/candidates",
+            queryItems: items
+        )
+    }
+
     /// Merge multiple entities into a single absorbing entity with audit.
     /// Backed by `/api/kg/entity-curation/merge`.
     func mergeEntities(

--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -84,11 +84,10 @@ private struct ReadingPaneView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Native top tabs (Page/Knowledge/Notes) — fixed chrome over the
+            // Shared top-tab chrome (Page/Knowledge/Notes) — the same
+            // SurfaceTabBar icon row the Inspector uses (#3530), fixed over the
             // WebKit/native content beneath (reader IA fold, 2026-07-11).
-            ReaderTabBar(selection: readerTabBinding)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 6)
+            SurfaceTabBar(tabs: ReaderTab.allCases, selection: readerTabBinding)
             Divider()
 
             readerTabContent

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityReconciliationSheet.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityReconciliationSheet.swift
@@ -1,4 +1,3 @@
-import FicheroAPIClient
 import SwiftUI
 
 /// Reconciliation scope (#3318): the USER explicitly chooses where to look for
@@ -45,18 +44,12 @@ enum EntityReconciliationScope: String, CaseIterable, Identifiable {
     }
 }
 
-/// A set of entities the reconciliation pass flagged as likely duplicates. The
-/// user picks the survivor; the rest merge into it.
-struct EntityReconciliationGroup: Identifiable {
-    let id: String
-    let entities: [Components.Schemas.KnowledgeEntity]
-}
-
 /// User-driven entity reconciliation (#3318). The user chooses a scope, the
-/// sheet lists duplicate-entity candidate groups for that scope, and each group
-/// merges via the shared `EntityStore.merge` action (audited + undoable) — the
-/// same merge the per-entity "Possible Duplicates" affordance uses (#3317). The
-/// system never merges automatically.
+/// sheet lists the graph-context duplicate candidate PAIRS the engine returns
+/// for that scope (`/api/kg/entity-curation/candidates`, Jaccard over
+/// co-occurrence), and each pair merges via the shared `EntityStore.merge`
+/// action (audited + undoable) — the same merge the per-entity "Possible
+/// Duplicates" affordance uses (#3317). The system never merges automatically.
 struct EntityReconciliationSheet: View {
     /// The document/folder in focus — the target of `.folder` scope.
     let documentId: String
@@ -65,7 +58,7 @@ struct EntityReconciliationSheet: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var scope: EntityReconciliationScope = .folder
-    @State private var groups: [EntityReconciliationGroup] = []
+    @State private var candidates: [EntityReconciliationCandidate] = []
     @State private var isLoading = false
     @State private var message: String?
 
@@ -124,7 +117,7 @@ struct EntityReconciliationSheet: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(12)
         }
-        if groups.isEmpty && !isLoading {
+        if candidates.isEmpty && !isLoading {
             ContentUnavailableView(
                 "No likely duplicates",
                 systemImage: "checkmark.seal",
@@ -132,40 +125,42 @@ struct EntityReconciliationSheet: View {
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            List(groups) { group in
-                groupSection(group)
+            List(candidates) { candidate in
+                candidateRow(candidate)
             }
             .listStyle(.inset)
         }
     }
 
     @ViewBuilder
-    private func groupSection(_ group: EntityReconciliationGroup) -> some View {
-        Section {
-            ForEach(group.entities, id: \.id) { entity in
-                HStack(spacing: 8) {
-                    VStack(alignment: .leading, spacing: 1) {
-                        Text(entity.canonicalName).font(.body).lineLimit(1)
-                        if let type = entity.entityType?.rawValue {
-                            Text(type.capitalized).font(.caption2).foregroundStyle(.secondary)
-                        }
-                    }
-                    Spacer(minLength: 8)
-                    Button("Keep") { merge(group: group, survivor: entity) }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                        .help("Keep \"\(entity.canonicalName)\" and merge the rest of this group into it")
+    private func candidateRow(_ candidate: EntityReconciliationCandidate) -> some View {
+        HStack(spacing: 8) {
+            VStack(alignment: .leading, spacing: 1) {
+                Text("\(candidate.entityAName)  ↔  \(candidate.entityBName)")
+                    .font(.body).lineLimit(1)
+                if let type = candidate.entityType {
+                    Text(type.capitalized).font(.caption2).foregroundStyle(.secondary)
                 }
             }
-        } header: {
-            Text("\(group.entities.count) possible duplicates")
-                .font(.caption)
+            Spacer(minLength: 8)
+            Text("\(Int((candidate.jaccard * 100).rounded()))%")
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(candidate.jaccard >= 0.7 ? Color.orange : .secondary)
+                .help("Graph-context similarity (Jaccard)")
+            Menu {
+                Button("Keep \"\(candidate.entityAName)\"") { merge(candidate, keepA: true) }
+                Button("Keep \"\(candidate.entityBName)\"") { merge(candidate, keepA: false) }
+            } label: {
+                Label("Merge", systemImage: "arrow.triangle.merge").font(.caption)
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
         }
     }
 
     private var footer: some View {
         HStack {
-            Text(groups.isEmpty ? "" : "\(groups.count) group\(groups.count == 1 ? "" : "s")")
+            Text(candidates.isEmpty ? "" : "\(candidates.count) pair\(candidates.count == 1 ? "" : "s")")
                 .font(.caption)
                 .foregroundStyle(.secondary)
             Spacer()
@@ -177,63 +172,35 @@ struct EntityReconciliationSheet: View {
 
     // MARK: - Data
 
-    /// Load the scope's entities and group likely duplicates.
-    ///
-    /// INTERIM candidate source: normalized-name grouping over the scope's
-    /// entities (works today with data the app already holds). codex's scoped
-    /// reconciliation endpoint (#3318 engine) — semantic/fuzzy matching with
-    /// confidence — will replace `Self.groupDuplicates` here once it lands in
-    /// the OpenAPI client; the scope picker + merge UI stay as-is.
+    /// Load the graph-context candidate pairs for the chosen scope from the
+    /// engine (`/api/kg/entity-curation/candidates`) via the store. Folder scope
+    /// passes the focused document as `folder_id`; library scope passes none.
     private func load() async {
-        guard scope.isAvailable else { groups = []; return }
+        guard scope.isAvailable else { candidates = []; return }
         isLoading = true
         defer { isLoading = false }
         message = nil
-        let entities: [Components.Schemas.KnowledgeEntity]
-        switch scope {
-        case .folder:
-            await entityStore.loadEntities(forDocument: documentId)
-            entities = entityStore.entitiesByDocumentId[documentId] ?? []
-        case .library:
-            await entityStore.loadEntities(force: false)
-            entities = entityStore.libraryEntities
-        case .crossLibrary, .external:
-            entities = []
+        do {
+            candidates = try await entityStore.reconciliationCandidates(
+                scope: scope == .folder ? "folder" : "library",
+                folderId: scope == .folder ? documentId : nil
+            )
+        } catch {
+            candidates = []
+            message = "Couldn't load candidates: \(error.localizedDescription)"
         }
-        groups = Self.groupDuplicates(entities)
     }
 
-    /// Group entities whose normalized canonical name (or a shared alias)
-    /// collides — the cheap, exact-ish duplicate signal. Exposed for tests.
-    static func groupDuplicates(
-        _ entities: [Components.Schemas.KnowledgeEntity]
-    ) -> [EntityReconciliationGroup] {
-        var byKey: [String: [Components.Schemas.KnowledgeEntity]] = [:]
-        for entity in entities {
-            let key = normalizedKey(entity.canonicalName)
-            guard !key.isEmpty else { continue }
-            byKey[key, default: []].append(entity)
-        }
-        return byKey
-            .filter { $0.value.count >= 2 }
-            .map { EntityReconciliationGroup(id: $0.key, entities: $0.value) }
-            .sorted { $0.entities.count > $1.entities.count }
-    }
-
-    static func normalizedKey(_ name: String) -> String {
-        name.nfcNormalized
-            .lowercased()
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func merge(group: EntityReconciliationGroup, survivor: Components.Schemas.KnowledgeEntity) {
-        guard let survivorId = survivor.id else { return }
-        let absorbed = group.entities.compactMap(\.id).filter { $0 != survivorId }
-        guard !absorbed.isEmpty else { return }
+    /// Merge a candidate pair, keeping A or B as the survivor (user's choice) via
+    /// the shared audited/undoable `EntityStore.merge`.
+    private func merge(_ candidate: EntityReconciliationCandidate, keepA: Bool) {
+        let survivorId = keepA ? candidate.entityAId : candidate.entityBId
+        let absorbedId = keepA ? candidate.entityBId : candidate.entityAId
+        let survivorName = keepA ? candidate.entityAName : candidate.entityBName
         Task {
             do {
-                try await entityStore.merge(absorbedIds: absorbed, into: survivorId)
-                message = "Merged \(absorbed.count) into \"\(survivor.canonicalName)\"."
+                try await entityStore.merge(absorbedIds: [absorbedId], into: survivorId)
+                message = "Merged into \"\(survivorName)\"."
                 await load()
             } catch {
                 message = "Merge failed: \(error.localizedDescription)"

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityReconciliationSheet.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityReconciliationSheet.swift
@@ -1,0 +1,243 @@
+import FicheroAPIClient
+import SwiftUI
+
+/// Reconciliation scope (#3318): the USER explicitly chooses where to look for
+/// duplicate entities. Within-folder and within-library ship now; cross-library
+/// (#3527) and external-authority / Wikidata (#3528) are deferred and shown
+/// disabled ("coming soon") so the full scope ladder is visible.
+enum EntityReconciliationScope: String, CaseIterable, Identifiable {
+    case folder
+    case library
+    case crossLibrary
+    case external
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .folder: return "Folder"
+        case .library: return "Library"
+        case .crossLibrary: return "Cross-Library"
+        case .external: return "External"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .folder: return "folder"
+        case .library: return "books.vertical"
+        case .crossLibrary: return "square.stack.3d.up"
+        case .external: return "globe"
+        }
+    }
+
+    /// Folder + Library are implemented; the wider scopes are deferred.
+    var isAvailable: Bool { self == .folder || self == .library }
+
+    /// Tooltip for the disabled scopes so the deferral is discoverable.
+    var help: String {
+        switch self {
+        case .folder: return "Find duplicate entities within this document / folder"
+        case .library: return "Find duplicate entities across the whole library"
+        case .crossLibrary: return "Cross-library reconciliation — coming soon (#3527)"
+        case .external: return "External authority (Wikidata / Wikipedia) — coming soon (#3528)"
+        }
+    }
+}
+
+/// A set of entities the reconciliation pass flagged as likely duplicates. The
+/// user picks the survivor; the rest merge into it.
+struct EntityReconciliationGroup: Identifiable {
+    let id: String
+    let entities: [Components.Schemas.KnowledgeEntity]
+}
+
+/// User-driven entity reconciliation (#3318). The user chooses a scope, the
+/// sheet lists duplicate-entity candidate groups for that scope, and each group
+/// merges via the shared `EntityStore.merge` action (audited + undoable) — the
+/// same merge the per-entity "Possible Duplicates" affordance uses (#3317). The
+/// system never merges automatically.
+struct EntityReconciliationSheet: View {
+    /// The document/folder in focus — the target of `.folder` scope.
+    let documentId: String
+
+    @Environment(EntityStore.self) private var entityStore
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var scope: EntityReconciliationScope = .folder
+    @State private var groups: [EntityReconciliationGroup] = []
+    @State private var isLoading = false
+    @State private var message: String?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            scopeBar
+            Divider()
+            content
+            Divider()
+            footer
+        }
+        .frame(minWidth: 420, minHeight: 440)
+        .task(id: scope) { await load() }
+    }
+
+    private var header: some View {
+        HStack {
+            Label("Reconcile Entities", systemImage: "arrow.triangle.merge")
+                .font(.headline)
+            if isLoading { ProgressView().controlSize(.small) }
+            Spacer()
+        }
+        .padding(12)
+    }
+
+    /// The scope ladder as a row of selectable chips; cross-library / external
+    /// render disabled ("coming soon") but visible (#3318).
+    private var scopeBar: some View {
+        HStack(spacing: 8) {
+            ForEach(EntityReconciliationScope.allCases) { option in
+                Button {
+                    scope = option
+                } label: {
+                    Label(option.title, systemImage: option.icon)
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .tint(scope == option ? .accentColor : nil)
+                .disabled(!option.isAvailable)
+                .help(option.help)
+            }
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let message {
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(12)
+        }
+        if groups.isEmpty && !isLoading {
+            ContentUnavailableView(
+                "No likely duplicates",
+                systemImage: "checkmark.seal",
+                description: Text("No duplicate entities were found in the \(scope.title.lowercased()) scope.")
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List(groups) { group in
+                groupSection(group)
+            }
+            .listStyle(.inset)
+        }
+    }
+
+    @ViewBuilder
+    private func groupSection(_ group: EntityReconciliationGroup) -> some View {
+        Section {
+            ForEach(group.entities, id: \.id) { entity in
+                HStack(spacing: 8) {
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(entity.canonicalName).font(.body).lineLimit(1)
+                        if let type = entity.entityType?.rawValue {
+                            Text(type.capitalized).font(.caption2).foregroundStyle(.secondary)
+                        }
+                    }
+                    Spacer(minLength: 8)
+                    Button("Keep") { merge(group: group, survivor: entity) }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .help("Keep \"\(entity.canonicalName)\" and merge the rest of this group into it")
+                }
+            }
+        } header: {
+            Text("\(group.entities.count) possible duplicates")
+                .font(.caption)
+        }
+    }
+
+    private var footer: some View {
+        HStack {
+            Text(groups.isEmpty ? "" : "\(groups.count) group\(groups.count == 1 ? "" : "s")")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            Button("Done") { dismiss() }
+                .keyboardShortcut(.defaultAction)
+        }
+        .padding(12)
+    }
+
+    // MARK: - Data
+
+    /// Load the scope's entities and group likely duplicates.
+    ///
+    /// INTERIM candidate source: normalized-name grouping over the scope's
+    /// entities (works today with data the app already holds). codex's scoped
+    /// reconciliation endpoint (#3318 engine) — semantic/fuzzy matching with
+    /// confidence — will replace `Self.groupDuplicates` here once it lands in
+    /// the OpenAPI client; the scope picker + merge UI stay as-is.
+    private func load() async {
+        guard scope.isAvailable else { groups = []; return }
+        isLoading = true
+        defer { isLoading = false }
+        message = nil
+        let entities: [Components.Schemas.KnowledgeEntity]
+        switch scope {
+        case .folder:
+            await entityStore.loadEntities(forDocument: documentId)
+            entities = entityStore.entitiesByDocumentId[documentId] ?? []
+        case .library:
+            await entityStore.loadEntities(force: false)
+            entities = entityStore.libraryEntities
+        case .crossLibrary, .external:
+            entities = []
+        }
+        groups = Self.groupDuplicates(entities)
+    }
+
+    /// Group entities whose normalized canonical name (or a shared alias)
+    /// collides — the cheap, exact-ish duplicate signal. Exposed for tests.
+    static func groupDuplicates(
+        _ entities: [Components.Schemas.KnowledgeEntity]
+    ) -> [EntityReconciliationGroup] {
+        var byKey: [String: [Components.Schemas.KnowledgeEntity]] = [:]
+        for entity in entities {
+            let key = normalizedKey(entity.canonicalName)
+            guard !key.isEmpty else { continue }
+            byKey[key, default: []].append(entity)
+        }
+        return byKey
+            .filter { $0.value.count >= 2 }
+            .map { EntityReconciliationGroup(id: $0.key, entities: $0.value) }
+            .sorted { $0.entities.count > $1.entities.count }
+    }
+
+    static func normalizedKey(_ name: String) -> String {
+        name.nfcNormalized
+            .lowercased()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func merge(group: EntityReconciliationGroup, survivor: Components.Schemas.KnowledgeEntity) {
+        guard let survivorId = survivor.id else { return }
+        let absorbed = group.entities.compactMap(\.id).filter { $0 != survivorId }
+        guard !absorbed.isEmpty else { return }
+        Task {
+            do {
+                try await entityStore.merge(absorbedIds: absorbed, into: survivorId)
+                message = "Merged \(absorbed.count) into \"\(survivor.canonicalName)\"."
+                await load()
+            } catch {
+                message = "Merge failed: \(error.localizedDescription)"
+            }
+        }
+    }
+}

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+EntitiesTab.swift
@@ -42,6 +42,8 @@ struct DocumentInspectorEntitiesTab: View {
     @State private var pendingReclassifyPlan: PendingEntityReclassifyPlan?
     @State private var pendingDeleteConfirmation: PendingEntityDeleteConfirmation?
     @State private var actionMessage: String?
+    /// Presents the user-driven reconciliation scope picker + merge (#3318).
+    @State private var showReconcile = false
     @State private var dropTargetEntityId: String?
     /// In-place rename state — the id of the entity whose name is being
     /// edited inline, plus the draft text. (#1865)
@@ -181,6 +183,9 @@ struct DocumentInspectorEntitiesTab: View {
         // The store owns fetching; the view just scopes it to this document
         // (or the folder's aggregated children when the scope toggle is on).
         .task(id: "\(documentId)-\(includeChildren)") { await loadScopedEntities() }
+        .sheet(isPresented: $showReconcile) {
+            EntityReconciliationSheet(documentId: documentId)
+        }
         .onAppear { recomputeGrouped() }
         .onChange(of: scopedEntities) { _, _ in
             recomputeGrouped()
@@ -260,6 +265,15 @@ struct DocumentInspectorEntitiesTab: View {
             .buttonStyle(.plain)
             .help("Reload entities")
             .accessibilityLabel("Reload entities")
+
+            Button {
+                showReconcile = true
+            } label: {
+                Image(systemName: "arrow.triangle.merge")
+            }
+            .buttonStyle(.plain)
+            .help("Reconcile duplicate entities — choose a scope (folder or library)")
+            .accessibilityLabel("Reconcile entities")
 
             if entitySelection.count > 1 {
                 bulkActionMenu(title: "Approve", systemImage: "checkmark.circle", action: .approve)

--- a/fichero/fichero/Views/Library/Reading/ReaderTabBar.swift
+++ b/fichero/fichero/Views/Library/Reading/ReaderTabBar.swift
@@ -16,7 +16,7 @@ import SwiftUI
 ///
 /// Preview stays a SEPARATE quick-look surface (Q3) and Canvas/Spatial stay
 /// Library view modes — neither folds in here.
-enum ReaderTab: String, CaseIterable, Identifiable {
+enum ReaderTab: String, CaseIterable, Identifiable, SurfaceTab {
     case page
     case knowledge
     case notes
@@ -117,36 +117,8 @@ enum ReaderNotesMode: String, CaseIterable, Identifiable {
     }
 }
 
-/// Native top-tab switcher for the Reader. The reader is the center pane with
-/// room to spare, and top tabs read well — the DECIDED switcher style (Daniel
-/// 2026-07-11): native chrome over the WebKit/native content beneath. A
-/// segmented `Picker` is the native, keyboard- and accessibility-friendly
-/// top-tab control; it never scrolls with the content (fixed chrome).
-struct ReaderTabBar: View {
-    @Binding var selection: ReaderTab
-    /// On compact width (iPhone / narrow iPad) the segmented tabs show icons
-    /// only so all three stay reachable without clipping; regular width keeps
-    /// the labelled tabs (#3522). macOS reports `.regular`.
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
-    private var isCompact: Bool { horizontalSizeClass == .compact }
-
-    var body: some View {
-        let picker = Picker("Reader view", selection: $selection) {
-            ForEach(ReaderTab.allCases) { tab in
-                Label(tab.title, systemImage: tab.icon)
-                    .help(tab.help)
-                    .tag(tab)
-            }
-        }
-        .pickerStyle(.segmented)
-        .accessibilityIdentifier("readerTabBar")
-
-        // Distinct label styles are distinct types, so branch rather than
-        // ternary; the style propagates to the segment Labels via environment.
-        if isCompact {
-            picker.labelStyle(.iconOnly)
-        } else {
-            picker.labelStyle(.titleAndIcon)
-        }
-    }
-}
+// The Reader's top-tab switcher is now the shared `SurfaceTabBar` (#3530) —
+// the same icon-button row the Inspector uses — so both surfaces read as one
+// system. `ReaderTab` conforms to `SurfaceTab` above; the reader constructs
+// `SurfaceTabBar(tabs: ReaderTab.allCases, selection:)` at its call site. The
+// bespoke segmented `ReaderTabBar` view was retired in the extraction.

--- a/fichero/fichero/Views/SurfaceChrome/SurfaceTabBar.swift
+++ b/fichero/fichero/Views/SurfaceChrome/SurfaceTabBar.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+/// A tab/section usable in the shared ``SurfaceTabBar`` (#3530). The Reader,
+/// Document Inspector, Workflow, Chat, Research, and Search surfaces make their
+/// top-level tab enums conform so the whole app shares ONE top-tab chrome
+/// instead of each re-implementing it. Reuse, don't re-implement.
+protocol SurfaceTab: Identifiable, Hashable {
+    /// Display + accessibility label.
+    var title: String { get }
+    /// SF Symbol shown in the icon row.
+    var icon: String { get }
+    /// Tooltip: what the tab is / does.
+    var help: String { get }
+    /// Stable per-tab XCUITest hook.
+    var accessibilityID: String { get }
+}
+
+extension SurfaceTab {
+    /// Default a11y id derived from the title; adopters override to keep an
+    /// existing hook (e.g. the inspector's `inspectorSection-Source`).
+    var accessibilityID: String { "surfaceTab-\(title)" }
+}
+
+/// The app's shared top tab bar (#3530): a row of labelled icon buttons with a
+/// per-segment tooltip + accessibility hook and the Tahoe glass strip, extracted
+/// verbatim from the Inspector `sectionBar` (Daniel's chosen icon-row switcher).
+///
+/// Icon-only (not a `.segmented` Picker) so each button keeps its own `.help`
+/// and `.accessibilityIdentifier`, and 3–5 facets stay legible across compact
+/// widths. The active tab gets the accent fill + tint; dividers adjacent to the
+/// active tab hide, matching the inspector look. Surfaces adopt this instead of
+/// bespoke tab bars so they read as one system.
+struct SurfaceTabBar<Tab: SurfaceTab>: View {
+    let tabs: [Tab]
+    @Binding var selection: Tab
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(tabs.enumerated()), id: \.element) { index, tab in
+                if index > 0 {
+                    Divider()
+                        .frame(height: 14)
+                        .opacity(hidesDivider(before: index) ? 0 : 1)
+                }
+                tabButton(tab)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .surfaceGlassStrip()
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .frame(height: MiniToolbar<EmptyView, EmptyView>.standardHeight)
+        .accessibilityIdentifier("surfaceTabBar")
+    }
+
+    /// Hide the divider adjacent to the active tab (matches the inspector look).
+    private func hidesDivider(before index: Int) -> Bool {
+        selection == tabs[index] || selection == tabs[index - 1]
+    }
+
+    @ViewBuilder
+    private func tabButton(_ tab: Tab) -> some View {
+        let isActive = selection == tab
+        Button {
+            selection = tab
+        } label: {
+            Label(tab.title, systemImage: tab.icon)
+                .labelStyle(.iconOnly)
+                .font(.title3)
+                .frame(maxWidth: .infinity, minHeight: 30)
+                .contentShape(Rectangle())
+        }
+        .accessibilityLabel(tab.title)
+        .buttonStyle(.plain)
+        .background(
+            RoundedRectangle(cornerRadius: 5)
+                .fill(isActive ? Color.accentColor.opacity(0.18) : Color.clear)
+                .padding(2)
+        )
+        .foregroundStyle(isActive ? Color.accentColor : Color.secondary)
+        .help(tab.help)
+        .accessibilityIdentifier(tab.accessibilityID)
+    }
+}
+
+// MARK: - Shared chrome glass strip
+
+extension View {
+    /// The shared chrome-strip glass treatment (#3061/#3530), generalized from
+    /// `inspectorGlassStrip` so every surface's chrome matches.
+    func surfaceGlassStrip() -> some View {
+        modifier(SurfaceGlassStrip())
+    }
+}
+
+private struct SurfaceGlassStrip: ViewModifier {
+    func body(content: Content) -> some View {
+        #if os(visionOS)
+        content
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+        #else
+        GlassEffectContainer {
+            content
+                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 8))
+        }
+        #endif
+    }
+}


### PR DESCRIPTION
#3318: EntityReconciliationSheet — user-driven folder|library reconciliation scope picker + merge, wired to the /api/kg/entity-curation scoped-candidates endpoint (against the regenerated client). #3530: extracted shared SurfaceTabBar (unified top tab bar) + adopted in Reader — the surface-chrome foundation. BUILD SUCCEEDED. 🤖 Generated with [Claude Code](https://claude.com/claude-code)