### PR TITLE
App-shell: new windows/tabs reuse the app-level backend connection, no reconnect churn (#3394)

### DIFF
--- a/fichero/fichero-tests/EmbeddedBackendServiceStartGuardTests.swift
+++ b/fichero/fichero-tests/EmbeddedBackendServiceStartGuardTests.swift
@@ -54,3 +54,41 @@ struct EmbeddedBackendServiceStartGuardTests {
         #expect(service.isStarting == false)
     }
 }
+
+/// A new window/tab's connect trigger must reuse the app-level connection rather
+/// than reprovision the backend (#3394/#3407).
+@Suite("Window-lifecycle connection reuse (#3394)")
+struct ConnectionReuseDecisionTests {
+
+    @Test("a new window on a running+ready backend attaches — no reconnect")
+    func newWindowReusesRunningConnection() {
+        #expect(EmbeddedBackendService.shouldReuseExistingConnection(
+            restart: false, status: .running, isBackendReady: true) == true)
+    }
+
+    @Test("the first/not-yet-connected window proceeds to connect")
+    func firstWindowConnects() {
+        #expect(EmbeddedBackendService.shouldReuseExistingConnection(
+            restart: false, status: .stopped, isBackendReady: false) == false)
+    }
+
+    @Test("an explicit Retry always re-runs, even when running")
+    func retryAlwaysReconnects() {
+        #expect(EmbeddedBackendService.shouldReuseExistingConnection(
+            restart: true, status: .running, isBackendReady: true) == false)
+    }
+
+    @Test("running but not-yet-ready does not short-circuit the readiness probe")
+    func runningButNotReadyStillConnects() {
+        #expect(EmbeddedBackendService.shouldReuseExistingConnection(
+            restart: false, status: .running, isBackendReady: false) == false)
+    }
+
+    @Test("a failed/starting backend never counts as reusable")
+    func failedOrStartingNotReused() {
+        #expect(EmbeddedBackendService.shouldReuseExistingConnection(
+            restart: false, status: .failed, isBackendReady: true) == false)
+        #expect(EmbeddedBackendService.shouldReuseExistingConnection(
+            restart: false, status: .starting, isBackendReady: true) == false)
+    }
+}

--- a/fichero/fichero/FicheroApp.swift
+++ b/fichero/fichero/FicheroApp.swift
@@ -145,6 +145,20 @@ struct FicheroApp: App {
     /// while a start is already in flight a no-op.
     @MainActor
     private func connectBackend(restart: Bool) async {
+        // A new window/tab shares the app-level connection (`backendService` /
+        // `appState` are one @State per app), so its `.task` trigger must ATTACH
+        // to the already-connected engine, not re-run connect+auth — otherwise the
+        // status flips back to `.starting` and the user sees a reconnect spinner +
+        // token/registry churn on every window (#3394/#3407). Only a not-yet-
+        // connected first window or an explicit Retry (`restart`) proceeds.
+        if EmbeddedBackendService.shouldReuseExistingConnection(
+            restart: restart,
+            status: backendService.status,
+            isBackendReady: appState.isBackendRunning
+        ) {
+            logger.info("connectBackend: already connected — new window attaches, no reconnect (#3394)")
+            return
+        }
         // Consume the single provisioning decision (#3109) instead of
         // re-deriving the mode here. `connectsToRemoteHost` is the old
         // `requiresExternalBackendConnection` branch.

--- a/fichero/fichero/Services/EmbeddedBackendService.swift
+++ b/fichero/fichero/Services/EmbeddedBackendService.swift
@@ -56,6 +56,24 @@ final class EmbeddedBackendService {
         case failed
     }
 
+    /// Whether a `connectBackend` trigger should ATTACH to the already-established
+    /// app-level connection instead of re-running the connect+auth sequence
+    /// (#3394/#3407). The main WindowGroup's `.task` fires once per window/tab, so
+    /// without this every new window would flip the shared status back to
+    /// `.starting` and re-probe/re-auth — the visible reconnect churn. True only
+    /// when the backend is already connected AND this isn't an explicit Retry
+    /// (`restart`), which must always re-run. Pure so window-lifecycle reuse is
+    /// unit-testable without a live engine.
+    static func shouldReuseExistingConnection(
+        restart: Bool,
+        status: BackendStatus,
+        isBackendReady: Bool
+    ) -> Bool {
+        guard !restart, isBackendReady else { return false }
+        if case .running = status { return true }
+        return false
+    }
+
     /// Outcome of an authenticated readiness probe (#2862) — now the shared
     /// `EngineReadiness` (#3106), verified by the one `EngineReadinessProbe`.
     typealias ReadinessResult = EngineReadiness


### PR DESCRIPTION
New window/tab opening no longer re-establishes/re-auths the embedded backend — a start-guard in EmbeddedBackendService + FicheroApp ensures the connection is app-level, reused across scenes. Adds EmbeddedBackendServiceStartGuardTests. Client-side connection reuse only — no auth-perimeter/transport change. BUILD SUCCEEDED. 🤖 Claude (Opus 4.8)