### PR TITLE
Image editing: fix all-black canvas on entering edit mode (#3593, commit 1)

### DIFF
--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
@@ -518,14 +518,24 @@ private extension ImageEditorView {
                 }
             } else {
                 // Single-mode: DocumentCanvas gives zoom/loupe/magnifier (#1402).
-                // Shows last rendered frame while loading (model.preview?.image may
-                // be nil briefly after an op; canvas retains the stale frame).
-                DocumentCanvas(
-                    content: .imageRendered(
-                        image: model.preview?.image,
-                        documentId: activeDocumentID
+                if let rendered = model.preview?.image {
+                    DocumentCanvas(
+                        content: .imageRendered(
+                            image: rendered,
+                            documentId: activeDocumentID
+                        )
                     )
-                )
+                } else {
+                    // No rendered frame yet — entering edit clears `preview` and
+                    // then awaits the (heavier) apply_edits render, so driving the
+                    // canvas with a nil rendered image left it blank/black on enter
+                    // (#3593). Fall back to the known-good source display image (the
+                    // exact canvas view mode already uses) so the pane shows the
+                    // picture immediately and swaps to the edited frame once it lands.
+                    DocumentCanvas(
+                        content: .imageStorageDisplay(documentId: activeDocument.id)
+                    )
+                }
             }
 
             // Busy overlay for any in-flight edit/load, in every compare mode


### PR DESCRIPTION
Entering edit mode no longer shows a blank/black Preview canvas — ImageEditorView now shows the image (source until the edited render lands) instead of an empty/nil canvas state. First slice of the #3593 image-editing UX exposure. BUILD SUCCEEDED. 🤖 Claude (Opus 4.8)