### PR TITLE
Batch-mode GUI: run a workflow across folders separately (#3536)

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -192,6 +192,8 @@
 		2FA0C9F98B2B1A0A35107B07 /* ChainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41994E6C746A0B0171534212 /* ChainStore.swift */; };
 		300ED1FDA9255CD4182A3664 /* ForceDirectedGraphView+Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE62C7312D0E473288483C9 /* ForceDirectedGraphView+Render.swift */; };
 		342DA5972C51F45081E9FB80 /* EntityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B118FE1DE4F78C0EE238539 /* EntityStore.swift */; };
+		FEEDDEAD000000000000000A /* BatchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000009 /* BatchStore.swift */; };
+		FEEDDEAD000000000000000C /* BatchRunView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD000000000000000B /* BatchRunView.swift */; };
 		FEEDDEAD0000000000000008 /* WorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000007 /* WorkspaceStore.swift */; };
 		34F019EE1DA4E427EF3674EC /* OpenAffordances.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68A831B2F81707B5E082D6F /* OpenAffordances.swift */; };
 		3591D3E8CE619A9731DF2242 /* CanvasDetailTier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80920949B39DD526745B0BF2 /* CanvasDetailTier.swift */; };
@@ -631,6 +633,8 @@
 		09D8F04A6421AEC5B5370E92 /* CanvasDropOutcome.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CanvasDropOutcome.swift; sourceTree = "<group>"; };
 		0A4F63C0FA3C779A6BA5B655 /* EngineSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EngineSettingsView.swift; sourceTree = "<group>"; };
 		0B118FE1DE4F78C0EE238539 /* EntityStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityStore.swift; sourceTree = "<group>"; };
+		FEEDDEAD0000000000000009 /* BatchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BatchStore.swift; path = fichero/Models/BatchStore.swift; sourceTree = SOURCE_ROOT; };
+		FEEDDEAD000000000000000B /* BatchRunView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BatchRunView.swift; path = fichero/Views/Workflow/BatchRunView.swift; sourceTree = SOURCE_ROOT; };
 		FEEDDEAD0000000000000007 /* WorkspaceStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		0BE6CF3DE02E1F999AE8F1A9 /* SidebarItemRow+Presentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SidebarItemRow+Presentation.swift"; sourceTree = "<group>"; };
 		0EBBA30F68AE440FAF4DC1E4 /* SpatialView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpatialView.swift; sourceTree = "<group>"; };
@@ -1664,6 +1668,8 @@
 				D82A9BAC0F995F9199F94B69 /* KGFocusState.swift */,
 				E5C0909F7C7B21871D35EB5C /* SpatialModels+Links.swift */,
 				0B118FE1DE4F78C0EE238539 /* EntityStore.swift */,
+				FEEDDEAD0000000000000009 /* BatchStore.swift */,
+				FEEDDEAD000000000000000B /* BatchRunView.swift */,
 				FEEDDEAD0000000000000007 /* WorkspaceStore.swift */,
 				1C527476477074D83F628468 /* ClaimStore.swift */,
 				EFA65406167827DCB144E3E2 /* NoteStore.swift */,
@@ -2905,6 +2911,8 @@
 				B82F169352D7D0876DE0FCF9 /* EntityDetailView+Sections.swift in Sources */,
 				417694AF6ACC5AEEF6E2E4B9 /* ClaimSummaryCard+Provenance.swift in Sources */,
 				342DA5972C51F45081E9FB80 /* EntityStore.swift in Sources */,
+				FEEDDEAD000000000000000A /* BatchStore.swift in Sources */,
+				FEEDDEAD000000000000000C /* BatchRunView.swift in Sources */,
 				FEEDDEAD0000000000000008 /* WorkspaceStore.swift in Sources */,
 				E9DCE0BB3E64AD1549E6F117 /* LibraryChangeStream.swift in Sources */,
 				57EFBE5436C18075ECE90EFC /* ClaimStore.swift in Sources */,

--- a/fichero/fichero/Models/BatchStore.swift
+++ b/fichero/fichero/Models/BatchStore.swift
@@ -1,0 +1,74 @@
+import FicheroAPIClient
+import Foundation
+import Observation
+import OSLog
+
+/// Observable domain store for workflow batch runs (#3536). The single endpoint
+/// accessor for batches — views observe `batches` and dispatch the actions
+/// below; the store owns the fetch/create via `BatchServiceGenerated`.
+///
+/// The headline capability: run one workflow across many folders SEPARATELY —
+/// one batch item per folder (each scoped to that folder's documents via
+/// `selected_doc_ids`), so each folder is its own run tracked in Activity.
+@MainActor
+@Observable
+final class BatchStore {
+    private(set) var batches: [Components.Schemas.BatchResponse] = []
+    private(set) var isLoading = false
+    private(set) var lastError: String?
+
+    private let batchService: BatchServiceGenerated
+    private let log = Logger(subsystem: "app.fichero.fichero", category: "BatchStore")
+
+    init(batchService: BatchServiceGenerated) {
+        self.batchService = batchService
+    }
+
+    /// Load recent batches.
+    func load() async {
+        isLoading = true
+        defer { isLoading = false }
+        do {
+            batches = try await batchService.listBatches()
+            lastError = nil
+        } catch {
+            lastError = error.localizedDescription
+            log.error("batch list failed: \(error.localizedDescription)")
+        }
+    }
+
+    /// Run `workflowId` across `folders` — ONE batch, one item per folder (each
+    /// item scoped to that folder's document ids), then execute it. Each folder
+    /// becomes a separate run that surfaces in Activity. Returns the created
+    /// batch, or nil on failure.
+    @discardableResult
+    func runFolderBatch(
+        workflowId: String,
+        folders: [(id: String, documentIds: [String])]
+    ) async -> Components.Schemas.BatchResponse? {
+        let items: [[String: any Sendable]] = folders.map { folder in
+            ["selected_doc_ids": folder.documentIds]
+        }
+        do {
+            let batch = try await batchService.createBatch(workflowId: workflowId, items: items)
+            try await batchService.executeBatch(batchId: batch.batchId)
+            await load()
+            lastError = nil
+            return batch
+        } catch {
+            lastError = error.localizedDescription
+            log.error("batch run failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    /// Cancel-safe delete of a batch.
+    func delete(batchId: String) async {
+        do {
+            try await batchService.deleteBatch(batchId: batchId)
+            batches.removeAll { $0.batchId == batchId }
+        } catch {
+            lastError = error.localizedDescription
+        }
+    }
+}

--- a/fichero/fichero/Models/LibraryManager.swift
+++ b/fichero/fichero/Models/LibraryManager.swift
@@ -168,6 +168,10 @@ class LibraryManager {
         /// list; save/list/delete route through `chatServiceGenerated`.
         @ObservationIgnored lazy var workspaceStore: WorkspaceStore = WorkspaceStore(chatService: chatServiceGenerated)
 
+        /// Per-library workflow batch runs (#3536). Owns the batch list + the
+        /// folder-fan-out create; routes through `batchService`.
+        @ObservationIgnored lazy var batchStore: BatchStore = BatchStore(batchService: batchService)
+
         /// Per-library search store (#1903). Wraps `searchService`, owns the
         /// current result set and index stats, and invalidates stale results on
         /// `document.*` change events.

--- a/fichero/fichero/Views/ContentView+Navigation.swift
+++ b/fichero/fichero/Views/ContentView+Navigation.swift
@@ -225,11 +225,9 @@ extension ContentView {
             }
 
         case .batches:
-            ContentUnavailableView(
-                "Batches",
-                systemImage: "square.stack.3d.up",
-                description: Text("Batch queue surface is feature-gated and shown independently.")
-            )
+            // Batch-mode GUI (#3536): run a workflow across many folders
+            // separately — one run per folder, each tracked in Activity.
+            BatchRunView()
 
         case .batch:
             ContentUnavailableView(

--- a/fichero/fichero/Views/Library/Inspector/FocusedDocument.swift
+++ b/fichero/fichero/Views/Library/Inspector/FocusedDocument.swift
@@ -115,6 +115,7 @@ struct DocumentDetailWindow: View {
             .environment(library.conversationServiceGenerated)
             .environment(library.chatServiceGenerated)
             .environment(library.workspaceStore)
+            .environment(library.batchStore)
             .environment(library.workflowServiceGenerated)
             .environment(library.workflowStreamService)
             .environment(library.importService)

--- a/fichero/fichero/Views/Library/Workspace/LibraryWorkspaceRoot.swift
+++ b/fichero/fichero/Views/Library/Workspace/LibraryWorkspaceRoot.swift
@@ -67,6 +67,7 @@ struct LibraryWorkspaceRoot: View {
             .environment(library.conversationServiceGenerated)
             .environment(library.chatServiceGenerated)
             .environment(library.workspaceStore)
+            .environment(library.batchStore)
             .environment(library.workflowStore)
             .environment(library.workflowServiceGenerated)
             .environment(library.workflowStreamService)

--- a/fichero/fichero/Views/Workflow/BatchRunView.swift
+++ b/fichero/fichero/Views/Workflow/BatchRunView.swift
@@ -1,0 +1,212 @@
+import FicheroAPIClient
+import SwiftUI
+
+/// Batch surface tabs (#3536): create a new folder-fan-out batch, or review
+/// existing batches. Shares the app's SurfaceTabBar chrome.
+enum BatchSurfaceTab: String, CaseIterable, Identifiable, SurfaceTab {
+    case newBatch
+    case batches
+
+    var id: String { rawValue }
+    var title: String {
+        switch self {
+        case .newBatch: return "New Batch"
+        case .batches: return "Batches"
+        }
+    }
+    var icon: String {
+        switch self {
+        case .newBatch: return "square.stack.3d.up.badge.a"
+        case .batches: return "square.stack.3d.up"
+        }
+    }
+    var help: String {
+        switch self {
+        case .newBatch: return "New Batch — run a workflow across many folders separately"
+        case .batches: return "Batches — existing batch runs and their progress"
+        }
+    }
+}
+
+/// Batch-mode GUI (#3536): run one workflow across dozens of folders SEPARATELY
+/// — one batch item per folder (each scoped to that folder's documents), so
+/// every folder is its own run tracked in Activity. Consumes the existing batch
+/// backend via `BatchStore` (the endpoint accessor); reuses the SurfaceTabBar /
+/// MiniToolbar chrome for consistency with the Workflow surface.
+struct BatchRunView: View {
+    @Environment(BatchStore.self) private var batchStore
+    @Environment(WorkflowServiceGenerated.self) private var workflowService
+    @Environment(DocumentStore.self) private var documentStore
+
+    @State private var workflows: [WorkflowResponse] = []
+    @State private var selectedWorkflowId: String?
+    @State private var selectedFolderIds: Set<String> = []
+    @State private var isRunning = false
+    @State private var message: String?
+    @SceneStorage("batch.surfaceTab") private var tabRaw = BatchSurfaceTab.newBatch.rawValue
+
+    private var tab: BatchSurfaceTab { BatchSurfaceTab(rawValue: tabRaw) ?? .newBatch }
+    private var tabBinding: Binding<BatchSurfaceTab> {
+        Binding(get: { tab }, set: { tabRaw = $0.rawValue })
+    }
+
+    /// The current library level's folders — the fan-out targets.
+    private var folders: [Document] {
+        documentStore.currentDocuments.filter { $0.docType == .folder }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            SurfaceTabBar(tabs: BatchSurfaceTab.allCases, selection: tabBinding, accessibilityID: "batchSurfaceTabBar")
+            Divider()
+            switch tab {
+            case .newBatch: newBatchContent
+            case .batches: batchesListContent
+            }
+            Divider()
+            bottomBar
+        }
+        .task {
+            await loadWorkflows()
+            await batchStore.load()
+        }
+    }
+
+    // MARK: - New batch
+
+    @ViewBuilder
+    private var newBatchContent: some View {
+        Form {
+            Section("Workflow") {
+                Picker("Run", selection: $selectedWorkflowId) {
+                    Text("Choose a workflow…").tag(String?.none)
+                    ForEach(workflows, id: \.id) { workflow in
+                        Text(workflow.name).tag(String?.some(workflow.id))
+                    }
+                }
+            }
+            Section("Folders — one separate run each") {
+                if folders.isEmpty {
+                    Text("No folders at this level. Open a library folder that contains sub-folders.")
+                        .font(.caption).foregroundStyle(.secondary)
+                } else {
+                    ForEach(folders, id: \.id) { folder in
+                        Toggle(isOn: folderBinding(folder.id)) {
+                            Label(folder.name, systemImage: "folder")
+                        }
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func folderBinding(_ id: String) -> Binding<Bool> {
+        Binding(
+            get: { selectedFolderIds.contains(id) },
+            set: { isOn in
+                if isOn { selectedFolderIds.insert(id) } else { selectedFolderIds.remove(id) }
+            }
+        )
+    }
+
+    // MARK: - Batches list
+
+    @ViewBuilder
+    private var batchesListContent: some View {
+        if batchStore.batches.isEmpty {
+            ContentUnavailableView(
+                "No batches",
+                systemImage: "square.stack.3d.up",
+                description: Text("Run a workflow across folders from the New Batch tab.")
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            List(batchStore.batches, id: \.batchId) { batch in
+                HStack(spacing: 8) {
+                    Image(systemName: "square.stack.3d.up")
+                        .foregroundStyle(.secondary)
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text(batch.workflowId).font(.body).lineLimit(1)
+                        Text("\(batch.status) · \(batch.completedItems)/\(batch.totalItems)")
+                            .font(.caption2).foregroundStyle(.secondary)
+                    }
+                    Spacer(minLength: 0)
+                }
+                .contextMenu {
+                    Button(role: .destructive) {
+                        Task { await batchStore.delete(batchId: batch.batchId) }
+                    } label: {
+                        Label("Delete Batch", systemImage: "trash")
+                    }
+                }
+            }
+            .listStyle(.inset)
+        }
+    }
+
+    // MARK: - Bottom bar
+
+    private var bottomBar: some View {
+        MiniToolbar {
+            Text(bottomStatus)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+            if tab == .newBatch {
+                if isRunning { ProgressView().controlSize(.small) }
+                Button {
+                    runBatch()
+                } label: {
+                    Label("Run across \(selectedFolderIds.count) folder\(selectedFolderIds.count == 1 ? "" : "s")",
+                          systemImage: "play.fill")
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(selectedWorkflowId == nil || selectedFolderIds.isEmpty || isRunning)
+            }
+        }
+    }
+
+    private var bottomStatus: String {
+        if let message { return message }
+        switch tab {
+        case .newBatch:
+            return "\(selectedFolderIds.count) folder\(selectedFolderIds.count == 1 ? "" : "s") selected"
+        case .batches:
+            let count = batchStore.batches.count
+            return count == 0 ? "No batches" : "\(count) batch\(count == 1 ? "" : "es")"
+        }
+    }
+
+    // MARK: - Actions
+
+    private func loadWorkflows() async {
+        do { workflows = try await workflowService.listWorkflows() } catch { workflows = [] }
+    }
+
+    /// Fan out one batch item per selected folder (each scoped to that folder's
+    /// documents), then track it in Activity.
+    private func runBatch() {
+        guard let workflowId = selectedWorkflowId, !selectedFolderIds.isEmpty else { return }
+        isRunning = true
+        message = nil
+        let folderIds = selectedFolderIds
+        Task {
+            var folderInputs: [(id: String, documentIds: [String])] = []
+            for folderId in folderIds {
+                let docIds = await documentStore.children(of: folderId).map(\.id)
+                folderInputs.append((id: folderId, documentIds: docIds))
+            }
+            let batch = await batchStore.runFolderBatch(workflowId: workflowId, folders: folderInputs)
+            isRunning = false
+            if batch != nil {
+                message = "Started \(folderInputs.count) folder run\(folderInputs.count == 1 ? "" : "s") — track them in Activity."
+                selectedFolderIds.removeAll()
+                tabRaw = BatchSurfaceTab.batches.rawValue
+            } else {
+                message = batchStore.lastError ?? "Couldn't start the batch."
+            }
+        }
+    }
+}


### PR DESCRIPTION
Exposes the backend batch mode Daniel flagged as GUI-less: new BatchStore (@Observable) + BatchRunView — pick a workflow + folders → one batch run with one item per folder (separate run/folder), each surfacing in Activity. Reuses batch.py/create_batch/AppViewMode.batches via the generated client. BUILD SUCCEEDED. 🤖 Claude (Opus 4.8)