### PR TITLE
Image editing UX: Inspector controls + edit mode overtakes Preview as canvas (#3593 c2/c3)

### DIFF
--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspector.swift
@@ -264,12 +264,17 @@ struct DocumentInspector: View {
 
     private static func availableTabs(for doc: Document?) -> [InspectorTab] {
         guard let doc else { return InspectorTab.allCases }
-        // Image Edits left the inspector for the dedicated editor / Reader canvas
-        // (#3434) — it is intentionally not a facet here.
         var tabs: [InspectorTab] = [
             .content, .artifacts, .annotations, .notes, .interpretations, .knowledgeGraph,
             .entities, .citations
         ]
+        // Image/page edit CONTROLS live in the Inspector, Lightroom-style (#3593,
+        // Daniel 2026-07-12 — this reverses #3434's "edits left the inspector":
+        // the controls belong here, the Preview is the live canvas). Only for the
+        // surfaces the editor supports (images and PDF/scanned pages).
+        if doc.fileType == .image || doc.fileType == .pdf || doc.docType == .page {
+            tabs.append(.edits)
+        }
         tabs.append(.info)
         return tabs
     }
@@ -375,6 +380,7 @@ private struct DocumentInspectorImageEditsTab: View {
     let document: Document
 
     @Environment(APIClient.self) private var apiClient
+    @Environment(StorageServiceGenerated.self) private var storageService
     @State private var model = ImageEditorModel()
 
     var body: some View {
@@ -410,6 +416,12 @@ private struct DocumentInspectorImageEditsTab: View {
         }
         .task(id: document.id) {
             await model.configure(apiClient: apiClient, documentId: document.id)
+            // Evict the storage-display cache after each edit so the Preview
+            // canvas re-fetches the edited bytes (#3593) — same hook the
+            // Preview-hosted editor uses (ImageEditorView).
+            model.onEditApplied = { [storageService] id in
+                storageService.invalidateImageCache(for: id)
+            }
         }
     }
 }

--- a/fichero/fichero/Views/Library/EditorView.swift
+++ b/fichero/fichero/Views/Library/EditorView.swift
@@ -14,11 +14,13 @@ struct EditorView: View {
     /// Current multi-file selection — drives batch-apply in the image editor (#1265).
     var selectedDocumentIDs: Set<String> = []
 
-    /// Whether the canvas is showing the editing surface (tools) rather than
-    /// the plain zoom/loupe preview. Off by default so chrome stays minimal
-    /// until the user opts into editing (#1453). Reset whenever the document
-    /// changes so a new selection always opens in view mode.
-    @State private var isEditing = false
+    /// Edit mode is the Inspector's "Edits" facet — the Lightroom "Develop
+    /// module" model (#3593, Daniel 2026-07-12): selecting it makes the Preview
+    /// the live editing canvas AND shows the controls in the Inspector, driven by
+    /// the one per-window `@SceneStorage` key the Inspector already owns. Reused
+    /// here (not a second state) so the two panes can never disagree. Persists
+    /// across documents, like Lightroom's Develop module, rather than resetting.
+    @SceneStorage("inspectorSelectedTab") private var inspectorSelectedTab: InspectorTab = .content
     @Environment(\.openURL) private var openURL
     @Environment(LibraryManager.self) private var libraryManager
     @Environment(WindowState.self) private var windowState
@@ -32,9 +34,22 @@ struct EditorView: View {
             }
         }
         .frame(minWidth: 300)
-        .onChange(of: document?.id) { _, _ in
-            isEditing = false
-        }
+    }
+
+    /// True when the Preview should present the editing canvas: the Inspector's
+    /// Edits facet is selected. Only meaningful for editable surfaces — the
+    /// preview route re-checks the document type before mounting the editor.
+    private var isEditing: Bool {
+        inspectorSelectedTab == .edits
+    }
+
+    /// The Preview's own edit toggle just flips the shared facet, so turning it
+    /// on shows the Inspector controls and turning it off leaves edit mode.
+    private var editModeBinding: Binding<Bool> {
+        Binding(
+            get: { inspectorSelectedTab == .edits },
+            set: { inspectorSelectedTab = $0 ? .edits : .content }
+        )
     }
 
     // MARK: - Document Preview
@@ -202,7 +217,7 @@ struct EditorView: View {
             DocumentCanvas(
                 content: .imageStorageDisplay(documentId: documentId),
                 onNavigateToDocument: supportsFolderNav ? onNavigateToDocument : nil,
-                isEditing: isImageEditable ? $isEditing : nil
+                isEditing: isImageEditable ? editModeBinding : nil
             )
         case .imageEditor:
             ImageEditorView(


### PR DESCRIPTION
Commit 2: image-edit controls exposed in the document Inspector (Lightroom-style — ImageEditChainPanel, already mounted at DocumentInspector.swift:388, now properly surfaced). Commit 3: entering edit mode overtakes the Preview pane as the live editing canvas (EditorView). Matches Daniel's model — controls in Inspector, Preview becomes the canvas. Reuses existing components (iterate-not-replace); backend chain stays source of truth. BUILD SUCCEEDED. 🤖 Claude (Opus 4.8)