### PR TITLE
Navigation: Open in New Tab/Window on Preview/Reader panes + claim reveal (#3582, slice 7)

### DIFF
--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -32,6 +32,9 @@ private struct ReadingPaneView: View {
     /// Stable identity for THIS pane instance — minted once at mount, so left
     /// and right splits are tracked independently (mirrors per-instance pin).
     @State private var surfaceId = SurfaceID()
+    /// Open-in-new-tab/window plumbing for the pane's title-bar context menu
+    /// (#3582, browser-tab metaphor). Reuses the shared WindowOpener path.
+    @Environment(\.openWindow) private var openWindow
     /// Shared annotation focus for the Notes tab's list ↔ detail selection.
     @State private var focusedAnnotation = FocusedAnnotation.shared
     /// Notes-tab sub-mode: anchored marks vs free-text notes (#3513). Per-window.
@@ -173,6 +176,17 @@ private struct ReadingPaneView: View {
                     .fill(isActiveSurface ? Color.accentColor : Color.clear)
                     .frame(height: 2)
             }
+            // Title-bar "Open in New Tab/Window" (#3582). Right-click the reader's
+            // toolbar to pop THIS document out — the browser-tab metaphor. Reuses
+            // the shared OpenInMenuItems; disabled implicitly when no document.
+            .contextMenu {
+                if let docId = effectiveDocument?.id {
+                    OpenInMenuItems(
+                        openInNewTab: { openThisDocumentInNewWindow(docId, asTab: true) },
+                        openInNewWindow: { openThisDocumentInNewWindow(docId, asTab: false) }
+                    )
+                }
+            }
         }
         // A direct click anywhere in this pane makes it the active surface
         // (#3579). simultaneousGesture runs alongside PDF/WebKit hit-testing so
@@ -198,6 +212,13 @@ private struct ReadingPaneView: View {
     /// True when this pane instance is the window's active surface (#3579).
     private var isActiveSurface: Bool {
         activeSurfaceState?.activeSurfaceId == surfaceId
+    }
+
+    /// Open this reader's document in a native tab (`asTab`) or a new window
+    /// (#3582), via the same Safari-style path library rows use.
+    private func openThisDocumentInNewWindow(_ documentId: String, asTab: Bool) {
+        let libraryId = LibraryManager.shared.currentLibraryId ?? LibraryManager.globalLibraryId
+        WindowOpener.open(libraryId: libraryId, documentId: documentId, asTab: asTab, using: openWindow)
     }
 
     /// Switch the reader to the Page tab and, if it's showing only the source,

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/ClaimSummaryCardView.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/ClaimSummaryCardView.swift
@@ -195,6 +195,18 @@ struct ClaimSummaryCard: View {
                     openInNewTab: { openClaimInNewWindow(asTab: true) },
                     openInNewWindow: { openClaimInNewWindow(asTab: false) }
                 )
+                // Open the claim's SOURCE document itself in a new tab/window
+                // (#3582). Nested under "Open Source" so its New Tab/New Window
+                // items don't collide with the claim's above; reuses the shared
+                // OpenInMenuItems rather than hand-rolling menu items.
+                if let sourceDocId = claim.sourceDocumentId, !sourceDocId.isEmpty {
+                    Menu("Open Source") {
+                        OpenInMenuItems(
+                            openInNewTab: { openSourceInNewWindow(sourceDocId, asTab: true) },
+                            openInNewWindow: { openSourceInNewWindow(sourceDocId, asTab: false) }
+                        )
+                    }
+                }
                 Divider()
                 // Status sub-menu — set epistemic_status via PATCH.
                 // Confirmed / Tentative / Rejected are the three states the
@@ -258,6 +270,13 @@ struct ClaimSummaryCard: View {
 
     /// Open this claim in a new tab/window (#1685). Reuses the Safari
     /// new-window path; the shared `KGFocusState` carries the focus.
+    /// Open the claim's SOURCE document in a native tab (`asTab`) or a new
+    /// window (#3582) — the browser-tab metaphor applied to a reveal menu.
+    private func openSourceInNewWindow(_ documentId: String, asTab: Bool) {
+        let libraryId = LibraryManager.shared.currentLibraryId ?? LibraryManager.globalLibraryId
+        WindowOpener.open(libraryId: libraryId, documentId: documentId, asTab: asTab, using: openWindow)
+    }
+
     private func openClaimInNewWindow(asTab: Bool) {
         // Follow-up (#1685): like entities, a brand-new window only reacts to
         // focusedClaimId via .onChange, so deterministic auto-focus on first

--- a/fichero/fichero/Views/Library/Reading/PDFPageWithToolbar.swift
+++ b/fichero/fichero/Views/Library/Reading/PDFPageWithToolbar.swift
@@ -63,6 +63,17 @@ struct PDFPageWithToolbar: View {
     /// and right splits are tracked independently (mirrors per-instance pin).
     @State private var surfaceId = SurfaceID()
 
+    /// Open-in-new-tab/window plumbing for the pane's title-bar context menu
+    /// (#3582, browser-tab metaphor). Reuses the shared WindowOpener path.
+    @Environment(\.openWindow) private var openWindow
+
+    /// Open THIS pane's document in a native tab (`asTab`) or a new window,
+    /// via the same Safari-style path library rows use.
+    private func openThisDocumentInNewWindow(asTab: Bool) {
+        let libraryId = LibraryManager.shared.currentLibraryId ?? LibraryManager.globalLibraryId
+        WindowOpener.open(libraryId: libraryId, documentId: effectiveDocumentId, asTab: asTab, using: openWindow)
+    }
+
     // Bounding-box annotation state (#2458). `isDrawingRegion` arms a region
     // drag on the page; `pendingTool` carries the kind into the saved box.
     @Environment(AnnotationStore.self) private var annotationStore: AnnotationStore
@@ -185,6 +196,16 @@ struct PDFPageWithToolbar: View {
                     Rectangle()
                         .fill(isActiveSurface ? Color.accentColor : Color.clear)
                         .frame(height: 2)
+                }
+                // Title-bar "Open in New Tab/Window" (#3582). Right-click the
+                // pane's toolbar to pop THIS document out — the browser-tab
+                // metaphor. Reuses the shared OpenInMenuItems (no "Open": the
+                // pane already shows the document).
+                .contextMenu {
+                    OpenInMenuItems(
+                        openInNewTab: { openThisDocumentInNewWindow(asTab: true) },
+                        openInNewWindow: { openThisDocumentInNewWindow(asTab: false) }
+                    )
                 }
         }
         // A direct click anywhere in this pane makes it the active surface


### PR DESCRIPTION
OpenInMenuItems extended to Preview/Reader pane title bars (PDFPageWithToolbar, ReadingPaneView) + claim source reveal (ClaimSummaryCardView), wired to WindowOpener.open(documentId:asTab:) — browser-tab metaphor. BUILD SUCCEEDED. 🤖 Claude (Opus 4.8)