### PR TITLE
Engine: close library handles + registry removal (#3393)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/library_registry.py
+++ b/fichero-engine/src/fichero/api/routes/library_registry.py
@@ -1013,6 +1013,9 @@ def update_library_access(
     stored_path = nfc_path(str(pkg_path))
 
     try:
+        # Close even for an already-removed row: close is the idempotent
+        # lifecycle operation, while the registry is its persisted projection.
+        db_manager.close_database(stored_path)
         existing = db.query(KnownLibrary, path=stored_path)
         if not existing:
             raise HTTPException(
@@ -1056,6 +1059,7 @@ def remove_known_library(
     stored_path = nfc_path(str(pkg_path))
 
     try:
+        db_manager.close_database(stored_path)
         existing = db.query(KnownLibrary, path=stored_path)
         if not existing:
             # Idempotent no-op — the library is already absent from the registry.

--- a/fichero-engine/src/fichero/db_manager.py
+++ b/fichero-engine/src/fichero/db_manager.py
@@ -123,7 +123,7 @@ class DatabaseManager:
 
     def close_database(self, package_path: str | Path):
         """Close the shared connection for a package."""
-        package_str = str(Path(nfc_path(package_path)))
+        package_str = str(Path(nfc_path(package_path)).expanduser().resolve())
 
         with self._lock:
             keys = [k for k in self._databases if k == package_str]

--- a/fichero-engine/tests/unit/test_library_registry.py
+++ b/fichero-engine/tests/unit/test_library_registry.py
@@ -277,6 +277,8 @@ class TestGlobalRegistryHeaderless:
         lib_path = tmp_path / unicodedata.normalize("NFC", "Chocó.fichero")
         lib_path.mkdir(parents=True, exist_ok=True)
         global_client.post("/api/registry/add", params={"path": str(lib_path)})
+        from fichero.db_manager import db_manager
+        db_manager.get_database(lib_path)
 
         db_manager.close_database(str(lib_path))
         normalized = unicodedata.normalize("NFC", str(lib_path))
@@ -500,10 +502,12 @@ class TestGlobalRegistryHeaderless:
     def test_remove_handles_spaces(self, global_client, tmp_path):
         """DELETE /api/registry/{path} works for a path containing spaces."""
         from urllib.parse import quote
+        from fichero.db_manager import db_manager
 
         lib_path = tmp_path / "My Marshall Library.fichero"
         lib_path.mkdir(parents=True, exist_ok=True)
         global_client.post("/api/registry/add", params={"path": str(lib_path)})
+        db_manager.get_database(lib_path)
 
         encoded = quote(str(lib_path.resolve()), safe="")
         removed = global_client.delete(f"/api/registry/{encoded}")
@@ -514,6 +518,11 @@ class TestGlobalRegistryHeaderless:
         listed = global_client.get("/api/registry")
         paths = [lib["path"] for lib in listed.json()["libraries"]]
         assert str(lib_path.resolve()) not in paths
+
+        assert str(lib_path.resolve()) not in db_manager._databases
+        db_manager.get_database(lib_path)
+        assert str(lib_path.resolve()) in db_manager._databases
+        db_manager.close_database(lib_path)
 
     def test_remove_is_idempotent(self, global_client, tmp_path):
         """Removing an unregistered library is a 200 no-op, not a 404."""


### PR DESCRIPTION
Closing a library now actually releases the backend DB handle (db_manager.close_database), not just the registry row; close is idempotent (closes even for an already-removed row). test_library_registry 26 passed; broader library/connection/registry/manager suite 462 passed (the 1 red — test_mutating_library_routes_use_write_authorized_db_dependency — is PRE-EXISTING at baseline, not a new offender; #3393 adds no route, filed separately). No regen. Frontend list-sync half stays for a Swift slice (disjoint). 🤖 Claude (Opus 4.8)