### PR TITLE
Workspace sidebar wiring: store + save-as-workspace from Chat (#3533 slice 1)

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		2FA0C9F98B2B1A0A35107B07 /* ChainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41994E6C746A0B0171534212 /* ChainStore.swift */; };
 		300ED1FDA9255CD4182A3664 /* ForceDirectedGraphView+Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE62C7312D0E473288483C9 /* ForceDirectedGraphView+Render.swift */; };
 		342DA5972C51F45081E9FB80 /* EntityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B118FE1DE4F78C0EE238539 /* EntityStore.swift */; };
+		FEEDDEAD0000000000000008 /* WorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000007 /* WorkspaceStore.swift */; };
 		34F019EE1DA4E427EF3674EC /* OpenAffordances.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68A831B2F81707B5E082D6F /* OpenAffordances.swift */; };
 		3591D3E8CE619A9731DF2242 /* CanvasDetailTier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80920949B39DD526745B0BF2 /* CanvasDetailTier.swift */; };
 		35B42F6B063872E635AD5362 /* WindowSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE84D175FC1F5C5644EB914 /* WindowSeed.swift */; };
@@ -630,6 +631,7 @@
 		09D8F04A6421AEC5B5370E92 /* CanvasDropOutcome.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CanvasDropOutcome.swift; sourceTree = "<group>"; };
 		0A4F63C0FA3C779A6BA5B655 /* EngineSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EngineSettingsView.swift; sourceTree = "<group>"; };
 		0B118FE1DE4F78C0EE238539 /* EntityStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityStore.swift; sourceTree = "<group>"; };
+		FEEDDEAD0000000000000007 /* WorkspaceStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		0BE6CF3DE02E1F999AE8F1A9 /* SidebarItemRow+Presentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SidebarItemRow+Presentation.swift"; sourceTree = "<group>"; };
 		0EBBA30F68AE440FAF4DC1E4 /* SpatialView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpatialView.swift; sourceTree = "<group>"; };
 		0F11A721FF01A4F5A66A4568 /* EntityRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityRowView.swift; sourceTree = "<group>"; };
@@ -1662,6 +1664,7 @@
 				D82A9BAC0F995F9199F94B69 /* KGFocusState.swift */,
 				E5C0909F7C7B21871D35EB5C /* SpatialModels+Links.swift */,
 				0B118FE1DE4F78C0EE238539 /* EntityStore.swift */,
+				FEEDDEAD0000000000000007 /* WorkspaceStore.swift */,
 				1C527476477074D83F628468 /* ClaimStore.swift */,
 				EFA65406167827DCB144E3E2 /* NoteStore.swift */,
 				3ABB27CA283069DA160FB5AA /* AnnotationStore.swift */,
@@ -2902,6 +2905,7 @@
 				B82F169352D7D0876DE0FCF9 /* EntityDetailView+Sections.swift in Sources */,
 				417694AF6ACC5AEEF6E2E4B9 /* ClaimSummaryCard+Provenance.swift in Sources */,
 				342DA5972C51F45081E9FB80 /* EntityStore.swift in Sources */,
+				FEEDDEAD0000000000000008 /* WorkspaceStore.swift in Sources */,
 				E9DCE0BB3E64AD1549E6F117 /* LibraryChangeStream.swift in Sources */,
 				57EFBE5436C18075ECE90EFC /* ClaimStore.swift in Sources */,
 				2F08B4F9E864BB8619BD5138 /* NoteStore.swift in Sources */,

--- a/fichero/fichero/Models/LibraryManager.swift
+++ b/fichero/fichero/Models/LibraryManager.swift
@@ -164,6 +164,10 @@ class LibraryManager {
         /// reacts to `research.*` change events.
         @ObservationIgnored lazy var researchStore: ResearchStore = ResearchStore(researchService: researchService)
 
+        /// Per-library saved agent workspaces (#3533 / #3547). Owns the workspace
+        /// list; save/list/delete route through `chatServiceGenerated`.
+        @ObservationIgnored lazy var workspaceStore: WorkspaceStore = WorkspaceStore(chatService: chatServiceGenerated)
+
         /// Per-library search store (#1903). Wraps `searchService`, owns the
         /// current result set and index stats, and invalidates stale results on
         /// `document.*` change events.

--- a/fichero/fichero/Models/WorkspaceStore.swift
+++ b/fichero/fichero/Models/WorkspaceStore.swift
@@ -1,0 +1,78 @@
+import FicheroAPIClient
+import Foundation
+import Observation
+import OSLog
+
+/// Observable domain store for saved agent workspaces (#3533 / #3547).
+///
+/// The single endpoint accessor for the workspace list: a view observes
+/// `workspaces` and dispatches the named actions below; the store owns fetching
+/// (never a view calling `ChatServiceGenerated` directly). `chat = agent =
+/// workspace` (Daniel #3540) — a chat is ephemeral until saved on-demand.
+///
+/// One instance per library (registered on `LibraryReference`), shared across
+/// that library's windows.
+@MainActor
+@Observable
+final class WorkspaceStore {
+    // ─── Published domain state (views read these directly) ───
+    private(set) var workspaces: [Components.Schemas.AgentWorkspace] = []
+    private(set) var isLoading = false
+    private(set) var loadError: String?
+
+    // ─── Transport: the EXISTING generated chat service, unchanged ───
+    private let chatService: ChatServiceGenerated
+    private let log = Logger(subsystem: "app.fichero.fichero", category: "WorkspaceStore")
+
+    init(chatService: ChatServiceGenerated) {
+        self.chatService = chatService
+    }
+
+    /// Load the saved workspaces. Idempotent unless `force`.
+    func load(force: Bool = false) async {
+        if !force, !workspaces.isEmpty, loadError == nil { return }
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            workspaces = try await chatService.listAgentWorkspaces()
+            loadError = nil
+        } catch {
+            loadError = error.localizedDescription
+            log.error("workspace list failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Save a conversation as a workspace (on-demand), then refresh the list so
+    /// the sidebar shows it. Returns the saved node, or nil on failure.
+    @discardableResult
+    func save(conversationId: String, title: String?) async -> Components.Schemas.AgentWorkspace? {
+        do {
+            let saved = try await chatService.saveConversationAsWorkspace(
+                conversationId: conversationId,
+                title: title
+            )
+            await load(force: true)
+            return saved
+        } catch {
+            loadError = error.localizedDescription
+            log.error("workspace save failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Fetch one workspace to restore its chat/agent session.
+    func get(id: String) async -> Components.Schemas.AgentWorkspace? {
+        try? await chatService.getAgentWorkspace(id: id)
+    }
+
+    /// Delete a workspace (reversible-safe per the backend), updating in place.
+    func delete(id: String) async {
+        do {
+            try await chatService.deleteAgentWorkspace(id: id)
+            workspaces.removeAll { $0.id == id }
+        } catch {
+            loadError = error.localizedDescription
+            log.error("workspace delete failed: \(error.localizedDescription)")
+        }
+    }
+}

--- a/fichero/fichero/Services/ChatServiceGenerated.swift
+++ b/fichero/fichero/Services/ChatServiceGenerated.swift
@@ -146,6 +146,56 @@ class ChatServiceGenerated {
             errors: response.errors
         )
     }
+
+    // MARK: - Agent workspaces (#3533 / #3547)
+
+    /// Save a conversation as a persistent agent WORKSPACE node (on-demand — a
+    /// chat is ephemeral until saved). POST /api/chat/conversations/{id}/workspace
+    func saveConversationAsWorkspace(
+        conversationId: String,
+        title: String?
+    ) async throws -> Components.Schemas.AgentWorkspace {
+        let response = try await client.api
+            .saveConversationAsWorkspaceApiChatConversationsConversationIdWorkspacePost(
+                path: .init(conversationId: conversationId),
+                body: .json(.init(title: title))
+            )
+        switch response {
+        case .ok(let okResponse): return try okResponse.body.json
+        default: throw ChatServiceError.unexpectedResponse
+        }
+    }
+
+    /// List saved agent workspaces. GET /api/chat/workspaces
+    func listAgentWorkspaces() async throws -> [Components.Schemas.AgentWorkspace] {
+        let response = try await client.api.listAgentWorkspacesApiChatWorkspacesGet()
+        switch response {
+        case .ok(let okResponse): return try okResponse.body.json.items
+        default: throw ChatServiceError.unexpectedResponse
+        }
+    }
+
+    /// Fetch one workspace (to restore its chat/agent session).
+    /// GET /api/chat/workspaces/{id}
+    func getAgentWorkspace(id: String) async throws -> Components.Schemas.AgentWorkspace {
+        let response = try await client.api
+            .getAgentWorkspaceApiChatWorkspacesWorkspaceIdGet(path: .init(workspaceId: id))
+        switch response {
+        case .ok(let okResponse): return try okResponse.body.json
+        default: throw ChatServiceError.unexpectedResponse
+        }
+    }
+
+    /// Delete a workspace (reversible-safe per the backend).
+    /// DELETE /api/chat/workspaces/{id}
+    func deleteAgentWorkspace(id: String) async throws {
+        let response = try await client.api
+            .deleteAgentWorkspaceApiChatWorkspacesWorkspaceIdDelete(path: .init(workspaceId: id))
+        switch response {
+        case .ok: return
+        default: throw ChatServiceError.unexpectedResponse
+        }
+    }
 }
 
 // MARK: - Error Types

--- a/fichero/fichero/Views/Chat/ChatView.swift
+++ b/fichero/fichero/Views/Chat/ChatView.swift
@@ -66,6 +66,8 @@ struct ChatView: View {
 
     @Environment(ChatServiceGenerated.self) var chatService
     @Environment(ConversationServiceGenerated.self) var conversationService
+    /// Saved-workspace store (#3533) — a chat is ephemeral until saved on-demand.
+    @Environment(WorkspaceStore.self) var workspaceStore
 
     /// Per-window chat tab (#3532), like the document inspector's @SceneStorage.
     @SceneStorage("chat.surfaceTab") private var chatTabRaw = ChatSurfaceTab.conversation.rawValue
@@ -195,15 +197,39 @@ struct ChatView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    /// Shared bottom mini-toolbar (#3532) — a per-tab status line. A
-    /// "Save as workspace" affordance (chat = workspace, #3547 backend) is a
-    /// deferred follow-up (#3533): wire the workspace save/list endpoints here.
+    /// Shared bottom mini-toolbar (#3532) — a per-tab status line plus the
+    /// on-demand "Save as Workspace" action (#3533): a chat is ephemeral until
+    /// the user saves it as a persistent workspace node (#3547 backend).
     private var chatBottomBar: some View {
         MiniToolbar {
             Text(chatBottomStatus)
                 .font(.caption)
                 .foregroundStyle(.secondary)
             Spacer(minLength: 0)
+            Button {
+                saveAsWorkspace()
+            } label: {
+                Label("Save as Workspace", systemImage: "square.and.arrow.down")
+            }
+            .buttonStyle(.borderless)
+            .controlSize(.small)
+            .disabled(backendConversationId == nil)
+            .help(backendConversationId == nil
+                  ? "Send a message first, then save this chat as a workspace"
+                  : "Save this chat as a reusable workspace node")
+            .accessibilityIdentifier("chatSaveAsWorkspace")
+        }
+    }
+
+    /// Persist the current conversation as a workspace via the store (#3533).
+    private func saveAsWorkspace() {
+        guard let conversationId = backendConversationId else { return }
+        let title = currentConversation.title
+        Task {
+            await workspaceStore.save(
+                conversationId: conversationId,
+                title: title.isEmpty ? nil : title
+            )
         }
     }
 

--- a/fichero/fichero/Views/Chat/ChatView.swift
+++ b/fichero/fichero/Views/Chat/ChatView.swift
@@ -1,5 +1,38 @@
 import SwiftUI
 
+/// The chat surface's top-level tabs on the shared chrome (#3532 phase 1):
+/// Conversation (messages), Sources (scoped documents), Knowledge (entities /
+/// claims surfaced from the conversation). Compare + research/agent folds are
+/// later slices. `chat = agent = workspace` (Daniel #3540).
+enum ChatSurfaceTab: String, CaseIterable, Identifiable, SurfaceTab {
+    case conversation
+    case sources
+    case knowledge
+
+    var id: String { rawValue }
+    var title: String {
+        switch self {
+        case .conversation: return "Conversation"
+        case .sources: return "Sources"
+        case .knowledge: return "Knowledge"
+        }
+    }
+    var icon: String {
+        switch self {
+        case .conversation: return "bubble.left.and.bubble.right"
+        case .sources: return "doc.on.doc"
+        case .knowledge: return "point.3.connected.trianglepath.dotted"
+        }
+    }
+    var help: String {
+        switch self {
+        case .conversation: return "Conversation — the chat messages"
+        case .sources: return "Sources — documents scoped into this conversation"
+        case .knowledge: return "Knowledge — entities and claims surfaced from this conversation"
+        }
+    }
+}
+
 /// RAG-style chat view for conversing with documents
 struct ChatView: View {
     let conversation: Conversation?
@@ -34,6 +67,13 @@ struct ChatView: View {
     @Environment(ChatServiceGenerated.self) var chatService
     @Environment(ConversationServiceGenerated.self) var conversationService
 
+    /// Per-window chat tab (#3532), like the document inspector's @SceneStorage.
+    @SceneStorage("chat.surfaceTab") private var chatTabRaw = ChatSurfaceTab.conversation.rawValue
+    private var chatTab: ChatSurfaceTab { ChatSurfaceTab(rawValue: chatTabRaw) ?? .conversation }
+    private var chatTabBinding: Binding<ChatSurfaceTab> {
+        Binding(get: { chatTab }, set: { chatTabRaw = $0.rawValue })
+    }
+
     init(
         conversation: Conversation?,
         selectedDocuments: Binding<Set<String>>,
@@ -51,7 +91,7 @@ struct ChatView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // View-specific toolbar at top
+            // View-specific toolbar at top (conversation switcher / provider).
             ChatViewToolbar(
                 conversationTitle: currentConversation.title,
                 conversations: visibleConversations,
@@ -65,26 +105,23 @@ struct ChatView: View {
                 onNewChat: startNewChat
             )
 
-            Divider()
-
-            // Messages list
-            ChatMessagesList(
-                conversation: currentConversation,
-                isLoading: isLoading,
-                errorMessage: errorMessage,
-                inputText: $inputText
+            // Shared top-tab chrome (#3532): Conversation / Sources / Knowledge.
+            SurfaceTabBar(
+                tabs: ChatSurfaceTab.allCases,
+                selection: chatTabBinding,
+                accessibilityID: "chatSurfaceTabBar"
             )
 
             Divider()
 
-            // Input area
-            ChatInputView(
-                inputText: $inputText,
-                isLoading: isLoading,
-                onSend: sendMessage
-            ) {
-                composerAttachMenu
+            switch chatTab {
+            case .conversation: conversationTabContent
+            case .sources: sourcesTabContent
+            case .knowledge: knowledgeTabContent
             }
+
+            Divider()
+            chatBottomBar
         }
         .sheet(isPresented: $showAttachSheet) {
             chatAttachSheet
@@ -113,6 +150,74 @@ struct ChatView: View {
             conversationService.conversations,
             folderPath: conversationFolderPath
         )
+    }
+
+    /// Conversation tab — the messages plus the composer (#3532).
+    private var conversationTabContent: some View {
+        VStack(spacing: 0) {
+            ChatMessagesList(
+                conversation: currentConversation,
+                isLoading: isLoading,
+                errorMessage: errorMessage,
+                inputText: $inputText
+            )
+            Divider()
+            ChatInputView(
+                inputText: $inputText,
+                isLoading: isLoading,
+                onSend: sendMessage
+            ) {
+                composerAttachMenu
+            }
+        }
+    }
+
+    /// Sources tab — the scoped-documents surface, reusing the existing
+    /// `ChatInspector` inline (previously only shown in the attach sheet), bound
+    /// to the same `selectedDocuments` so scope stays in one place (#3532).
+    private var sourcesTabContent: some View {
+        ChatInspector(
+            selectedDocuments: $selectedDocuments,
+            suggestedDocumentIDs: [],
+            onAddSuggestedDocuments: nil
+        )
+    }
+
+    /// Knowledge tab — entities/claims surfaced from the conversation. The chrome
+    /// facet lands now; wiring the conversation-scoped KG content is a later
+    /// #3532 slice (no chat-knowledge component to reuse yet).
+    private var knowledgeTabContent: some View {
+        ContentUnavailableView(
+            "Knowledge",
+            systemImage: "point.3.connected.trianglepath.dotted",
+            description: Text("Entities and claims surfaced from this conversation will appear here.")
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// Shared bottom mini-toolbar (#3532) — a per-tab status line. A
+    /// "Save as workspace" affordance (chat = workspace, #3547 backend) is a
+    /// deferred follow-up (#3533): wire the workspace save/list endpoints here.
+    private var chatBottomBar: some View {
+        MiniToolbar {
+            Text(chatBottomStatus)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var chatBottomStatus: String {
+        switch chatTab {
+        case .conversation:
+            let count = currentConversation.messages.count
+            return "\(count) message\(count == 1 ? "" : "s")"
+        case .sources:
+            let count = selectedDocuments.count
+            return count == 0 ? "No sources pinned" : "\(count) source\(count == 1 ? "" : "s")"
+        case .knowledge:
+            return "Knowledge"
+        }
     }
 
     /// Composer pin menu (#2449 hybrid step 3): the chat is already grounded on

--- a/fichero/fichero/Views/Library/Inspector/FocusedDocument.swift
+++ b/fichero/fichero/Views/Library/Inspector/FocusedDocument.swift
@@ -114,6 +114,7 @@ struct DocumentDetailWindow: View {
             .environment(library.searchService)
             .environment(library.conversationServiceGenerated)
             .environment(library.chatServiceGenerated)
+            .environment(library.workspaceStore)
             .environment(library.workflowServiceGenerated)
             .environment(library.workflowStreamService)
             .environment(library.importService)

--- a/fichero/fichero/Views/Library/Workspace/LibraryWorkspaceRoot.swift
+++ b/fichero/fichero/Views/Library/Workspace/LibraryWorkspaceRoot.swift
@@ -66,6 +66,7 @@ struct LibraryWorkspaceRoot: View {
             .environment(library.searchService)
             .environment(library.conversationServiceGenerated)
             .environment(library.chatServiceGenerated)
+            .environment(library.workspaceStore)
             .environment(library.workflowStore)
             .environment(library.workflowServiceGenerated)
             .environment(library.workflowStreamService)


### PR DESCRIPTION
New @Observable WorkspaceStore (store is the only endpoint accessor per observable-data-layer) consuming the #3547 chat.py workspace endpoints via the generated client; 'save as workspace' action from the Chat surface (on-demand per #3540). Sidebar list + reopen = slice 2. BUILD SUCCEEDED. 🤖 Claude (Opus 4.8)