### PR TITLE
Engine: cache image previews off the event loop, chain-keyed (#3216)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/image_editing.py
+++ b/fichero-engine/src/fichero/api/routes/image_editing.py
@@ -6,6 +6,7 @@ Stores per-document non-destructive edit chains and renders previews on demand.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import io
 import tempfile
 from datetime import datetime, timezone
@@ -538,6 +539,38 @@ def _write_derived_image(document_id: str, page: int, image: Image.Image) -> str
     save_kwargs = {"quality": 92} if image_format == "JPEG" else {}
     image.save(out_path, format=image_format, **save_kwargs)
     return str(out_path)
+
+
+def _render_preview(
+    db: Database, document_id: str, apply_edits: bool, page: int
+) -> tuple[bytes, str]:
+    """Render one preview in a worker thread; cached renders are disposable."""
+    doc = _get_or_404_document(db, document_id)
+    chain = _get_chain(db, document_id) if apply_edits else None
+    version = chain.updated_at.isoformat() if chain else "raw"
+    key = hashlib.sha256(f"{document_id}:{page}:{apply_edits}:{version}".encode()).hexdigest()
+    cache_dir = db.path.parent / "storage" / "preview-cache" / document_id / f"page-{page}"
+    cache_path = cache_dir / f"{key}.bin"
+    media_path = cache_dir / f"{key}.type"
+    if cache_path.exists() and media_path.exists():
+        return cache_path.read_bytes(), media_path.read_text()
+
+    image = _load_source_image(_resolve_source_or_404(db, doc), page=page)
+    if chain:
+        for op in chain.operations:
+            if int(op.get("page", page)) == page:
+                image = apply_operation(image, op)
+    buffer = io.BytesIO()
+    image_format, media_type = _image_response_format(image)
+    image.save(buffer, format=image_format, **({"quality": 92} if image_format == "JPEG" else {}))
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    cache_path.write_bytes(buffer.getvalue())
+    media_path.write_text(media_type)
+    # ponytail: four revisions/page; increase only if users visibly revisit more history.
+    for stale in sorted(cache_dir.glob("*.bin"), key=lambda path: path.stat().st_mtime, reverse=True)[4:]:
+        stale.unlink(missing_ok=True)
+        stale.with_suffix(".type").unlink(missing_ok=True)
+    return buffer.getvalue(), media_type
 
 
 def _append_operation(
@@ -1288,25 +1321,10 @@ async def preview_image(
     page: int = Query(1, ge=1, description="PDF page number (1-indexed)"),
     db: Database = Depends(get_library_database),
 ) -> Response:
-    doc = _get_or_404_document(db, document_id)
-    source_path = _resolve_source_or_404(db, doc)
-
-    image = _load_source_image(source_path, page=page)
-    if apply_edits:
-        chain = _get_chain(db, document_id)
-        if chain:
-            for op in chain.operations:
-                op_page = int(op.get("page", page))
-                if op_page != page:
-                    continue
-                image = _apply_operation(image, op)
-
-    buffer = io.BytesIO()
-    image_format, media_type = _image_response_format(image)
-    save_kwargs = {"quality": 92} if image_format == "JPEG" else {}
-    image.save(buffer, format=image_format, **save_kwargs)
-    buffer.seek(0)
-    return Response(content=buffer.getvalue(), media_type=media_type)
+    content, media_type = await asyncio.to_thread(
+        _render_preview, db, document_id, apply_edits, page
+    )
+    return Response(content=content, media_type=media_type)
 
 
 # ---------------------------------------------------------------------------

--- a/fichero-engine/tests/unit/test_routes_image_editing.py
+++ b/fichero-engine/tests/unit/test_routes_image_editing.py
@@ -13,6 +13,7 @@ from PIL import Image
 
 from fichero.api.auth import initialize_token
 from fichero.api.main import app
+from fichero.api.routes import image_editing
 from fichero.models import DocType, Document, FileType
 
 
@@ -414,6 +415,32 @@ class TestImagePreviewRoute:
         assert r.headers["content-type"].startswith("image/jpeg")
         img = Image.open(io.BytesIO(r.content))
         assert img.size == (90, 60)
+
+    def test_preview_uses_worker_thread(self, db, tmp_path, monkeypatch):
+        doc = _make_image_doc(db, tmp_path)
+        async def rendered(*_args):
+            return b"image", "image/jpeg"
+        monkeypatch.setattr(image_editing.asyncio, "to_thread", rendered)
+        response = asyncio.run(image_editing.preview_image(doc.id, db=db))
+        assert response.body == b"image"
+
+    def test_preview_cache_invalidates_on_chain_change(self, db, tmp_path, monkeypatch):
+        doc = _make_image_doc(db, tmp_path)
+        calls = 0
+        original = image_editing._load_source_image
+        def counted(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return original(*args, **kwargs)
+        monkeypatch.setattr(image_editing, "_load_source_image", counted)
+        image_editing._render_preview(db, doc.id, True, 1)
+        image_editing._render_preview(db, doc.id, True, 1)
+        assert calls == 1
+        image_editing.set_operations_impl(
+            db, doc.id, [{"op": "rotate", "params": {"angle": 90}}]
+        )
+        image_editing._render_preview(db, doc.id, True, 1)
+        assert calls == 2
 
     def test_preview_honours_exif_orientation(self, client, db, tmp_path):
         # A JPEG whose pixels are stored landscape (90x60) but tagged


### PR DESCRIPTION
GET /images/{id}/preview render moved off the event loop (asyncio.to_thread) + a derived-render cache keyed by (document_id, page, chain.updated_at) mirroring the mtime-keyed thumbnail cache; cache is regeneratable, never authoritative. Gate: test_routes_image_editing 33 passed; broader image/edit/storage/preview suite 313 passed. No regen. 🤖 Claude (Opus 4.8)