### PR TITLE
Docs: document W3C annotation export endpoint (#3360)

### DIFF
--- a/docs/contributor/api-reference/index.md
+++ b/docs/contributor/api-reference/index.md
@@ -21,6 +21,16 @@ client and document the engine routes. In the current contract it includes route
 families for documents, search, workflows, workflow execution, annotations,
 providers, knowledge-graph endpoints, mind-palace endpoints, and more.
 
+## W3C annotation export
+
+`GET /api/documents/{doc_id}/annotations.jsonld`
+
+- Purpose: export a document's annotations as a W3C Web Annotation
+  `AnnotationPage`, including the JSON-LD context and annotation targets.
+- Path param: `doc_id` (required string), the source document id.
+- Response: `200` with the JSON-LD AnnotationPage object; missing documents
+  return `404`.
+
 ## Fold endpoints documented here
 
 The node-model fold shipped backend storage changes this session, but the API


### PR DESCRIPTION
Documents GET /api/documents/{doc_id}/annotations.jsonld (W3C Web Annotation AnnotationPage export) in the API reference, clearing the docs-coverage contract red. Docs-only; endpoint-coverage-matrix + docs-publication checks pass. 🤖 Claude (Opus 4.8)