### PR TITLE
Engine: expose workspace actions as MCP tools (#3569)

### DIFF
--- a/fichero-engine/src/fichero/cli/client.py
+++ b/fichero-engine/src/fichero/cli/client.py
@@ -137,6 +137,13 @@ def _read_cli_session_payload(as_user: str | None = None) -> dict[str, Any]:
 
 def _read_token(base_url: str | None = None, as_user: str | None = None) -> str | None:
     """Read the selected auth token, scoped to the actual backend host."""
+    # An explicitly selected account must never fall back to the loopback
+    # bootstrap credential: that would attribute an agent MCP action to owner.
+    if as_user:
+        payload = _read_cli_session_payload(as_user=as_user)
+        token = payload.get("session_token")
+        return token.strip() if isinstance(token, str) and token.strip() else None
+
     env = os.environ.get("FICHERO_SESSION_TOKEN")
     if env:
         return env.strip()

--- a/fichero-engine/src/fichero/mcp_server.py
+++ b/fichero-engine/src/fichero/mcp_server.py
@@ -57,6 +57,25 @@ def _client() -> FicheroClient:
     )
 
 
+def _agent_client() -> FicheroClient:
+    """Build the dedicated agent-account client for audited MCP mutations."""
+    client = FicheroClient(
+        base_url=_CONFIG["base_url"],
+        library_path=_CONFIG["library_path"],
+        as_user="agent",
+    )
+    if not client.token:
+        client.close()
+        raise RuntimeError("No stored session for agent; run `fichero auth login agent`.")
+    return client
+
+
+def _workspace_action(name: str, params: dict[str, str]) -> Any:
+    """Invoke a workspace action through the one audited write endpoint."""
+    with _agent_client() as client:
+        return client.request("POST", "/api/actions/invoke", json={"name": name, "params": params})
+
+
 # -- health ----------------------------------------------------------------
 @mcp.tool()
 def fichero_health() -> Any:
@@ -300,6 +319,31 @@ def fichero_activity(limit: int = 50) -> Any:
     """Show recent workflow activity."""
     with _client() as client:
         return client.recent_activity(limit=limit)
+
+
+# -- agent workspace actions ----------------------------------------------
+@mcp.tool()
+def fichero_workspace_add_source(workspace_id: str, document_id: str) -> Any:
+    """Add a source document to an agent workspace."""
+    return _workspace_action("workspace.add_source", {"workspace_id": workspace_id, "document_id": document_id})
+
+
+@mcp.tool()
+def fichero_workspace_remove_source(workspace_id: str, document_id: str) -> Any:
+    """Remove a source document from an agent workspace."""
+    return _workspace_action("workspace.remove_source", {"workspace_id": workspace_id, "document_id": document_id})
+
+
+@mcp.tool()
+def fichero_workspace_surface_claim(workspace_id: str, claim_id: str) -> Any:
+    """Surface a knowledge claim in an agent workspace."""
+    return _workspace_action("workspace.surface_claim", {"workspace_id": workspace_id, "claim_id": claim_id})
+
+
+@mcp.tool()
+def fichero_workspace_add_note(workspace_id: str, text: str) -> Any:
+    """Add an agent note to an agent workspace."""
+    return _workspace_action("workspace.add_note", {"workspace_id": workspace_id, "text": text})
 
 
 # -- knowledge graph / content (read) --------------------------------------

--- a/fichero-engine/tests/unit/test_cli_client.py
+++ b/fichero-engine/tests/unit/test_cli_client.py
@@ -541,6 +541,17 @@ def test_token_read_from_selected_cli_user_session(monkeypatch, tmp_path):
     assert client_module._read_token(as_user="bob") == "bob-token"
 
 
+def test_selected_cli_user_never_falls_back_to_bootstrap(monkeypatch, tmp_path):
+    monkeypatch.delenv("FICHERO_SESSION_TOKEN", raising=False)
+    monkeypatch.delenv("FICHERO_API_KEY", raising=False)
+    monkeypatch.setattr(client_module, "_CLI_SESSION_PATH", tmp_path / "missing-session.json")
+    bootstrap_path = tmp_path / ".api-key"
+    bootstrap_path.write_text("bootstrap-token", encoding="utf-8")
+    monkeypatch.setattr(client_module, "_TOKEN_PATH", bootstrap_path)
+
+    assert client_module._read_token(as_user="agent") is None
+
+
 def test_token_ignores_bad_cli_session_file_and_falls_back_to_bootstrap(
     monkeypatch, tmp_path
 ):

--- a/fichero-engine/tests/unit/test_mcp_server.py
+++ b/fichero-engine/tests/unit/test_mcp_server.py
@@ -42,6 +42,10 @@ EXPECTED_TOOLS = {
     "fichero_artifact_get",
     "fichero_search",
     "fichero_activity",
+    "fichero_workspace_add_source",
+    "fichero_workspace_remove_source",
+    "fichero_workspace_surface_claim",
+    "fichero_workspace_add_note",
 }
 
 
@@ -229,6 +233,45 @@ def test_auth_and_library_headers_are_set(monkeypatch):
     assert seen[0].headers["x-fichero-library-path"] == quote(
         "/tmp/Lib.fichero", safe="/"
     )
+
+
+@pytest.mark.parametrize(
+    ("tool", "params", "action", "action_params"),
+    [
+        (
+            mcp_server.fichero_workspace_add_source,
+            ("workspace-1", "doc-1"),
+            "workspace.add_source",
+            {"workspace_id": "workspace-1", "document_id": "doc-1"},
+        ),
+        (
+            mcp_server.fichero_workspace_remove_source,
+            ("workspace-1", "doc-1"),
+            "workspace.remove_source",
+            {"workspace_id": "workspace-1", "document_id": "doc-1"},
+        ),
+        (
+            mcp_server.fichero_workspace_surface_claim,
+            ("workspace-1", "claim-1"),
+            "workspace.surface_claim",
+            {"workspace_id": "workspace-1", "claim_id": "claim-1"},
+        ),
+        (
+            mcp_server.fichero_workspace_add_note,
+            ("workspace-1", "Remember this"),
+            "workspace.add_note",
+            {"workspace_id": "workspace-1", "text": "Remember this"},
+        ),
+    ],
+)
+def test_workspace_tools_invoke_audited_action(
+    monkeypatch, tool, params, action, action_params
+):
+    with _mock_client(monkeypatch) as seen:
+        monkeypatch.setattr(mcp_server, "_agent_client", mcp_server._client)
+        tool(*params)
+    assert seen[0].url.path == "/api/actions/invoke"
+    assert json.loads(seen[0].content) == {"name": action, "params": action_params}
 
 
 def test_create_note_hits_core_notes_endpoint(monkeypatch):

--- a/fichero-engine/tests/unit/test_mcp_workspace_tools.py
+++ b/fichero-engine/tests/unit/test_mcp_workspace_tools.py
@@ -1,0 +1,125 @@
+"""Workspace MCP tools delegate to the audited action registry (#3569)."""
+
+from __future__ import annotations
+
+import pytest
+
+from fichero import accounts, authz, mcp_server
+from fichero.actions.registry import ActionContext, registry
+from fichero.knowledge_models import KnowledgeClaim
+from fichero.models import ActionAudit, DocType, Document
+
+
+class _ActionClient:
+    """In-process stand-in for the MCP server's audited HTTP endpoint."""
+
+    def __init__(self, db, actor: str = "agent"):
+        self.db = db
+        self.actor = actor
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return None
+
+    def request(self, method, path, *, json):
+        assert (method, path) == ("POST", "/api/actions/invoke")
+        result = registry.invoke(
+            self.db,
+            json["name"],
+            json["params"],
+            ActionContext(actor=self.actor, library_path=str(self.db.path.parent)),
+        )
+        return {"ok": result.ok, "audit_id": result.audit_id, "result": result.result}
+
+
+def _workspace(db) -> Document:
+    workspace = Document(
+        name="Agent workspace",
+        doc_type=DocType.folder,
+        node_kind="workspace",
+        is_workspace=True,
+        metadata={"workspace_kind": "agent"},
+    )
+    db.save(workspace)
+    return workspace
+
+
+@pytest.mark.parametrize(
+    ("tool", "action", "prepare", "arguments", "expected_role"),
+    [
+        (
+            mcp_server.fichero_workspace_add_source,
+            "workspace.add_source",
+            lambda db: Document(name="Source"),
+            lambda workspace, target: (workspace.id, target.id),
+            "agent_source",
+        ),
+        (
+            mcp_server.fichero_workspace_remove_source,
+            "workspace.remove_source",
+            lambda db: Document(name="Source"),
+            lambda workspace, target: (workspace.id, target.id),
+            None,
+        ),
+        (
+            mcp_server.fichero_workspace_surface_claim,
+            "workspace.surface_claim",
+            lambda db: KnowledgeClaim(text="The petition was filed in 1844."),
+            lambda workspace, target: (workspace.id, target.id),
+            "surfaced_claim",
+        ),
+        (
+            mcp_server.fichero_workspace_add_note,
+            "workspace.add_note",
+            lambda db: None,
+            lambda workspace, target: (workspace.id, "Check the ledger date."),
+            "agent_note",
+        ),
+    ],
+)
+def test_workspace_mcp_tools_mutate_and_audit(
+    db, monkeypatch, tool, action, prepare, arguments, expected_role
+):
+    workspace = _workspace(db)
+    target = prepare(db)
+    if target is not None:
+        db.save(target)
+    if action == "workspace.remove_source":
+        registry.invoke(
+            db,
+            "workspace.add_source",
+            {"workspace_id": workspace.id, "document_id": target.id},
+            ActionContext(actor="agent", library_path=str(db.path.parent)),
+        )
+    monkeypatch.setattr(mcp_server, "_agent_client", lambda: _ActionClient(db))
+
+    tool(*arguments(workspace, target))
+
+    items = db.get(Document, workspace.id).curated_items
+    assert (items and items[0]["role"] == expected_role) if expected_role else not items
+    audit = sorted(db.all(ActionAudit), key=lambda row: row.created_at)[-1]
+    assert (audit.action_name, audit.actor) == (action, "agent")
+
+
+def test_workspace_mcp_tool_denies_unauthorized_actor(db, app_db, monkeypatch):
+    monkeypatch.setenv("FICHERO_MULTIUSER", "1")
+    agent = app_db.create_user(
+        username="agent", display_name="Agent", password_hash=accounts.hash_password("agent")
+    )
+    viewer = app_db.create_user(
+        username="viewer", display_name="Viewer", password_hash=accounts.hash_password("viewer")
+    )
+    library_path = authz.normalize_library_path(str(db.path.parent))
+    app_db.set_library_role(user_id=agent.id, library_path=library_path, role="editor")
+    app_db.set_library_role(user_id=viewer.id, library_path=library_path, role="viewer")
+    workspace = _workspace(db)
+    source = Document(name="Source")
+    db.save(source)
+    monkeypatch.setattr(
+        mcp_server, "_agent_client", lambda: _ActionClient(db, actor="viewer")
+    )
+
+    with pytest.raises(authz.AuthorizationError):
+        mcp_server.fichero_workspace_add_source(workspace.id, source.id)


### PR DESCRIPTION
mcp_server.py registers workspace-action MCP tools that WRAP the #3561 audited actions (add_source/remove_source/surface_claim/add_note) — audit/authz/undo stay one path; actor = agent account. So the in-app agent (#2067) can actually 'do stuff' in its workspace. Gate: test_mcp_workspace_tools/test_mcp_server/test_cli_client green; broader mcp/action/workspace/authz/audit suite 1035 passed. No regen. 🤖 Claude (Opus 4.8)