### PR TITLE
Chrome: WorkflowInspector + Document Inspector adopt shared SurfaceTabBar (#3530)

### DIFF
--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
@@ -142,49 +142,25 @@ struct DocumentInspector: View {
     /// Stays icon-only buttons (not a `.segmented` Picker) so per-section `.help`
     /// tooltips and `.accessibilityIdentifier` XCUITest hooks attach per segment.
     /// Multi-facet sections reveal a sub-picker below (see ``facetPicker``).
-    @ViewBuilder
+    /// The shared `SurfaceTabBar` (#3530) — the same icon-button row the Reader
+    /// uses — over the document's available sections. Per-section help + XCUITest
+    /// hooks (`inspectorSection-Source`, …) and the container `inspectorSectionBar`
+    /// hook are preserved via `InspectorSection: SurfaceTab` + the container id.
     private var sectionBar: some View {
-        let sections = availableSections(for: document)
-        let activeSection = Self.section(for: selectedTab, in: document)
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 0) {
-                ForEach(Array(sections.enumerated()), id: \.element) { index, section in
-                    if index > 0 {
-                        Divider()
-                            .frame(height: 14)
-                            .opacity(activeSection == section || activeSection == sections[index - 1] ? 0 : 1)
-                    }
-                    Button {
-                        selectSection(section)
-                    } label: {
-                        Label(section.rawValue, systemImage: section.icon)
-                            .labelStyle(.iconOnly)
-                            .font(.title3)
-                            .frame(maxWidth: .infinity, minHeight: 30)
-                            .contentShape(Rectangle())
-                    }
-                    .accessibilityLabel(section.rawValue)
-                    .buttonStyle(.plain)
-                    .background(
-                        RoundedRectangle(cornerRadius: 5)
-                            .fill(activeSection == section
-                                    ? Color.accentColor.opacity(0.18)
-                                    : Color.clear)
-                            .padding(2)
-                    )
-                    .foregroundStyle(activeSection == section ? Color.accentColor : Color.secondary)
-                    .help(section.helpText)
-                    // Stable per-section XCUITest hook, e.g. "inspectorSection-Source".
-                    .accessibilityIdentifier(section.accessibilityIdentifier)
-                }
-            }
-        }
-        .frame(maxWidth: .infinity)
-        .inspectorGlassStrip()
-        .padding(.horizontal, 8)
-        .padding(.vertical, 6)
-        .frame(height: MiniToolbar<EmptyView, EmptyView>.standardHeight)
-        .accessibilityIdentifier("inspectorSectionBar")
+        SurfaceTabBar(
+            tabs: availableSections(for: document),
+            selection: sectionSelectionBinding,
+            accessibilityID: "inspectorSectionBar"
+        )
+    }
+
+    /// Active section ↔ selected facet: reads the section the current tab belongs
+    /// to; selecting a section switches to its first facet (unchanged behaviour).
+    private var sectionSelectionBinding: Binding<InspectorSection> {
+        Binding(
+            get: { Self.section(for: selectedTab, in: document) },
+            set: { selectSection($0) }
+        )
     }
 
     /// Sub-facet selector shown only when the active section absorbs more than

--- a/fichero/fichero/Views/Library/Inspector/InspectorSection.swift
+++ b/fichero/fichero/Views/Library/Inspector/InspectorSection.swift
@@ -63,3 +63,11 @@ enum InspectorSection: String, CaseIterable, Identifiable {
         allCases.first { $0.facets.contains(tab) }
     }
 }
+
+/// Adopt the shared top-tab chrome (#3530): the inspector section bar is now a
+/// `SurfaceTabBar<InspectorSection>`, the same icon row the Reader uses.
+extension InspectorSection: SurfaceTab {
+    var title: String { rawValue }
+    var help: String { helpText }
+    var accessibilityID: String { accessibilityIdentifier }
+}

--- a/fichero/fichero/Views/SurfaceChrome/SurfaceTabBar.swift
+++ b/fichero/fichero/Views/SurfaceChrome/SurfaceTabBar.swift
@@ -33,6 +33,9 @@ extension SurfaceTab {
 struct SurfaceTabBar<Tab: SurfaceTab>: View {
     let tabs: [Tab]
     @Binding var selection: Tab
+    /// Container XCUITest hook. Defaults to `surfaceTabBar`; adopters override to
+    /// preserve an existing hook (e.g. the inspector's `inspectorSectionBar`).
+    var accessibilityID: String = "surfaceTabBar"
 
     var body: some View {
         HStack(spacing: 0) {
@@ -50,7 +53,7 @@ struct SurfaceTabBar<Tab: SurfaceTab>: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
         .frame(height: MiniToolbar<EmptyView, EmptyView>.standardHeight)
-        .accessibilityIdentifier("surfaceTabBar")
+        .accessibilityIdentifier(accessibilityID)
     }
 
     /// Hide the divider adjacent to the active tab (matches the inspector look).

--- a/fichero/fichero/Views/Workflow/WorkflowInspector.swift
+++ b/fichero/fichero/Views/Workflow/WorkflowInspector.swift
@@ -8,7 +8,7 @@ struct WorkflowInspector: View {
     @Binding var workflow: Workflow
     let onAddNode: (ToolInfo, CGPoint) -> Void
 
-    @State var selectedTab: InspectorTab = .builtin
+    @State var selectedTab: WorkflowInspectorTab = .builtin
 
     // Built-in tools loaded from workflow registry (grouped by category)
     @State var toolCategories: [CategoryTools] = []
@@ -24,10 +24,16 @@ struct WorkflowInspector: View {
     @Environment(AppState.self) var appState
     @ObservedObject var featureManager = FeatureManager.shared
 
-    enum InspectorTab: String, Hashable {
+    /// Workflow tool-palette tabs. Renamed from the old private `InspectorTab`
+    /// to avoid colliding with the Library inspector's `InspectorTab` and to
+    /// adopt the shared `SurfaceTab` chrome (#3530).
+    enum WorkflowInspectorTab: String, Hashable, CaseIterable, Identifiable, SurfaceTab {
         case builtin = "Built-in"
         case mcp = "MCP"
         case agents = "Agents"
+
+        var id: String { rawValue }
+        var title: String { rawValue }
 
         var icon: String {
             switch self {
@@ -36,10 +42,18 @@ struct WorkflowInspector: View {
             case .agents: return "person.2"
             }
         }
+
+        var help: String {
+            switch self {
+            case .builtin: return "Built-in tools — the workflow's native tool palette"
+            case .mcp: return "MCP tools — tools from connected Model Context Protocol servers"
+            case .agents: return "Agents — sub-agent tools available to the workflow"
+            }
+        }
     }
 
-    private var availableTabs: [InspectorTab] {
-        var tabs: [InspectorTab] = [.builtin]
+    private var availableTabs: [WorkflowInspectorTab] {
+        var tabs: [WorkflowInspectorTab] = [.builtin]
         if featureManager.isWorkflowToolsMCPEnabled {
             tabs.append(.mcp)
         }
@@ -55,31 +69,13 @@ struct WorkflowInspector: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Icon-only tab bar (matches library inspector style)
-            HStack(spacing: 2) {
-                ForEach(availableTabs, id: \.self) { tab in
-                    Button {
-                        selectedTab = tab
-                    } label: {
-                        Image(systemName: tab.icon)
-                            .font(.system(size: 16, weight: .regular))
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 7)
-                            .contentShape(Rectangle())
-                    }
-                    .buttonStyle(.plain)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(selectedTab == tab
-                                    ? Color.accentColor.opacity(0.15)
-                                    : Color.clear)
-                    )
-                    .foregroundStyle(selectedTab == tab ? Color.accentColor : Color.secondary)
-                    .help(tab.rawValue)
-                }
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 6)
+            // Shared top-tab chrome (#3530) — the same SurfaceTabBar icon row the
+            // Reader and Document Inspector use.
+            SurfaceTabBar(
+                tabs: availableTabs,
+                selection: $selectedTab,
+                accessibilityID: "workflowInspectorTabBar"
+            )
 
             Divider()
 


### PR DESCRIPTION
WorkflowInspector migrated to the shared SurfaceTabBar (private InspectorTab enum → shared chrome). Continues #3530 (Reader already adopted). BUILD SUCCEEDED. 🤖 Generated with [Claude Code](https://claude.com/claude-code)