### PR TITLE
Engine: batch-apply reversible image op across a folder + serialize DuckDB writes (#3557)

### DIFF
--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -11775,6 +11775,115 @@
         }
       }
     },
+    "/api/images/batch-apply": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Batch Apply Image Operation",
+        "description": "Apply one reversible crop or split spec to every image under a folder.",
+        "operationId": "batch_apply_image_operation_api_images_batch_apply_post",
+        "parameters": [
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchImageApplyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/images/batch-apply/{batch_id}/undo": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Undo Batch Image Operation",
+        "description": "Reverse every completed derived child recorded by an image batch.",
+        "operationId": "undo_batch_image_operation_api_images_batch_apply__batch_id__undo_post",
+        "parameters": [
+          {
+            "name": "batch_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Batch Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchImageUndoResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/images/crops/batch": {
       "post": {
         "tags": [
@@ -35785,6 +35894,94 @@
           "updated"
         ],
         "title": "BatchEntityCurationResponse"
+      },
+      "BatchImageApplyRequest": {
+        "properties": {
+          "folder_id": {
+            "type": "string",
+            "title": "Folder Id"
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "crop",
+              "split"
+            ],
+            "title": "Operation"
+          },
+          "bbox": {
+            "prefixItems": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "type": "array",
+            "maxItems": 4,
+            "minItems": 4,
+            "nullable": true,
+            "title": "Bbox"
+          },
+          "bboxes": {
+            "items": {
+              "prefixItems": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "integer"
+                }
+              ],
+              "type": "array",
+              "maxItems": 4,
+              "minItems": 4
+            },
+            "type": "array",
+            "nullable": true,
+            "title": "Bboxes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "folder_id",
+          "operation"
+        ],
+        "title": "BatchImageApplyRequest"
+      },
+      "BatchImageUndoResponse": {
+        "properties": {
+          "batch_id": {
+            "type": "string",
+            "title": "Batch Id"
+          },
+          "deleted_child_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Deleted Child Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "batch_id",
+          "deleted_child_ids"
+        ],
+        "title": "BatchImageUndoResponse"
       },
       "BatchItemResponse": {
         "properties": {

--- a/fichero-engine/src/fichero/api/routes/image_editing.py
+++ b/fichero-engine/src/fichero/api/routes/image_editing.py
@@ -8,9 +8,9 @@ from __future__ import annotations
 import asyncio
 import io
 import tempfile
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
 from pydantic import BaseModel, Field, field_validator
@@ -18,8 +18,11 @@ from PIL import Image, ImageChops, ImageEnhance, ImageFilter, ImageOps
 
 from fichero.api.auth import action_context
 from fichero.api.main import get_library_database, get_library_database_for_write
+from fichero.api.routes.batch import BatchResponse, get_batch_manager
+from fichero.api.routes.documents import _descendant_document_ids
 from fichero.db import Database
-from fichero.models import DocType, Document, ImageEditChain
+from fichero.models import DocType, Document, FileType, ImageEditChain
+from fichero.workflows.batch import BatchItemStatus, BatchStatus
 from fichero.storage import resolve_source
 from fichero.workflows.tools.fuzzy_clean_images import apply_fuzzy_clean
 
@@ -122,6 +125,18 @@ class ImageCropResponse(BaseModel):
 
 class ImageBatchCropResponse(BaseModel):
     children: list[ImageCropResponse]
+
+
+class BatchImageApplyRequest(BaseModel):
+    folder_id: str
+    operation: Literal["crop", "split"]
+    bbox: tuple[int, int, int, int] | None = None
+    bboxes: list[tuple[int, int, int, int]] | None = None
+
+
+class BatchImageUndoResponse(BaseModel):
+    batch_id: str
+    deleted_child_ids: list[str]
 
 
 def _get_or_404_document(db: Database, document_id: str) -> Document:
@@ -661,6 +676,20 @@ def crop_image_child_impl(
     return child
 
 
+def _folder_images(db: Database, folder_id: str) -> list[Document]:
+    folder = _get_or_404_document(db, folder_id)
+    if folder.doc_type != DocType.folder:
+        raise HTTPException(status_code=422, detail="Batch source must be a folder")
+    ids = _descendant_document_ids(db, folder.id)
+    return [
+        document
+        for document_id in ids
+        if (document := db.get(Document, document_id))
+        and document.deleted_at is None
+        and document.file_type == FileType.image
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Extracted mutation logic (`*_impl`) — the proven business logic each route
 # already ran, lifted into plain functions so BOTH the route handler AND the
@@ -958,6 +987,142 @@ async def segment_image(
         ctx,
     )
     return ImageEditChainResponse.model_validate(result.result)
+
+
+@router.post("/batch-apply", response_model=BatchResponse)
+async def batch_apply_image_operation(
+    request: BatchImageApplyRequest,
+    db: Database = Depends(get_library_database_for_write),
+    ctx: "ActionContext" = Depends(action_context),
+) -> BatchResponse:
+    """Apply one reversible crop or split spec to every image under a folder."""
+    images = _folder_images(db, request.folder_id)
+    if not images:
+        raise HTTPException(status_code=422, detail="Folder has no image documents")
+    if request.operation == "crop":
+        if request.bbox is None:
+            raise HTTPException(status_code=422, detail="Crop batch requires bbox")
+        operation_request: CropOperationRequest | ImageSplitRequest = CropOperationRequest(
+            left=request.bbox[0], top=request.bbox[1], width=request.bbox[2], height=request.bbox[3]
+        )
+    else:
+        operation_request = ImageSplitRequest(bboxes=request.bboxes)
+
+    inputs = [
+        {"source_id": image.id, "operation": request.operation, "child_ids": []}
+        for image in images
+    ]
+    created = await asyncio.to_thread(
+        registry.invoke,
+        db,
+        "batch.create",
+        {"workflow_id": "image.batch_apply", "items": inputs, "max_concurrent": 1},
+        ctx,
+    )
+    manager = get_batch_manager()
+    batch = await manager.get_batch(created.result["batch_id"])
+    if batch is None:
+        raise HTTPException(status_code=500, detail="Batch persistence failed")
+    batch.status = BatchStatus.RUNNING
+    batch.started_at = datetime.now(timezone.utc)
+    manager.activity_tracker.batch_started(
+        batch_id=batch.batch_id,
+        workflow_id=batch.workflow_id,
+        total_items=batch.total_items,
+        max_concurrent=batch.max_concurrent,
+    )
+
+    for item, image in zip(batch.items, images, strict=True):
+        item.status = BatchItemStatus.RUNNING
+        item.started_at = datetime.now(timezone.utc)
+        manager.activity_tracker.batch_item_started(
+            batch_id=batch.batch_id,
+            thread_id=item.thread_id,
+            item_index=item.item_index,
+            workflow_id=batch.workflow_id,
+        )
+        try:
+            action_name = "image.crop_child" if request.operation == "crop" else "image.split"
+            result = await asyncio.to_thread(
+                registry.invoke,
+                db,
+                action_name,
+                {
+                    "source_id": image.id,
+                    **operation_request.model_dump(mode="json"),
+                },
+                ctx,
+            )
+            item.inputs["child_ids"] = (
+                [result.result["child"]["id"]]
+                if request.operation == "crop"
+                else [child["id"] for child in result.result["children"]]
+            )
+            item.status = BatchItemStatus.COMPLETED
+            item.completed_at = datetime.now(timezone.utc)
+            manager.activity_tracker.batch_item_completed(
+                batch_id=batch.batch_id,
+                thread_id=item.thread_id,
+                item_index=item.item_index,
+                duration_ms=0,
+                workflow_id=batch.workflow_id,
+            )
+        except Exception as exc:
+            item.status = BatchItemStatus.FAILED
+            item.error = str(exc)
+            item.completed_at = datetime.now(timezone.utc)
+            manager.activity_tracker.batch_item_failed(
+                batch_id=batch.batch_id,
+                thread_id=item.thread_id,
+                item_index=item.item_index,
+                error=item.error,
+                workflow_id=batch.workflow_id,
+            )
+        await manager._save_batch(batch)
+
+    batch.status = (
+        BatchStatus.PARTIAL_FAILURE
+        if batch.failed_items and batch.completed_items
+        else BatchStatus.FAILED
+        if batch.failed_items
+        else BatchStatus.COMPLETED
+    )
+    batch.completed_at = datetime.now(timezone.utc)
+    await manager._save_batch(batch)
+    manager.activity_tracker.batch_completed(
+        batch_id=batch.batch_id,
+        workflow_id=batch.workflow_id,
+        total_items=batch.total_items,
+        completed_items=batch.completed_items,
+        failed_items=batch.failed_items,
+        duration_ms=0,
+        status=batch.status.value,
+    )
+    return BatchResponse.from_batch(batch, include_items=True)
+
+
+@router.post("/batch-apply/{batch_id}/undo", response_model=BatchImageUndoResponse)
+async def undo_batch_image_operation(
+    batch_id: str,
+    db: Database = Depends(get_library_database_for_write),
+    ctx: "ActionContext" = Depends(action_context),
+) -> BatchImageUndoResponse:
+    """Reverse every completed derived child recorded by an image batch."""
+    batch = await get_batch_manager().get_batch(batch_id)
+    if batch is None or batch.workflow_id != "image.batch_apply":
+        raise HTTPException(status_code=404, detail="Image batch not found")
+    child_ids = [
+        child_id
+        for item in batch.items
+        for child_id in item.inputs.get("child_ids", [])
+    ]
+    for child_id in child_ids:
+        child = db.get(Document, child_id)
+        if child and child.deleted_at is None:
+            await asyncio.to_thread(
+                registry.invoke, db, "document.delete", {"doc_id": child_id}, ctx
+            )
+    return BatchImageUndoResponse(batch_id=batch_id, deleted_child_ids=child_ids)
 
 
 @router.post("/crops/batch", response_model=ImageBatchCropResponse)

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -5492,6 +5492,44 @@ def register_generated_openapi_commands(
         root_app.add_typer(target_app, name='images')
         existing_apps['images'] = target_app
 
+    @target_app.command("batch-apply-operation")
+    def images_batch_apply_operation_post(
+        ctx: typer.Context,
+        bbox: Optional[str] = typer.Option(None, "--bbox", help="Request field: bbox."),
+        bboxes: Optional[str] = typer.Option(None, "--bboxes", help="Request field: bboxes."),
+        folder_id: str = typer.Option(..., "--folder-id", help="Request field: folder_id."),
+        operation: str = typer.Option(..., "--operation", help="Request field: operation."),
+    ) -> None:
+        """Batch Apply Image Operation (POST /api/images/batch-apply)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/images/batch-apply"
+            params = None
+            payload = _build_json_payload({
+                "bbox": bbox,
+                "bboxes": bboxes,
+                "folder_id": folder_id,
+                "operation": operation,
+            }, {
+                "bbox": {'prefixItems': [{'type': 'integer'}, {'type': 'integer'}, {'type': 'integer'}, {'type': 'integer'}], 'type': 'array', 'maxItems': 4, 'minItems': 4, 'nullable': True, 'title': 'Bbox', 'x-cli-required': False},
+                "bboxes": {'items': {'prefixItems': [{'type': 'integer'}, {'type': 'integer'}, {'type': 'integer'}, {'type': 'integer'}], 'type': 'array', 'maxItems': 4, 'minItems': 4}, 'type': 'array', 'nullable': True, 'title': 'Bboxes', 'x-cli-required': False},
+                "folder_id": {'type': 'string', 'title': 'Folder Id', 'x-cli-required': True},
+                "operation": {'type': 'string', 'enum': ['crop', 'split'], 'title': 'Operation', 'x-cli-required': True},
+            }, required=True)
+            return client.request("POST", endpoint_path, params=params, json=payload)
+        invoke(ctx, op_call)
+
+    @target_app.command("undo-batch-operation")
+    def images_undo_batch_operation_post(
+        ctx: typer.Context,
+        batch_id: str = typer.Argument(..., help="Path parameter: batch_id."),
+    ) -> None:
+        """Undo Batch Image Operation (POST /api/images/batch-apply/{batch_id}/undo)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/images/batch-apply/{batch_id}/undo"
+            params = None
+            return client.request("POST", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
     @target_app.command("batch-crop")
     def images_batch_crop_post(
         ctx: typer.Context,

--- a/fichero-engine/src/fichero/execution/batch.py
+++ b/fichero-engine/src/fichero/execution/batch.py
@@ -24,6 +24,7 @@ import duckdb
 
 from fichero.workflows.runtime import create_compiled_app, build_initial_state
 from fichero.workflows.activity import get_activity_tracker
+from fichero.workflows.activity_store import duckdb_connection_lock
 from fichero.workflows.workflow_store import WorkflowStore
 
 logger = logging.getLogger(__name__)
@@ -288,10 +289,11 @@ class BatchManager:
         """Save batch state to database."""
 
         def _save():
-            conn = duckdb.connect(self.db_path)
-            try:
-                # Save batch
-                conn.execute(
+            with duckdb_connection_lock(self.db_path):
+                conn = duckdb.connect(self.db_path)
+                try:
+                    # Save batch
+                    conn.execute(
                     """
                     INSERT OR REPLACE INTO batches
                     (batch_id, workflow_id, status, max_concurrent, created_at, started_at, completed_at, error_message)
@@ -309,10 +311,10 @@ class BatchManager:
                     ],
                 )
 
-                # Save items
-                for item in batch.items:
+                    # Save items
+                    for item in batch.items:
 
-                    conn.execute(
+                        conn.execute(
                         """
                         INSERT OR REPLACE INTO batch_items
                         (batch_id, thread_id, item_index, inputs, status, error, started_at, completed_at)
@@ -328,9 +330,9 @@ class BatchManager:
                             item.started_at,
                             item.completed_at,
                         ],
-                    )
-            finally:
-                conn.close()
+                        )
+                finally:
+                    conn.close()
 
         await asyncio.to_thread(_save)
 

--- a/fichero-engine/src/fichero/workflows/activity.py
+++ b/fichero-engine/src/fichero/workflows/activity.py
@@ -656,23 +656,17 @@ def get_activity_tracker(db_path: Optional[str] = None) -> ActivityTracker:
             # Fire-and-forget: wrap in try/except so a DB error never blocks
             # library-open or startup.
             try:
-                import asyncio
-
-                loop = asyncio.get_event_loop()
-                if loop.is_running():
-                    asyncio.ensure_future(
-                        _recover_stale_runs_bg(tracker, db_path),
-                        loop=loop,
-                    )
-                else:
-                    logger.debug(
-                        "recover_stale_runs skipped for %s: no running event loop",
-                        db_path,
-                    )
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                logger.debug(
+                    "recover_stale_runs skipped for %s: no running event loop", db_path
+                )
             except Exception:
                 logger.exception(
                     "recover_stale_runs scheduling failed for %s (ignored)", db_path
                 )
+            else:
+                loop.create_task(_recover_stale_runs_bg(tracker, db_path))
         else:
             logger.debug(f"Reusing existing ActivityTracker for: {db_path}")
         return _activity_trackers[db_path]

--- a/fichero-engine/src/fichero/workflows/activity_store.py
+++ b/fichero-engine/src/fichero/workflows/activity_store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import threading
 from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
@@ -24,6 +25,15 @@ from fichero.workflows.activity_types import (
 )
 
 logger = logging.getLogger(__name__)
+
+_connection_locks: dict[str, threading.RLock] = {}
+_connection_locks_guard = threading.Lock()
+
+
+def duckdb_connection_lock(db_path: str) -> threading.RLock:
+    """Return the process-local lock for independent DuckDB connections."""
+    with _connection_locks_guard:
+        return _connection_locks.setdefault(str(db_path), threading.RLock())
 
 
 # Columns of workflow_runs in the canonical CREATE TABLE order. Used by the
@@ -647,9 +657,10 @@ class ActivityStore:
 
         def _save():
             logger.info(f"ActivityStore.save: connecting to {self.db_path}")
-            conn = duckdb.connect(self.db_path)
-            try:
-                conn.execute(
+            with duckdb_connection_lock(self.db_path):
+                conn = duckdb.connect(self.db_path)
+                try:
+                    conn.execute(
                     """
                     INSERT INTO activities
                     (id, type, level, timestamp, message, workflow_id, batch_id,
@@ -671,12 +682,12 @@ class ActivityStore:
                         activity.error,
                     ],
                 )
-                logger.info(f"ActivityStore.save: INSERT successful for {activity.id}")
-            except Exception as e:
-                logger.error(f"ActivityStore.save: INSERT failed: {e}")
-                raise
-            finally:
-                conn.close()
+                    logger.info(f"ActivityStore.save: INSERT successful for {activity.id}")
+                except Exception as e:
+                    logger.error(f"ActivityStore.save: INSERT failed: {e}")
+                    raise
+                finally:
+                    conn.close()
 
         await asyncio.to_thread(_save)
 

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -3826,6 +3826,28 @@
     "images": [
       {
         "method": "POST",
+        "path": "/images/batch-apply",
+        "operation_id": "batch_apply_image_operation_api_images_batch_apply_post",
+        "summary": "Batch Apply Image Operation",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "BatchImageApplyRequest",
+        "response_model": "BatchResponse"
+      },
+      {
+        "method": "POST",
+        "path": "/images/batch-apply/{batch_id}/undo",
+        "operation_id": "undo_batch_image_operation_api_images_batch_apply__batch_id__undo_post",
+        "summary": "Undo Batch Image Operation",
+        "path_params": [
+          "batch_id"
+        ],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "BatchImageUndoResponse"
+      },
+      {
+        "method": "POST",
         "path": "/images/crops/batch",
         "operation_id": "batch_crop_images_api_images_crops_batch_post",
         "summary": "Batch Crop Images",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -11775,6 +11775,115 @@
         }
       }
     },
+    "/api/images/batch-apply": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Batch Apply Image Operation",
+        "description": "Apply one reversible crop or split spec to every image under a folder.",
+        "operationId": "batch_apply_image_operation_api_images_batch_apply_post",
+        "parameters": [
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchImageApplyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/images/batch-apply/{batch_id}/undo": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Undo Batch Image Operation",
+        "description": "Reverse every completed derived child recorded by an image batch.",
+        "operationId": "undo_batch_image_operation_api_images_batch_apply__batch_id__undo_post",
+        "parameters": [
+          {
+            "name": "batch_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Batch Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchImageUndoResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/images/crops/batch": {
       "post": {
         "tags": [
@@ -35785,6 +35894,94 @@
           "updated"
         ],
         "title": "BatchEntityCurationResponse"
+      },
+      "BatchImageApplyRequest": {
+        "properties": {
+          "folder_id": {
+            "type": "string",
+            "title": "Folder Id"
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "crop",
+              "split"
+            ],
+            "title": "Operation"
+          },
+          "bbox": {
+            "prefixItems": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "type": "array",
+            "maxItems": 4,
+            "minItems": 4,
+            "nullable": true,
+            "title": "Bbox"
+          },
+          "bboxes": {
+            "items": {
+              "prefixItems": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "integer"
+                }
+              ],
+              "type": "array",
+              "maxItems": 4,
+              "minItems": 4
+            },
+            "type": "array",
+            "nullable": true,
+            "title": "Bboxes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "folder_id",
+          "operation"
+        ],
+        "title": "BatchImageApplyRequest"
+      },
+      "BatchImageUndoResponse": {
+        "properties": {
+          "batch_id": {
+            "type": "string",
+            "title": "Batch Id"
+          },
+          "deleted_child_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Deleted Child Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "batch_id",
+          "deleted_child_ids"
+        ],
+        "title": "BatchImageUndoResponse"
       },
       "BatchItemResponse": {
         "properties": {

--- a/fichero-engine/tests/unit/test_batch_image_apply.py
+++ b/fichero-engine/tests/unit/test_batch_image_apply.py
@@ -1,0 +1,118 @@
+"""Batch application of the reversible image-node operations (#3557)."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from fichero.api.routes import batch as batch_routes
+from fichero.models import DocType, Document, FileType
+from fichero.workflows.batch import BatchManager
+
+
+def _image(db, folder: Document, name: str) -> Document:
+    path = db.path.parent / "files" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (100, 80), "white").save(path, format="PNG")
+    document = Document(
+        name=name, parent_id=folder.id, path=str(path), file_type=FileType.image
+    )
+    db.save(document)
+    return document
+
+
+def _hash(document: Document) -> str:
+    return hashlib.sha256(Path(document.path).read_bytes()).hexdigest()
+
+
+@pytest.fixture
+def batch_manager(tmp_path, monkeypatch):
+    manager = BatchManager(str(tmp_path / "batch-apply.duckdb"))
+    monkeypatch.setattr(batch_routes, "_batch_manager", manager)
+    return manager
+
+
+def test_batch_crop_creates_one_child_per_image_and_undo_restores_all(
+    client, db, batch_manager
+):
+    folder = Document(name="Images", doc_type=DocType.folder)
+    db.save(folder)
+    sources = [_image(db, folder, "one.png"), _image(db, folder, "two.png")]
+    source_rows = [db.get(Document, source.id).model_dump(mode="json") for source in sources]
+    source_hashes = [_hash(source) for source in sources]
+
+    applied = client.post(
+        "/api/images/batch-apply",
+        json={
+            "folder_id": folder.id,
+            "operation": "crop",
+            "bbox": [10, 10, 50, 40],
+        },
+    )
+    assert applied.status_code == 200
+    payload = applied.json()
+    assert payload["status"] == "completed"
+    assert [item["status"] for item in payload["items"]] == ["completed", "completed"]
+    child_ids = [item["inputs"]["child_ids"][0] for item in payload["items"]]
+    assert {db.get(Document, child_id).derived_from for child_id in child_ids} == {
+        source.id for source in sources
+    }
+    assert all(db.get(Document, child_id).bbox == (10, 10, 50, 40) for child_id in child_ids)
+    assert [db.get(Document, source.id).model_dump(mode="json") for source in sources] == source_rows
+    assert [_hash(source) for source in sources] == source_hashes
+
+    undone = client.post(f"/api/images/batch-apply/{payload['batch_id']}/undo")
+    assert undone.status_code == 200
+    assert set(undone.json()["deleted_child_ids"]) == set(child_ids)
+    assert all(db.get(Document, child_id).deleted_at is not None for child_id in child_ids)
+
+
+def test_batch_split_dispatches_existing_split_primitive(client, db, batch_manager):
+    folder = Document(name="Images", doc_type=DocType.folder)
+    db.save(folder)
+    source = _image(db, folder, "spread.png")
+
+    applied = client.post(
+        "/api/images/batch-apply",
+        json={
+            "folder_id": folder.id,
+            "operation": "split",
+            "bboxes": [[0, 0, 100, 80]],
+        },
+    )
+    assert applied.status_code == 200
+    child_id = applied.json()["items"][0]["inputs"]["child_ids"][0]
+    assert db.get(Document, child_id).derived_from == source.id
+    assert db.get(Document, child_id).bbox == (0, 0, 100, 80)
+
+
+def test_batch_item_failure_isolated_to_bad_image(client, db, batch_manager):
+    folder = Document(name="Images", doc_type=DocType.folder)
+    db.save(folder)
+    good = _image(db, folder, "good.png")
+    bad = Document(
+        name="missing.png",
+        parent_id=folder.id,
+        path=str(db.path.parent / "files" / "missing.png"),
+        file_type=FileType.image,
+    )
+    db.save(bad)
+
+    applied = client.post(
+        "/api/images/batch-apply",
+        json={
+            "folder_id": folder.id,
+            "operation": "crop",
+            "bbox": [10, 10, 50, 40],
+        },
+    )
+    assert applied.status_code == 200
+    items = applied.json()["items"]
+    assert applied.json()["status"] == "partial_failure"
+    completed = next(item for item in items if item["status"] == "completed")
+    failed = next(item for item in items if item["status"] == "failed")
+    assert failed["error"]
+    assert db.get(Document, completed["inputs"]["child_ids"][0]).derived_from == good.id

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -11775,6 +11775,115 @@
         }
       }
     },
+    "/api/images/batch-apply": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Batch Apply Image Operation",
+        "description": "Apply one reversible crop or split spec to every image under a folder.",
+        "operationId": "batch_apply_image_operation_api_images_batch_apply_post",
+        "parameters": [
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchImageApplyRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/images/batch-apply/{batch_id}/undo": {
+      "post": {
+        "tags": [
+          "images",
+          "images"
+        ],
+        "summary": "Undo Batch Image Operation",
+        "description": "Reverse every completed derived child recorded by an image batch.",
+        "operationId": "undo_batch_image_operation_api_images_batch_apply__batch_id__undo_post",
+        "parameters": [
+          {
+            "name": "batch_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Batch Id"
+            }
+          },
+          {
+            "name": "X-Fichero-Origin-Window",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "X-Fichero-Origin-Window"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchImageUndoResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/images/crops/batch": {
       "post": {
         "tags": [
@@ -35785,6 +35894,94 @@
           "updated"
         ],
         "title": "BatchEntityCurationResponse"
+      },
+      "BatchImageApplyRequest": {
+        "properties": {
+          "folder_id": {
+            "type": "string",
+            "title": "Folder Id"
+          },
+          "operation": {
+            "type": "string",
+            "enum": [
+              "crop",
+              "split"
+            ],
+            "title": "Operation"
+          },
+          "bbox": {
+            "prefixItems": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "integer"
+              }
+            ],
+            "type": "array",
+            "maxItems": 4,
+            "minItems": 4,
+            "nullable": true,
+            "title": "Bbox"
+          },
+          "bboxes": {
+            "items": {
+              "prefixItems": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "integer"
+                }
+              ],
+              "type": "array",
+              "maxItems": 4,
+              "minItems": 4
+            },
+            "type": "array",
+            "nullable": true,
+            "title": "Bboxes"
+          }
+        },
+        "type": "object",
+        "required": [
+          "folder_id",
+          "operation"
+        ],
+        "title": "BatchImageApplyRequest"
+      },
+      "BatchImageUndoResponse": {
+        "properties": {
+          "batch_id": {
+            "type": "string",
+            "title": "Batch Id"
+          },
+          "deleted_child_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Deleted Child Ids"
+          }
+        },
+        "type": "object",
+        "required": [
+          "batch_id",
+          "deleted_child_ids"
+        ],
+        "title": "BatchImageUndoResponse"
       },
       "BatchItemResponse": {
         "properties": {


### PR DESCRIPTION
batch-apply(folder, crop|split spec) → one reversible derived child per image, per-item failure isolation, batch-undo restores all (reuses batch.py + #3537/#1595 primitives). The flaky batch test exposed a REAL bug: batch + activity DuckDB writes weren't serialized — fixed in batch.py/activity.py/activity_store.py. Gate: batch test 5×-green; broader activity/batch/execution suite 350 passed; regen ×3 synced; app builds green. 🤖 Claude (Opus 4.8)