### PR TITLE
Research embeds the one unified chat surface — unification complete (#3532 slice 3)

### DIFF
--- a/fichero/fichero/Views/Research/ResearchChatPane.swift
+++ b/fichero/fichero/Views/Research/ResearchChatPane.swift
@@ -1,9 +1,18 @@
 import SwiftUI
 
 /// Chat pane embedded in a research project workspace.
-/// Reuses ChatView, but scopes its saved conversation list to the research
-/// project's folder path (`/research/{project_id}`) so each workspace keeps
-/// its own thread shelf without forking the chat surface.
+///
+/// Research keeps its 3-pane layout (chat | browser | tasks), but the
+/// conversation component IS the one unified chat surface — this embeds the
+/// shared `ChatView` (the SurfaceTabBar Conversation / Sources / Knowledge /
+/// Compare surface from #3532 slices 1-2), never a separate chat
+/// implementation. That completes the chat / research / agent unification
+/// (#3532 / #3540: "just one chat interface… always an agent with MCP tools").
+///
+/// The only Research-specific bit is scoping: the saved-conversation shelf is
+/// pinned to the project's folder path (`/research/{project_id}`), so each
+/// workspace keeps its own threads without forking the surface (Research =
+/// workspace, ties #3533).
 struct ResearchChatPane: View {
     var project: ResearchProject
     @Environment(ConversationServiceGenerated.self) var conversationServiceGenerated


### PR DESCRIPTION
Research's conversation pane already embeds the shared ChatView that slices 1-2 upgraded to the SurfaceTabBar surface (Conversation/Sources/Knowledge/Compare) — so chat/research/agent are one interface by construction; 3-pane kept, /research/{project_id} scoping preserved. Small clarifying touch on ResearchChatPane. BUILD SUCCEEDED. Completes #3532. 🤖 Claude (Opus 4.8)