### PR TITLE
Fix spurious Reconnect prompt: a clean SSE stream end is not a failure (#3351)

### DIFF
--- a/fichero/fichero-tests/LibraryChangeStreamTransportTests.swift
+++ b/fichero/fichero-tests/LibraryChangeStreamTransportTests.swift
@@ -200,4 +200,29 @@ struct LibraryChangeStreamTransportTests {
         #expect(LibraryChangeStream.shouldSurfaceUnavailable(failureCount: 1) == false)
         #expect(LibraryChangeStream.shouldSurfaceUnavailable(failureCount: 2) == true)
     }
+
+    // MARK: - No spurious reconnect prompt (#3351)
+
+    @Test("engine reachable: a healthy stream leaves the reconnect pill hidden")
+    func reachableEngineHidesPausedPill() async throws {
+        // A reachable engine returns 200 and streams a frame, then the stub's
+        // finite frame list ends the connection cleanly (a server-side rotation).
+        // The reconnect pill must NOT be shown — that clean end is not a failure.
+        let stream = makeStream(frames: [dataFrame(type: "entity.updated")])
+        #expect(stream.liveUpdatesUnavailable == false, "starts hidden")
+
+        try await stream.subscribeOnce(resyncOnConnect: false)
+
+        #expect(stream.isConnected, "reachable → connected during the stream")
+        #expect(stream.liveUpdatesUnavailable == false,
+                "reachable engine must never surface a Reconnect prompt (#3351)")
+    }
+
+    @Test("a single dropped cycle does not surface the pill (transient settles)")
+    func singleTransientDoesNotSurface() {
+        // The two-strike debounce: one miss self-heals on the next backoff tick
+        // and stays invisible. Before #3351 a clean end pre-incremented the count,
+        // so a lone transient could hit the threshold; now only genuine errors do.
+        #expect(LibraryChangeStream.shouldSurfaceUnavailable(failureCount: 1) == false)
+    }
 }

--- a/fichero/fichero/Services/ActivityStreamService.swift
+++ b/fichero/fichero/Services/ActivityStreamService.swift
@@ -64,7 +64,6 @@ final class ActivityStreamService {
         var backoffNanos: UInt64 = 1_000_000_000
         var consecutiveUnavailableCycles = 0
         while !Task.isCancelled {
-            var cycleEndedWithError = false
             do {
                 try await subscribeOnce(onEvent: onEvent)
                 consecutiveUnavailableCycles = 0
@@ -80,7 +79,6 @@ final class ActivityStreamService {
                 return
             } catch {
                 if !Task.isCancelled {
-                    cycleEndedWithError = true
                     log.error("activity stream dropped: \(error.localizedDescription, privacy: .public)")
                     consecutiveUnavailableCycles += 1
                     liveUpdatesUnavailable = Self.shouldSurfaceUnavailable(
@@ -89,12 +87,12 @@ final class ActivityStreamService {
                 }
             }
             if Task.isCancelled { break }
-            if !cycleEndedWithError {
-                consecutiveUnavailableCycles += 1
-                liveUpdatesUnavailable = Self.shouldSurfaceUnavailable(
-                    failureCount: consecutiveUnavailableCycles
-                )
-            }
+            // A CLEAN end (subscribeOnce returned without throwing) is a healthy
+            // server-side connection rotation, NOT a failure (#3351): the loop
+            // reconnects next tick and `liveUpdatesUnavailable` was cleared on
+            // connect. Counting it made a normal rotation + one transient error
+            // surface the reconnect pill prematurely (spurious "Reconnect" while
+            // healthy). Only genuine errors (the catch above) count.
             try? await Task.sleep(nanoseconds: backoffNanos)
             backoffNanos = min(backoffNanos * 2, 30_000_000_000)
         }

--- a/fichero/fichero/Services/LibraryChangeStream.swift
+++ b/fichero/fichero/Services/LibraryChangeStream.swift
@@ -261,7 +261,6 @@ final class LibraryChangeStream {
         var hasConnectedBefore = false
         var consecutiveUnavailableCycles = 0
         while !Task.isCancelled {
-            var cycleEndedWithError = false
             do {
                 try await subscribeOnce(resyncOnConnect: hasConnectedBefore)
                 hasConnectedBefore = true
@@ -279,7 +278,6 @@ final class LibraryChangeStream {
                 return
             } catch {
                 if !Task.isCancelled {
-                    cycleEndedWithError = true
                     // ponytail: require a second consecutive miss before surfacing
                     // the paused pill; one dropped cycle often self-heals on the
                     // next backoff tick and should stay invisible to the user.
@@ -293,12 +291,13 @@ final class LibraryChangeStream {
                 }
             }
             isConnected = false
-            if !Task.isCancelled, !cycleEndedWithError {
-                consecutiveUnavailableCycles += 1
-                liveUpdatesUnavailable = Self.shouldSurfaceUnavailable(
-                    failureCount: consecutiveUnavailableCycles
-                )
-            }
+            // A CLEAN end (subscribeOnce returned without throwing) is a healthy
+            // server-side connection rotation, NOT a failure (#3351): the loop
+            // reconnects on the next tick, and `liveUpdatesUnavailable` was already
+            // cleared to false on connect. Counting it as an unavailable cycle made
+            // a normal rotation followed by a single transient error surface the
+            // reconnect pill prematurely — the spurious "Reconnect" prompt while the
+            // backend is healthy. Only genuine errors (the catch above) count.
             if Task.isCancelled { break }
             try? await Task.sleep(nanoseconds: backoffNanos)
             backoffNanos = Self.nextBackoffNanos(after: backoffNanos)


### PR DESCRIPTION
Root cause: a clean end of the library change-stream / activity SSE was treated as a connection failure, firing the Reconnect prompt while the backend was healthy. LibraryChangeStream + ActivityStreamService now distinguish a clean stream end from a real failure. Adds LibraryChangeStreamTransportTests. Also an EVERY-FRAME-PERFECT consistency fix (#3618) — no false 'Reconnecting' state. BUILD SUCCEEDED. 🤖 Claude (Opus 4.8)