### PR TITLE
Engine: reversible batch image crops (#3537)

### DIFF
--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -11775,6 +11775,179 @@
         }
       }
     },
+    "/api/images/crops/batch": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Batch Crop Images",
+        "description": "Apply one crop region to many images as independent derived children.",
+        "operationId": "batch_crop_images_api_images_crops_batch_post",
+        "parameters": [
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImageBatchCropRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageBatchCropResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/images/{document_id}/crop": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Crop Image Child",
+        "description": "Crop an image into a non-destructive derived child node.",
+        "operationId": "crop_image_child_api_images__document_id__crop_post",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CropOperationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageCropResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/images/{document_id}/uncrop": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Uncrop Image Child",
+        "description": "Soft-delete one crop child through the existing reversible document action.",
+        "operationId": "uncrop_image_child_api_images__document_id__uncrop_post",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageCropResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/images/{document_id}/split": {
       "post": {
         "tags": [
@@ -44627,6 +44800,86 @@
         },
         "type": "object",
         "title": "HeuristicRequest"
+      },
+      "ImageBatchCropRequest": {
+        "properties": {
+          "left": {
+            "type": "integer",
+            "title": "Left"
+          },
+          "top": {
+            "type": "integer",
+            "title": "Top"
+          },
+          "width": {
+            "type": "integer",
+            "title": "Width"
+          },
+          "height": {
+            "type": "integer",
+            "title": "Height"
+          },
+          "auto_orient": {
+            "type": "boolean",
+            "title": "Auto Orient",
+            "default": true
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page",
+            "default": 1
+          },
+          "document_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Document Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "left",
+          "top",
+          "width",
+          "height",
+          "document_ids"
+        ],
+        "title": "ImageBatchCropRequest"
+      },
+      "ImageBatchCropResponse": {
+        "properties": {
+          "children": {
+            "items": {
+              "$ref": "#/components/schemas/ImageCropResponse"
+            },
+            "type": "array",
+            "title": "Children"
+          }
+        },
+        "type": "object",
+        "required": [
+          "children"
+        ],
+        "title": "ImageBatchCropResponse"
+      },
+      "ImageCropResponse": {
+        "properties": {
+          "source_document_id": {
+            "type": "string",
+            "title": "Source Document Id"
+          },
+          "child": {
+            "$ref": "#/components/schemas/Document"
+          }
+        },
+        "type": "object",
+        "required": [
+          "source_document_id",
+          "child"
+        ],
+        "title": "ImageCropResponse"
       },
       "ImageEditChainResponse": {
         "properties": {

--- a/fichero-engine/src/fichero/api/routes/image_editing.py
+++ b/fichero-engine/src/fichero/api/routes/image_editing.py
@@ -111,6 +111,19 @@ class ImageUnsplitResponse(BaseModel):
     deleted_child_ids: list[str]
 
 
+class ImageBatchCropRequest(CropOperationRequest):
+    document_ids: list[str] = Field(min_length=1)
+
+
+class ImageCropResponse(BaseModel):
+    source_document_id: str
+    child: Document
+
+
+class ImageBatchCropResponse(BaseModel):
+    children: list[ImageCropResponse]
+
+
 def _get_or_404_document(db: Database, document_id: str) -> Document:
     doc = db.get(Document, document_id)
     if not doc:
@@ -604,6 +617,50 @@ def unsplit_image_impl(db: Database, source_id: str) -> list[Document]:
     return children
 
 
+def _validate_crop_bounds(db: Database, source_id: str, request: CropOperationRequest) -> Document:
+    source = _get_or_404_document(db, source_id)
+    image = _load_source_image(_resolve_source_or_404(db, source), page=request.page)
+    if (
+        request.left < 0
+        or request.top < 0
+        or request.width <= 0
+        or request.height <= 0
+        or request.left + request.width > image.width
+        or request.top + request.height > image.height
+    ):
+        raise HTTPException(status_code=422, detail="Crop bbox is outside source image bounds")
+    return source
+
+
+def crop_image_child_impl(
+    db: Database, source_id: str, request: CropOperationRequest
+) -> Document:
+    """Reuse the crop edit-chain on a derived child, never on its source."""
+    source = _validate_crop_bounds(db, source_id, request)
+    bbox = (request.left, request.top, request.width, request.height)
+    child = Document(
+        parent_id=source.id,
+        doc_type=DocType.chunk,
+        file_type=source.file_type,
+        name=f"{source.name} crop",
+        path=source.path,
+        bbox=bbox,
+        metadata={
+            "derived_from": source.id,
+            "crop_source_id": source.id,
+            "source_bbox": list(bbox),
+            "view_kind": "image_crop",
+        },
+        source_authority=source.source_authority,
+        source_metadata=source.source_metadata,
+        provenance_chain=source.provenance_chain.copy(),
+        image_provenance=source.image_provenance,
+    )
+    db.save(child)
+    crop_image_impl(db, child.id, request)
+    return child
+
+
 # ---------------------------------------------------------------------------
 # Extracted mutation logic (`*_impl`) — the proven business logic each route
 # already ran, lifted into plain functions so BOTH the route handler AND the
@@ -903,6 +960,62 @@ async def segment_image(
     return ImageEditChainResponse.model_validate(result.result)
 
 
+@router.post("/crops/batch", response_model=ImageBatchCropResponse)
+async def batch_crop_images(
+    request: ImageBatchCropRequest,
+    db: Database = Depends(get_library_database_for_write),
+    ctx: "ActionContext" = Depends(action_context),
+) -> ImageBatchCropResponse:
+    """Apply one crop region to many images as independent derived children."""
+    source_ids = list(dict.fromkeys(request.document_ids))
+    for source_id in source_ids:
+        _validate_crop_bounds(db, source_id, request)
+    children = []
+    for source_id in source_ids:
+        result = await asyncio.to_thread(
+            registry.invoke,
+            db,
+            "image.crop_child",
+            {"source_id": source_id, **request.model_dump(mode="json")},
+            ctx,
+        )
+        children.append(ImageCropResponse.model_validate(result.result))
+    return ImageBatchCropResponse(children=children)
+
+
+@router.post("/{document_id}/crop", response_model=ImageCropResponse)
+async def crop_image_child(
+    document_id: str,
+    request: CropOperationRequest,
+    db: Database = Depends(get_library_database_for_write),
+    ctx: "ActionContext" = Depends(action_context),
+) -> ImageCropResponse:
+    """Crop an image into a non-destructive derived child node."""
+    result = await asyncio.to_thread(
+        registry.invoke,
+        db,
+        "image.crop_child",
+        {"source_id": document_id, **request.model_dump(mode="json")},
+        ctx,
+    )
+    return ImageCropResponse.model_validate(result.result)
+
+
+@router.post("/{document_id}/uncrop", response_model=ImageCropResponse)
+async def uncrop_image_child(
+    document_id: str,
+    db: Database = Depends(get_library_database_for_write),
+    ctx: "ActionContext" = Depends(action_context),
+) -> ImageCropResponse:
+    """Soft-delete one crop child through the existing reversible document action."""
+    child = _get_or_404_document(db, document_id)
+    source_id = (child.metadata or {}).get("crop_source_id")
+    if not source_id:
+        raise HTTPException(status_code=404, detail="Crop child not found")
+    await asyncio.to_thread(registry.invoke, db, "document.delete", {"doc_id": child.id}, ctx)
+    return ImageCropResponse(source_document_id=source_id, child=child)
+
+
 @router.post("/{document_id}/split", response_model=ImageSplitResponse)
 async def split_image(
     document_id: str,
@@ -1049,6 +1162,10 @@ class SplitImageActionParams(ImageSplitRequest):
 
 
 class UnsplitImageActionParams(BaseModel):
+    source_id: str
+
+
+class CropChildActionParams(CropOperationRequest):
     source_id: str
 
 
@@ -1312,4 +1429,27 @@ def _action_unsplit_image(
         before={"children": snapshots},
         emit_type="image.unsplit",
         document_ids=[params.source_id, *result.deleted_child_ids],
+    )
+
+
+@action(
+    "image.crop_child",
+    CropChildActionParams,
+    domains=["image", "document"],
+    undoable=True,
+    invert=lambda _before, after, _ctx: (
+        ("document.delete", {"doc_id": after["child_id"]}) if after else None
+    ),
+)
+def _action_crop_image_child(
+    db: Database, params: CropChildActionParams, ctx: ActionContext
+) -> tuple[dict, ChangeSpec]:
+    child = crop_image_child_impl(db, params.source_id, params)
+    result = ImageCropResponse(source_document_id=params.source_id, child=child)
+    return result.model_dump(mode="json"), ChangeSpec(
+        domains=["image", "document"],
+        target_ids=[params.source_id, child.id],
+        after={"child_id": child.id},
+        emit_type="image.cropped",
+        document_ids=[params.source_id, child.id],
     )

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -5492,6 +5492,74 @@ def register_generated_openapi_commands(
         root_app.add_typer(target_app, name='images')
         existing_apps['images'] = target_app
 
+    @target_app.command("batch-crop")
+    def images_batch_crop_post(
+        ctx: typer.Context,
+        auto_orient: Optional[bool] = typer.Option(None, "--auto-orient/--no-auto-orient", help="Request field: auto_orient."),
+        document_ids: str = typer.Option(..., "--document-ids", help="Request field: document_ids."),
+        height: int = typer.Option(..., "--height", help="Request field: height."),
+        left: int = typer.Option(..., "--left", help="Request field: left."),
+        page: Optional[int] = typer.Option(None, "--page", help="Request field: page."),
+        top: int = typer.Option(..., "--top", help="Request field: top."),
+        width: int = typer.Option(..., "--width", help="Request field: width."),
+    ) -> None:
+        """Batch Crop Images (POST /api/images/crops/batch)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/images/crops/batch"
+            params = None
+            payload = _build_json_payload({
+                "auto_orient": auto_orient,
+                "document_ids": document_ids,
+                "height": height,
+                "left": left,
+                "page": page,
+                "top": top,
+                "width": width,
+            }, {
+                "auto_orient": {'type': 'boolean', 'title': 'Auto Orient', 'default': True, 'x-cli-required': False},
+                "document_ids": {'items': {'type': 'string'}, 'type': 'array', 'minItems': 1, 'title': 'Document Ids', 'x-cli-required': True},
+                "height": {'type': 'integer', 'title': 'Height', 'x-cli-required': True},
+                "left": {'type': 'integer', 'title': 'Left', 'x-cli-required': True},
+                "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
+                "top": {'type': 'integer', 'title': 'Top', 'x-cli-required': True},
+                "width": {'type': 'integer', 'title': 'Width', 'x-cli-required': True},
+            }, required=True)
+            return client.request("POST", endpoint_path, params=params, json=payload)
+        invoke(ctx, op_call)
+
+    @target_app.command("crop-child")
+    def images_crop_child_post(
+        ctx: typer.Context,
+        document_id: str = typer.Argument(..., help="Path parameter: document_id."),
+        auto_orient: Optional[bool] = typer.Option(None, "--auto-orient/--no-auto-orient", help="Request field: auto_orient."),
+        height: int = typer.Option(..., "--height", help="Request field: height."),
+        left: int = typer.Option(..., "--left", help="Request field: left."),
+        page: Optional[int] = typer.Option(None, "--page", help="Request field: page."),
+        top: int = typer.Option(..., "--top", help="Request field: top."),
+        width: int = typer.Option(..., "--width", help="Request field: width."),
+    ) -> None:
+        """Crop Image Child (POST /api/images/{document_id}/crop)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/images/{document_id}/crop"
+            params = None
+            payload = _build_json_payload({
+                "auto_orient": auto_orient,
+                "height": height,
+                "left": left,
+                "page": page,
+                "top": top,
+                "width": width,
+            }, {
+                "auto_orient": {'type': 'boolean', 'title': 'Auto Orient', 'default': True, 'x-cli-required': False},
+                "height": {'type': 'integer', 'title': 'Height', 'x-cli-required': True},
+                "left": {'type': 'integer', 'title': 'Left', 'x-cli-required': True},
+                "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
+                "top": {'type': 'integer', 'title': 'Top', 'x-cli-required': True},
+                "width": {'type': 'integer', 'title': 'Width', 'x-cli-required': True},
+            }, required=True)
+            return client.request("POST", endpoint_path, params=params, json=payload)
+        invoke(ctx, op_call)
+
     @target_app.command("delete-edit-chain")
     def images_delete_edit_chain_delete(
         ctx: typer.Context,
@@ -5729,6 +5797,18 @@ def register_generated_openapi_commands(
                 "bboxes": {'items': {'prefixItems': [{'type': 'integer'}, {'type': 'integer'}, {'type': 'integer'}, {'type': 'integer'}], 'type': 'array', 'maxItems': 4, 'minItems': 4}, 'type': 'array', 'nullable': True, 'title': 'Bboxes', 'x-cli-required': False},
             }, required=True)
             return client.request("POST", endpoint_path, params=params, json=payload)
+        invoke(ctx, op_call)
+
+    @target_app.command("uncrop-child")
+    def images_uncrop_child_post(
+        ctx: typer.Context,
+        document_id: str = typer.Argument(..., help="Path parameter: document_id."),
+    ) -> None:
+        """Uncrop Image Child (POST /api/images/{document_id}/uncrop)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/images/{document_id}/uncrop"
+            params = None
+            return client.request("POST", endpoint_path, params=params)
         invoke(ctx, op_call)
 
     @target_app.command("unsplit")

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -3825,6 +3825,28 @@
     ],
     "images": [
       {
+        "method": "POST",
+        "path": "/images/crops/batch",
+        "operation_id": "batch_crop_images_api_images_crops_batch_post",
+        "summary": "Batch Crop Images",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "ImageBatchCropRequest",
+        "response_model": "ImageBatchCropResponse"
+      },
+      {
+        "method": "POST",
+        "path": "/images/{document_id}/crop",
+        "operation_id": "crop_image_child_api_images__document_id__crop_post",
+        "summary": "Crop Image Child",
+        "path_params": [
+          "document_id"
+        ],
+        "query_params": [],
+        "request_model": "CropOperationRequest",
+        "response_model": "ImageCropResponse"
+      },
+      {
         "method": "DELETE",
         "path": "/images/{document_id}/edits",
         "operation_id": "delete_edit_chain_api_images__document_id__edits_delete",
@@ -3966,6 +3988,18 @@
         "query_params": [],
         "request_model": "ImageSplitRequest",
         "response_model": "ImageSplitResponse"
+      },
+      {
+        "method": "POST",
+        "path": "/images/{document_id}/uncrop",
+        "operation_id": "uncrop_image_child_api_images__document_id__uncrop_post",
+        "summary": "Uncrop Image Child",
+        "path_params": [
+          "document_id"
+        ],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "ImageCropResponse"
       },
       {
         "method": "POST",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -11775,6 +11775,179 @@
         }
       }
     },
+    "/api/images/crops/batch": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Batch Crop Images",
+        "description": "Apply one crop region to many images as independent derived children.",
+        "operationId": "batch_crop_images_api_images_crops_batch_post",
+        "parameters": [
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImageBatchCropRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageBatchCropResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/images/{document_id}/crop": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Crop Image Child",
+        "description": "Crop an image into a non-destructive derived child node.",
+        "operationId": "crop_image_child_api_images__document_id__crop_post",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CropOperationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageCropResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/images/{document_id}/uncrop": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Uncrop Image Child",
+        "description": "Soft-delete one crop child through the existing reversible document action.",
+        "operationId": "uncrop_image_child_api_images__document_id__uncrop_post",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageCropResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/images/{document_id}/split": {
       "post": {
         "tags": [
@@ -44627,6 +44800,86 @@
         },
         "type": "object",
         "title": "HeuristicRequest"
+      },
+      "ImageBatchCropRequest": {
+        "properties": {
+          "left": {
+            "type": "integer",
+            "title": "Left"
+          },
+          "top": {
+            "type": "integer",
+            "title": "Top"
+          },
+          "width": {
+            "type": "integer",
+            "title": "Width"
+          },
+          "height": {
+            "type": "integer",
+            "title": "Height"
+          },
+          "auto_orient": {
+            "type": "boolean",
+            "title": "Auto Orient",
+            "default": true
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page",
+            "default": 1
+          },
+          "document_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Document Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "left",
+          "top",
+          "width",
+          "height",
+          "document_ids"
+        ],
+        "title": "ImageBatchCropRequest"
+      },
+      "ImageBatchCropResponse": {
+        "properties": {
+          "children": {
+            "items": {
+              "$ref": "#/components/schemas/ImageCropResponse"
+            },
+            "type": "array",
+            "title": "Children"
+          }
+        },
+        "type": "object",
+        "required": [
+          "children"
+        ],
+        "title": "ImageBatchCropResponse"
+      },
+      "ImageCropResponse": {
+        "properties": {
+          "source_document_id": {
+            "type": "string",
+            "title": "Source Document Id"
+          },
+          "child": {
+            "$ref": "#/components/schemas/Document"
+          }
+        },
+        "type": "object",
+        "required": [
+          "source_document_id",
+          "child"
+        ],
+        "title": "ImageCropResponse"
       },
       "ImageEditChainResponse": {
         "properties": {

--- a/fichero-engine/tests/unit/test_routes_image_editing.py
+++ b/fichero-engine/tests/unit/test_routes_image_editing.py
@@ -314,6 +314,56 @@ class TestReversibleImageSplit:
         assert overlapping.status_code == 422
 
 
+class TestReversibleImageCrop:
+    def test_crop_child_preserves_source_then_uncrop(self, client, db, tmp_path):
+        source = _make_image_doc(db, tmp_path, size=(100, 80))
+        source_before = db.get(Document, source.id).model_dump(mode="json")
+
+        cropped = client.post(
+            f"/api/images/{source.id}/crop",
+            json={"left": 10, "top": 15, "width": 50, "height": 40},
+        )
+        assert cropped.status_code == 200
+        child = cropped.json()["child"]
+        assert child["bbox"] == [10, 15, 50, 40]
+        assert child["metadata"]["derived_from"] == source.id
+        assert db.get(Document, source.id).model_dump(mode="json") == source_before
+
+        uncropped = client.post(f"/api/images/{child['id']}/uncrop")
+        assert uncropped.status_code == 200
+        assert db.get(Document, child["id"]).deleted_at is not None
+        assert db.get(Document, source.id).model_dump(mode="json") == source_before
+
+    def test_batch_crop_applies_one_spec_to_each_source(self, client, db, tmp_path):
+        first = _make_image_doc(db, tmp_path, name="first.jpg", size=(100, 80))
+        second = _make_image_doc(db, tmp_path, name="second.jpg", size=(100, 80))
+
+        response = client.post(
+            "/api/images/crops/batch",
+            json={
+                "document_ids": [first.id, second.id],
+                "left": 5,
+                "top": 10,
+                "width": 40,
+                "height": 30,
+            },
+        )
+        assert response.status_code == 200
+        assert [item["source_document_id"] for item in response.json()["children"]] == [
+            first.id,
+            second.id,
+        ]
+
+    def test_crop_rejects_out_of_bounds_bbox(self, client, db, tmp_path):
+        source = _make_image_doc(db, tmp_path, size=(100, 80))
+
+        response = client.post(
+            f"/api/images/{source.id}/crop",
+            json={"left": 80, "top": 20, "width": 30, "height": 40},
+        )
+        assert response.status_code == 422
+
+
 class TestImagePreviewRoute:
     def test_preview_resolves_library_relative_source_path(
         self, client, db, test_package

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -11775,6 +11775,179 @@
         }
       }
     },
+    "/api/images/crops/batch": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Batch Crop Images",
+        "description": "Apply one crop region to many images as independent derived children.",
+        "operationId": "batch_crop_images_api_images_crops_batch_post",
+        "parameters": [
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImageBatchCropRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageBatchCropResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/images/{document_id}/crop": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Crop Image Child",
+        "description": "Crop an image into a non-destructive derived child node.",
+        "operationId": "crop_image_child_api_images__document_id__crop_post",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CropOperationRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageCropResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/images/{document_id}/uncrop": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Uncrop Image Child",
+        "description": "Soft-delete one crop child through the existing reversible document action.",
+        "operationId": "uncrop_image_child_api_images__document_id__uncrop_post",
+        "parameters": [
+          {
+            "name": "document_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Document Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageCropResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/images/{document_id}/split": {
       "post": {
         "tags": [
@@ -44627,6 +44800,86 @@
         },
         "type": "object",
         "title": "HeuristicRequest"
+      },
+      "ImageBatchCropRequest": {
+        "properties": {
+          "left": {
+            "type": "integer",
+            "title": "Left"
+          },
+          "top": {
+            "type": "integer",
+            "title": "Top"
+          },
+          "width": {
+            "type": "integer",
+            "title": "Width"
+          },
+          "height": {
+            "type": "integer",
+            "title": "Height"
+          },
+          "auto_orient": {
+            "type": "boolean",
+            "title": "Auto Orient",
+            "default": true
+          },
+          "page": {
+            "type": "integer",
+            "title": "Page",
+            "default": 1
+          },
+          "document_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Document Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "left",
+          "top",
+          "width",
+          "height",
+          "document_ids"
+        ],
+        "title": "ImageBatchCropRequest"
+      },
+      "ImageBatchCropResponse": {
+        "properties": {
+          "children": {
+            "items": {
+              "$ref": "#/components/schemas/ImageCropResponse"
+            },
+            "type": "array",
+            "title": "Children"
+          }
+        },
+        "type": "object",
+        "required": [
+          "children"
+        ],
+        "title": "ImageBatchCropResponse"
+      },
+      "ImageCropResponse": {
+        "properties": {
+          "source_document_id": {
+            "type": "string",
+            "title": "Source Document Id"
+          },
+          "child": {
+            "$ref": "#/components/schemas/Document"
+          }
+        },
+        "type": "object",
+        "required": [
+          "source_document_id",
+          "child"
+        ],
+        "title": "ImageCropResponse"
       },
       "ImageEditChainResponse": {
         "properties": {


### PR DESCRIPTION
Reversible crop → derived child region-node (derived_from + bbox), reusing segment_images/crop-tool patterns (crop out a ruler/scale-bar; source preserved; uncrop reversible). Applicable per-image across a batch. Gate: test_routes_image_editing.py 27 passed; OpenAPI regen ×3 synced; app builds green (integrated with #3532p1). 🤖 Claude (Opus 4.8)