### PR TITLE
★ EVERY FRAME PERFECT: sized skeletons + cross-fade for image/PDF/thumbnail loads (#3616)

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -403,6 +403,7 @@
 		A1BFB2EC2F043F4500EAA55A /* FicheroDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2E92F043F4500EAA55A /* FicheroDocument.swift */; };
 		A1BFB2F02F043FA100EAA55A /* BackendConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2EF2F043FA100EAA55A /* BackendConnectionView.swift */; };
 		A1BFB2F32F045C8A00EAA55A /* LibraryImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2F22F045C8A00EAA55A /* LibraryImageView.swift */; };
+		SKEL00012F045C8A00EAA55A /* SkeletonPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = SKEL00022F045C8A00EAA55A /* SkeletonPlaceholder.swift */; };
 		A1BFB4032F057B9300EAA55A /* QuickLookComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB3FF2F057B9300EAA55A /* QuickLookComponents.swift */; };
 		A1BFB4052F057B9300EAA55A /* FolderAccessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB3FB2F057B9300EAA55A /* FolderAccessManager.swift */; };
 		A1BFB4092F057BAC00EAA55A /* ViewMenuCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4082F057BAC00EAA55A /* ViewMenuCommands.swift */; };
@@ -1019,6 +1020,7 @@
 		A1BFB2EA2F043F4500EAA55A /* ViewContexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewContexts.swift; sourceTree = "<group>"; };
 		A1BFB2EF2F043FA100EAA55A /* BackendConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendConnectionView.swift; sourceTree = "<group>"; };
 		A1BFB2F22F045C8A00EAA55A /* LibraryImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryImageView.swift; sourceTree = "<group>"; };
+		SKEL00022F045C8A00EAA55A /* SkeletonPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonPlaceholder.swift; sourceTree = "<group>"; };
 		A1BFB3FB2F057B9300EAA55A /* FolderAccessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderAccessManager.swift; sourceTree = "<group>"; };
 		A1BFB3FF2F057B9300EAA55A /* QuickLookComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookComponents.swift; sourceTree = "<group>"; };
 		A1BFB4082F057BAC00EAA55A /* ViewMenuCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMenuCommands.swift; sourceTree = "<group>"; };
@@ -1971,6 +1973,7 @@
 				A1BFB2EF2F043FA100EAA55A /* BackendConnectionView.swift */,
 				A3CD4902A47A5787D61C6D72 /* FlowLayout.swift */,
 				A1BFB2F22F045C8A00EAA55A /* LibraryImageView.swift */,
+				SKEL00022F045C8A00EAA55A /* SkeletonPlaceholder.swift */,
 				A1BFB2D42F042C6D00EAA55A /* ProviderLogoView.swift */,
 				A1BFB2D52F042C6D00EAA55A /* StatusBadge.swift */,
 				A1BFB4F12F30000100EAA55A /* MacPlainTextEditor.swift */,
@@ -2664,6 +2667,7 @@
 				841 /* ErrorModel.swift in Sources */,
 				A1BFB4612F0AADC000EAA55A /* LayoutMode.swift in Sources */,
 				A1BFB2F32F045C8A00EAA55A /* LibraryImageView.swift in Sources */,
+				SKEL00012F045C8A00EAA55A /* SkeletonPlaceholder.swift in Sources */,
 				202674952F475B1D008EAB5D /* NodeConfigView.swift in Sources */,
 				202674D22F478A13008EAB5D /* LibraryView+DisplayModes.swift in Sources */,
 				AA112233001122AA /* LibraryView+Sorting.swift in Sources */,

--- a/fichero/fichero/Views/Components/LibraryImageView.swift
+++ b/fichero/fichero/Views/Components/LibraryImageView.swift
@@ -33,16 +33,19 @@ struct LibraryImageView: View {
             if let image = image {
                 image
                     .resizable()
-            } else if isLoading {
-                ProgressView()
-                    .scaleEffect(0.6)
             } else if loadError != nil {
                 Image(systemName: "photo")
                     .foregroundColor(.secondary)
             } else {
-                Color.clear
+                // ★ EVERY FRAME PERFECT (#3616): a sized skeleton at the surface
+                // color instead of a bare centered spinner, filling the reserved
+                // cell so the thumbnail cross-fades in (below) with no pop.
+                SkeletonPlaceholder()
             }
         }
+        // Cross-fade the branch swap: the skeleton fades out as the loaded image
+        // fades in, keyed to image presence (feeds #3619's precise transitions).
+        .animation(.easeOut(duration: 0.25), value: image == nil)
         .task(id: loadKey) {
             guard !Task.isCancelled else { return }
             await loadImage(for: loadKey)

--- a/fichero/fichero/Views/Components/SkeletonPlaceholder.swift
+++ b/fichero/fichero/Views/Components/SkeletonPlaceholder.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+
+/// ★ EVERY FRAME PERFECT (#3616): a stable, correctly-sized placeholder shown
+/// while content loads, instead of a bare spinner or a blank frame. It fills the
+/// space the real content will occupy (the caller reserves the size), so the
+/// image/thumbnail cross-fades in with no relayout or popping.
+///
+/// A subtle surface-color rectangle with a gentle breathing highlight — enough
+/// to read as "loading" without a spinner. Respects Reduce Motion (static fill).
+/// Cross-platform via the shared `platformColor` shim.
+struct SkeletonPlaceholder: View {
+    /// Matches the corner radius of the container it fills (e.g. a thumbnail tile).
+    var cornerRadius: CGFloat = 0
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var pulse = false
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: cornerRadius)
+            .fill(Color(platformColor: .windowBackgroundColor))
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .fill(Color.primary.opacity(pulse ? 0.08 : 0.03))
+            )
+            .onAppear {
+                guard !reduceMotion else { return }
+                withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                    pulse = true
+                }
+            }
+            // Decorative — the surrounding surface already conveys "loading" to
+            // assistive tech via its own state; a shimmer rect adds no meaning.
+            .accessibilityHidden(true)
+    }
+}
+
+#Preview("Skeleton — tile") {
+    SkeletonPlaceholder(cornerRadius: 6)
+        .frame(width: 100, height: 133)
+        .padding()
+}

--- a/fichero/fichero/Views/Library/DocumentCanvas.swift
+++ b/fichero/fichero/Views/Library/DocumentCanvas.swift
@@ -116,11 +116,15 @@ private struct StorageDisplayImageCanvas: View {
                     Button("Retry") { Task { await loadImage() } }
                 }
             } else {
-                ProgressView()
-                    .controlSize(.small)
+                // ★ EVERY FRAME PERFECT (#3616): a sized skeleton filling the
+                // reserved pane instead of a bare spinner, so the image/PDF page
+                // cross-fades in (below) with no blank frame or pop.
+                SkeletonPlaceholder()
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        // Cross-fade the branch swap as the loaded image replaces the skeleton.
+        .animation(.easeOut(duration: 0.25), value: image == nil)
         .task(id: documentId) { await loadImage() }
     }
 

--- a/fichero/fichero/Views/Library/Reading/PDFThumbnailView.swift
+++ b/fichero/fichero/Views/Library/Reading/PDFThumbnailView.swift
@@ -28,12 +28,13 @@ struct PDFThumbnailView: View {
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                 } else {
-                    // Placeholder while rendering.
-                    Image(systemName: "doc.richtext")
-                        .font(.system(size: min(size.width, size.height) * 0.35))
-                        .foregroundStyle(.secondary)
+                    // ★ EVERY FRAME PERFECT (#3616): a sized skeleton at the
+                    // surface color instead of a bare icon while PDFKit renders,
+                    // cross-fading to the page image below (ties #3210).
+                    SkeletonPlaceholder(cornerRadius: 4)
                 }
             }
+            .animation(.easeOut(duration: 0.25), value: image == nil)
             // Multi-page badge (#946) — paper-stack icon + page count
             // sitting bottom-right, drawn only when the PDF has more
             // than one page AND we're showing page 0 (the parent doc).


### PR DESCRIPTION
New reusable SkeletonPlaceholder; Preview image/PDF (DocumentCanvas/LibraryImageView) + PDF thumbnails now show a correct-size placeholder that cross-fades to content — no spinners, no popping, size reserved up-front (also serves #3617). BUILD SUCCEEDED (with the #3413 regen). 🤖 Claude (Opus 4.8)