### PR TITLE
Navigation: ActiveSurfaceState — track + indicate the active Preview/Reader pane (#3579, slice 4)

### DIFF
--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -26,6 +26,12 @@ private struct ReadingPaneView: View {
     /// Per-window source-navigation bus (#2105/#3437). A reveal brings the reader
     /// to the Page tab so the highlighted source is visible (#3521).
     @Environment(ClaimSourceNavigationState.self) private var claimSourceNavigationState: ClaimSourceNavigationState?
+    /// Per-window active-surface marker (#3579). A direct click in this pane
+    /// makes it active; the MiniToolbar draws an accent hairline when it is.
+    @Environment(ActiveSurfaceState.self) private var activeSurfaceState: ActiveSurfaceState?
+    /// Stable identity for THIS pane instance — minted once at mount, so left
+    /// and right splits are tracked independently (mirrors per-instance pin).
+    @State private var surfaceId = SurfaceID()
     /// Shared annotation focus for the Notes tab's list ↔ detail selection.
     @State private var focusedAnnotation = FocusedAnnotation.shared
     /// Notes-tab sub-mode: anchored marks vs free-text notes (#3513). Per-window.
@@ -159,12 +165,29 @@ private struct ReadingPaneView: View {
                 .foregroundStyle(isPinned ? Color.accentColor : Color.secondary)
                 .help(isPinned ? "Unpin — follow current selection" : "Pin to current document")
             })
+            // Active-surface indicator (#3579): accent hairline on the toolbar
+            // strip when this pane is the active one. Additive overlay — flips
+            // one pane's fill, no relayout.
+            .overlay(alignment: .top) {
+                Rectangle()
+                    .fill(isActiveSurface ? Color.accentColor : Color.clear)
+                    .frame(height: 2)
+            }
         }
+        // A direct click anywhere in this pane makes it the active surface
+        // (#3579). simultaneousGesture runs alongside PDF/WebKit hit-testing so
+        // it never steals the click — same pattern as focusedPane tracking.
+        .simultaneousGesture(TapGesture().onEnded { activeSurfaceState?.activeSurfaceId = surfaceId })
         // A source reveal (#2105) brings the reader to the Page tab so the
         // highlighted / scrolled-to source is actually visible (#3521).
         .onChange(of: claimSourceNavigationState?.requestID) { _, newID in
             if newID != nil { revealSourceInPageTab() }
         }
+    }
+
+    /// True when this pane instance is the window's active surface (#3579).
+    private var isActiveSurface: Bool {
+        activeSurfaceState?.activeSurfaceId == surfaceId
     }
 
     /// Switch the reader to the Page tab and, if it's showing only the source,

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -103,6 +103,9 @@ struct ContentView: View {
     // window never drives another (#3437). Injected into the subtree below.
     @State var entitySearchState = EntitySearchState()
     @State var claimSourceNavigationState = ClaimSourceNavigationState()
+    /// Which Preview/Reader pane updates on the next library click (#3579).
+    /// Per-window like the others; injected below, read by the pane views.
+    @State var activeSurfaceState = ActiveSurfaceState()
     /// Drives the distraction-free full-window reading overlay (#2520).
     @State private var isImmersiveReading = false
     @State private var focusedDocument = FocusedDocument.shared
@@ -588,6 +591,7 @@ struct ContentView: View {
             // Scope both request buses to this window's subtree (#3437).
             .environment(entitySearchState)
             .environment(claimSourceNavigationState)
+            .environment(activeSurfaceState)
             .onReceive(NotificationCenter.default.publisher(for: .ficheroSelectDocumentRequested)) { note in
                 handleAppleScriptSelectDocument(note)
             }

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift
@@ -128,6 +128,27 @@ final class ClaimSourceNavigationState {
     }
 }
 
+// MARK: - Active surface (#3579)
+
+/// Stable identity for one Preview/Reader pane instance. A fresh value is
+/// minted at pane mount (`@State private var surfaceId = SurfaceID()`), so left
+/// and right split panes qualify independently — mirroring the per-instance
+/// `isPinned` design (#3579, §0.2).
+struct SurfaceID: Hashable {
+    private let id = UUID()
+}
+
+/// Per-window "which pane updates on the next library click" marker (#3579).
+/// Scoped to the window/library via the SwiftUI environment (NOT `.shared`),
+/// matching `ClaimSourceNavigationState` and the #3437 scoping invariant locked
+/// by `InspectorNavigationScopingTests`. A direct click inside a Preview/Reader
+/// pane writes its `SurfaceID` here; the active pane draws an accent hairline.
+@Observable
+@MainActor
+final class ActiveSurfaceState {
+    var activeSurfaceId: SurfaceID?
+}
+
 // MARK: - Notification names
 
 extension Notification.Name {

--- a/fichero/fichero/Views/Library/Reading/PDFPageWithToolbar.swift
+++ b/fichero/fichero/Views/Library/Reading/PDFPageWithToolbar.swift
@@ -56,6 +56,13 @@ struct PDFPageWithToolbar: View {
     @State private var isPinned = false
     @State private var pinnedDocumentId: String?
 
+    /// Per-window active-surface marker (#3579). A direct click in this pane
+    /// makes it active; the reader toolbar draws an accent hairline when it is.
+    @Environment(ActiveSurfaceState.self) private var activeSurfaceState: ActiveSurfaceState?
+    /// Stable identity for THIS pane instance — minted once at mount, so left
+    /// and right splits are tracked independently (mirrors per-instance pin).
+    @State private var surfaceId = SurfaceID()
+
     // Bounding-box annotation state (#2458). `isDrawingRegion` arms a region
     // drag on the page; `pendingTool` carries the kind into the saved box.
     @Environment(AnnotationStore.self) private var annotationStore: AnnotationStore
@@ -172,7 +179,23 @@ struct PDFPageWithToolbar: View {
             pageContent
             Divider()
             readerToolbar
+                // Active-surface indicator (#3579): accent hairline on the
+                // toolbar strip when this pane is active. Additive, no relayout.
+                .overlay(alignment: .top) {
+                    Rectangle()
+                        .fill(isActiveSurface ? Color.accentColor : Color.clear)
+                        .frame(height: 2)
+                }
         }
+        // A direct click anywhere in this pane makes it the active surface
+        // (#3579). simultaneousGesture runs alongside PDFKit hit-testing so it
+        // never steals the click — same pattern as focusedPane tracking.
+        .simultaneousGesture(TapGesture().onEnded { activeSurfaceState?.activeSurfaceId = surfaceId })
+    }
+
+    /// True when this pane instance is the window's active surface (#3579).
+    private var isActiveSurface: Bool {
+        activeSurfaceState?.activeSurfaceId == surfaceId
     }
 
     private var pageContent: some View {


### PR DESCRIPTION
New per-window @Observable ActiveSurfaceState (NOT .shared, per #3437/InspectorNavigationScopingTests): a click inside a Preview/Reader pane marks it active; accent hairline on the active pane's MiniToolbar strip. Additive, no relayout. Pin reconciliation is slice 5 (#3580). BUILD SUCCEEDED (independent of the #3576 regen). 🤖 Claude (Opus 4.8)