### PR TITLE
Navigation: Location endpoint + MCP reveal tool + regen 3.0-bounds fix + pin⇄active (#3576/#3578/#3580)

### DIFF
--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -12241,6 +12241,49 @@
         }
       }
     },
+    "/api/locations/resolve": {
+      "post": {
+        "tags": [
+          "locations",
+          "locations"
+        ],
+        "summary": "Resolve Location",
+        "description": "Resolve a page-child anchor once, for every UI/MCP caller.",
+        "operationId": "resolve_location_api_locations_resolve_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolvedLocation"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/library": {
       "post": {
         "tags": [
@@ -37305,6 +37348,26 @@
         ],
         "title": "ChainStepResultInfo"
       },
+      "CharacterRange": {
+        "properties": {
+          "start": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Start"
+          },
+          "end": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "End"
+          }
+        },
+        "type": "object",
+        "required": [
+          "start",
+          "end"
+        ],
+        "title": "CharacterRange"
+      },
       "ChatConversationListResponse": {
         "properties": {
           "items": {
@@ -40648,18 +40711,22 @@
         "properties": {
           "left": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Left"
           },
           "top": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Top"
           },
           "width": {
             "type": "integer",
+            "exclusiveMinimum": 0.0,
             "title": "Width"
           },
           "height": {
             "type": "integer",
+            "exclusiveMinimum": 0.0,
             "title": "Height"
           },
           "auto_orient": {
@@ -45002,18 +45069,22 @@
         "properties": {
           "left": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Left"
           },
           "top": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Top"
           },
           "width": {
             "type": "integer",
+            "exclusiveMinimum": 0.0,
             "title": "Width"
           },
           "height": {
             "type": "integer",
+            "exclusiveMinimum": 0.0,
             "title": "Height"
           },
           "auto_orient": {
@@ -49017,6 +49088,64 @@
         ],
         "title": "LocalServiceState",
         "description": "Lifecycle state for an app-managed local inference service."
+      },
+      "Location": {
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Documentid"
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1.0,
+            "nullable": true,
+            "title": "Page"
+          },
+          "bbox": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "maxItems": 4,
+            "minItems": 4,
+            "nullable": true,
+            "title": "Bbox"
+          },
+          "charRange": {
+            "$ref": "#/components/schemas/CharacterRange",
+            "nullable": true
+          },
+          "claimId": {
+            "type": "string",
+            "nullable": true,
+            "title": "Claimid"
+          },
+          "entityId": {
+            "type": "string",
+            "nullable": true,
+            "title": "Entityid"
+          },
+          "surface": {
+            "$ref": "#/components/schemas/LocationSurface",
+            "default": "both"
+          }
+        },
+        "type": "object",
+        "required": [
+          "documentId"
+        ],
+        "title": "Location"
+      },
+      "LocationSurface": {
+        "type": "string",
+        "enum": [
+          "preview",
+          "reader",
+          "inspector",
+          "both"
+        ],
+        "title": "LocationSurface"
       },
       "LoginRequest": {
         "properties": {
@@ -55624,6 +55753,64 @@
         "type": "object",
         "title": "ResolveRequest"
       },
+      "ResolvedLocation": {
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Documentid"
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1.0,
+            "nullable": true,
+            "title": "Page"
+          },
+          "bbox": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "maxItems": 4,
+            "minItems": 4,
+            "nullable": true,
+            "title": "Bbox"
+          },
+          "charRange": {
+            "$ref": "#/components/schemas/CharacterRange",
+            "nullable": true
+          },
+          "claimId": {
+            "type": "string",
+            "nullable": true,
+            "title": "Claimid"
+          },
+          "entityId": {
+            "type": "string",
+            "nullable": true,
+            "title": "Entityid"
+          },
+          "surface": {
+            "$ref": "#/components/schemas/LocationSurface",
+            "default": "both"
+          },
+          "resolvedDocumentId": {
+            "type": "string",
+            "title": "Resolveddocumentid"
+          },
+          "resolvedPage": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Resolvedpage"
+          }
+        },
+        "type": "object",
+        "required": [
+          "documentId",
+          "resolvedDocumentId"
+        ],
+        "title": "ResolvedLocation"
+      },
       "ResumeWorkflowRequest": {
         "properties": {
           "inputs": {
@@ -55811,6 +55998,8 @@
         "properties": {
           "angle": {
             "type": "number",
+            "maximum": 360.0,
+            "minimum": -360.0,
             "title": "Angle"
           },
           "expand": {

--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -40721,13 +40721,15 @@
           },
           "width": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Width"
+            "exclusiveMinimum": true,
+            "title": "Width",
+            "minimum": 0.0
           },
           "height": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Height"
+            "exclusiveMinimum": true,
+            "title": "Height",
+            "minimum": 0.0
           },
           "auto_orient": {
             "type": "boolean",
@@ -45079,13 +45081,15 @@
           },
           "width": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Width"
+            "exclusiveMinimum": true,
+            "title": "Width",
+            "minimum": 0.0
           },
           "height": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Height"
+            "exclusiveMinimum": true,
+            "title": "Height",
+            "minimum": 0.0
           },
           "auto_orient": {
             "type": "boolean",

--- a/fichero-engine/scripts/export_openapi_schema.py
+++ b/fichero-engine/scripts/export_openapi_schema.py
@@ -81,6 +81,21 @@ def convert_nullable_schemas(obj: dict | list) -> dict | list:
     return result
 
 
+def convert_exclusive_bounds(obj: Any) -> Any:
+    """Down-convert Pydantic numeric exclusive bounds for OpenAPI 3.0."""
+    if isinstance(obj, list):
+        return [convert_exclusive_bounds(item) for item in obj]
+    if not isinstance(obj, dict):
+        return obj
+    result = {key: convert_exclusive_bounds(value) for key, value in obj.items()}
+    for exclusive, inclusive in (("exclusiveMinimum", "minimum"), ("exclusiveMaximum", "maximum")):
+        value = result.get(exclusive)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            result[inclusive] = value
+            result[exclusive] = True
+    return result
+
+
 def _replace_schema_refs(obj: Any, ref_map: dict[str, str]) -> Any:
     """Recursively replace component $ref targets with canonical names."""
     if isinstance(obj, list):
@@ -295,6 +310,7 @@ def build_openapi_schema() -> dict:
 
     # Step 4: Convert nullable schemas for Swift compatibility
     openapi_schema = convert_nullable_schemas(openapi_schema)
+    openapi_schema = convert_exclusive_bounds(openapi_schema)
 
     # Step 5: Use OpenAPI 3.0.3 for better Swift compatibility (nullable is a 3.0 feature)
     openapi_schema["openapi"] = "3.0.3"

--- a/fichero-engine/src/fichero/api/main.py
+++ b/fichero-engine/src/fichero/api/main.py
@@ -1353,6 +1353,7 @@ from fichero.api.routes import (  # noqa: E402
     library_registry,
     local_inference,
     local_models,
+    locations,
     mcp_servers,
     mcp_tools,
     pairing,
@@ -1422,6 +1423,7 @@ _CORE_ROUTE_SPECS: list[RouteSpec] = [
     (folders.router, "/api/folders", ["folders"]),
     (ingest.router, "/api/ingest", ["ingest"]),
     (image_editing.router, "/api", ["images"]),
+    (locations.router, "/api", ["locations"]),
     # /api/library — bootstrap a fresh .fichero package from the CLI
     # without going through SwiftUI's NSDocument flow (#1075 follow-up).
     (library.router, "/api", ["library"]),

--- a/fichero-engine/src/fichero/api/routes/__init__.py
+++ b/fichero-engine/src/fichero/api/routes/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "kg_curation_rules",
     "library_links",
     "local_models",
+    "locations",
     "mcp_servers",
     "mcp_tools",
     "migrations",

--- a/fichero-engine/src/fichero/api/routes/locations.py
+++ b/fichero-engine/src/fichero/api/routes/locations.py
@@ -1,0 +1,74 @@
+"""Typed, read-only resolution of document navigation anchors (#3576)."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from fichero.api.main import get_library_database
+from fichero.db import Database
+from fichero.models import DocType, Document
+
+router = APIRouter(prefix="/locations", tags=["locations"])
+
+
+class LocationSurface(str, Enum):
+    preview = "preview"
+    reader = "reader"
+    inspector = "inspector"
+    both = "both"
+
+
+class CharacterRange(BaseModel):
+    start: int = Field(ge=0)
+    end: int = Field(ge=0)
+
+    @model_validator(mode="after")
+    def ordered(self):
+        if self.end < self.start:
+            raise ValueError("end must be >= start")
+        return self
+
+
+class Location(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    document_id: str = Field(alias="documentId", min_length=1)
+    page: int | None = Field(default=None, ge=1)
+    bbox: list[float] | None = Field(default=None, min_length=4, max_length=4)
+    char_range: CharacterRange | None = Field(default=None, alias="charRange")
+    claim_id: str | None = Field(default=None, alias="claimId")
+    entity_id: str | None = Field(default=None, alias="entityId")
+    surface: LocationSurface = LocationSurface.both
+
+    @model_validator(mode="after")
+    def valid_bbox(self):
+        if self.bbox and (any(v < 0 or v > 1 for v in self.bbox) or self.bbox[0] + self.bbox[2] > 1 or self.bbox[1] + self.bbox[3] > 1):
+            raise ValueError("bbox must be normalized [x,y,w,h] within 0..1")
+        return self
+
+
+class ResolvedLocation(Location):
+    resolved_document_id: str = Field(alias="resolvedDocumentId")
+    resolved_page: int | None = Field(default=None, alias="resolvedPage")
+
+
+@router.post("/resolve", response_model=ResolvedLocation)
+async def resolve_location(location: Location, db: Database = Depends(get_library_database)) -> ResolvedLocation:
+    """Resolve a page-child anchor once, for every UI/MCP caller."""
+    document = db.get(Document, location.document_id)
+    if document is None:
+        raise HTTPException(404, "Document not found")
+    parent = document
+    page = location.page
+    if document.doc_type == DocType.page and document.parent_id:
+        parent = db.get(Document, document.parent_id)
+        if parent is None:
+            raise HTTPException(422, "Page parent not found")
+        page = document.sequence or page
+    if page is not None:
+        pages = list(db.query(Document, parent_id=parent.id, doc_type=DocType.page))
+        if pages and not 1 <= page <= len(pages):
+            raise HTTPException(422, "Page is outside document range")
+    return ResolvedLocation(**location.model_dump(by_alias=False), resolvedDocumentId=parent.id, resolvedPage=page)

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -5556,11 +5556,11 @@ def register_generated_openapi_commands(
             }, {
                 "auto_orient": {'type': 'boolean', 'title': 'Auto Orient', 'default': True, 'x-cli-required': False},
                 "document_ids": {'items': {'type': 'string'}, 'type': 'array', 'minItems': 1, 'title': 'Document Ids', 'x-cli-required': True},
-                "height": {'type': 'integer', 'exclusiveMinimum': 0.0, 'title': 'Height', 'x-cli-required': True},
+                "height": {'type': 'integer', 'exclusiveMinimum': True, 'title': 'Height', 'minimum': 0.0, 'x-cli-required': True},
                 "left": {'type': 'integer', 'minimum': 0.0, 'title': 'Left', 'x-cli-required': True},
                 "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
                 "top": {'type': 'integer', 'minimum': 0.0, 'title': 'Top', 'x-cli-required': True},
-                "width": {'type': 'integer', 'exclusiveMinimum': 0.0, 'title': 'Width', 'x-cli-required': True},
+                "width": {'type': 'integer', 'exclusiveMinimum': True, 'title': 'Width', 'minimum': 0.0, 'x-cli-required': True},
             }, required=True)
             return client.request("POST", endpoint_path, params=params, json=payload)
         invoke(ctx, op_call)
@@ -5589,11 +5589,11 @@ def register_generated_openapi_commands(
                 "width": width,
             }, {
                 "auto_orient": {'type': 'boolean', 'title': 'Auto Orient', 'default': True, 'x-cli-required': False},
-                "height": {'type': 'integer', 'exclusiveMinimum': 0.0, 'title': 'Height', 'x-cli-required': True},
+                "height": {'type': 'integer', 'exclusiveMinimum': True, 'title': 'Height', 'minimum': 0.0, 'x-cli-required': True},
                 "left": {'type': 'integer', 'minimum': 0.0, 'title': 'Left', 'x-cli-required': True},
                 "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
                 "top": {'type': 'integer', 'minimum': 0.0, 'title': 'Top', 'x-cli-required': True},
-                "width": {'type': 'integer', 'exclusiveMinimum': 0.0, 'title': 'Width', 'x-cli-required': True},
+                "width": {'type': 'integer', 'exclusiveMinimum': True, 'title': 'Width', 'minimum': 0.0, 'x-cli-required': True},
             }, required=True)
             return client.request("POST", endpoint_path, params=params, json=payload)
         invoke(ctx, op_call)
@@ -5667,11 +5667,11 @@ def register_generated_openapi_commands(
                 "width": width,
             }, {
                 "auto_orient": {'type': 'boolean', 'title': 'Auto Orient', 'default': True, 'x-cli-required': False},
-                "height": {'type': 'integer', 'exclusiveMinimum': 0.0, 'title': 'Height', 'x-cli-required': True},
+                "height": {'type': 'integer', 'exclusiveMinimum': True, 'title': 'Height', 'minimum': 0.0, 'x-cli-required': True},
                 "left": {'type': 'integer', 'minimum': 0.0, 'title': 'Left', 'x-cli-required': True},
                 "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
                 "top": {'type': 'integer', 'minimum': 0.0, 'title': 'Top', 'x-cli-required': True},
-                "width": {'type': 'integer', 'exclusiveMinimum': 0.0, 'title': 'Width', 'x-cli-required': True},
+                "width": {'type': 'integer', 'exclusiveMinimum': True, 'title': 'Width', 'minimum': 0.0, 'x-cli-required': True},
             }, required=True)
             return client.request("POST", endpoint_path, params=params, json=payload)
         invoke(ctx, op_call)

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -5556,11 +5556,11 @@ def register_generated_openapi_commands(
             }, {
                 "auto_orient": {'type': 'boolean', 'title': 'Auto Orient', 'default': True, 'x-cli-required': False},
                 "document_ids": {'items': {'type': 'string'}, 'type': 'array', 'minItems': 1, 'title': 'Document Ids', 'x-cli-required': True},
-                "height": {'type': 'integer', 'title': 'Height', 'x-cli-required': True},
-                "left": {'type': 'integer', 'title': 'Left', 'x-cli-required': True},
+                "height": {'type': 'integer', 'exclusiveMinimum': 0.0, 'title': 'Height', 'x-cli-required': True},
+                "left": {'type': 'integer', 'minimum': 0.0, 'title': 'Left', 'x-cli-required': True},
                 "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
-                "top": {'type': 'integer', 'title': 'Top', 'x-cli-required': True},
-                "width": {'type': 'integer', 'title': 'Width', 'x-cli-required': True},
+                "top": {'type': 'integer', 'minimum': 0.0, 'title': 'Top', 'x-cli-required': True},
+                "width": {'type': 'integer', 'exclusiveMinimum': 0.0, 'title': 'Width', 'x-cli-required': True},
             }, required=True)
             return client.request("POST", endpoint_path, params=params, json=payload)
         invoke(ctx, op_call)
@@ -5589,11 +5589,11 @@ def register_generated_openapi_commands(
                 "width": width,
             }, {
                 "auto_orient": {'type': 'boolean', 'title': 'Auto Orient', 'default': True, 'x-cli-required': False},
-                "height": {'type': 'integer', 'title': 'Height', 'x-cli-required': True},
-                "left": {'type': 'integer', 'title': 'Left', 'x-cli-required': True},
+                "height": {'type': 'integer', 'exclusiveMinimum': 0.0, 'title': 'Height', 'x-cli-required': True},
+                "left": {'type': 'integer', 'minimum': 0.0, 'title': 'Left', 'x-cli-required': True},
                 "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
-                "top": {'type': 'integer', 'title': 'Top', 'x-cli-required': True},
-                "width": {'type': 'integer', 'title': 'Width', 'x-cli-required': True},
+                "top": {'type': 'integer', 'minimum': 0.0, 'title': 'Top', 'x-cli-required': True},
+                "width": {'type': 'integer', 'exclusiveMinimum': 0.0, 'title': 'Width', 'x-cli-required': True},
             }, required=True)
             return client.request("POST", endpoint_path, params=params, json=payload)
         invoke(ctx, op_call)
@@ -5667,11 +5667,11 @@ def register_generated_openapi_commands(
                 "width": width,
             }, {
                 "auto_orient": {'type': 'boolean', 'title': 'Auto Orient', 'default': True, 'x-cli-required': False},
-                "height": {'type': 'integer', 'title': 'Height', 'x-cli-required': True},
-                "left": {'type': 'integer', 'title': 'Left', 'x-cli-required': True},
+                "height": {'type': 'integer', 'exclusiveMinimum': 0.0, 'title': 'Height', 'x-cli-required': True},
+                "left": {'type': 'integer', 'minimum': 0.0, 'title': 'Left', 'x-cli-required': True},
                 "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
-                "top": {'type': 'integer', 'title': 'Top', 'x-cli-required': True},
-                "width": {'type': 'integer', 'title': 'Width', 'x-cli-required': True},
+                "top": {'type': 'integer', 'minimum': 0.0, 'title': 'Top', 'x-cli-required': True},
+                "width": {'type': 'integer', 'exclusiveMinimum': 0.0, 'title': 'Width', 'x-cli-required': True},
             }, required=True)
             return client.request("POST", endpoint_path, params=params, json=payload)
         invoke(ctx, op_call)
@@ -5747,7 +5747,7 @@ def register_generated_openapi_commands(
                 "expand": expand,
                 "page": page,
             }, {
-                "angle": {'type': 'number', 'title': 'Angle', 'x-cli-required': True},
+                "angle": {'type': 'number', 'maximum': 360.0, 'minimum': -360.0, 'title': 'Angle', 'x-cli-required': True},
                 "expand": {'type': 'boolean', 'title': 'Expand', 'default': True, 'x-cli-required': False},
                 "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
             }, required=True)
@@ -8564,6 +8564,47 @@ def register_generated_openapi_commands(
             endpoint_path = f"/api/local-models/{model_type}/{model_id}"
             params = None
             return client.request("DELETE", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
+    target_app = existing_apps.get('locations')
+    if target_app is None:
+        target_app = typer.Typer(help='Generated OpenAPI commands for locations endpoints.', no_args_is_help=True)
+        root_app.add_typer(target_app, name='locations')
+        existing_apps['locations'] = target_app
+
+    @target_app.command("resolve")
+    def locations_resolve_post(
+        ctx: typer.Context,
+        bbox: Optional[str] = typer.Option(None, "--bbox", help="Request field: bbox."),
+        charRange: Optional[str] = typer.Option(None, "--charRange", help="Request field: charRange."),
+        claimId: Optional[str] = typer.Option(None, "--claimId", help="Request field: claimId."),
+        documentId: str = typer.Option(..., "--documentId", help="Request field: documentId."),
+        entityId: Optional[str] = typer.Option(None, "--entityId", help="Request field: entityId."),
+        page: Optional[int] = typer.Option(None, "--page", help="Request field: page."),
+        surface: Optional[str] = typer.Option(None, "--surface", help="Request field: surface."),
+    ) -> None:
+        """Resolve Location (POST /api/locations/resolve)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/locations/resolve"
+            params = None
+            payload = _build_json_payload({
+                "bbox": bbox,
+                "charRange": charRange,
+                "claimId": claimId,
+                "documentId": documentId,
+                "entityId": entityId,
+                "page": page,
+                "surface": surface,
+            }, {
+                "bbox": {'items': {'type': 'number'}, 'type': 'array', 'maxItems': 4, 'minItems': 4, 'nullable': True, 'title': 'Bbox', 'x-cli-required': False},
+                "charRange": {'properties': {'start': {'type': 'integer', 'minimum': 0.0, 'title': 'Start'}, 'end': {'type': 'integer', 'minimum': 0.0, 'title': 'End'}}, 'type': 'object', 'required': ['start', 'end'], 'title': 'CharacterRange', 'x-cli-required': False},
+                "claimId": {'type': 'string', 'nullable': True, 'title': 'Claimid', 'x-cli-required': False},
+                "documentId": {'type': 'string', 'minLength': 1, 'title': 'Documentid', 'x-cli-required': True},
+                "entityId": {'type': 'string', 'nullable': True, 'title': 'Entityid', 'x-cli-required': False},
+                "page": {'type': 'integer', 'minimum': 1.0, 'nullable': True, 'title': 'Page', 'x-cli-required': False},
+                "surface": {'type': 'string', 'enum': ['preview', 'reader', 'inspector', 'both'], 'title': 'LocationSurface', 'x-cli-required': False},
+            }, required=True)
+            return client.request("POST", endpoint_path, params=params, json=payload)
         invoke(ctx, op_call)
 
     target_app = existing_apps.get('mcp')

--- a/fichero-engine/src/fichero/mcp_server.py
+++ b/fichero-engine/src/fichero/mcp_server.py
@@ -346,6 +346,25 @@ def fichero_workspace_add_note(workspace_id: str, text: str) -> Any:
     return _workspace_action("workspace.add_note", {"workspace_id": workspace_id, "text": text})
 
 
+@mcp.tool()
+def fichero_reveal_location(
+    documentId: str,
+    page: int | None = None,
+    bbox: list[float] | None = None,
+    charRange: dict[str, int] | None = None,
+    claimId: str | None = None,
+    entityId: str | None = None,
+    surface: str = "both",
+) -> Any:
+    """Resolve a document/page/bbox anchor for navigation."""
+    payload = {"documentId": documentId, "surface": surface}
+    for key, value in (("page", page), ("bbox", bbox), ("charRange", charRange), ("claimId", claimId), ("entityId", entityId)):
+        if value is not None:
+            payload[key] = value
+    with _client() as client:
+        return client.request("POST", "/api/locations/resolve", json=payload)
+
+
 # -- knowledge graph / content (read) --------------------------------------
 @mcp.tool()
 def fichero_kg_neighborhood(

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -6046,6 +6046,18 @@
         "response_model": "fichero__models__DeleteModelResponse"
       }
     ],
+    "locations": [
+      {
+        "method": "POST",
+        "path": "/locations/resolve",
+        "operation_id": "resolve_location_api_locations_resolve_post",
+        "summary": "Resolve Location",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "Location",
+        "response_model": "ResolvedLocation"
+      }
+    ],
     "mcp": [
       {
         "method": "GET",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -12241,6 +12241,49 @@
         }
       }
     },
+    "/api/locations/resolve": {
+      "post": {
+        "tags": [
+          "locations",
+          "locations"
+        ],
+        "summary": "Resolve Location",
+        "description": "Resolve a page-child anchor once, for every UI/MCP caller.",
+        "operationId": "resolve_location_api_locations_resolve_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolvedLocation"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/library": {
       "post": {
         "tags": [
@@ -37305,6 +37348,26 @@
         ],
         "title": "ChainStepResultInfo"
       },
+      "CharacterRange": {
+        "properties": {
+          "start": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Start"
+          },
+          "end": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "End"
+          }
+        },
+        "type": "object",
+        "required": [
+          "start",
+          "end"
+        ],
+        "title": "CharacterRange"
+      },
       "ChatConversationListResponse": {
         "properties": {
           "items": {
@@ -40648,18 +40711,22 @@
         "properties": {
           "left": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Left"
           },
           "top": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Top"
           },
           "width": {
             "type": "integer",
+            "exclusiveMinimum": 0.0,
             "title": "Width"
           },
           "height": {
             "type": "integer",
+            "exclusiveMinimum": 0.0,
             "title": "Height"
           },
           "auto_orient": {
@@ -45002,18 +45069,22 @@
         "properties": {
           "left": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Left"
           },
           "top": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Top"
           },
           "width": {
             "type": "integer",
+            "exclusiveMinimum": 0.0,
             "title": "Width"
           },
           "height": {
             "type": "integer",
+            "exclusiveMinimum": 0.0,
             "title": "Height"
           },
           "auto_orient": {
@@ -49017,6 +49088,64 @@
         ],
         "title": "LocalServiceState",
         "description": "Lifecycle state for an app-managed local inference service."
+      },
+      "Location": {
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Documentid"
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1.0,
+            "nullable": true,
+            "title": "Page"
+          },
+          "bbox": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "maxItems": 4,
+            "minItems": 4,
+            "nullable": true,
+            "title": "Bbox"
+          },
+          "charRange": {
+            "$ref": "#/components/schemas/CharacterRange",
+            "nullable": true
+          },
+          "claimId": {
+            "type": "string",
+            "nullable": true,
+            "title": "Claimid"
+          },
+          "entityId": {
+            "type": "string",
+            "nullable": true,
+            "title": "Entityid"
+          },
+          "surface": {
+            "$ref": "#/components/schemas/LocationSurface",
+            "default": "both"
+          }
+        },
+        "type": "object",
+        "required": [
+          "documentId"
+        ],
+        "title": "Location"
+      },
+      "LocationSurface": {
+        "type": "string",
+        "enum": [
+          "preview",
+          "reader",
+          "inspector",
+          "both"
+        ],
+        "title": "LocationSurface"
       },
       "LoginRequest": {
         "properties": {
@@ -55624,6 +55753,64 @@
         "type": "object",
         "title": "ResolveRequest"
       },
+      "ResolvedLocation": {
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Documentid"
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1.0,
+            "nullable": true,
+            "title": "Page"
+          },
+          "bbox": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "maxItems": 4,
+            "minItems": 4,
+            "nullable": true,
+            "title": "Bbox"
+          },
+          "charRange": {
+            "$ref": "#/components/schemas/CharacterRange",
+            "nullable": true
+          },
+          "claimId": {
+            "type": "string",
+            "nullable": true,
+            "title": "Claimid"
+          },
+          "entityId": {
+            "type": "string",
+            "nullable": true,
+            "title": "Entityid"
+          },
+          "surface": {
+            "$ref": "#/components/schemas/LocationSurface",
+            "default": "both"
+          },
+          "resolvedDocumentId": {
+            "type": "string",
+            "title": "Resolveddocumentid"
+          },
+          "resolvedPage": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Resolvedpage"
+          }
+        },
+        "type": "object",
+        "required": [
+          "documentId",
+          "resolvedDocumentId"
+        ],
+        "title": "ResolvedLocation"
+      },
       "ResumeWorkflowRequest": {
         "properties": {
           "inputs": {
@@ -55811,6 +55998,8 @@
         "properties": {
           "angle": {
             "type": "number",
+            "maximum": 360.0,
+            "minimum": -360.0,
             "title": "Angle"
           },
           "expand": {

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -40721,13 +40721,15 @@
           },
           "width": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Width"
+            "exclusiveMinimum": true,
+            "title": "Width",
+            "minimum": 0.0
           },
           "height": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Height"
+            "exclusiveMinimum": true,
+            "title": "Height",
+            "minimum": 0.0
           },
           "auto_orient": {
             "type": "boolean",
@@ -45079,13 +45081,15 @@
           },
           "width": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Width"
+            "exclusiveMinimum": true,
+            "title": "Width",
+            "minimum": 0.0
           },
           "height": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Height"
+            "exclusiveMinimum": true,
+            "title": "Height",
+            "minimum": 0.0
           },
           "auto_orient": {
             "type": "boolean",

--- a/fichero-engine/tests/unit/test_locations.py
+++ b/fichero-engine/tests/unit/test_locations.py
@@ -1,0 +1,28 @@
+from fichero.api.routes.locations import Location, LocationSurface, resolve_location
+from fichero.models import DocType, Document
+import asyncio
+import pytest
+from fastapi import HTTPException
+
+
+def test_resolves_document_and_semantic_anchors(db):
+    doc = Document(name="source")
+    db.save(doc)
+    result = asyncio.run(resolve_location(Location(documentId=doc.id, claimId="c", entityId="e", surface=LocationSurface.preview), db))
+    assert (result.resolved_document_id, result.claim_id, result.entity_id) == (doc.id, "c", "e")
+
+
+def test_page_child_resolves_parent_page(db):
+    parent = Document(name="pdf")
+    child = Document(name="page", parent_id=parent.id, doc_type=DocType.page, sequence=1)
+    db.save(parent)
+    db.save(child)
+    result = asyncio.run(resolve_location(Location(documentId=child.id), db))
+    assert (result.resolved_document_id, result.resolved_page) == (parent.id, 1)
+
+
+def test_rejects_invalid_document_page_and_bbox(db):
+    with pytest.raises(HTTPException, match="Document not found"):
+        asyncio.run(resolve_location(Location(documentId="missing"), db))
+    with pytest.raises(ValueError, match="bbox"):
+        Location(documentId="x", bbox=[0, 0, 2, 1])

--- a/fichero-engine/tests/unit/test_mcp_server.py
+++ b/fichero-engine/tests/unit/test_mcp_server.py
@@ -46,6 +46,7 @@ EXPECTED_TOOLS = {
     "fichero_workspace_remove_source",
     "fichero_workspace_surface_claim",
     "fichero_workspace_add_note",
+    "fichero_reveal_location",
 }
 
 
@@ -233,6 +234,15 @@ def test_auth_and_library_headers_are_set(monkeypatch):
     assert seen[0].headers["x-fichero-library-path"] == quote(
         "/tmp/Lib.fichero", safe="/"
     )
+
+
+def test_reveal_location_hits_typed_resolver(monkeypatch):
+    with _mock_client(monkeypatch) as seen:
+        mcp_server.fichero_reveal_location("page-1", page=2, bbox=[0, 0, 1, 1])
+    assert seen[0].url.path == "/api/locations/resolve"
+    assert json.loads(seen[0].content) == {
+        "documentId": "page-1", "page": 2, "bbox": [0, 0, 1, 1], "surface": "both"
+    }
 
 
 @pytest.mark.parametrize(

--- a/fichero-engine/tests/unit/test_openapi_export.py
+++ b/fichero-engine/tests/unit/test_openapi_export.py
@@ -148,3 +148,19 @@ def test_kg_query_and_export_surface_is_present():
     assert "/api/kg/export/rdf" in paths
     assert "/api/kg/sparql" in paths
     assert paths["/api/kg/sparql"]["post"].get("deprecated") is True
+
+
+def test_openapi_30_has_no_numeric_exclusive_bounds():
+    exporter = _load_exporter()
+
+    def walk(value):
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if key in {"exclusiveMinimum", "exclusiveMaximum"}:
+                    assert not isinstance(item, (int, float)) or isinstance(item, bool)
+                walk(item)
+        elif isinstance(value, list):
+            for item in value:
+                walk(item)
+
+    walk(exporter.build_openapi_schema())

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -12241,6 +12241,49 @@
         }
       }
     },
+    "/api/locations/resolve": {
+      "post": {
+        "tags": [
+          "locations",
+          "locations"
+        ],
+        "summary": "Resolve Location",
+        "description": "Resolve a page-child anchor once, for every UI/MCP caller.",
+        "operationId": "resolve_location_api_locations_resolve_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Location"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResolvedLocation"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/library": {
       "post": {
         "tags": [
@@ -37305,6 +37348,26 @@
         ],
         "title": "ChainStepResultInfo"
       },
+      "CharacterRange": {
+        "properties": {
+          "start": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "Start"
+          },
+          "end": {
+            "type": "integer",
+            "minimum": 0.0,
+            "title": "End"
+          }
+        },
+        "type": "object",
+        "required": [
+          "start",
+          "end"
+        ],
+        "title": "CharacterRange"
+      },
       "ChatConversationListResponse": {
         "properties": {
           "items": {
@@ -40648,18 +40711,22 @@
         "properties": {
           "left": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Left"
           },
           "top": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Top"
           },
           "width": {
             "type": "integer",
+            "exclusiveMinimum": 0.0,
             "title": "Width"
           },
           "height": {
             "type": "integer",
+            "exclusiveMinimum": 0.0,
             "title": "Height"
           },
           "auto_orient": {
@@ -45002,18 +45069,22 @@
         "properties": {
           "left": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Left"
           },
           "top": {
             "type": "integer",
+            "minimum": 0.0,
             "title": "Top"
           },
           "width": {
             "type": "integer",
+            "exclusiveMinimum": 0.0,
             "title": "Width"
           },
           "height": {
             "type": "integer",
+            "exclusiveMinimum": 0.0,
             "title": "Height"
           },
           "auto_orient": {
@@ -49017,6 +49088,64 @@
         ],
         "title": "LocalServiceState",
         "description": "Lifecycle state for an app-managed local inference service."
+      },
+      "Location": {
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Documentid"
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1.0,
+            "nullable": true,
+            "title": "Page"
+          },
+          "bbox": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "maxItems": 4,
+            "minItems": 4,
+            "nullable": true,
+            "title": "Bbox"
+          },
+          "charRange": {
+            "$ref": "#/components/schemas/CharacterRange",
+            "nullable": true
+          },
+          "claimId": {
+            "type": "string",
+            "nullable": true,
+            "title": "Claimid"
+          },
+          "entityId": {
+            "type": "string",
+            "nullable": true,
+            "title": "Entityid"
+          },
+          "surface": {
+            "$ref": "#/components/schemas/LocationSurface",
+            "default": "both"
+          }
+        },
+        "type": "object",
+        "required": [
+          "documentId"
+        ],
+        "title": "Location"
+      },
+      "LocationSurface": {
+        "type": "string",
+        "enum": [
+          "preview",
+          "reader",
+          "inspector",
+          "both"
+        ],
+        "title": "LocationSurface"
       },
       "LoginRequest": {
         "properties": {
@@ -55624,6 +55753,64 @@
         "type": "object",
         "title": "ResolveRequest"
       },
+      "ResolvedLocation": {
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Documentid"
+          },
+          "page": {
+            "type": "integer",
+            "minimum": 1.0,
+            "nullable": true,
+            "title": "Page"
+          },
+          "bbox": {
+            "items": {
+              "type": "number"
+            },
+            "type": "array",
+            "maxItems": 4,
+            "minItems": 4,
+            "nullable": true,
+            "title": "Bbox"
+          },
+          "charRange": {
+            "$ref": "#/components/schemas/CharacterRange",
+            "nullable": true
+          },
+          "claimId": {
+            "type": "string",
+            "nullable": true,
+            "title": "Claimid"
+          },
+          "entityId": {
+            "type": "string",
+            "nullable": true,
+            "title": "Entityid"
+          },
+          "surface": {
+            "$ref": "#/components/schemas/LocationSurface",
+            "default": "both"
+          },
+          "resolvedDocumentId": {
+            "type": "string",
+            "title": "Resolveddocumentid"
+          },
+          "resolvedPage": {
+            "type": "integer",
+            "nullable": true,
+            "title": "Resolvedpage"
+          }
+        },
+        "type": "object",
+        "required": [
+          "documentId",
+          "resolvedDocumentId"
+        ],
+        "title": "ResolvedLocation"
+      },
       "ResumeWorkflowRequest": {
         "properties": {
           "inputs": {
@@ -55811,6 +55998,8 @@
         "properties": {
           "angle": {
             "type": "number",
+            "maximum": 360.0,
+            "minimum": -360.0,
             "title": "Angle"
           },
           "expand": {

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -40721,13 +40721,15 @@
           },
           "width": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Width"
+            "exclusiveMinimum": true,
+            "title": "Width",
+            "minimum": 0.0
           },
           "height": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Height"
+            "exclusiveMinimum": true,
+            "title": "Height",
+            "minimum": 0.0
           },
           "auto_orient": {
             "type": "boolean",
@@ -45079,13 +45081,15 @@
           },
           "width": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Width"
+            "exclusiveMinimum": true,
+            "title": "Width",
+            "minimum": 0.0
           },
           "height": {
             "type": "integer",
-            "exclusiveMinimum": 0.0,
-            "title": "Height"
+            "exclusiveMinimum": true,
+            "title": "Height",
+            "minimum": 0.0
           },
           "auto_orient": {
             "type": "boolean",

--- a/fichero/fichero-tests/InspectorNavigationScopingTests.swift
+++ b/fichero/fichero-tests/InspectorNavigationScopingTests.swift
@@ -39,4 +39,71 @@ final class InspectorNavigationScopingTests: XCTestCase {
         XCTAssertEqual(EntitySearchState().requestID, 0)
         XCTAssertEqual(ClaimSourceNavigationState().requestID, 0)
     }
+
+    // MARK: - Active-surface pin ⇄ active reconciliation (#3580, §2.3)
+
+    func testSoleUnpinnedPaneAutoActivates() {
+        // No dead state: one unpinned Preview/Reader pane ⇒ it is active without
+        // any direct click (§2.3).
+        let state = ActiveSurfaceState()
+        let a = SurfaceID()
+        state.registerUnpinned(a)
+        XCTAssertEqual(state.activeSurfaceId, a)
+    }
+
+    func testTwoPanesLeaveActiveToTheDirectClick() {
+        // With more than one unpinned pane there is no sole winner — active is
+        // only set by an explicit click, not by mounting.
+        let state = ActiveSurfaceState()
+        let a = SurfaceID(), b = SurfaceID()
+        state.registerUnpinned(a)   // a auto-active (sole so far)
+        state.registerUnpinned(b)   // now two — active stays on a
+        XCTAssertEqual(state.activeSurfaceId, a)
+        state.activate(b)
+        XCTAssertEqual(state.activeSurfaceId, b)
+    }
+
+    func testPinningActiveClearsItThenHandsSurvivorTheSlot() {
+        // Pin the active pane: it stops following selection (active clears), and
+        // the lone remaining unpinned pane silently becomes active (§2.3 reqs 1+2).
+        let state = ActiveSurfaceState()
+        let a = SurfaceID(), b = SurfaceID()
+        state.registerUnpinned(a)
+        state.registerUnpinned(b)
+        state.activate(b)
+        XCTAssertEqual(state.activeSurfaceId, b)
+
+        state.unregister(b)  // b pins → leaves the pool
+        XCTAssertEqual(state.activeSurfaceId, a, "sole survivor auto-activates")
+    }
+
+    func testClickOnPinnedPaneIsSkipped() {
+        // A pinned pane (never registered / already unregistered) is never picked
+        // as a new active target (§2.1).
+        let state = ActiveSurfaceState()
+        let a = SurfaceID(), pinned = SurfaceID()
+        state.registerUnpinned(a)
+        state.activate(pinned)  // pinned isn't in the pool
+        XCTAssertEqual(state.activeSurfaceId, a, "click on a pinned pane must not steal active")
+    }
+
+    func testAllPanesPinnedLeavesNoActive() {
+        // Every pane pinned ⇒ nothing follows selection ⇒ no active indicator.
+        let state = ActiveSurfaceState()
+        let a = SurfaceID()
+        state.registerUnpinned(a)
+        state.unregister(a)
+        XCTAssertNil(state.activeSurfaceId)
+    }
+
+    func testTwoActiveSurfaceStatesAreIndependent() {
+        // Per-window scoping (#3437): activating a pane in window A must not
+        // touch window B.
+        let windowA = ActiveSurfaceState()
+        let windowB = ActiveSurfaceState()
+        let a = SurfaceID()
+        windowA.registerUnpinned(a)
+        XCTAssertEqual(windowA.activeSurfaceId, a)
+        XCTAssertNil(windowB.activeSurfaceId, "an active pane in window A must not light up window B")
+    }
 }

--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -177,7 +177,17 @@ private struct ReadingPaneView: View {
         // A direct click anywhere in this pane makes it the active surface
         // (#3579). simultaneousGesture runs alongside PDF/WebKit hit-testing so
         // it never steals the click — same pattern as focusedPane tracking.
-        .simultaneousGesture(TapGesture().onEnded { activeSurfaceState?.activeSurfaceId = surfaceId })
+        .simultaneousGesture(TapGesture().onEnded { activeSurfaceState?.activate(surfaceId) })
+        // Join/leave the active-surface pool (#3580). Registering when it appears
+        // makes a sole pane auto-active; toggling on isPinned clears active if it
+        // pointed here (pinned panes never follow selection) and hands a lone
+        // survivor the active slot.
+        .onAppear { activeSurfaceState?.registerUnpinned(surfaceId) }
+        .onDisappear { activeSurfaceState?.unregister(surfaceId) }
+        .onChange(of: isPinned) { _, pinned in
+            if pinned { activeSurfaceState?.unregister(surfaceId) }
+            else { activeSurfaceState?.registerUnpinned(surfaceId) }
+        }
         // A source reveal (#2105) brings the reader to the Page tab so the
         // highlighted / scrolled-to source is actually visible (#3521).
         .onChange(of: claimSourceNavigationState?.requestID) { _, newID in

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift
@@ -146,7 +146,47 @@ struct SurfaceID: Hashable {
 @Observable
 @MainActor
 final class ActiveSurfaceState {
-    var activeSurfaceId: SurfaceID?
+    /// The pane that updates on the next library click, or nil when no unpinned
+    /// Preview/Reader pane exists. All mutation flows through the methods below
+    /// so the pin ⇄ active invariants (#3580, §2.3) hold in one place.
+    private(set) var activeSurfaceId: SurfaceID?
+
+    /// Currently-mounted, UNPINNED Preview/Reader panes (#3580). A pane can't
+    /// tell on its own whether it's "the only unpinned one", so the set lives
+    /// here — the minimal shared state needed to kill the dead-active case.
+    private var unpinnedSurfaces: Set<SurfaceID> = []
+
+    /// A pane appears (or unpins): it joins the pool and, if it's now the sole
+    /// unpinned pane, silently becomes active — no dead state (§2.3).
+    func registerUnpinned(_ id: SurfaceID) {
+        unpinnedSurfaces.insert(id)
+        resolveSoleActive()
+    }
+
+    /// A pane pins, disappears, or its split collapses: it leaves the pool. If
+    /// it was the active one, active clears; a lone survivor then auto-activates.
+    func unregister(_ id: SurfaceID) {
+        unpinnedSurfaces.remove(id)
+        if activeSurfaceId == id { activeSurfaceId = nil }
+        resolveSoleActive()
+    }
+
+    /// A direct click picks this pane as active — unless it's pinned, in which
+    /// case it's skipped (§2.1: a pinned pane is never a NEW active target).
+    func activate(_ id: SurfaceID) {
+        guard unpinnedSurfaces.contains(id) else { return }
+        activeSurfaceId = id
+    }
+
+    /// No dead state: exactly one unpinned pane ⇒ it is active. If the active id
+    /// no longer names an unpinned pane, clear it.
+    private func resolveSoleActive() {
+        if unpinnedSurfaces.count == 1 {
+            activeSurfaceId = unpinnedSurfaces.first
+        } else if let active = activeSurfaceId, !unpinnedSurfaces.contains(active) {
+            activeSurfaceId = nil
+        }
+    }
 }
 
 // MARK: - Notification names

--- a/fichero/fichero/Views/Library/Reading/PDFPageWithToolbar.swift
+++ b/fichero/fichero/Views/Library/Reading/PDFPageWithToolbar.swift
@@ -190,7 +190,17 @@ struct PDFPageWithToolbar: View {
         // A direct click anywhere in this pane makes it the active surface
         // (#3579). simultaneousGesture runs alongside PDFKit hit-testing so it
         // never steals the click — same pattern as focusedPane tracking.
-        .simultaneousGesture(TapGesture().onEnded { activeSurfaceState?.activeSurfaceId = surfaceId })
+        .simultaneousGesture(TapGesture().onEnded { activeSurfaceState?.activate(surfaceId) })
+        // Join/leave the active-surface pool (#3580). Registering when it appears
+        // makes a sole pane auto-active; toggling on isPinned clears active if it
+        // pointed here (pinned panes never follow selection) and hands a lone
+        // survivor the active slot.
+        .onAppear { activeSurfaceState?.registerUnpinned(surfaceId) }
+        .onDisappear { activeSurfaceState?.unregister(surfaceId) }
+        .onChange(of: isPinned) { _, pinned in
+            if pinned { activeSurfaceState?.unregister(surfaceId) }
+            else { activeSurfaceState?.registerUnpinned(surfaceId) }
+        }
     }
 
     /// True when this pane instance is the window's active surface (#3579).


### PR DESCRIPTION
Batch (all build green together):
- #3576 Location model + POST /api/locations/resolve (one resolution path; page-child→parent). test_locations 3 passed.
- #3578 fichero_reveal_location MCP tool wrapping the resolve endpoint (agent can address doc/page/bbox). test_mcp_server green.
- Regen toolchain fix: export_openapi_schema.py now down-converts numeric JSON-Schema exclusiveMinimum/Maximum to OpenAPI-3.0 boolean form ({minimum:N, exclusiveMinimum:true}) so the Swift OpenAPIKit generator builds; 0 numeric exclusive bounds remain; test_openapi_export added. Fixes a latent toolchain incompat that would break every future regen.
- #3580 pin⇄active reconciliation (pinned pane never follows; sole unpinned auto-active).
Gate: full Swift BUILD SUCCEEDED; regen synced ×3; pre-existing model-download red is unrelated (filed). 🤖 Claude (Opus 4.8)