### PR TITLE
Engine: save agent chats as workspace nodes (#3547)

### DIFF
--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -5164,6 +5164,248 @@
         }
       }
     },
+    "/api/chat/conversations/{conversation_id}/workspace": {
+      "post": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Save Conversation As Workspace",
+        "description": "Explicitly save a non-empty chat session as an undoable workspace node.",
+        "operationId": "save_conversation_as_workspace_api_chat_conversations__conversation_id__workspace_post",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentWorkspaceSaveRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspace"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/chat/workspaces": {
+      "get": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "List Agent Workspaces",
+        "description": "List explicit agent-session workspace nodes in the current library.",
+        "operationId": "list_agent_workspaces_api_chat_workspaces_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspaceListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/chat/workspaces/{workspace_id}": {
+      "get": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Get Agent Workspace",
+        "description": "Reload a saved session, including its conversation history and members.",
+        "operationId": "get_agent_workspace_api_chat_workspaces__workspace_id__get",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspace"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Delete Agent Workspace",
+        "description": "Soft-delete a workspace node through the existing undoable document action.",
+        "operationId": "delete_agent_workspace_api_chat_workspaces__workspace_id__delete",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspaceDeletedResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/chat/workspaces/{workspace_id}/members": {
+      "patch": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Patch Agent Workspace Members",
+        "description": "Add or remove source, entity, claim, or note references from a workspace.",
+        "operationId": "patch_agent_workspace_members_api_chat_workspaces__workspace_id__members_patch",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentWorkspaceMembershipPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspace"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/chat/conversations/{conversation_id}": {
       "get": {
         "tags": [
@@ -8807,6 +9049,95 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OrphanCleanupResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/documents/groups": {
+      "post": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Create Document Group",
+        "description": "Create a reversible logical stack without modifying source children.",
+        "operationId": "create_document_group_api_documents_groups_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentGroupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Document"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/documents/groups/{group_id}/ungroup": {
+      "post": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Ungroup Document",
+        "description": "Restore every stack member to its original parent and order.",
+        "operationId": "ungroup_document_api_documents_groups__group_id__ungroup_post",
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Group Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Document"
+                  },
+                  "title": "Response Ungroup Document Api Documents Groups  Group Id  Ungroup Post"
                 }
               }
             }
@@ -33297,6 +33628,147 @@
         "title": "AgentNoteSourceAnchor",
         "description": "User-visible provenance anchor for AI working-memory notes (#2152)."
       },
+      "AgentWorkspace": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Provider"
+          },
+          "model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Model"
+          },
+          "message_history_ref": {
+            "type": "string",
+            "title": "Message History Ref"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            },
+            "type": "array",
+            "title": "Messages"
+          },
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceCuratedItem"
+            },
+            "type": "array",
+            "title": "Members"
+          },
+          "scoped_document_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scoped Document Ids"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "message_history_ref",
+          "messages",
+          "members",
+          "scoped_document_ids",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "AgentWorkspace",
+        "description": "A persisted agent session represented by a normal workspace node."
+      },
+      "AgentWorkspaceDeletedResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "id"
+        ],
+        "title": "AgentWorkspaceDeletedResponse"
+      },
+      "AgentWorkspaceListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AgentWorkspace"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "count"
+        ],
+        "title": "AgentWorkspaceListResponse"
+      },
+      "AgentWorkspaceMembershipPatch": {
+        "properties": {
+          "add": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceCuratedItem"
+            },
+            "type": "array",
+            "title": "Add"
+          },
+          "remove_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Remove Ids"
+          }
+        },
+        "type": "object",
+        "title": "AgentWorkspaceMembershipPatch",
+        "description": "Add or remove the curated source, entity, claim, and note references."
+      },
+      "AgentWorkspaceSaveRequest": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "nullable": true,
+            "title": "Title"
+          }
+        },
+        "type": "object",
+        "title": "AgentWorkspaceSaveRequest",
+        "description": "Optional title for an explicit, on-demand conversation workspace save."
+      },
       "AgentWriteRecordResponse": {
         "properties": {
           "id": {
@@ -40762,6 +41234,29 @@
           "success"
         ],
         "title": "DocumentFetchResponse"
+      },
+      "DocumentGroupRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Name"
+          },
+          "child_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 2,
+            "title": "Child Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "child_ids"
+        ],
+        "title": "DocumentGroupRequest"
       },
       "DocumentInspectorResponse": {
         "properties": {

--- a/fichero-engine/src/fichero/api/routes/chat.py
+++ b/fichero-engine/src/fichero/api/routes/chat.py
@@ -14,7 +14,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from langchain_core.messages import HumanMessage, SystemMessage
 from pydantic import BaseModel, ConfigDict, Field
 
-from fichero.actions.registry import ActionContext, ChangeSpec, action
+from fichero.actions.registry import ActionContext, ChangeSpec, action, registry
 from fichero.api.auth import action_context
 from fichero.api.change_stream import emit_change
 from fichero.api.routes.claims import _descendant_doc_ids
@@ -28,6 +28,7 @@ from fichero.models import (
     Model as ModelModel,
     Provider as ProviderModel,
 )
+from fichero.api.routes.documents import WorkspaceCuratedItem, WorkspacePatchRequest
 from fichero.keychain import has_api_key
 from fichero.llm import LLMConfig, get_langchain_model
 from fichero.node_aliases import DanglingAliasError, is_alias, resolve_alias
@@ -192,6 +193,107 @@ class ConversationHistory(BaseModel):
     updated_at: str
     folder_path: str = "/"
     sort_order: int = 0
+
+
+class AgentWorkspaceSaveRequest(BaseModel):
+    """Optional title for an explicit, on-demand conversation workspace save."""
+
+    title: str | None = Field(default=None, min_length=1)
+
+
+class AgentWorkspaceMembershipPatch(BaseModel):
+    """Add or remove the curated source, entity, claim, and note references."""
+
+    add: list[WorkspaceCuratedItem] = Field(default_factory=list)
+    remove_ids: list[str] = Field(default_factory=list)
+
+
+class AgentWorkspace(BaseModel):
+    """A persisted agent session represented by a normal workspace node."""
+
+    id: str
+    title: str
+    provider: str | None = None
+    model: str | None = None
+    message_history_ref: str
+    messages: list[ChatMessage]
+    members: list[WorkspaceCuratedItem]
+    scoped_document_ids: list[str]
+    created_at: str
+    updated_at: str
+
+
+class AgentWorkspaceListResponse(BaseModel):
+    items: list[AgentWorkspace]
+    count: int
+
+
+class AgentWorkspaceDeletedResponse(BaseModel):
+    status: str
+    id: str
+
+
+_AGENT_WORKSPACE_KIND = "agent"
+
+
+def _workspace_metadata(document: Document) -> dict[str, Any]:
+    return document.metadata if isinstance(document.metadata, dict) else {}
+
+
+def _is_agent_workspace(document: Document) -> bool:
+    return (
+        document.doc_type == DocType.folder
+        and document.node_kind == "workspace"
+        and document.deleted_at is None
+        and _workspace_metadata(document).get("workspace_kind") == _AGENT_WORKSPACE_KIND
+    )
+
+
+def _agent_workspace_or_404(db: Database, workspace_id: str) -> Document:
+    workspace = db.get(Document, workspace_id)
+    if not workspace or not _is_agent_workspace(workspace):
+        raise HTTPException(status_code=404, detail="Agent workspace not found")
+    return workspace
+
+
+def _agent_workspace_response(db: Database, workspace: Document) -> AgentWorkspace:
+    metadata = _workspace_metadata(workspace)
+    conversation_id = str(metadata.get("message_history_ref") or "")
+    conversation = db.get(Conversation, conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=409, detail="Workspace conversation is missing")
+    members = [
+        WorkspaceCuratedItem.model_validate(item)
+        for item in workspace.curated_items
+        if isinstance(item, dict)
+    ]
+    return AgentWorkspace(
+        id=workspace.id,
+        title=workspace.name,
+        provider=metadata.get("provider"),
+        model=metadata.get("model"),
+        message_history_ref=conversation_id,
+        messages=[ChatMessage.model_validate(message) for message in conversation.messages],
+        members=members,
+        scoped_document_ids=list(metadata.get("scoped_document_ids") or []),
+        created_at=_safe_isoformat(workspace.created_at),
+        updated_at=_safe_isoformat(workspace.updated_at),
+    )
+
+
+def _conversation_scoped_members(conversation: Conversation) -> list[WorkspaceCuratedItem]:
+    document_ids = list(conversation.document_ids)
+    if conversation.scope_document_id and conversation.scope_document_id not in document_ids:
+        document_ids.append(conversation.scope_document_id)
+    return [
+        WorkspaceCuratedItem(
+            id=f"source:{document_id}",
+            target_type="document",
+            target_id=document_id,
+            role="scoped_source",
+        )
+        for document_id in document_ids
+    ]
 
 
 # Note: Providers and models now come from the database (configured via Providers UI)
@@ -533,6 +635,123 @@ async def list_conversations(
     result.sort(key=lambda x: (x["sort_order"], x["updated_at"]), reverse=False)
 
     return ChatConversationListResponse(items=result, count=len(result))
+
+
+@router.post(
+    "/conversations/{conversation_id}/workspace", response_model=AgentWorkspace
+)
+async def save_conversation_as_workspace(
+    conversation_id: str,
+    request: AgentWorkspaceSaveRequest,
+    db: Database = Depends(get_library_database_for_write),
+    ctx: ActionContext = Depends(action_context),
+) -> AgentWorkspace:
+    """Explicitly save a non-empty chat session as an undoable workspace node."""
+    conversation = db.get(Conversation, conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    if not conversation.messages:
+        raise HTTPException(status_code=422, detail="Cannot save an empty conversation")
+
+    existing = next(
+        (
+            document
+            for document in db.query(Document)
+            if _is_agent_workspace(document)
+            and _workspace_metadata(document).get("message_history_ref") == conversation.id
+        ),
+        None,
+    )
+    if existing:
+        return _agent_workspace_response(db, existing)
+
+    scoped_members = _conversation_scoped_members(conversation)
+    result = registry.invoke(
+        db,
+        "document.create",
+        {
+            "name": request.title or conversation.title,
+            "doc_type": DocType.folder.value,
+            "node_kind": "workspace",
+            "metadata": {
+                "workspace_kind": _AGENT_WORKSPACE_KIND,
+                "message_history_ref": conversation.id,
+                "provider": conversation.provider,
+                "model": conversation.model,
+                "scoped_document_ids": [member.target_id for member in scoped_members],
+            },
+        },
+        ctx,
+    )
+    workspace = Document.model_validate(result.result)
+    registry.invoke(
+        db,
+        "document.patch_workspace",
+        {
+            "doc_id": workspace.id,
+            "patch": WorkspacePatchRequest(add=scoped_members).model_dump(mode="json"),
+        },
+        ctx,
+    )
+    return _agent_workspace_response(db, _agent_workspace_or_404(db, workspace.id))
+
+
+@router.get("/workspaces", response_model=AgentWorkspaceListResponse)
+async def list_agent_workspaces(
+    db: Database = Depends(get_library_database),
+) -> AgentWorkspaceListResponse:
+    """List explicit agent-session workspace nodes in the current library."""
+    items = [
+        _agent_workspace_response(db, workspace)
+        for workspace in db.query(Document)
+        if _is_agent_workspace(workspace)
+    ]
+    items.sort(key=lambda workspace: workspace.updated_at, reverse=True)
+    return AgentWorkspaceListResponse(items=items, count=len(items))
+
+
+@router.get("/workspaces/{workspace_id}", response_model=AgentWorkspace)
+async def get_agent_workspace(
+    workspace_id: str,
+    db: Database = Depends(get_library_database),
+) -> AgentWorkspace:
+    """Reload a saved session, including its conversation history and members."""
+    return _agent_workspace_response(db, _agent_workspace_or_404(db, workspace_id))
+
+
+@router.patch("/workspaces/{workspace_id}/members", response_model=AgentWorkspace)
+async def patch_agent_workspace_members(
+    workspace_id: str,
+    request: AgentWorkspaceMembershipPatch,
+    db: Database = Depends(get_library_database_for_write),
+    ctx: ActionContext = Depends(action_context),
+) -> AgentWorkspace:
+    """Add or remove source, entity, claim, or note references from a workspace."""
+    _agent_workspace_or_404(db, workspace_id)
+    registry.invoke(
+        db,
+        "document.patch_workspace",
+        {
+            "doc_id": workspace_id,
+            "patch": WorkspacePatchRequest(
+                add=request.add, remove_ids=request.remove_ids
+            ).model_dump(mode="json"),
+        },
+        ctx,
+    )
+    return _agent_workspace_response(db, _agent_workspace_or_404(db, workspace_id))
+
+
+@router.delete("/workspaces/{workspace_id}", response_model=AgentWorkspaceDeletedResponse)
+async def delete_agent_workspace(
+    workspace_id: str,
+    db: Database = Depends(get_library_database_for_write),
+    ctx: ActionContext = Depends(action_context),
+) -> AgentWorkspaceDeletedResponse:
+    """Soft-delete a workspace node through the existing undoable document action."""
+    _agent_workspace_or_404(db, workspace_id)
+    registry.invoke(db, "document.delete", {"doc_id": workspace_id}, ctx)
+    return AgentWorkspaceDeletedResponse(status="deleted", id=workspace_id)
 
 
 @router.get("/conversations/{conversation_id}")

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -2477,6 +2477,24 @@ def register_generated_openapi_commands(
             return client.request("POST", endpoint_path, params=params)
         invoke(ctx, op_call)
 
+    @target_app.command("save-conversation-as-workspace")
+    def chat_save_conversation_as_workspace_post(
+        ctx: typer.Context,
+        conversation_id: str = typer.Argument(..., help="Path parameter: conversation_id."),
+        title: Optional[str] = typer.Option(None, "--title", help="Request field: title."),
+    ) -> None:
+        """Save Conversation As Workspace (POST /api/chat/conversations/{conversation_id}/workspace)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/chat/conversations/{conversation_id}/workspace"
+            params = None
+            payload = _build_json_payload({
+                "title": title,
+            }, {
+                "title": {'type': 'string', 'minLength': 1, 'nullable': True, 'title': 'Title', 'x-cli-required': False},
+            }, required=True)
+            return client.request("POST", endpoint_path, params=params, json=payload)
+        invoke(ctx, op_call)
+
     @target_app.command("extract-text")
     def chat_extract_text_post(
         ctx: typer.Context,
@@ -2506,6 +2524,65 @@ def register_generated_openapi_commands(
             endpoint_path = "/api/chat/providers"
             params = None
             return client.request("GET", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
+    @target_app.command("list-agent-workspaces")
+    def chat_list_agent_workspaces_get(
+        ctx: typer.Context,
+    ) -> None:
+        """List Agent Workspaces (GET /api/chat/workspaces)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/chat/workspaces"
+            params = None
+            return client.request("GET", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
+    @target_app.command("delete-agent-workspace")
+    def chat_delete_agent_workspace_delete(
+        ctx: typer.Context,
+        workspace_id: str = typer.Argument(..., help="Path parameter: workspace_id."),
+        yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    ) -> None:
+        """Delete Agent Workspace (DELETE /api/chat/workspaces/{workspace_id})."""
+        if not yes:
+            typer.confirm("Delete chat?", abort=True)
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/chat/workspaces/{workspace_id}"
+            params = None
+            return client.request("DELETE", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
+    @target_app.command("get-agent-workspace")
+    def chat_get_agent_workspace_get(
+        ctx: typer.Context,
+        workspace_id: str = typer.Argument(..., help="Path parameter: workspace_id."),
+    ) -> None:
+        """Get Agent Workspace (GET /api/chat/workspaces/{workspace_id})."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/chat/workspaces/{workspace_id}"
+            params = None
+            return client.request("GET", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
+    @target_app.command("patch-agent-workspace-members")
+    def chat_patch_agent_workspace_members_patch(
+        ctx: typer.Context,
+        workspace_id: str = typer.Argument(..., help="Path parameter: workspace_id."),
+        add: Optional[str] = typer.Option(None, "--add", help="Request field: add."),
+        remove_ids: Optional[str] = typer.Option(None, "--remove-ids", help="Request field: remove_ids."),
+    ) -> None:
+        """Patch Agent Workspace Members (PATCH /api/chat/workspaces/{workspace_id}/members)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/chat/workspaces/{workspace_id}/members"
+            params = None
+            payload = _build_json_payload({
+                "add": add,
+                "remove_ids": remove_ids,
+            }, {
+                "add": {'items': {'$ref': '#/components/schemas/WorkspaceCuratedItem'}, 'type': 'array', 'title': 'Add', 'x-cli-required': False},
+                "remove_ids": {'items': {'type': 'string'}, 'type': 'array', 'title': 'Remove Ids', 'x-cli-required': False},
+            }, required=True)
+            return client.request("PATCH", endpoint_path, params=params, json=payload)
         invoke(ctx, op_call)
 
     target_app = existing_apps.get('citation-usages')
@@ -3725,6 +3802,38 @@ def register_generated_openapi_commands(
             endpoint_path = "/api/documents/collections"
             params = None
             return client.request("GET", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
+    @target_app.command("create-group")
+    def documents_create_group_post(
+        ctx: typer.Context,
+        child_ids: str = typer.Option(..., "--child-ids", help="Request field: child_ids."),
+        name: str = typer.Option(..., "--name", help="Request field: name."),
+    ) -> None:
+        """Create Document Group (POST /api/documents/groups)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/documents/groups"
+            params = None
+            payload = _build_json_payload({
+                "child_ids": child_ids,
+                "name": name,
+            }, {
+                "child_ids": {'items': {'type': 'string'}, 'type': 'array', 'minItems': 2, 'title': 'Child Ids', 'x-cli-required': True},
+                "name": {'type': 'string', 'minLength': 1, 'title': 'Name', 'x-cli-required': True},
+            }, required=True)
+            return client.request("POST", endpoint_path, params=params, json=payload)
+        invoke(ctx, op_call)
+
+    @target_app.command("ungroup")
+    def documents_ungroup_post(
+        ctx: typer.Context,
+        group_id: str = typer.Argument(..., help="Path parameter: group_id."),
+    ) -> None:
+        """Ungroup Document (POST /api/documents/groups/{group_id}/ungroup)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/documents/groups/{group_id}/ungroup"
+            params = None
+            return client.request("POST", endpoint_path, params=params)
         invoke(ctx, op_call)
 
     @target_app.command("import-file")

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -1760,6 +1760,18 @@
       },
       {
         "method": "POST",
+        "path": "/chat/conversations/{conversation_id}/workspace",
+        "operation_id": "save_conversation_as_workspace_api_chat_conversations__conversation_id__workspace_post",
+        "summary": "Save Conversation As Workspace",
+        "path_params": [
+          "conversation_id"
+        ],
+        "query_params": [],
+        "request_model": "AgentWorkspaceSaveRequest",
+        "response_model": "AgentWorkspace"
+      },
+      {
+        "method": "POST",
         "path": "/chat/extract-text",
         "operation_id": "extract_text_api_chat_extract_text_post",
         "summary": "Extract Text",
@@ -1777,6 +1789,52 @@
         "query_params": [],
         "request_model": null,
         "response_model": "ChatProviderListResponse"
+      },
+      {
+        "method": "GET",
+        "path": "/chat/workspaces",
+        "operation_id": "list_agent_workspaces_api_chat_workspaces_get",
+        "summary": "List Agent Workspaces",
+        "path_params": [],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "AgentWorkspaceListResponse"
+      },
+      {
+        "method": "DELETE",
+        "path": "/chat/workspaces/{workspace_id}",
+        "operation_id": "delete_agent_workspace_api_chat_workspaces__workspace_id__delete",
+        "summary": "Delete Agent Workspace",
+        "path_params": [
+          "workspace_id"
+        ],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "AgentWorkspaceDeletedResponse"
+      },
+      {
+        "method": "GET",
+        "path": "/chat/workspaces/{workspace_id}",
+        "operation_id": "get_agent_workspace_api_chat_workspaces__workspace_id__get",
+        "summary": "Get Agent Workspace",
+        "path_params": [
+          "workspace_id"
+        ],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "AgentWorkspace"
+      },
+      {
+        "method": "PATCH",
+        "path": "/chat/workspaces/{workspace_id}/members",
+        "operation_id": "patch_agent_workspace_members_api_chat_workspaces__workspace_id__members_patch",
+        "summary": "Patch Agent Workspace Members",
+        "path_params": [
+          "workspace_id"
+        ],
+        "query_params": [],
+        "request_model": "AgentWorkspaceMembershipPatch",
+        "response_model": "AgentWorkspace"
       }
     ],
     "citation-usages": [
@@ -2523,6 +2581,28 @@
         "query_params": [],
         "request_model": null,
         "response_model": "fichero__models__DocumentListResponse"
+      },
+      {
+        "method": "POST",
+        "path": "/documents/groups",
+        "operation_id": "create_document_group_api_documents_groups_post",
+        "summary": "Create Document Group",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "DocumentGroupRequest",
+        "response_model": "Document"
+      },
+      {
+        "method": "POST",
+        "path": "/documents/groups/{group_id}/ungroup",
+        "operation_id": "ungroup_document_api_documents_groups__group_id__ungroup_post",
+        "summary": "Ungroup Document",
+        "path_params": [
+          "group_id"
+        ],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "[Document]"
       },
       {
         "method": "POST",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -5164,6 +5164,248 @@
         }
       }
     },
+    "/api/chat/conversations/{conversation_id}/workspace": {
+      "post": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Save Conversation As Workspace",
+        "description": "Explicitly save a non-empty chat session as an undoable workspace node.",
+        "operationId": "save_conversation_as_workspace_api_chat_conversations__conversation_id__workspace_post",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentWorkspaceSaveRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspace"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/chat/workspaces": {
+      "get": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "List Agent Workspaces",
+        "description": "List explicit agent-session workspace nodes in the current library.",
+        "operationId": "list_agent_workspaces_api_chat_workspaces_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspaceListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/chat/workspaces/{workspace_id}": {
+      "get": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Get Agent Workspace",
+        "description": "Reload a saved session, including its conversation history and members.",
+        "operationId": "get_agent_workspace_api_chat_workspaces__workspace_id__get",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspace"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Delete Agent Workspace",
+        "description": "Soft-delete a workspace node through the existing undoable document action.",
+        "operationId": "delete_agent_workspace_api_chat_workspaces__workspace_id__delete",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspaceDeletedResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/chat/workspaces/{workspace_id}/members": {
+      "patch": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Patch Agent Workspace Members",
+        "description": "Add or remove source, entity, claim, or note references from a workspace.",
+        "operationId": "patch_agent_workspace_members_api_chat_workspaces__workspace_id__members_patch",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentWorkspaceMembershipPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspace"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/chat/conversations/{conversation_id}": {
       "get": {
         "tags": [
@@ -8807,6 +9049,95 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OrphanCleanupResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/documents/groups": {
+      "post": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Create Document Group",
+        "description": "Create a reversible logical stack without modifying source children.",
+        "operationId": "create_document_group_api_documents_groups_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentGroupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Document"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/documents/groups/{group_id}/ungroup": {
+      "post": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Ungroup Document",
+        "description": "Restore every stack member to its original parent and order.",
+        "operationId": "ungroup_document_api_documents_groups__group_id__ungroup_post",
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Group Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Document"
+                  },
+                  "title": "Response Ungroup Document Api Documents Groups  Group Id  Ungroup Post"
                 }
               }
             }
@@ -33297,6 +33628,147 @@
         "title": "AgentNoteSourceAnchor",
         "description": "User-visible provenance anchor for AI working-memory notes (#2152)."
       },
+      "AgentWorkspace": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Provider"
+          },
+          "model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Model"
+          },
+          "message_history_ref": {
+            "type": "string",
+            "title": "Message History Ref"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            },
+            "type": "array",
+            "title": "Messages"
+          },
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceCuratedItem"
+            },
+            "type": "array",
+            "title": "Members"
+          },
+          "scoped_document_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scoped Document Ids"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "message_history_ref",
+          "messages",
+          "members",
+          "scoped_document_ids",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "AgentWorkspace",
+        "description": "A persisted agent session represented by a normal workspace node."
+      },
+      "AgentWorkspaceDeletedResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "id"
+        ],
+        "title": "AgentWorkspaceDeletedResponse"
+      },
+      "AgentWorkspaceListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AgentWorkspace"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "count"
+        ],
+        "title": "AgentWorkspaceListResponse"
+      },
+      "AgentWorkspaceMembershipPatch": {
+        "properties": {
+          "add": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceCuratedItem"
+            },
+            "type": "array",
+            "title": "Add"
+          },
+          "remove_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Remove Ids"
+          }
+        },
+        "type": "object",
+        "title": "AgentWorkspaceMembershipPatch",
+        "description": "Add or remove the curated source, entity, claim, and note references."
+      },
+      "AgentWorkspaceSaveRequest": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "nullable": true,
+            "title": "Title"
+          }
+        },
+        "type": "object",
+        "title": "AgentWorkspaceSaveRequest",
+        "description": "Optional title for an explicit, on-demand conversation workspace save."
+      },
       "AgentWriteRecordResponse": {
         "properties": {
           "id": {
@@ -40762,6 +41234,29 @@
           "success"
         ],
         "title": "DocumentFetchResponse"
+      },
+      "DocumentGroupRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Name"
+          },
+          "child_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 2,
+            "title": "Child Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "child_ids"
+        ],
+        "title": "DocumentGroupRequest"
       },
       "DocumentInspectorResponse": {
         "properties": {

--- a/fichero-engine/tests/unit/test_routes_chat.py
+++ b/fichero-engine/tests/unit/test_routes_chat.py
@@ -624,6 +624,113 @@ class TestDeleteConversation:
 
 
 # ---------------------------------------------------------------------------
+# Agent workspace nodes (#3547)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentWorkspaceNodes:
+    def test_save_list_reload_and_soft_delete_round_trip(self, client, db):
+        conversation = _make_conv("workspace-conversation", "Letter investigation")
+        conversation.provider = "openai"
+        conversation.model = "gpt-4o-mini"
+        conversation.document_ids = ["source-a"]
+        conversation.messages = [
+            {"role": "user", "content": "What does this letter say?"},
+            {"role": "assistant", "content": "It concerns the 1844 petition."},
+        ]
+        db.save(conversation)
+
+        saved = client.post(
+            f"/api/chat/conversations/{conversation.id}/workspace",
+            json={"title": "Petition workspace"},
+        )
+        assert saved.status_code == 200
+        workspace = saved.json()
+        assert workspace["title"] == "Petition workspace"
+        assert workspace["model"] == "gpt-4o-mini"
+        assert workspace["message_history_ref"] == conversation.id
+        assert workspace["members"][0]["id"] == "source:source-a"
+        assert workspace["members"][0]["target_type"] == "document"
+        assert workspace["members"][0]["target_id"] == "source-a"
+        assert workspace["members"][0]["role"] == "scoped_source"
+        assert workspace["members"][0]["added_at"]
+
+        listed = client.get("/api/chat/workspaces")
+        assert listed.status_code == 200
+        assert [item["id"] for item in listed.json()["items"]] == [workspace["id"]]
+
+        reloaded = client.get(f"/api/chat/workspaces/{workspace['id']}")
+        assert reloaded.status_code == 200
+        assert reloaded.json()["messages"] == conversation.messages
+
+        deleted = client.delete(f"/api/chat/workspaces/{workspace['id']}")
+        assert deleted.status_code == 200
+        assert deleted.json() == {"status": "deleted", "id": workspace["id"]}
+        assert db.get(Document, workspace["id"]).deleted_at is not None
+        assert db.get(Conversation, conversation.id) is not None
+
+    def test_membership_add_and_remove(self, client, db):
+        conversation = _make_conv("workspace-members", "Members")
+        conversation.messages = [{"role": "user", "content": "Find relevant claims."}]
+        db.save(conversation)
+        workspace_id = client.post(
+            f"/api/chat/conversations/{conversation.id}/workspace", json={}
+        ).json()["id"]
+
+        added = client.patch(
+            f"/api/chat/workspaces/{workspace_id}/members",
+            json={
+                "add": [
+                    {
+                        "id": "entity:rosario",
+                        "target_type": "entity",
+                        "target_id": "rosario",
+                        "role": "surfaced_entity",
+                    },
+                    {
+                        "id": "claim:petition",
+                        "target_type": "claim",
+                        "target_id": "petition",
+                        "role": "surfaced_claim",
+                    },
+                    {
+                        "id": "note:question",
+                        "target_type": "note",
+                        "target_id": "question",
+                        "notes": "Check the date against the ledger.",
+                    },
+                ]
+            },
+        )
+        assert added.status_code == 200
+        assert {item["id"] for item in added.json()["members"]} == {
+            "entity:rosario",
+            "claim:petition",
+            "note:question",
+        }
+
+        removed = client.patch(
+            f"/api/chat/workspaces/{workspace_id}/members",
+            json={"remove_ids": ["claim:petition"]},
+        )
+        assert removed.status_code == 200
+        assert {item["id"] for item in removed.json()["members"]} == {
+            "entity:rosario",
+            "note:question",
+        }
+
+    def test_empty_conversation_cannot_be_saved(self, client, db):
+        conversation = _make_conv("workspace-empty", "Empty")
+        db.save(conversation)
+
+        response = client.post(
+            f"/api/chat/conversations/{conversation.id}/workspace", json={}
+        )
+        assert response.status_code == 422
+        assert response.json()["detail"] == "Cannot save an empty conversation"
+
+
+# ---------------------------------------------------------------------------
 # POST /api/chat/conversations/reorder
 # ---------------------------------------------------------------------------
 

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -5164,6 +5164,248 @@
         }
       }
     },
+    "/api/chat/conversations/{conversation_id}/workspace": {
+      "post": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Save Conversation As Workspace",
+        "description": "Explicitly save a non-empty chat session as an undoable workspace node.",
+        "operationId": "save_conversation_as_workspace_api_chat_conversations__conversation_id__workspace_post",
+        "parameters": [
+          {
+            "name": "conversation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Conversation Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentWorkspaceSaveRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspace"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/chat/workspaces": {
+      "get": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "List Agent Workspaces",
+        "description": "List explicit agent-session workspace nodes in the current library.",
+        "operationId": "list_agent_workspaces_api_chat_workspaces_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspaceListResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/chat/workspaces/{workspace_id}": {
+      "get": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Get Agent Workspace",
+        "description": "Reload a saved session, including its conversation history and members.",
+        "operationId": "get_agent_workspace_api_chat_workspaces__workspace_id__get",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspace"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Delete Agent Workspace",
+        "description": "Soft-delete a workspace node through the existing undoable document action.",
+        "operationId": "delete_agent_workspace_api_chat_workspaces__workspace_id__delete",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspaceDeletedResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/chat/workspaces/{workspace_id}/members": {
+      "patch": {
+        "tags": [
+          "chat"
+        ],
+        "summary": "Patch Agent Workspace Members",
+        "description": "Add or remove source, entity, claim, or note references from a workspace.",
+        "operationId": "patch_agent_workspace_members_api_chat_workspaces__workspace_id__members_patch",
+        "parameters": [
+          {
+            "name": "workspace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Workspace Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentWorkspaceMembershipPatch"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWorkspace"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/chat/conversations/{conversation_id}": {
       "get": {
         "tags": [
@@ -8807,6 +9049,95 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/OrphanCleanupResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/documents/groups": {
+      "post": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Create Document Group",
+        "description": "Create a reversible logical stack without modifying source children.",
+        "operationId": "create_document_group_api_documents_groups_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DocumentGroupRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Document"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/documents/groups/{group_id}/ungroup": {
+      "post": {
+        "tags": [
+          "documents"
+        ],
+        "summary": "Ungroup Document",
+        "description": "Restore every stack member to its original parent and order.",
+        "operationId": "ungroup_document_api_documents_groups__group_id__ungroup_post",
+        "parameters": [
+          {
+            "name": "group_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Group Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Document"
+                  },
+                  "title": "Response Ungroup Document Api Documents Groups  Group Id  Ungroup Post"
                 }
               }
             }
@@ -33297,6 +33628,147 @@
         "title": "AgentNoteSourceAnchor",
         "description": "User-visible provenance anchor for AI working-memory notes (#2152)."
       },
+      "AgentWorkspace": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "title": {
+            "type": "string",
+            "title": "Title"
+          },
+          "provider": {
+            "type": "string",
+            "nullable": true,
+            "title": "Provider"
+          },
+          "model": {
+            "type": "string",
+            "nullable": true,
+            "title": "Model"
+          },
+          "message_history_ref": {
+            "type": "string",
+            "title": "Message History Ref"
+          },
+          "messages": {
+            "items": {
+              "$ref": "#/components/schemas/ChatMessage"
+            },
+            "type": "array",
+            "title": "Messages"
+          },
+          "members": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceCuratedItem"
+            },
+            "type": "array",
+            "title": "Members"
+          },
+          "scoped_document_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Scoped Document Ids"
+          },
+          "created_at": {
+            "type": "string",
+            "title": "Created At"
+          },
+          "updated_at": {
+            "type": "string",
+            "title": "Updated At"
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "title",
+          "message_history_ref",
+          "messages",
+          "members",
+          "scoped_document_ids",
+          "created_at",
+          "updated_at"
+        ],
+        "title": "AgentWorkspace",
+        "description": "A persisted agent session represented by a normal workspace node."
+      },
+      "AgentWorkspaceDeletedResponse": {
+        "properties": {
+          "status": {
+            "type": "string",
+            "title": "Status"
+          },
+          "id": {
+            "type": "string",
+            "title": "Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "status",
+          "id"
+        ],
+        "title": "AgentWorkspaceDeletedResponse"
+      },
+      "AgentWorkspaceListResponse": {
+        "properties": {
+          "items": {
+            "items": {
+              "$ref": "#/components/schemas/AgentWorkspace"
+            },
+            "type": "array",
+            "title": "Items"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "items",
+          "count"
+        ],
+        "title": "AgentWorkspaceListResponse"
+      },
+      "AgentWorkspaceMembershipPatch": {
+        "properties": {
+          "add": {
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceCuratedItem"
+            },
+            "type": "array",
+            "title": "Add"
+          },
+          "remove_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Remove Ids"
+          }
+        },
+        "type": "object",
+        "title": "AgentWorkspaceMembershipPatch",
+        "description": "Add or remove the curated source, entity, claim, and note references."
+      },
+      "AgentWorkspaceSaveRequest": {
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1,
+            "nullable": true,
+            "title": "Title"
+          }
+        },
+        "type": "object",
+        "title": "AgentWorkspaceSaveRequest",
+        "description": "Optional title for an explicit, on-demand conversation workspace save."
+      },
       "AgentWriteRecordResponse": {
         "properties": {
           "id": {
@@ -40762,6 +41234,29 @@
           "success"
         ],
         "title": "DocumentFetchResponse"
+      },
+      "DocumentGroupRequest": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Name"
+          },
+          "child_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 2,
+            "title": "Child Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "child_ids"
+        ],
+        "title": "DocumentGroupRequest"
       },
       "DocumentInspectorResponse": {
         "properties": {


### PR DESCRIPTION
Chat = agent = workspace (Daniel 2026-07-12). Reuses chat.py session model (ponytail — extends, no new subsystem): persist an agent chat as a workspace node with membership (sources/knowledge/notes), on-demand save, create/get/list/delete. OpenAPI regen synced across all 3 openapi.json + surface + endpoints.json + Swift client. Gate: test_routes_chat.py 31 passed; app builds green with the regenerated client (integrated with #3531). 🤖 Claude (Opus 4.8)