### PR TITLE
Chat: fold Comparison into a Compare facet; one agent surface (#3532 slice 2)

### DIFF
--- a/fichero/fichero/Views/Chat/ChatView.swift
+++ b/fichero/fichero/Views/Chat/ChatView.swift
@@ -8,6 +8,7 @@ enum ChatSurfaceTab: String, CaseIterable, Identifiable, SurfaceTab {
     case conversation
     case sources
     case knowledge
+    case compare
 
     var id: String { rawValue }
     var title: String {
@@ -15,6 +16,7 @@ enum ChatSurfaceTab: String, CaseIterable, Identifiable, SurfaceTab {
         case .conversation: return "Conversation"
         case .sources: return "Sources"
         case .knowledge: return "Knowledge"
+        case .compare: return "Compare"
         }
     }
     var icon: String {
@@ -22,6 +24,7 @@ enum ChatSurfaceTab: String, CaseIterable, Identifiable, SurfaceTab {
         case .conversation: return "bubble.left.and.bubble.right"
         case .sources: return "doc.on.doc"
         case .knowledge: return "point.3.connected.trianglepath.dotted"
+        case .compare: return "rectangle.split.2x1"
         }
     }
     var help: String {
@@ -29,6 +32,7 @@ enum ChatSurfaceTab: String, CaseIterable, Identifiable, SurfaceTab {
         case .conversation: return "Conversation — the chat messages"
         case .sources: return "Sources — documents scoped into this conversation"
         case .knowledge: return "Knowledge — entities and claims surfaced from this conversation"
+        case .compare: return "Compare — run the same prompt across multiple agents/models side by side"
         }
     }
 }
@@ -120,6 +124,7 @@ struct ChatView: View {
             case .conversation: conversationTabContent
             case .sources: sourcesTabContent
             case .knowledge: knowledgeTabContent
+            case .compare: compareTabContent
             }
 
             Divider()
@@ -185,6 +190,14 @@ struct ChatView: View {
         )
     }
 
+    /// Compare tab — the folded-in ModelComparison capability (#3532 slice 2):
+    /// run one prompt across multiple agents/models side by side, now a facet of
+    /// the one chat surface rather than a standalone top-level mode. Reuses
+    /// `ModelComparisonView` verbatim (it is self-contained).
+    private var compareTabContent: some View {
+        ModelComparisonView()
+    }
+
     /// Knowledge tab — entities/claims surfaced from the conversation. The chrome
     /// facet lands now; wiring the conversation-scoped KG content is a later
     /// #3532 slice (no chat-knowledge component to reuse yet).
@@ -243,6 +256,8 @@ struct ChatView: View {
             return count == 0 ? "No sources pinned" : "\(count) source\(count == 1 ? "" : "s")"
         case .knowledge:
             return "Knowledge"
+        case .compare:
+            return "Compare agents / models"
         }
     }
 

--- a/fichero/fichero/Views/Sidebar/SidebarView+PinnedNavigationRows.swift
+++ b/fichero/fichero/Views/Sidebar/SidebarView+PinnedNavigationRows.swift
@@ -67,15 +67,6 @@ extension SidebarView {
         )
     }
 
-    private func comparisonNavigationRow() -> some View {
-        pinnedNavigationRow(
-            "Model Comparison",
-            systemImage: "rectangle.split.2x1",
-            tag: .browser(.comparison),
-            help: "Open the model comparison workspace"
-        )
-    }
-
     private func chatWithDocsNavigationRow() -> some View {
         Button {
             onOpenChatWithCurrentScope?()
@@ -169,9 +160,9 @@ extension SidebarView {
             workflowsNavigationRow()
         }
 
-        if FeatureManager.shared.isChatEnabled {
-            comparisonNavigationRow()
-        }
+        // Model Comparison is no longer a standalone top-level mode — it folded
+        // into the Chat surface's Compare facet (#3532 slice 2 / #3540). The
+        // sidebar entry is retired; open Compare from within the chat.
 
         if FeatureManager.shared.isChatEnabled {
             chatWithDocsNavigationRow()


### PR DESCRIPTION
ModelComparison folds into the unified chat as a Compare facet; the standalone Comparison sidebar entry is retired. Agent routes into the one chat interface (Daniel #3540: 'the chrome is the same for all three... just one chat interface... always an agent with MCP tools'). Research untouched (keeps 3-pane — later slice). BUILD SUCCEEDED (integrated with #3557). 🤖 Claude (Opus 4.8)