### PR TITLE
Navigation: rewire source reveal through engine locations/resolve (#3577, slice 2)

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -337,6 +337,7 @@
 		A13E7C2F2F27E17F00EC9EE1 /* SearchServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C2D2F27E17F00EC9EE1 /* SearchServiceGenerated.swift */; };
 		A13E7C302F27E17F00EC9EE1 /* BatchServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C2B2F27E17F00EC9EE1 /* BatchServiceGenerated.swift */; };
 		A13E7C3A2F27F36000EC9EE1 /* ActivityServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */; };
+		LOC00012F27F36000EC9EE1 /* LocationServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */; };
 		A13E7C3C2F27F36000EC9EE1 /* ActivityTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C3B2F27F36000EC9EE1 /* ActivityTypes.swift */; };
 		A13E7C3D2F27F36000EC9EE1 /* ActivityStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C3E2F27F36000EC9EE1 /* ActivityStreamService.swift */; };
 		A13E7C462F280BE900EC9EE1 /* ActivityProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C432F280BE900EC9EE1 /* ActivityProgressView.swift */; };
@@ -949,6 +950,7 @@
 		A13E7C2C2F27E17F00EC9EE1 /* ProviderServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderServiceGenerated.swift; sourceTree = "<group>"; };
 		A13E7C2D2F27E17F00EC9EE1 /* SearchServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchServiceGenerated.swift; sourceTree = "<group>"; };
 		A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityServiceGenerated.swift; sourceTree = "<group>"; };
+		LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServiceGenerated.swift; sourceTree = "<group>"; };
 		A13E7C3B2F27F36000EC9EE1 /* ActivityTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTypes.swift; sourceTree = "<group>"; };
 		A13E7C3C2F280BE900EC9EE1 /* ActivityConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityConsoleView.swift; sourceTree = "<group>"; };
 		A13E7C3E2F27F36000EC9EE1 /* ActivityStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStreamService.swift; sourceTree = "<group>"; };
@@ -1742,6 +1744,7 @@
 				A13E7C2C2F27E17F00EC9EE1 /* ProviderServiceGenerated.swift */,
 				A13E7C2D2F27E17F00EC9EE1 /* SearchServiceGenerated.swift */,
 				A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */,
+				LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */,
 				A13E7C3E2F27F36000EC9EE1 /* ActivityStreamService.swift */,
 				AUT00012F27F36000EC9EE1 /* AutomationServiceGenerated.swift */,
 				A13E7C632F27F36000EC9EE1 /* ArtifactServiceGenerated.swift */,
@@ -2604,6 +2607,7 @@
 				039 /* ChainService.swift in Sources */,
 				200BCF382F3D548000D7851A /* ContentView+Persistence.swift in Sources */,
 				A13E7C3A2F27F36000EC9EE1 /* ActivityServiceGenerated.swift in Sources */,
+				LOC00012F27F36000EC9EE1 /* LocationServiceGenerated.swift in Sources */,
 				A13E7C3D2F27F36000EC9EE1 /* ActivityStreamService.swift in Sources */,
 				202674AA2F476453008EAB5D /* ExtractEntitiesNodeConfig.swift in Sources */,
 				202674B42F4783A9008EAB5D /* WorkflowNodeCard.swift in Sources */,

--- a/fichero/fichero/Models/DocumentStore.swift
+++ b/fichero/fichero/Models/DocumentStore.swift
@@ -99,6 +99,12 @@ final class DocumentStore {
     @ObservationIgnored
     let documentService: DocumentServiceGenerated
 
+    /// Typed locations client (#3577). Shares `api`'s FicheroClient. Resolves a
+    /// navigation `Location` (page-child → parent, page range) through the one
+    /// engine route so the UI doesn't re-implement that resolution.
+    @ObservationIgnored
+    let locationService: LocationServiceGenerated
+
     /// Publish a document change event.
     func publish(_ change: DocumentChange) {
         documentChanges.send(change)
@@ -165,6 +171,7 @@ final class DocumentStore {
     init(apiClient: APIClient) {
         self.api = apiClient
         self.documentService = DocumentServiceGenerated(ficheroClient: apiClient.client)
+        self.locationService = LocationServiceGenerated(ficheroClient: apiClient.client)
     }
 
     // MARK: - Connection

--- a/fichero/fichero/Services/LocationServiceGenerated.swift
+++ b/fichero/fichero/Services/LocationServiceGenerated.swift
@@ -1,0 +1,45 @@
+import FicheroAPIClient
+import Foundation
+import OpenAPIRuntime
+import OSLog
+
+private let logger = Logger(subsystem: "app.fichero.fichero", category: "LocationServiceGenerated")
+
+/// Resolves navigation anchors through the engine's single
+/// `POST /api/locations/resolve` route (#3576/#3577). Page-child → parent
+/// resolution (and page-range validation) now lives ONCE in the engine, so
+/// every UI/MCP caller shares it instead of re-implementing it client-side.
+/// Mirrors `DocumentServiceGenerated`: a thin service over the generated
+/// OpenAPI client — no hand-rolled URLSession.
+@MainActor
+class LocationServiceGenerated {
+    let client: FicheroClient
+
+    init(ficheroClient: FicheroClient) {
+        self.client = ficheroClient
+    }
+
+    /// Resolve a `Location` to its parent document + resolved page. Throws on
+    /// 404 (document/parent missing) or 422 (out-of-range) so callers can fall
+    /// back to their legacy navigation path — a reveal must never crash.
+    func resolve(_ location: Components.Schemas.Location) async throws -> Components.Schemas.ResolvedLocation {
+        let response = try await client.api.resolveLocationApiLocationsResolvePost(.init(
+            body: .json(location)
+        ))
+
+        switch response {
+        case .ok(let okResponse):
+            return try okResponse.body.json
+        case .unprocessableContent(let error):
+            let detail = try? error.body.json
+            throw LocationServiceError.validationError(detail?.detail?.description ?? "Validation error")
+        case .undocumented(let statusCode, _):
+            throw LocationServiceError.unexpectedResponse(statusCode)
+        }
+    }
+}
+
+enum LocationServiceError: Error {
+    case validationError(String)
+    case unexpectedResponse(Int)
+}

--- a/fichero/fichero/Views/ContentView+State.swift
+++ b/fichero/fichero/Views/ContentView+State.swift
@@ -908,10 +908,11 @@ extension ContentView {
             )
         }
         // Resolve page-child source documents to their parent file and
-        // select it. Then forward the page-navigation request that
-        // PDFPageView consumes for scrolling/highlighting.
+        // select it — now via the ONE engine route (#3577) instead of the
+        // inline client-side walk. Then forward the SAME page-navigation
+        // request that PDFPageView consumes for scrolling/highlighting.
         Task { @MainActor in
-            await navigateToSourcePage(docId)
+            await revealResolvedSource(request)
             var info: [String: Any] = ["documentId": docId]
             if let claimId = request.claimId { info["claimId"] = claimId }
             if let pageLabel = request.pageLabel { info["pageLabel"] = pageLabel }

--- a/fichero/fichero/Views/ContentView+WorkflowActions.swift
+++ b/fichero/fichero/Views/ContentView+WorkflowActions.swift
@@ -113,8 +113,14 @@ extension ContentView {
             target = source
         }
 
-        // Open the containing folder so target shows up in the grid; if
-        // target has no parent (top-level), just point sidebar at it.
+        await navigateToResolvedSource(target)
+    }
+
+    /// Open the containing folder so `target` shows up in the grid and select
+    /// it; if `target` is top-level, just point the sidebar at it. Shared by the
+    /// engine-resolved reveal (#3577) and the legacy client-side resolver above.
+    @MainActor
+    func navigateToResolvedSource(_ target: Document) async {
         if let folderId = target.parentId, !folderId.isEmpty {
             do {
                 let folder = try await documentStore.documentService.getDocument(folderId)
@@ -126,6 +132,24 @@ extension ContentView {
             }
         } else {
             navigateToDocument(target)
+        }
+    }
+
+    /// Resolve a source anchor to its parent document + page through the ONE
+    /// engine route (#3577) — page-child → parent resolution no longer lives in
+    /// the app — then select it. Falls back to the legacy client-side walk if
+    /// the engine resolve fails so a reveal never breaks (no regression).
+    @MainActor
+    func revealResolvedSource(_ request: ClaimSourceNavigationRequest) async {
+        do {
+            let resolved = try await documentStore.locationService.resolve(request.asLocation)
+            let target = try await documentStore.documentService.getDocument(resolved.resolvedDocumentId)
+            await navigateToResolvedSource(target)
+        } catch {
+            workflowLogger.warning(
+                "revealResolvedSource: engine resolve failed (\(error.localizedDescription)); falling back to client-side navigateToSourcePage"
+            )
+            await navigateToSourcePage(request.documentId)
         }
     }
 

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+Shared.swift
@@ -110,6 +110,41 @@ struct ClaimSourceNavigationRequest: Equatable {
     var destination: SourceDestination = .reader
 }
 
+extension SourceDestination {
+    /// Widen to the engine's `LocationSurface` (#3577). `SourceDestination` has
+    /// no `.inspector` case, so this only ever produces preview/reader/both.
+    var locationSurface: Components.Schemas.LocationSurface {
+        switch self {
+        case .preview: return .preview
+        case .reader: return .reader
+        case .both: return .both
+        }
+    }
+}
+
+extension ClaimSourceNavigationRequest {
+    /// This request as the engine-known `Location` (#3577). The Swift request
+    /// keeps its own shape (locked by `SourceNavigationContractTests`); this is
+    /// the thin wrapper that lets `locationService.resolve` do page-child →
+    /// parent resolution in ONE place. `pageIndex` is 0-based here but the engine
+    /// `page` is 1-based, so it is bumped by one.
+    var asLocation: Components.Schemas.Location {
+        let charRange: Components.Schemas.CharacterRange? = {
+            guard let charStart, let charEnd else { return nil }
+            return Components.Schemas.CharacterRange(start: charStart, end: charEnd)
+        }()
+        return Components.Schemas.Location(
+            documentId: documentId,
+            page: pageIndex.map { $0 + 1 },
+            bbox: bbox,
+            charRange: charRange,
+            claimId: claimId,
+            entityId: nil,
+            surface: destination.locationSurface
+        )
+    }
+}
+
 /// Per-window claim/entity/citation source-navigation request bus. Scoped to
 /// the window/library via the SwiftUI environment (#3437) — NOT a process-global
 /// singleton, so a source reveal in one window never navigates another.


### PR DESCRIPTION
handleOpenClaimSource now resolves page-child→parent via the generated LocationService.resolve (resolution lives ONCE in the engine, #3576). ClaimSourceNavigationRequest gains an additive asLocation mapping (SourceDestination→LocationSurface) — stored fields unchanged, so SourceNavigationContractTests + InspectorNavigationScopingTests are preserved by construction. Same .ficheroNavigateToPage notification posted (reveal/highlight unchanged). BUILD SUCCEEDED. 🤖 Claude (Opus 4.8)