### PR TITLE
Library drift: frontend reconciles open-library set with backend registry + on reconnect (#3393 frontend)

### DIFF
--- a/fichero/fichero-tests/LibraryManagerTests.swift
+++ b/fichero/fichero-tests/LibraryManagerTests.swift
@@ -52,6 +52,71 @@ final class LibraryManagerTests: XCTestCase {
         }
     }
 
+    // MARK: - Registry Reconciliation (#3393)
+
+    func testReconciliationOpensRegistryLibrariesMissingLocally() {
+        let global = LibraryManager.globalLibraryId
+        let plan = LibraryManager.registryReconciliation(
+            openLibraries: [(id: global, path: "/L/Global.fichero")],
+            registryPaths: ["/L/Global.fichero", "/L/A.fichero", "/L/B.fichero"],
+            globalLibraryId: global
+        )
+        XCTAssertEqual(plan.pathsToOpen, ["/L/A.fichero", "/L/B.fichero"],
+                       "registry libraries not open locally are opened")
+        XCTAssertTrue(plan.idsToDrop.isEmpty)
+    }
+
+    func testReconciliationDropsOpenLibrariesTheBackendClosed() {
+        let global = LibraryManager.globalLibraryId
+        let stale = UUID()
+        let plan = LibraryManager.registryReconciliation(
+            openLibraries: [(id: global, path: "/L/Global.fichero"),
+                            (id: stale, path: "/L/Closed.fichero")],
+            registryPaths: ["/L/Global.fichero"],
+            globalLibraryId: global
+        )
+        XCTAssertEqual(plan.idsToDrop, [stale], "a library absent from the registry is dropped")
+        XCTAssertTrue(plan.pathsToOpen.isEmpty)
+    }
+
+    func testReconciliationNeverDropsTheGlobalLibrary() {
+        let global = LibraryManager.globalLibraryId
+        let plan = LibraryManager.registryReconciliation(
+            openLibraries: [(id: global, path: "/L/Global.fichero")],
+            registryPaths: [],  // backend lists nothing
+            globalLibraryId: global
+        )
+        XCTAssertTrue(plan.idsToDrop.isEmpty, "Global is never dropped, even when absent from the registry")
+    }
+
+    func testReconciliationIsNoOpWhenInSync() {
+        let global = LibraryManager.globalLibraryId
+        let a = UUID()
+        let plan = LibraryManager.registryReconciliation(
+            openLibraries: [(id: global, path: "/L/Global.fichero"), (id: a, path: "/L/A.fichero")],
+            registryPaths: ["/L/Global.fichero", "/L/A.fichero"],
+            globalLibraryId: global
+        )
+        XCTAssertTrue(plan.pathsToOpen.isEmpty)
+        XCTAssertTrue(plan.idsToDrop.isEmpty)
+    }
+
+    func testReconciliationComparesPathsNFCNormalized() {
+        // Same library, one side NFD (decomposed "é"), the other NFC — must match,
+        // so a Unicode-normalization mismatch never double-opens or false-drops.
+        let global = LibraryManager.globalLibraryId
+        let a = UUID()
+        let nfd = "/L/Cafe\u{0301}.fichero"   // e + combining acute
+        let nfc = "/L/Caf\u{00E9}.fichero"    // é precomposed
+        let plan = LibraryManager.registryReconciliation(
+            openLibraries: [(id: a, path: nfd)],
+            registryPaths: [nfc],
+            globalLibraryId: global
+        )
+        XCTAssertTrue(plan.pathsToOpen.isEmpty, "NFD-open vs NFC-registry is the same library")
+        XCTAssertTrue(plan.idsToDrop.isEmpty)
+    }
+
     // MARK: - Library Creation Tests
 
     func testCreateNewLibrary() async throws {

--- a/fichero/fichero/Models/LibraryManager+Helpers.swift
+++ b/fichero/fichero/Models/LibraryManager+Helpers.swift
@@ -45,7 +45,65 @@ extension LibraryManager {
     func refreshAfterBackendBecameReady() async {
         await KnownLibraryRegistryStore.shared.refresh()
         adoptPairedRemoteLibrary()
+        reconcileOpenLibrariesFromRegistry()
         await backendDidBecomeReady()
+    }
+
+    /// The open set the app shows must MIRROR the backend registry — the set of
+    /// libraries the engine actually has open (#3393). Local UserDefaults restore
+    /// alone drifts: the backend can hold a dozen open while the sidebar shows two
+    /// (or shows one the backend already closed). Reconcile against the registry
+    /// the store just fetched: open any registry library not yet open, and drop
+    /// any open (non-Global) library the backend no longer lists.
+    ///
+    /// Local embedded backend only. For a remote host the registry is
+    /// recents/known, NOT the set open for remote use (see
+    /// `adoptPairedRemoteLibrary`), so remote reconciliation would over-open.
+    func reconcileOpenLibrariesFromRegistry() {
+        guard !EngineConfig.requiresExternalBackendConnection else { return }
+
+        let registryPaths = KnownLibraryRegistryStore.shared.libraries.map(\.path)
+        // A failed / empty registry fetch must never clear the sidebar — only
+        // reconcile when the backend actually reported an open set.
+        guard !registryPaths.isEmpty else { return }
+
+        let plan = Self.registryReconciliation(
+            openLibraries: openLibraries.map { (id: $0.id, path: $0.url.path) },
+            registryPaths: registryPaths,
+            globalLibraryId: Self.globalLibraryId
+        )
+
+        for path in plan.pathsToOpen {
+            let url = URL(fileURLWithPath: path)
+            // Skip registry entries whose package is gone from disk — opening a
+            // missing package would just fail; the backend row is stale.
+            guard FileManager.default.fileExists(atPath: url.path) else { continue }
+            _ = openLibrary(at: url, makeCurrent: false)
+        }
+        for id in plan.idsToDrop {
+            // Local drop only — the backend already closed it (it's absent from
+            // the registry), so no backend DELETE, unlike closeAndUnregisterLibrary.
+            closeLibrary(id)
+        }
+    }
+
+    /// Pure set-diff between the app's open libraries and the backend registry
+    /// (#3393). Extracted so the reconciliation logic is unit-testable without
+    /// LibraryReference / FileManager / network side effects. Paths are compared
+    /// NFC-normalized (backend keys the registry NFC, #3071/#3076).
+    static func registryReconciliation(
+        openLibraries: [(id: UUID, path: String)],
+        registryPaths: [String],
+        globalLibraryId: UUID
+    ) -> (pathsToOpen: [String], idsToDrop: [UUID]) {
+        let registrySet = Set(registryPaths.map(\.nfcNormalized))
+        let openSet = Set(openLibraries.map { $0.path.nfcNormalized })
+
+        let pathsToOpen = registryPaths.filter { !openSet.contains($0.nfcNormalized) }
+        let idsToDrop = openLibraries
+            .filter { $0.id != globalLibraryId && !registrySet.contains($0.path.nfcNormalized) }
+            .map(\.id)
+        return (pathsToOpen, idsToDrop)
     }
 
     func reconfigureGeneratedClientsForCurrentHost() {

--- a/fichero/fichero/Views/Shell/DocumentTabView.swift
+++ b/fichero/fichero/Views/Shell/DocumentTabView.swift
@@ -244,6 +244,11 @@ struct DocumentTabView: View {
     private func completeBackendRetryReadiness() async {
         appState.startBackendHeartbeat()
         await KnownLibraryRegistryStore.shared.refresh()
+        // Reconnect after the engine was down: the backend's open set may have
+        // changed (restarted, libraries closed elsewhere), so mirror it into the
+        // sidebar just like the cold-launch path (#3393). Must run after refresh()
+        // and before backendDidBecomeReady() loads each open library's data.
+        libraryManager.reconcileOpenLibrariesFromRegistry()
         await libraryManager.backendDidBecomeReady()
     }
 }


### PR DESCRIPTION
Frontend half of #3393 (engine half already merged): LibraryManager reconciles the frontend open-library set against the backend registry (no drift), and re-reconciles on backend retry/reconnect. Adds LibraryManagerTests. BUILD SUCCEEDED. Completes #3393 (both halves). 🤖 Claude (Opus 4.8)