### PR TITLE
Engine: audited agent workspace actions (#3561)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/chat.py
+++ b/fichero-engine/src/fichero/api/routes/chat.py
@@ -9,6 +9,7 @@ import logging
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Optional
+from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -28,7 +29,12 @@ from fichero.models import (
     Model as ModelModel,
     Provider as ProviderModel,
 )
-from fichero.api.routes.documents import WorkspaceCuratedItem, WorkspacePatchRequest
+from fichero.api.routes.documents import (
+    WorkspaceCuratedItem,
+    WorkspacePatchRequest,
+    patch_workspace_items_impl,
+)
+from fichero.knowledge_models import KnowledgeClaim
 from fichero.keychain import has_api_key
 from fichero.llm import LLMConfig, get_langchain_model
 from fichero.node_aliases import DanglingAliasError, is_alias, resolve_alias
@@ -231,6 +237,21 @@ class AgentWorkspaceListResponse(BaseModel):
 class AgentWorkspaceDeletedResponse(BaseModel):
     status: str
     id: str
+
+
+class WorkspaceSourceActionParams(BaseModel):
+    workspace_id: str
+    document_id: str
+
+
+class WorkspaceClaimActionParams(BaseModel):
+    workspace_id: str
+    claim_id: str
+
+
+class WorkspaceNoteActionParams(BaseModel):
+    workspace_id: str
+    text: str = Field(min_length=1)
 
 
 _AGENT_WORKSPACE_KIND = "agent"
@@ -1265,3 +1286,136 @@ def _action_restore_conversation(
         emit_type="conversation.updated" if before else "conversation.created",
     )
     return after, spec
+
+
+def _invert_workspace_membership(
+    before: dict | None, after: dict | None, ctx: ActionContext
+) -> tuple[str, dict] | None:
+    if not before:
+        return None
+    return ("document.restore", {"documents": [before]})
+
+
+def _mutate_agent_workspace(
+    db: Database, workspace_id: str, patch: WorkspacePatchRequest
+) -> tuple[dict, ChangeSpec]:
+    workspace = _agent_workspace_or_404(db, workspace_id)
+    updated, before = patch_workspace_items_impl(db, workspace.id, patch)
+    return (
+        {"workspace_id": updated.id, "items": updated.curated_items},
+        ChangeSpec(
+            domains=["document"],
+            target_ids=[updated.id],
+            before=before,
+            after=updated.model_dump(mode="json"),
+            emit_type="document.updated",
+            document_ids=[updated.id],
+        ),
+    )
+
+
+@action(
+    "workspace.add_source",
+    WorkspaceSourceActionParams,
+    domains=["document"],
+    undoable=True,
+    invert=_invert_workspace_membership,
+)
+def _action_workspace_add_source(
+    db: Database, params: WorkspaceSourceActionParams, ctx: ActionContext
+) -> tuple[dict, ChangeSpec]:
+    if db.get(Document, params.document_id) is None:
+        raise HTTPException(status_code=404, detail="Source document not found")
+    return _mutate_agent_workspace(
+        db,
+        params.workspace_id,
+        WorkspacePatchRequest(
+            add=[
+                WorkspaceCuratedItem(
+                    id=f"source:{params.document_id}",
+                    target_type="document",
+                    target_id=params.document_id,
+                    role="agent_source",
+                )
+            ]
+        ),
+    )
+
+
+@action(
+    "workspace.remove_source",
+    WorkspaceSourceActionParams,
+    domains=["document"],
+    undoable=True,
+    invert=_invert_workspace_membership,
+)
+def _action_workspace_remove_source(
+    db: Database, params: WorkspaceSourceActionParams, ctx: ActionContext
+) -> tuple[dict, ChangeSpec]:
+    workspace = _agent_workspace_or_404(db, params.workspace_id)
+    item_id = f"source:{params.document_id}"
+    if not any(item.get("id") == item_id for item in workspace.curated_items):
+        raise HTTPException(status_code=404, detail="Workspace source not found")
+    return _mutate_agent_workspace(
+        db, params.workspace_id, WorkspacePatchRequest(remove_ids=[item_id])
+    )
+
+
+@action(
+    "workspace.surface_claim",
+    WorkspaceClaimActionParams,
+    domains=["document", "claim"],
+    undoable=True,
+    invert=_invert_workspace_membership,
+)
+def _action_workspace_surface_claim(
+    db: Database, params: WorkspaceClaimActionParams, ctx: ActionContext
+) -> tuple[dict, ChangeSpec]:
+    if db.get(KnowledgeClaim, params.claim_id) is None:
+        raise HTTPException(status_code=404, detail="Knowledge claim not found")
+    result, spec = _mutate_agent_workspace(
+        db,
+        params.workspace_id,
+        WorkspacePatchRequest(
+            add=[
+                WorkspaceCuratedItem(
+                    id=f"claim:{params.claim_id}",
+                    target_type="claim",
+                    target_id=params.claim_id,
+                    role="surfaced_claim",
+                )
+            ]
+        ),
+    )
+    spec.claim_ids = [params.claim_id]
+    return result, spec
+
+
+@action(
+    "workspace.add_note",
+    WorkspaceNoteActionParams,
+    domains=["document"],
+    undoable=True,
+    invert=_invert_workspace_membership,
+)
+def _action_workspace_add_note(
+    db: Database, params: WorkspaceNoteActionParams, ctx: ActionContext
+) -> tuple[dict, ChangeSpec]:
+    item_id = f"note:{uuid4().hex}"
+    result, spec = _mutate_agent_workspace(
+        db,
+        params.workspace_id,
+        WorkspacePatchRequest(
+            add=[
+                WorkspaceCuratedItem(
+                    id=item_id,
+                    target_type="note",
+                    target_id=item_id,
+                    role="agent_note",
+                    notes=params.text,
+                )
+            ]
+        ),
+    )
+    result["item_id"] = item_id
+    return result, spec

--- a/fichero-engine/tests/unit/test_workspace_actions.py
+++ b/fichero-engine/tests/unit/test_workspace_actions.py
@@ -1,0 +1,135 @@
+"""Audited agent workspace membership actions (#3561)."""
+
+from __future__ import annotations
+
+import pytest
+
+from fichero import accounts, authz
+from fichero.actions.registry import ActionContext, registry
+from fichero.knowledge_models import KnowledgeClaim
+from fichero.models import ActionAudit, DocType, Document
+
+
+def _workspace(db) -> Document:
+    workspace = Document(
+        name="Agent workspace",
+        doc_type=DocType.folder,
+        node_kind="workspace",
+        is_workspace=True,
+        metadata={"workspace_kind": "agent", "message_history_ref": "conversation-1"},
+    )
+    db.save(workspace)
+    return workspace
+
+
+def _ctx(db, actor: str = "agent") -> ActionContext:
+    return ActionContext(actor=actor, library_path=str(db.path.parent))
+
+
+def _undo(db, result, ctx: ActionContext) -> None:
+    audit = db.get(ActionAudit, result.audit_id)
+    registration = registry.get(audit.action_name)
+    inverse = registration.invert(audit.before, audit.after, ctx)
+    assert inverse is not None
+    registry.invoke(db, inverse[0], inverse[1], ctx)
+
+
+def test_add_source_mutates_audits_and_undoes(db):
+    workspace = _workspace(db)
+    source = Document(name="Source")
+    db.save(source)
+    ctx = _ctx(db)
+
+    result = registry.invoke(
+        db,
+        "workspace.add_source",
+        {"workspace_id": workspace.id, "document_id": source.id},
+        ctx,
+    )
+    assert db.get(Document, workspace.id).curated_items[0]["target_id"] == source.id
+    assert db.get(ActionAudit, result.audit_id).actor == "agent"
+    _undo(db, result, ctx)
+    assert db.get(Document, workspace.id).curated_items == []
+
+
+def test_remove_source_mutates_audits_and_undoes(db):
+    workspace = _workspace(db)
+    source = Document(name="Source")
+    db.save(source)
+    ctx = _ctx(db)
+    registry.invoke(
+        db,
+        "workspace.add_source",
+        {"workspace_id": workspace.id, "document_id": source.id},
+        ctx,
+    )
+
+    result = registry.invoke(
+        db,
+        "workspace.remove_source",
+        {"workspace_id": workspace.id, "document_id": source.id},
+        ctx,
+    )
+    assert db.get(Document, workspace.id).curated_items == []
+    assert db.get(ActionAudit, result.audit_id).action_name == "workspace.remove_source"
+    _undo(db, result, ctx)
+    assert db.get(Document, workspace.id).curated_items[0]["target_id"] == source.id
+
+
+def test_surface_claim_mutates_audits_and_undoes(db):
+    workspace = _workspace(db)
+    claim = KnowledgeClaim(text="The petition was filed in 1844.")
+    db.save(claim)
+    ctx = _ctx(db)
+
+    result = registry.invoke(
+        db,
+        "workspace.surface_claim",
+        {"workspace_id": workspace.id, "claim_id": claim.id},
+        ctx,
+    )
+    assert db.get(Document, workspace.id).curated_items[0]["target_id"] == claim.id
+    assert db.get(ActionAudit, result.audit_id).action_name == "workspace.surface_claim"
+    _undo(db, result, ctx)
+    assert db.get(Document, workspace.id).curated_items == []
+
+
+def test_add_note_mutates_audits_and_undoes(db):
+    workspace = _workspace(db)
+    ctx = _ctx(db)
+
+    result = registry.invoke(
+        db,
+        "workspace.add_note",
+        {"workspace_id": workspace.id, "text": "Check the ledger date."},
+        ctx,
+    )
+    assert db.get(Document, workspace.id).curated_items[0]["notes"] == "Check the ledger date."
+    assert db.get(ActionAudit, result.audit_id).action_name == "workspace.add_note"
+    _undo(db, result, ctx)
+    assert db.get(Document, workspace.id).curated_items == []
+
+
+def test_workspace_actions_deny_unauthorized_actor(db, app_db, monkeypatch):
+    monkeypatch.setenv("FICHERO_MULTIUSER", "1")
+    agent = app_db.create_user(
+        username="agent", display_name="Agent", password_hash=accounts.hash_password("agent")
+    )
+    viewer = app_db.create_user(
+        username="viewer", display_name="Viewer", password_hash=accounts.hash_password("viewer")
+    )
+    library_path = str(db.path.parent)
+    normalized = authz.normalize_library_path(library_path)
+    app_db.set_library_role(user_id=agent.id, library_path=normalized, role="editor")
+    app_db.set_library_role(user_id=viewer.id, library_path=normalized, role="viewer")
+    workspace = _workspace(db)
+    source = Document(name="Source")
+    db.save(source)
+
+    with pytest.raises(authz.AuthorizationError):
+        registry.invoke(
+            db,
+            "workspace.add_source",
+            {"workspace_id": workspace.id, "document_id": source.id},
+            _ctx(db, viewer.username),
+        )


### PR DESCRIPTION
add_source/remove_source/surface_claim/add_note as audited actions on chat.py workspace routes (actor = agent account, writes #3547 membership, undoable). Reuses the existing action/authz layer — new write routes are authz-guarded (guardrail shows no missing-entry). Gate: test_workspace_actions.py 5 passed (incl. unauthorized-actor-denied); broader action/workspace/audit suite 1020 passed (the 1 red is a PRE-EXISTING stale-allowlist entry unrelated to this change — filed separately). 🤖 Claude (Opus 4.8)