### PR TITLE
Engine: live backend library-handle inventory endpoint (#3413 complete)

### DIFF
--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -12348,6 +12348,28 @@
         }
       }
     },
+    "/api/registry/open": {
+      "get": {
+        "tags": [
+          "library"
+        ],
+        "summary": "List Open Libraries",
+        "description": "List the library connections currently open in the backend.\n\nUnlike ``GET /registry``, this is not persisted state: it is a lock-safe\nsnapshot of the handles currently held by ``DatabaseManager``.",
+        "operationId": "list_open_libraries_api_registry_open_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenLibraryHandlesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/registry/unicode-collisions": {
       "get": {
         "tags": [
@@ -52023,6 +52045,52 @@
           "success"
         ],
         "title": "OpenItemResponse"
+      },
+      "OpenLibraryHandle": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "is_open": {
+            "type": "boolean",
+            "title": "Is Open",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "path"
+        ],
+        "title": "OpenLibraryHandle",
+        "description": "A live package connection owned by the backend database manager."
+      },
+      "OpenLibraryHandlesResponse": {
+        "properties": {
+          "libraries": {
+            "items": {
+              "$ref": "#/components/schemas/OpenLibraryHandle"
+            },
+            "type": "array",
+            "title": "Libraries"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "libraries",
+          "count"
+        ],
+        "title": "OpenLibraryHandlesResponse",
+        "description": "Response from GET /api/registry/open \u2014 live backend library handles."
       },
       "OrphanCleanupResponse": {
         "properties": {

--- a/fichero-engine/src/fichero/api/routes/library_registry.py
+++ b/fichero-engine/src/fichero/api/routes/library_registry.py
@@ -11,6 +11,7 @@ and these endpoints do NOT require an ``X-Fichero-Library-Path`` header.
 
 Endpoints:
   GET /api/registry                 — List all known libraries
+  GET /api/registry/open            — List live backend library handles
   POST /api/registry/add            — Add a library path to registry
   POST /api/registry/update-access  — Mark library as accessed (for sorting)
   DELETE /api/registry/{path}       — Remove from registry (idempotent)
@@ -43,6 +44,8 @@ from fichero.models import (
     Document,
     KnownLibrary,
     LibraryRegistryResponse,
+    OpenLibraryHandle,
+    OpenLibraryHandlesResponse,
     UnicodeLibraryCollision,
     UnicodeLibraryCollisionIdentity,
     UnicodeLibraryCollisionResponse,
@@ -884,6 +887,20 @@ def list_known_libraries(
     except Exception as e:
         logger.error("Failed to list known libraries: %s", e)
         raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+@router.get("/registry/open", response_model=OpenLibraryHandlesResponse)
+def list_open_libraries() -> OpenLibraryHandlesResponse:
+    """List the library connections currently open in the backend.
+
+    Unlike ``GET /registry``, this is not persisted state: it is a lock-safe
+    snapshot of the handles currently held by ``DatabaseManager``.
+    """
+    libraries = [
+        OpenLibraryHandle(id=path, path=path)
+        for path in db_manager.open_library_paths()
+    ]
+    return OpenLibraryHandlesResponse(libraries=libraries, count=len(libraries))
 
 
 @router.get("/registry/unicode-collisions", response_model=UnicodeLibraryCollisionResponse)

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -10926,6 +10926,17 @@ def register_generated_openapi_commands(
             return client.request("POST", endpoint_path, params=params)
         invoke(ctx, op_call)
 
+    @target_app.command("list-open-libraries")
+    def registry_list_open_libraries_get(
+        ctx: typer.Context,
+    ) -> None:
+        """List Open Libraries (GET /api/registry/open)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/registry/open"
+            params = None
+            return client.request("GET", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
     @target_app.command("list-unicode-library-collisions")
     def registry_list_unicode_library_collisions_get(
         ctx: typer.Context,

--- a/fichero-engine/src/fichero/db_manager.py
+++ b/fichero-engine/src/fichero/db_manager.py
@@ -182,6 +182,11 @@ class DatabaseManager:
         """Number of packages with an open shared connection."""
         return len(self._databases)
 
+    def open_library_paths(self) -> list[str]:
+        """Return a stable snapshot of package paths with live connections."""
+        with self._lock:
+            return sorted(self._databases)
+
     def close_all(self):
         """Close every package's shared connection."""
         with self._lock:

--- a/fichero-engine/src/fichero/models.py
+++ b/fichero-engine/src/fichero/models.py
@@ -1679,6 +1679,22 @@ class LibraryRegistryResponse(BaseModel):
     count: int
 
 
+class OpenLibraryHandle(BaseModel):
+    """A live package connection owned by the backend database manager."""
+
+    # The manager cache key is the only stable identity for a live handle.
+    id: str
+    path: str
+    is_open: bool = True
+
+
+class OpenLibraryHandlesResponse(BaseModel):
+    """Response from GET /api/registry/open — live backend library handles."""
+
+    libraries: list[OpenLibraryHandle]
+    count: int
+
+
 class UnicodeLibraryCollisionIdentity(BaseModel):
     """One side of a Unicode-equivalent library collision."""
 
@@ -2217,6 +2233,8 @@ __all__ = [
     # Known library registry (#1131)
     "KnownLibrary",
     "LibraryRegistryResponse",
+    "OpenLibraryHandle",
+    "OpenLibraryHandlesResponse",
     "UnicodeLibraryCollisionIdentity",
     "UnicodeLibraryCollision",
     "UnicodeLibraryCollisionResponse",

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -7586,6 +7586,16 @@
       },
       {
         "method": "GET",
+        "path": "/registry/open",
+        "operation_id": "list_open_libraries_api_registry_open_get",
+        "summary": "List Open Libraries",
+        "path_params": [],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "OpenLibraryHandlesResponse"
+      },
+      {
+        "method": "GET",
         "path": "/registry/unicode-collisions",
         "operation_id": "list_unicode_library_collisions_api_registry_unicode_collisions_get",
         "summary": "List Unicode Library Collisions",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -12348,6 +12348,28 @@
         }
       }
     },
+    "/api/registry/open": {
+      "get": {
+        "tags": [
+          "library"
+        ],
+        "summary": "List Open Libraries",
+        "description": "List the library connections currently open in the backend.\n\nUnlike ``GET /registry``, this is not persisted state: it is a lock-safe\nsnapshot of the handles currently held by ``DatabaseManager``.",
+        "operationId": "list_open_libraries_api_registry_open_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenLibraryHandlesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/registry/unicode-collisions": {
       "get": {
         "tags": [
@@ -52023,6 +52045,52 @@
           "success"
         ],
         "title": "OpenItemResponse"
+      },
+      "OpenLibraryHandle": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "is_open": {
+            "type": "boolean",
+            "title": "Is Open",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "path"
+        ],
+        "title": "OpenLibraryHandle",
+        "description": "A live package connection owned by the backend database manager."
+      },
+      "OpenLibraryHandlesResponse": {
+        "properties": {
+          "libraries": {
+            "items": {
+              "$ref": "#/components/schemas/OpenLibraryHandle"
+            },
+            "type": "array",
+            "title": "Libraries"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "libraries",
+          "count"
+        ],
+        "title": "OpenLibraryHandlesResponse",
+        "description": "Response from GET /api/registry/open \u2014 live backend library handles."
       },
       "OrphanCleanupResponse": {
         "properties": {

--- a/fichero-engine/tests/unit/test_library_registry.py
+++ b/fichero-engine/tests/unit/test_library_registry.py
@@ -237,6 +237,35 @@ class TestGlobalRegistryHeaderless:
         assert body["count"] == 0
         assert body["libraries"] == []
 
+    def test_open_inventory_reflects_live_manager_handles(self, global_client, tmp_path):
+        """Live inventory reports handles opened outside persisted registry flows."""
+        from fichero.db_manager import db_manager
+
+        library_path = (tmp_path / "OutsideRegistry.fichero").resolve()
+        library_path.mkdir()
+        db_manager.get_database(library_path)
+        try:
+            listed = global_client.get("/api/registry/open")
+            assert listed.status_code == 200, listed.text
+            body = listed.json()
+            assert body["count"] == len(db_manager.open_library_paths())
+            assert {library["path"] for library in body["libraries"]} == set(
+                db_manager.open_library_paths()
+            )
+            assert {
+                "id": str(library_path),
+                "path": str(library_path),
+                "is_open": True,
+            } in body["libraries"]
+
+            db_manager.close_database(library_path)
+            closed = global_client.get("/api/registry/open")
+            assert str(library_path) not in {
+                library["path"] for library in closed.json()["libraries"]
+            }
+        finally:
+            db_manager.close_database(library_path)
+
     def test_add_then_list_no_header(self, global_client, tmp_path):
         """POST /api/registry/add + GET /api/registry, no header."""
         lib_path = tmp_path / "Headerless.fichero"
@@ -277,7 +306,6 @@ class TestGlobalRegistryHeaderless:
         lib_path = tmp_path / unicodedata.normalize("NFC", "Chocó.fichero")
         lib_path.mkdir(parents=True, exist_ok=True)
         global_client.post("/api/registry/add", params={"path": str(lib_path)})
-        from fichero.db_manager import db_manager
         db_manager.get_database(lib_path)
 
         db_manager.close_database(str(lib_path))

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -12348,6 +12348,28 @@
         }
       }
     },
+    "/api/registry/open": {
+      "get": {
+        "tags": [
+          "library"
+        ],
+        "summary": "List Open Libraries",
+        "description": "List the library connections currently open in the backend.\n\nUnlike ``GET /registry``, this is not persisted state: it is a lock-safe\nsnapshot of the handles currently held by ``DatabaseManager``.",
+        "operationId": "list_open_libraries_api_registry_open_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OpenLibraryHandlesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/registry/unicode-collisions": {
       "get": {
         "tags": [
@@ -52023,6 +52045,52 @@
           "success"
         ],
         "title": "OpenItemResponse"
+      },
+      "OpenLibraryHandle": {
+        "properties": {
+          "id": {
+            "type": "string",
+            "title": "Id"
+          },
+          "path": {
+            "type": "string",
+            "title": "Path"
+          },
+          "is_open": {
+            "type": "boolean",
+            "title": "Is Open",
+            "default": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "id",
+          "path"
+        ],
+        "title": "OpenLibraryHandle",
+        "description": "A live package connection owned by the backend database manager."
+      },
+      "OpenLibraryHandlesResponse": {
+        "properties": {
+          "libraries": {
+            "items": {
+              "$ref": "#/components/schemas/OpenLibraryHandle"
+            },
+            "type": "array",
+            "title": "Libraries"
+          },
+          "count": {
+            "type": "integer",
+            "title": "Count"
+          }
+        },
+        "type": "object",
+        "required": [
+          "libraries",
+          "count"
+        ],
+        "title": "OpenLibraryHandlesResponse",
+        "description": "Response from GET /api/registry/open \u2014 live backend library handles."
       },
       "OrphanCleanupResponse": {
         "properties": {


### PR DESCRIPTION
New endpoint lists db_manager's LIVE open handles (distinct from the persisted /api/registry), so the frontend can reconcile against actually-open libraries — closes the #3413 sliver codex triaged. OpenAPI regen ×3 synced; regenerated Swift client compiles (build green). test_library_registry 27 passed; broader library/registry/db_manager 360 passed. 🤖 Claude (Opus 4.8)