### PR TITLE
Engine: validate image edit op dicts + stop persisting absolute temp paths (#3217)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/image_editing.py
+++ b/fichero-engine/src/fichero/api/routes/image_editing.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Response
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator
 from PIL import Image, ImageChops, ImageEnhance, ImageFilter, ImageOps
 
 from fichero.api.auth import action_context
@@ -41,16 +41,16 @@ class ImageEditChainResponse(BaseModel):
 
 
 class CropOperationRequest(BaseModel):
-    left: int
-    top: int
-    width: int
-    height: int
+    left: int = Field(ge=0)
+    top: int = Field(ge=0)
+    width: int = Field(gt=0)
+    height: int = Field(gt=0)
     auto_orient: bool = True
     page: int = 1
 
 
 class RotateOperationRequest(BaseModel):
-    angle: float
+    angle: float = Field(ge=-360.0, le=360.0)
     expand: bool = True
     page: int = 1
 
@@ -79,6 +79,47 @@ class SegmentOperationRequest(BaseModel):
     min_area: int = Field(100, ge=1)
     max_segments: int = Field(20, ge=1, le=200)
     page: int = Field(1, ge=1)
+
+
+class FactorOperationRequest(BaseModel):
+    factor: float = Field(1.0, ge=0.0, le=10.0)
+    page: int = Field(1, ge=1)
+
+
+class FuzzyCleanOperationRequest(BaseModel):
+    despeckle_radius: int = Field(3, ge=1, le=25)
+    background_clean: bool = True
+    page: int = Field(1, ge=1)
+
+
+_OPERATION_MODELS = {
+    "crop": CropOperationRequest, "rotate": RotateOperationRequest,
+    "straighten": StraightenOperationRequest, "enhance": EnhanceOperationRequest,
+    "remove_background": RemoveBackgroundOperationRequest, "segment": SegmentOperationRequest,
+    "brightness": FactorOperationRequest, "contrast": FactorOperationRequest,
+    "sharpen": FactorOperationRequest, "fuzzy_clean": FuzzyCleanOperationRequest,
+}
+_PARAMETERLESS_OPERATIONS = {"flip_horizontal", "flip_vertical", "auto_levels", "grayscale"}
+
+
+def _validate_operations(operations: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Reject malformed edit chains before they become persisted state."""
+    clean: list[dict[str, Any]] = []
+    for operation in operations:
+        name = str(operation.get("op", "")).strip().lower()
+        params = operation.get("params", {})
+        if not isinstance(params, dict):
+            raise HTTPException(422, f"Invalid params for operation: {name or 'missing'}")
+        model = _OPERATION_MODELS.get(name)
+        if model is None and name not in _PARAMETERLESS_OPERATIONS:
+            raise HTTPException(422, f"Unsupported image operation: {name or 'missing'}")
+        try:
+            if model is not None:
+                model.model_validate({**params, "page": operation.get("page", 1)})
+        except ValidationError as exc:
+            raise HTTPException(422, detail=exc.errors()) from exc
+        clean.append({key: value for key, value in operation.items() if key != "derived_path"})
+    return clean
 
 
 class ImageSplitRequest(BaseModel):
@@ -502,6 +543,7 @@ def _write_derived_image(document_id: str, page: int, image: Image.Image) -> str
 def _append_operation(
     db: Database, document_id: str, operation: dict[str, Any]
 ) -> ImageEditChain:
+    operation.pop("derived_path", None)
     chain = _get_chain(db, document_id)
     if chain:
         chain.operations.append(operation)
@@ -708,6 +750,7 @@ def set_operations_impl(
 ) -> ImageEditChain:
     """Replace a document's entire edit chain (the PUT /edits body)."""
     _get_or_404_document(db, document_id)
+    operations = _validate_operations(operations)
     chain = _get_chain(db, document_id)
     if chain:
         chain.operations = operations

--- a/fichero-engine/tests/unit/test_image_editing_actions.py
+++ b/fichero-engine/tests/unit/test_image_editing_actions.py
@@ -275,8 +275,8 @@ class TestAppendOpActions:
 
         ops = _ops(db, doc.id)
         assert [o["op"] for o in ops] == ["crop"]
-        # the render ran — a derived preview path was stamped
-        assert "derived_path" in ops[0]
+        # The chain is portable state; derived previews are regeneratable caches.
+        assert "derived_path" not in ops[0]
         assert ops[0]["params"]["width"] == 40
 
         audit = db.get(ActionAudit, result.audit_id)
@@ -510,7 +510,7 @@ class TestAppendOpActions:
         )
         ops = _ops(db, doc.id)
         assert ops[0]["op"] == "remove_background"
-        assert ops[0]["derived_path"].endswith(".png")
+        assert "derived_path" not in ops[0]
         assert db.get(ActionAudit, result.audit_id) is not None
 
     def test_enhance_validation_rejects_negative_brightness(self, db, tmp_path):

--- a/fichero-engine/tests/unit/test_routes_image_editing.py
+++ b/fichero-engine/tests/unit/test_routes_image_editing.py
@@ -74,6 +74,29 @@ def _make_segmentable_image_doc(db, tmp_path, name: str = "segments.png"):
 
 
 class TestImageEditChainRoutes:
+    @pytest.mark.parametrize(
+        "operation",
+        [
+            {"op": "invent", "params": {}},
+            {"op": "rotate", "params": {"angle": 999}},
+            {"op": "crop", "params": {"left": 0, "top": 0, "width": -1, "height": 2}},
+        ],
+    )
+    def test_put_rejects_invalid_operations(self, client, db, tmp_path, operation):
+        doc = _make_image_doc(db, tmp_path)
+        response = client.put(f"/api/images/{doc.id}/edits", json={"operations": [operation]})
+        assert response.status_code == 422
+
+    def test_valid_chain_round_trips_without_transient_path(self, client, db, tmp_path):
+        doc = _make_image_doc(db, tmp_path)
+        response = client.put(
+            f"/api/images/{doc.id}/edits",
+            json={"operations": [{"op": "rotate", "params": {"angle": 90}}]},
+        )
+        assert response.status_code == 200
+        assert "derived_path" not in response.json()["operations"][0]
+        assert client.get(f"/api/images/{doc.id}/preview").status_code == 200
+
     def test_put_get_delete_chain(self, client, db, tmp_path):
         doc = _make_image_doc(db, tmp_path)
 
@@ -121,7 +144,7 @@ class TestImageEditChainRoutes:
             "height": 30,
             "auto_orient": True,
         }
-        assert "derived_path" in ops[0]
+        assert "derived_path" not in ops[0]
 
     def test_rotate_operation_appends_chain(self, client, db, tmp_path):
         doc = _make_image_doc(db, tmp_path, size=(80, 50))
@@ -134,7 +157,7 @@ class TestImageEditChainRoutes:
         assert len(ops) == 1
         assert ops[0]["op"] == "rotate"
         assert ops[0]["params"] == {"angle": 90.0, "expand": True}
-        assert "derived_path" in ops[0]
+        assert "derived_path" not in ops[0]
 
     def test_enhance_operation_appends_chain(self, client, db, tmp_path):
         doc = _make_gray_image_doc(db, tmp_path)
@@ -158,7 +181,7 @@ class TestImageEditChainRoutes:
             "sharpen": 1.5,
             "auto_levels": True,
         }
-        assert "derived_path" in ops[0]
+        assert "derived_path" not in ops[0]
 
     def test_remove_background_operation_appends_chain(self, client, db, tmp_path):
         doc = _make_foreground_image_doc(db, tmp_path)
@@ -171,7 +194,7 @@ class TestImageEditChainRoutes:
         assert len(ops) == 1
         assert ops[0]["op"] == "remove_background"
         assert ops[0]["params"] == {"method": "threshold", "threshold": 5}
-        assert ops[0]["derived_path"].endswith(".png")
+        assert "derived_path" not in ops[0]
 
     def test_segment_operation_appends_chain_and_creates_chunk_docs(
         self, client, db, tmp_path
@@ -198,7 +221,7 @@ class TestImageEditChainRoutes:
         assert [op["op"] for op in ops] == ["remove_background", "segment"]
         assert len(ops[1]["segments"]) == 2
         assert len(ops[1]["child_document_ids"]) == 2
-        assert "derived_path" in ops[1]
+        assert "derived_path" not in ops[1]
 
         children = sorted(
             db.query(Document, parent_id=doc.id, doc_type=DocType.chunk),


### PR DESCRIPTION
PUT /edits now validates each operation against the known op vocabulary + param ranges (clear 422 on unknown op / bad param, no silent accept). Portable edit chains — no machine-specific absolute temp derived_path persisted into the library DB (the render is a regeneratable cache; #3218 replays from the chain). Gate: test_image_editing_actions 28 passed; broader image/edit/storage suite 299 passed. No regen. 🤖 Claude (Opus 4.8)