### PR TITLE
Engine: harden change-stream/SSE lifecycle — clean vs error close, resource release (#3631)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/activity.py
+++ b/fichero-engine/src/fichero/api/routes/activity.py
@@ -348,20 +348,23 @@ async def stream_activities(
                     for task in (tracker_task, change_task):
                         if not task.done():
                             task.cancel()
-                    for task in (tracker_task, change_task):
-                        if task.cancelled():
-                            continue
-                        if task.done():
-                            try:
-                                task.result()
-                            except StopAsyncIteration:
-                                return
-                            except asyncio.CancelledError:
-                                pass
+                    results = await asyncio.gather(
+                        tracker_task, change_task, return_exceptions=True
+                    )
+                    if any(isinstance(result, StopAsyncIteration) for result in results):
+                        return
+        except asyncio.CancelledError:
+            logger.info("activity-stream: client cancelled cleanly lib=%s", library_path)
+            raise
+        except GeneratorExit:
+            logger.info("activity-stream: client closed cleanly lib=%s", library_path)
+            raise
         except Exception as e:
+            logger.exception("activity-stream: SSE failed lib=%s", library_path)
             error_event = {"error": str(e)}
             yield f"data: {json.dumps(error_event)}\n\n"
         finally:
+            await tracker_stream.aclose()
             tracker.unsubscribe(sub_id)
             _change_hub.unsubscribe(library_path, change_subscription.queue)
 

--- a/fichero-engine/src/fichero/api/routes/changes.py
+++ b/fichero-engine/src/fichero/api/routes/changes.py
@@ -60,6 +60,10 @@ async def stream_library_changes(
                 yield format_change_sse(replay_event)
             while True:
                 if await request.is_disconnected():
+                    logger.info(
+                        "change-stream: client disconnected cleanly lib=%s",
+                        x_fichero_library_path,
+                    )
                     break
                 try:
                     event = await asyncio.wait_for(
@@ -69,6 +73,21 @@ async def stream_library_changes(
                 except asyncio.TimeoutError:
                     # Keepalive comment prevents idle-connection timeouts.
                     yield ": keepalive\n\n"
+        except asyncio.CancelledError:
+            logger.info(
+                "change-stream: client cancelled cleanly lib=%s",
+                x_fichero_library_path,
+            )
+            raise
+        except GeneratorExit:
+            logger.info(
+                "change-stream: client closed cleanly lib=%s",
+                x_fichero_library_path,
+            )
+            raise
+        except Exception:
+            logger.exception("change-stream: SSE failed lib=%s", x_fichero_library_path)
+            raise
         finally:
             _change_hub.unsubscribe(x_fichero_library_path, queue)
 

--- a/fichero-engine/tests/unit/test_changes_stream_endpoint.py
+++ b/fichero-engine/tests/unit/test_changes_stream_endpoint.py
@@ -141,7 +141,7 @@ class TestChangesStreamEndpoint:
             await stream.aclose()
 
     async def test_stream_unsubscribes_when_client_disconnects(
-        self, test_package, monkeypatch
+        self, test_package, monkeypatch, caplog
     ):
         captured = _patch_subscribe_to_capture_queue(monkeypatch)
         request = _FakeRequest()
@@ -160,11 +160,13 @@ class TestChangesStreamEndpoint:
 
         request.disconnected = True
 
-        with pytest.raises(StopAsyncIteration):
-            await anext(stream)
+        with caplog.at_level("INFO", logger="fichero.api.routes.changes"):
+            with pytest.raises(StopAsyncIteration):
+                await anext(stream)
 
         assert change_stream._change_hub.subscriber_count(library_path) == before
         assert "queue" in captured
+        assert "disconnected cleanly" in caplog.text
 
     async def test_stream_replays_events_after_last_event_id(
         self, test_package, monkeypatch
@@ -293,7 +295,8 @@ class TestChangesStreamEndpoint:
         request = _FakeRequest()
         library_path = str(test_package)
 
-        async def _timeout(*_args, **_kwargs):
+        async def _timeout(awaitable, **_kwargs):
+            awaitable.close()
             request.disconnected = True
             raise asyncio.TimeoutError
 

--- a/fichero-engine/tests/unit/test_routes_activity.py
+++ b/fichero-engine/tests/unit/test_routes_activity.py
@@ -155,6 +155,68 @@ class TestGetActivityStats:
 
 class TestActivityStream:
     @pytest.mark.asyncio
+    async def test_stream_disconnect_drains_pending_tasks(self, monkeypatch):
+        from fichero.api.routes.activity import stream_activities
+
+        tracker = _make_mock_tracker([])
+        stopped = asyncio.Event()
+        started = asyncio.Event()
+
+        async def stream(_sub_id, _filter):
+            try:
+                started.set()
+                await asyncio.Future()
+                yield None  # pragma: no cover
+            finally:
+                stopped.set()
+
+        tracker.stream = stream
+        test_hub = _ChangeHub()
+        monkeypatch.setattr(activity_routes, "_change_hub", test_hub)
+
+        async def wait_until_started(tasks, **_kwargs):
+            await started.wait()
+            return set(), set(tasks)
+
+        monkeypatch.setattr(activity_routes.asyncio, "wait", wait_until_started)
+        db = MagicMock(path=Path("/tmp/test-activity.fichero/fichero.duckdb"))
+        with patch("fichero.api.routes.activity.get_activity_tracker", return_value=tracker):
+            response = await stream_activities(db=db, types=None, levels=None)
+
+        try:
+            assert await anext(response.body_iterator) == ": keepalive\n\n"
+        finally:
+            await response.body_iterator.aclose()
+
+        assert stopped.is_set()
+        tracker.unsubscribe.assert_called_once_with("sub-1")
+        assert test_hub.subscriber_count("/tmp/test-activity.fichero") == 0
+
+    @pytest.mark.asyncio
+    async def test_stream_logs_and_surfaces_unexpected_error(self, caplog):
+        from fichero.api.routes.activity import stream_activities
+
+        tracker = _make_mock_tracker([])
+
+        async def stream(_sub_id, _filter):
+            raise RuntimeError("tracker failed")
+            yield None  # pragma: no cover
+
+        tracker.stream = stream
+        with patch("fichero.api.routes.activity.get_activity_tracker", return_value=tracker):
+            response = await stream_activities(
+                db=MagicMock(path="/tmp/test.fichero"), types=None, levels=None
+            )
+
+        try:
+            with caplog.at_level("ERROR", logger="fichero.api.routes.activity"):
+                assert '"error": "tracker failed"' in await anext(response.body_iterator)
+        finally:
+            await response.body_iterator.aclose()
+
+        assert "activity-stream: SSE failed" in caplog.text
+
+    @pytest.mark.asyncio
     async def test_stream_yields_activity_response_sse_shape(self):
         from fichero.api.routes.activity import stream_activities
 


### PR DESCRIPTION
Server-side fix-then-sweep on #3351: activity + changes SSE endpoints now distinguish clean close (client disconnect/normal end) from error close (no error-spam on normal disconnect) and release resources on client-disconnect. test_routes_activity + test_changes_stream 8 passed; broader stream/sse/activity/change suite 413 passed. No regen. 🤖 Claude (Opus 4.8)