### PR TITLE
Engine: harden navigation Location resolve path (#3601)

### DIFF
--- a/fichero-engine/tests/unit/test_locations.py
+++ b/fichero-engine/tests/unit/test_locations.py
@@ -26,3 +26,30 @@ def test_rejects_invalid_document_page_and_bbox(db):
         asyncio.run(resolve_location(Location(documentId="missing"), db))
     with pytest.raises(ValueError, match="bbox"):
         Location(documentId="x", bbox=[0, 0, 2, 1])
+
+
+@pytest.mark.parametrize("surface", list(LocationSurface))
+def test_location_preserves_valid_anchors_without_writes(db, surface):
+    doc = Document(name="source")
+    db.save(doc)
+    before = len(db.all(Document))
+    location = Location(
+        documentId=doc.id, bbox=[0.1, 0.2, 0.3, 0.4],
+        charRange={"start": 1, "end": 3}, claimId="claim", entityId="entity", surface=surface,
+    )
+    result = asyncio.run(resolve_location(location, db))
+    assert result.model_dump(by_alias=True)["resolvedDocumentId"] == doc.id
+    assert result.bbox == location.bbox and result.char_range.start == 1
+    assert len(db.all(Document)) == before
+
+
+def test_page_range_and_derived_child_are_sane(db):
+    parent = Document(name="parent")
+    page = Document(name="page", parent_id=parent.id, doc_type=DocType.page, sequence=1)
+    child = Document(name="crop", parent_id=parent.id, metadata={"derived_from": parent.id})
+    db.save(parent)
+    db.save(page)
+    db.save(child)
+    with pytest.raises(HTTPException, match="outside"):
+        asyncio.run(resolve_location(Location(documentId=parent.id, page=2), db))
+    assert asyncio.run(resolve_location(Location(documentId=child.id), db)).resolved_document_id == child.id


### PR DESCRIPTION
Cross-cutting tests for POST /api/locations/resolve + MCP reveal: unknown-doc, page-child→parent, bbox range, charRange, claim/entity-only anchors, all surface values, read-only assertion. test_locations 8 passed; broader location/mcp/reveal suite 194 passed. Test-only — no production bug found (nav path solid). 🤖 Claude (Opus 4.8)