### PR TITLE
Engine: image edits flow to OCR/export/thumbnails via resolve_edited_source (#3218)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/image_editing.py
+++ b/fichero-engine/src/fichero/api/routes/image_editing.py
@@ -24,6 +24,7 @@ from fichero.db import Database
 from fichero.models import DocType, Document, FileType, ImageEditChain
 from fichero.workflows.batch import BatchItemStatus, BatchStatus
 from fichero.storage import resolve_source
+from fichero.image_ops import apply_operation
 from fichero.workflows.tools.fuzzy_clean_images import apply_fuzzy_clean
 
 router = APIRouter(prefix="/images", tags=["images"])
@@ -385,6 +386,10 @@ def _apply_saved_operations(
 
 
 def _apply_operation(image: Image.Image, op: dict[str, Any]) -> Image.Image:
+    return apply_operation(image, op)
+
+    # Kept below temporarily for source compatibility while operations move to
+    # fichero.image_ops; the return above is the sole runtime path.
     name = str(op.get("op", "")).strip().lower()
     params = op.get("params") or {}
     if not isinstance(params, dict):

--- a/fichero-engine/src/fichero/api/routes/storage.py
+++ b/fichero-engine/src/fichero/api/routes/storage.py
@@ -149,7 +149,7 @@ async def get_thumbnail(
             # Warm the companion display image so both formats exist after the
             # first access — avoids the asymmetry where only the requested format
             # is created lazily (#2216/#2217).
-            if thumb_path and not get_display(doc, package_path):
+            if thumb_path and not get_display(doc, package_path, db=db):
                 background_tasks.add_task(
                     asyncio.to_thread, ensure_display, doc,
                     package_path=package_path, db=db,
@@ -197,7 +197,7 @@ async def get_display_image(
     from fichero.storage import get_display, ensure_display, get_thumbnail, ensure_thumbnail
 
     # Try to get existing display image (with package path for library isolation)
-    display_path = get_display(doc, package_path)
+    display_path = get_display(doc, package_path, db=db)
 
     # If no display image, try to generate one
     if not display_path:

--- a/fichero-engine/src/fichero/export_service.py
+++ b/fichero-engine/src/fichero/export_service.py
@@ -23,7 +23,7 @@ from fichero.models import (
     KnowledgeClaim,
     KnowledgeEntity,
 )
-from fichero.storage import get_display, resolve_source
+from fichero.storage import resolve_edited_source
 
 logger = logging.getLogger(__name__)
 
@@ -244,7 +244,7 @@ def export_eleventy_site(
         asset_refs: list[_AssetRef] = []
         if _is_image_document(doc):
             assets_dir.mkdir(exist_ok=True)
-            asset_refs = _copy_document_assets(doc, assets_dir, package)
+            asset_refs = _copy_document_assets(db, doc, assets_dir, package)
 
         used = used_per_dir.setdefault(str(doc_dir), set())
         filename = _unique_filename(_slugify(doc.name), used, ".md")
@@ -992,7 +992,7 @@ def export_markdown_folder(
         filename = _unique_filename(_slugify(doc.name), used_names, ".md")
         doc_path = output_dir / filename
         asset_refs = (
-            _copy_document_assets(doc, assets_dir, package) if include_assets else []
+            _copy_document_assets(db, doc, assets_dir, package) if include_assets else []
         )
         body = _render_document_markdown(db, doc, asset_refs)
         doc_path.write_text(body, encoding="utf-8")
@@ -1047,7 +1047,7 @@ def export_word_docx(
 
     for index, doc in enumerate(documents, start=1):
         text = _document_text(db, doc)
-        image_source = _docx_image_source(doc, package)
+        image_source = _docx_image_source(db, doc, package)
         if image_source:
             rel_id = f"rIdImage{index}"
             media_name = f"image{index}{image_source.suffix.lower() or '.jpg'}"
@@ -1353,6 +1353,7 @@ def _text_artifacts(db: Database, document_id: str) -> list[Artifact]:
 
 
 def _copy_document_assets(
+    db: Database,
     doc: Document,
     assets_dir: Path,
     package_path: Path | None,
@@ -1360,7 +1361,7 @@ def _copy_document_assets(
     if not _is_image_document(doc):
         return []
 
-    source = _require_image_source(doc, package_path)
+    source = _require_image_source(db, doc, package_path)
 
     suffix = source.suffix.lower() or ".jpg"
     filename = _unique_filename(
@@ -1372,16 +1373,14 @@ def _copy_document_assets(
     return [_AssetRef(path=str(dest), markdown_path=f"assets/{filename}")]
 
 
-def _docx_image_source(doc: Document, package_path: Path | None) -> Path | None:
+def _docx_image_source(db: Database, doc: Document, package_path: Path | None) -> Path | None:
     if not _is_image_document(doc):
         return None
-    return _require_image_source(doc, package_path)
+    return _require_image_source(db, doc, package_path)
 
 
-def _require_image_source(doc: Document, package_path: Path | None) -> Path:
-    source = get_display(doc, package_path=package_path) or resolve_source(
-        doc, library_root=package_path
-    )
+def _require_image_source(db: Database, doc: Document, package_path: Path | None) -> Path:
+    source = resolve_edited_source(doc, db)
     if source is not None and source.exists() and source.is_file():
         return source
     message = (

--- a/fichero-engine/src/fichero/image_ops.py
+++ b/fichero-engine/src/fichero/image_ops.py
@@ -1,0 +1,106 @@
+"""Shared non-destructive image-edit operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import HTTPException
+from PIL import Image, ImageChops, ImageEnhance, ImageFilter, ImageOps
+
+from fichero.workflows.tools.fuzzy_clean_images import apply_fuzzy_clean
+
+
+def _remove_black_background_opencv(image: Image.Image) -> Image.Image:
+    import cv2  # type: ignore[import-not-found]
+    import numpy as np
+
+    gray = cv2.cvtColor(np.array(image.convert("RGB")), cv2.COLOR_RGB2GRAY)
+    if np.count_nonzero(gray < 80) / gray.size < 0.01:
+        return image.convert("RGBA")
+    _, binary = cv2.threshold(gray, 80, 255, cv2.THRESH_BINARY)
+    contours, _ = cv2.findContours(binary, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        return image.convert("RGBA")
+    areas = [cv2.contourArea(contour) for contour in contours]
+    mask = np.zeros_like(binary)
+    for contour, area in zip(contours, areas):
+        if area >= max(areas) * 0.2:
+            cv2.drawContours(mask, [contour], -1, 255, thickness=-1)
+    mask = cv2.GaussianBlur(mask, (21, 21), 0)
+    ys, xs = np.nonzero(mask)
+    if not len(xs):
+        return image.convert("RGBA")
+    rgba = image.convert("RGBA")
+    rgba.putalpha(Image.fromarray(mask))
+    return rgba.crop((int(xs.min()), int(ys.min()), int(xs.max()) + 1, int(ys.max()) + 1))
+
+
+def _remove_background(image: Image.Image, params: dict[str, Any]) -> Image.Image:
+    method = str(params.get("method", "opencv")).strip().lower()
+    if method == "rembg":
+        try:
+            from rembg import remove
+        except ImportError as exc:
+            raise HTTPException(501, "rembg is not installed in this backend") from exc
+        return remove(image.convert("RGBA"))
+    if method == "opencv":
+        try:
+            import cv2  # type: ignore[import-not-found]
+        except ImportError:
+            method = "threshold"
+        else:
+            del cv2
+            return _remove_black_background_opencv(image)
+    if method == "threshold":
+        rgba = image.convert("RGBA")
+        rgb = image.convert("RGB")
+        diff = ImageChops.difference(rgb, Image.new("RGB", rgb.size, rgb.getpixel((0, 0)))).convert("L")
+        rgba.putalpha(diff.point(lambda value: 255 if value > int(params.get("threshold", 28)) else 0))
+        return rgba
+    raise HTTPException(400, f"Unsupported background method: {method}")
+
+
+def apply_operation(image: Image.Image, op: dict[str, Any]) -> Image.Image:
+    """Apply one saved image-edit operation; shared by preview and consumers."""
+    name = str(op.get("op", "")).strip().lower()
+    params = op.get("params") or {}
+    if not isinstance(params, dict):
+        raise HTTPException(400, f"Invalid params for operation: {name}")
+    if name in {"rotate", "straighten"}:
+        return image.rotate(float(params.get("angle", 0)), expand=bool(params.get("expand", True)))
+    if name == "crop":
+        base = ImageOps.exif_transpose(image) if bool(params.get("auto_orient", True)) else image
+        left, top = int(params.get("left", 0)), int(params.get("top", 0))
+        width, height = int(params.get("width", base.width)), int(params.get("height", base.height))
+        right, bottom = min(left + width, base.width), min(top + height, base.height)
+        if width <= 0 or height <= 0 or left < 0 or top < 0 or right <= left or bottom <= top:
+            raise HTTPException(400, "Crop bounds are invalid")
+        return base.crop((left, top, right, bottom))
+    if name == "flip_horizontal":
+        return ImageOps.mirror(image)
+    if name == "flip_vertical":
+        return ImageOps.flip(image)
+    if name == "brightness":
+        return ImageEnhance.Brightness(image).enhance(float(params.get("factor", 1.0)))
+    if name == "contrast":
+        return ImageEnhance.Contrast(image).enhance(float(params.get("factor", 1.0)))
+    if name == "sharpen":
+        return ImageEnhance.Sharpness(image).enhance(float(params.get("factor", 1.0)))
+    if name == "auto_levels":
+        return ImageOps.autocontrast(image)
+    if name == "enhance":
+        edited = image.filter(ImageFilter.MedianFilter(size=3)) if params.get("denoise") else image
+        if params.get("auto_levels"):
+            edited = ImageOps.autocontrast(edited)
+        for enhancer, key in ((ImageEnhance.Brightness, "brightness"), (ImageEnhance.Contrast, "contrast"), (ImageEnhance.Sharpness, "sharpen")):
+            edited = enhancer(edited).enhance(float(params.get(key, 1.0)))
+        return edited
+    if name == "fuzzy_clean":
+        return apply_fuzzy_clean(image, despeckle_radius=int(params.get("despeckle_radius", 3)), background_clean=bool(params.get("background_clean", True)))
+    if name == "remove_background":
+        return _remove_background(image, params)
+    if name == "segment":
+        return image
+    if name == "grayscale":
+        return ImageOps.grayscale(image).convert("RGB")
+    raise HTTPException(400, f"Unsupported operation: {name}")

--- a/fichero-engine/src/fichero/storage.py
+++ b/fichero-engine/src/fichero/storage.py
@@ -263,7 +263,11 @@ def _resolve_thumbnail_cache_candidate(
     """Resolve the active thumbnail cache file and supporting source paths."""
     size = size or settings.thumb_size
     alias_path = _thumb_path(doc.id, package_path)
-    source = resolve_source(doc, library_root=package_path)
+    source = (
+        resolve_edited_source(doc, db)
+        if db is not None
+        else resolve_source(doc, library_root=package_path)
+    )
     pdf_render = _resolve_pdf_render_source(doc, db=db, library_root=package_path)
 
     if not source and not pdf_render:
@@ -423,6 +427,38 @@ def resolve_source(
     return None
 
 
+def resolve_edited_source(
+    doc: "Document", db: "Database", *, page: int = 1
+) -> Path | None:
+    """Return the cached replay of a document's saved edit chain, if any."""
+    from fichero.image_ops import apply_operation
+    from fichero.models import ImageEditChain
+
+    source = resolve_source(doc, library_root=db.path.parent)
+    if source is None:
+        return None
+    chains = list(db.query(ImageEditChain, document_id=doc.id))
+    if not chains:
+        return source
+    chain = chains[0]
+    operations = [op for op in chain.operations if int(op.get("page", page)) == page]
+    if not operations:
+        return source
+    version = int(chain.updated_at.timestamp() * 1_000_000)
+    cache = db.path.parent / "storage" / "edited" / doc.id[:2] / f"{doc.id}__p{page}__{version}.png"
+    if cache.exists():
+        return cache
+    if Image is None:
+        raise RuntimeError("Pillow is required to render saved image edits")
+    with Image.open(source) as opened:
+        image = ImageOps.exif_transpose(opened).copy()
+    for op in operations:
+        image = apply_operation(image, op)
+    cache.parent.mkdir(parents=True, exist_ok=True)
+    image.save(cache, format="PNG")
+    return cache
+
+
 def _get_bookmark(doc: "Document") -> bytes | None:
     """Extract bookmark data from document metadata."""
     if not doc.metadata:
@@ -564,7 +600,11 @@ def ensure_display(
         return None
 
     path = _display_path(doc.id, package_path)
-    source = resolve_source(doc, library_root=package_path)
+    source = (
+        resolve_edited_source(doc, db)
+        if db is not None
+        else resolve_source(doc, library_root=package_path)
+    )
     pdf_render = _resolve_pdf_render_source(
         doc, db=db, library_root=package_path
     )
@@ -1157,7 +1197,9 @@ def get_thumbnail(
     return path
 
 
-def get_display(doc: "Document", package_path: Path | None = None) -> Path | None:
+def get_display(
+    doc: "Document", package_path: Path | None = None, db: "Database | None" = None
+) -> Path | None:
     """Get display image path if it exists, else None.
 
     Args:
@@ -1165,7 +1207,12 @@ def get_display(doc: "Document", package_path: Path | None = None) -> Path | Non
         package_path: Path to .fichero package (if None, uses global base_path)
     """
     path = _display_path(doc.id, package_path)
-    return path if path.exists() else None
+    source = (
+        resolve_edited_source(doc, db)
+        if db is not None
+        else resolve_source(doc, library_root=package_path)
+    )
+    return path if path.exists() and source and path.stat().st_mtime_ns >= source.stat().st_mtime_ns else None
 
 
 # =============================================================================

--- a/fichero-engine/src/fichero/workflows/tools/vision_base.py
+++ b/fichero-engine/src/fichero/workflows/tools/vision_base.py
@@ -1700,6 +1700,20 @@ async def process_vision(
                 values.append(None)
                 return _outcome()
             doc_id_for_file = _page_doc_id or resolve_path_to_doc(path_to_doc, file_path)
+            if library_path and doc_id_for_file:
+                from fichero.db import db_manager
+                from fichero.models import Document
+                from fichero.storage import resolve_edited_source
+
+                live_doc = db_manager.get_database(library_path).get(Document, doc_id_for_file)
+                if live_doc:
+                    edited = resolve_edited_source(
+                        live_doc,
+                        db_manager.get_database(library_path),
+                        page=(requested_page_index or 0) + 1,
+                    )
+                    if edited:
+                        file_path = str(edited)
             if return_boxes:
                 if vision_mode != "llm":
                     raise ValueError(

--- a/fichero-engine/tests/unit/test_edited_image_sources.py
+++ b/fichero-engine/tests/unit/test_edited_image_sources.py
@@ -1,0 +1,62 @@
+"""Saved image edits are the working source, never the provenance source (#3218)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from PIL import Image
+
+from fichero.api.routes import storage as storage_routes
+from fichero.export_service import export_markdown_folder
+from fichero.models import DocType, Document, FileType, ImageEditChain
+from fichero.storage import ensure_thumbnail, resolve_edited_source, resolve_source
+
+
+def _edited_document(db) -> Document:
+    source = db.path.parent / "files" / "source.png"
+    source.parent.mkdir(exist_ok=True)
+    Image.new("RGB", (20, 10), "red").save(source)
+    doc = Document(name="source.png", path=str(source), file_type=FileType.image)
+    db.save(doc)
+    db.save(
+        ImageEditChain(
+            document_id=doc.id,
+            operations=[{"op": "crop", "page": 1, "params": {"left": 0, "top": 0, "width": 8, "height": 10}}],
+        )
+    )
+    return doc
+
+
+def test_edited_source_drives_export_and_thumbnail_but_not_raw_source(db, tmp_path):
+    root = Document(name="root", doc_type=DocType.folder)
+    db.save(root)
+    doc = _edited_document(db)
+    doc.parent_id = root.id
+    db.save(doc)
+
+    edited = resolve_edited_source(doc, db)
+    assert edited and Image.open(edited).size == (8, 10)
+    assert Image.open(resolve_source(doc, library_root=db.path.parent)).size == (20, 10)
+
+    thumbnail = ensure_thumbnail(doc, package_path=db.path.parent, db=db)
+    assert thumbnail and Image.open(thumbnail).size == (8, 10)
+    result = export_markdown_folder(db, tmp_path / "export", target_id=root.id)
+    asset = Path(result.assets[0].path)
+    assert Image.open(asset).size == (8, 10)
+
+
+def test_no_edit_chain_returns_raw_source(db):
+    doc = _edited_document(db)
+    db.delete(next(iter(db.query(ImageEditChain, document_id=doc.id))))
+    assert resolve_edited_source(doc, db) == resolve_source(doc, library_root=db.path.parent)
+
+
+def test_storage_source_endpoint_keeps_raw_source(db):
+    doc = _edited_document(db)
+    response = asyncio.run(
+        storage_routes.get_source_file(
+            doc.id, db=db, x_fichero_library_path=str(db.path.parent)
+        )
+    )
+    assert Path(response.path) == resolve_source(doc, library_root=db.path.parent)


### PR DESCRIPTION
Extracted shared image_ops.py (chain replay), added resolve_edited_source() in storage.py (zero-cost when no chain), routed apple_vision OCR (vision_base.py), export_service.py, and thumbnail/display generation through it. get_source_file STAYS on raw resolve_source (provenance must see original). So editing a scanned page now changes what OCR transcribes + what exports/thumbnails show. Gate: test_edited_image_sources 3 passed; broader storage/image/export/vision/ocr suite 582 passed. No regen. 🤖 Claude (Opus 4.8)