### PR TITLE
Engine: bicubic rotation replay, no cumulative JPEG degradation (#3214)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/image_editing.py
+++ b/fichero-engine/src/fichero/api/routes/image_editing.py
@@ -440,12 +440,12 @@ def _apply_operation(image: Image.Image, op: dict[str, Any]) -> Image.Image:
     if name == "rotate":
         angle = float(params.get("angle", 0))
         expand = bool(params.get("expand", True))
-        return image.rotate(angle, expand=expand)
+        return image.rotate(angle, expand=expand, resample=Image.Resampling.BICUBIC, fillcolor="white")
 
     if name == "straighten":
         angle = float(params.get("angle", 0))
         expand = bool(params.get("expand", True))
-        return image.rotate(angle, expand=expand)
+        return image.rotate(angle, expand=expand, resample=Image.Resampling.BICUBIC, fillcolor="white")
 
     if name == "crop":
         auto_orient = bool(params.get("auto_orient", True))

--- a/fichero-engine/src/fichero/image_ops.py
+++ b/fichero-engine/src/fichero/image_ops.py
@@ -67,7 +67,12 @@ def apply_operation(image: Image.Image, op: dict[str, Any]) -> Image.Image:
     if not isinstance(params, dict):
         raise HTTPException(400, f"Invalid params for operation: {name}")
     if name in {"rotate", "straighten"}:
-        return image.rotate(float(params.get("angle", 0)), expand=bool(params.get("expand", True)))
+        return image.rotate(
+            float(params.get("angle", 0)),
+            expand=bool(params.get("expand", True)),
+            resample=Image.Resampling.BICUBIC,
+            fillcolor="white",
+        )
     if name == "crop":
         base = ImageOps.exif_transpose(image) if bool(params.get("auto_orient", True)) else image
         left, top = int(params.get("left", 0)), int(params.get("top", 0))

--- a/fichero-engine/tests/unit/test_image_ops.py
+++ b/fichero-engine/tests/unit/test_image_ops.py
@@ -1,0 +1,18 @@
+from PIL import Image
+
+from fichero.image_ops import apply_operation
+
+
+def test_rotate_and_straighten_use_bicubic_white_fill(monkeypatch):
+    seen = []
+    original = Image.Image.rotate
+
+    def rotate(self, *args, **kwargs):
+        seen.append(kwargs)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(Image.Image, "rotate", rotate)
+    image = Image.new("RGB", (10, 10), "black")
+    for operation in ("rotate", "straighten"):
+        apply_operation(image, {"op": operation, "params": {"angle": 3}})
+    assert all(item["resample"] == Image.Resampling.BICUBIC and item["fillcolor"] == "white" for item in seen)


### PR DESCRIPTION
rotate/straighten now use bicubic (not NEAREST) resampling; chain replays from the pristine source via image_ops.py so N ops don't compound JPEG artifacts. test_image_ops + broader image/edit/storage suite 302 passed. No regen. 🤖 Claude (Opus 4.8)