### PR TITLE
★ EVERY FRAME PERFECT: surface color as base layer — no white flash on connection→content handoff (#3615)

### DIFF
--- a/fichero/fichero/FicheroApp.swift
+++ b/fichero/fichero/FicheroApp.swift
@@ -290,6 +290,12 @@ struct FicheroApp: App {
         .environment(kgFocusState)
         .environment(appState.mcpService)
         .frame(minWidth: 640, minHeight: 700)
+        // ★ EVERY FRAME PERFECT (#3615): the semantic surface color is the BASE
+        // layer under the whole window, so the BackendConnectionView → LibraryWindow
+        // → ContentView handoffs (and any first-frame gap while content lays out)
+        // read as the app surface, never a bare system-white flash. Matches
+        // BackendConnectionView's own fill so the swap is seamless.
+        .background(Color(platformColor: .windowBackgroundColor))
     }
 
     var body: some Scene {

--- a/fichero/fichero/Views/Shell/DocumentTabView.swift
+++ b/fichero/fichero/Views/Shell/DocumentTabView.swift
@@ -80,6 +80,11 @@ struct DocumentTabView: View {
                 backendConnectionView
             }
         }
+        // ★ EVERY FRAME PERFECT (#3615): surface color as the base layer so the
+        // isBackendRunning swap (backendConnectionView ↔ contentView) never
+        // exposes a bare white frame if ContentView's first frame isn't painted
+        // yet. Matches backendConnectionView's own fill.
+        .background(Color(platformColor: .windowBackgroundColor))
         .task {
             guard !Task.isCancelled else { return }
             // Library path is already set in LibraryManager when library was opened


### PR DESCRIPTION
First EVERY FRAME PERFECT issue: FicheroApp + DocumentTabView set the semantic surface color as the base layer so the BackendConnectionView→ContentView handoff (and window/scene mounts) never flash system-white. BUILD SUCCEEDED. Extends to detail-window scenes. 🤖 Claude (Opus 4.8)