### PR TITLE
App-shell: actionable connection screen — 'can't connect' vs 'not running' (#3341)

### DIFF
--- a/fichero/fichero-tests/AccessErrorTests.swift
+++ b/fichero/fichero-tests/AccessErrorTests.swift
@@ -173,4 +173,47 @@ struct AccessErrorTests {
         )
         #expect(AppState.diagnosis(for: .tlsPinFailure).contains("Reset the certificate"))
     }
+
+    // MARK: - Connection-failure title never over-claims "not running" (#3341)
+
+    @Test func unreachableEmbeddedSaysCantConnectNotNotRunning() {
+        // The engine may be running but we couldn't reach it (wrong port /
+        // transient) — the actionable screen must NOT claim it's "not running".
+        let title = BackendConnectionView.connectionFailureTitle(
+            accessError: .engineUnreachable,
+            authBroken: false,
+            usesExternalBackendConnection: false
+        )
+        #expect(title == "Can't Connect to Engine")
+        #expect(title != "Engine Not Running")
+    }
+
+    @Test func unclassifiedEmbeddedFailureStillNeverSaysNotRunning() {
+        let title = BackendConnectionView.connectionFailureTitle(
+            accessError: nil,
+            authBroken: false,
+            usesExternalBackendConnection: false
+        )
+        #expect(title == "Can't Connect to Engine")
+    }
+
+    @Test func authBrokenRoutesToTheActionableAuthTitle() {
+        // Health-200-but-auth-broken: connected to the engine, stale sign-in →
+        // the "Can't Authenticate" screen (Reset Sign-In & Retry), never "not running".
+        let title = BackendConnectionView.connectionFailureTitle(
+            accessError: .unauthenticated,
+            authBroken: true,
+            usesExternalBackendConnection: false
+        )
+        #expect(title == "Can't Authenticate to Engine")
+    }
+
+    @Test func externalUnreachableReadsAsBackendNotReachable() {
+        let title = BackendConnectionView.connectionFailureTitle(
+            accessError: .engineUnreachable,
+            authBroken: false,
+            usesExternalBackendConnection: true
+        )
+        #expect(title == "Backend Not Reachable")
+    }
 }

--- a/fichero/fichero/Views/Components/BackendConnectionView.swift
+++ b/fichero/fichero/Views/Components/BackendConnectionView.swift
@@ -132,7 +132,25 @@ struct BackendConnectionView: View {
             // pre-window NSAlert (#3111).
             return "Port 8765 Is In Use"
         }
-        switch failureAccessError {
+        return Self.connectionFailureTitle(
+            accessError: failureAccessError,
+            authBroken: appState.authBroken,
+            usesExternalBackendConnection: usesExternalBackendConnection
+        )
+    }
+
+    /// Pure phase → failure-title mapping (#3341). Extracted so the invariant
+    /// "never claim the engine is NOT RUNNING when we only failed to CONNECT" is
+    /// unit-testable. When the engine is reachable-but-unusable (unreachable /
+    /// unclassified failure), the copy says "Can't Connect to Engine" — the
+    /// engine may well be running (wrong port / transient / socket); the screen's
+    /// Retry + Show Log let the user act, and the detail carries the real reason.
+    static func connectionFailureTitle(
+        accessError: AccessError?,
+        authBroken: Bool,
+        usesExternalBackendConnection: Bool
+    ) -> String {
+        switch accessError {
         case .staleBootstrapToken:
             return "Engine Token Mismatch"
         case .tlsPinFailure:
@@ -143,15 +161,21 @@ struct BackendConnectionView: View {
             return "No Access to Engine"
         case .transport:
             return "Connection Failed"
-        case .unauthenticated, .engineUnreachable, .none:
+        case .engineUnreachable:
+            // Couldn't reach the engine — NOT the same as "not running" (#3341).
+            return usesExternalBackendConnection ? "Backend Not Reachable" : "Can't Connect to Engine"
+        case .unauthenticated, .none:
             break
         }
-        if appState.authBroken {
+        if authBroken {
             // Health-200-but-auth-broken: the specific state that used to blank
-            // the window with silent 401s (#2864).
+            // the window with silent 401s (#2864). Connected to the engine, but
+            // the saved sign-in is stale → the Reset Sign-In & Retry action.
             return "Can't Authenticate to Engine"
         }
-        return usesExternalBackendConnection ? "Backend Not Reachable" : "Engine Not Running"
+        // Unclassified failure (e.g. `.failed`): we know we couldn't connect, not
+        // that the engine is stopped — so never assert "Engine Not Running" (#3341).
+        return usesExternalBackendConnection ? "Backend Not Reachable" : "Can't Connect to Engine"
     }
 
     /// Prefer the specific diagnosis (port occupied by PID / auth rejected /


### PR DESCRIPTION
BackendConnectionView now distinguishes 'engine running but app can't connect' from 'engine not running' and shows the actionable screen (real reason + Retry) instead of a dead 'Engine Not Running'. + AccessErrorTests. Finishes the connection cluster. BUILD SUCCEEDED. 🤖 Claude (Opus 4.8)