### PR TITLE
Engine: cross-library entity reconciliation scope (#3527)

### DIFF
--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -23701,7 +23701,8 @@
             "schema": {
               "enum": [
                 "library",
-                "folder"
+                "folder",
+                "cross-library"
               ],
               "type": "string",
               "default": "library",

--- a/fichero-engine/src/fichero/api/routes/kg_entity_curation.py
+++ b/fichero-engine/src/fichero/api/routes/kg_entity_curation.py
@@ -12,7 +12,7 @@ import asyncio
 from datetime import datetime
 from typing import Any, Literal
 
-from fastapi import APIRouter, Depends, Header, HTTPException, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
 from fichero.api.library_header import require_library_path
@@ -20,6 +20,7 @@ from fichero.api.auth import action_context, request_actor
 from fichero.api.change_stream import emit_change
 from fichero.api.main import get_library_database, get_library_database_for_write
 from fichero.db import Database
+from fichero.db_manager import db_manager
 from fichero.db_embeddings import KG_ENTITY_EMBEDDINGS_TABLE
 from fichero.knowledge_models import (
     EntityMergeAudit,
@@ -567,6 +568,59 @@ class CandidatePair(BaseModel):
     jaccard: float = Field(ge=0.0, le=1.0)
     shared_neighbors: int
     entity_type: str | None = None
+    entity_a_library_path: str | None = None
+    entity_b_library_path: str | None = None
+
+
+def _cross_library_candidate_pairs(
+    request: Request,
+    *,
+    same_type_only: bool,
+    top_k: int,
+) -> list[CandidatePair]:
+    """Match rule-resolved entity names across the libraries this user may read."""
+    from fichero import authz
+    from fichero.workflows.tools._entity_writer import _apply_entity_resolution_rules
+
+    by_key: dict[tuple[str, str | None], list[tuple[str, KnowledgeEntity]]] = {}
+    # ponytail: cross-library vectors are per-library stores; use the existing
+    # rule-resolved identity until a shared vector index is intentionally added.
+    bootstrap_auth = getattr(getattr(request, "state", None), "bootstrap_auth", False)
+    user = getattr(getattr(request, "state", None), "user", None)
+    for library_path in db_manager.open_library_paths():
+        if not bootstrap_auth and not authz.can_read(user, library_path):
+            continue
+        library_db = db_manager.get_database(library_path)
+        for entity in library_db.query(KnowledgeEntity):
+            resolved = _apply_entity_resolution_rules(
+                library_db, entity.canonical_name, entity.entity_type
+            )
+            if resolved is None:
+                continue
+            name, entity_type = resolved
+            key = (name.casefold(), entity_type.value if same_type_only else None)
+            by_key.setdefault(key, []).append((library_path, entity))
+
+    rows: list[CandidatePair] = []
+    for entities in by_key.values():
+        for index, (left_path, left) in enumerate(entities):
+            for right_path, right in entities[index + 1 :]:
+                if left_path == right_path:
+                    continue
+                rows.append(
+                    CandidatePair(
+                        entity_a_id=left.id,
+                        entity_a_name=left.canonical_name,
+                        entity_b_id=right.id,
+                        entity_b_name=right.canonical_name,
+                        jaccard=1.0,
+                        shared_neighbors=0,
+                        entity_type=left.entity_type.value,
+                        entity_a_library_path=left_path,
+                        entity_b_library_path=right_path,
+                    )
+                )
+    return rows[:top_k]
 
 
 @router.get(
@@ -583,10 +637,11 @@ class CandidatePair(BaseModel):
     ),
 )
 async def candidate_pairs(
+    request: Request,
     min_jaccard: float = Query(default=0.5, ge=0.0, le=1.0),
     top_k: int = Query(default=20, ge=1, le=200),
     same_type_only: bool = Query(default=True),
-    scope: Literal["library", "folder"] = Query(default="library"),
+    scope: Literal["library", "folder", "cross-library"] = Query(default="library"),
     folder_id: str | None = Query(default=None),
     db: Database = Depends(get_library_database),
 ) -> KGGraphListResponse:
@@ -596,6 +651,12 @@ async def candidate_pairs(
     """
     import networkx as nx
     from fichero.kg.graph import build_full_cooccurrence
+
+    if scope == "cross-library":
+        rows = _cross_library_candidate_pairs(
+            request, same_type_only=same_type_only, top_k=top_k
+        )
+        return KGGraphListResponse(items=rows, count=len(rows))
 
     graph = build_full_cooccurrence(db)
     if scope == "folder":

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -23701,7 +23701,8 @@
             "schema": {
               "enum": [
                 "library",
-                "folder"
+                "folder",
+                "cross-library"
               ],
               "type": "string",
               "default": "library",

--- a/fichero-engine/tests/unit/test_routes_entity_curation_scope.py
+++ b/fichero-engine/tests/unit/test_routes_entity_curation_scope.py
@@ -1,4 +1,17 @@
-"""Scoped entity-reconciliation candidate route coverage (#3318)."""
+"""Scoped entity-reconciliation candidate route coverage (#3318, #3527)."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from fichero.api.routes import kg_entity_curation
+from fichero.db import Database
+from fichero.knowledge_models import (
+    EntityResolutionRule,
+    EntityResolutionRuleType,
+    EntityType,
+    KnowledgeEntity,
+)
 
 
 def test_folder_scope_requires_folder_id(client):
@@ -13,3 +26,51 @@ def test_library_scope_is_the_default(client):
 
     assert response.status_code == 200
     assert response.json() == {"items": [], "count": 0}
+
+
+@pytest.mark.asyncio
+async def test_cross_library_scope_matches_open_libraries_and_respects_rules(
+    tmp_path, monkeypatch
+):
+    first_path = str((tmp_path / "First.fichero").resolve())
+    second_path = str((tmp_path / "Second.fichero").resolve())
+    first = Database(path=tmp_path / "First.fichero" / "fichero.duckdb")
+    second = Database(path=tmp_path / "Second.fichero" / "fichero.duckdb")
+    first_entity = KnowledgeEntity(canonical_name="Rosario", entity_type=EntityType.person)
+    second_entity = KnowledgeEntity(canonical_name="Rosario", entity_type=EntityType.person)
+    first.save(first_entity)
+    second.save(second_entity)
+    databases = {first_path: first, second_path: second}
+    monkeypatch.setattr(
+        kg_entity_curation.db_manager, "open_library_paths", lambda: list(databases)
+    )
+    monkeypatch.setattr(
+        kg_entity_curation.db_manager, "get_database", databases.__getitem__
+    )
+    request = SimpleNamespace(
+        state=SimpleNamespace(bootstrap_auth=True, user=None)
+    )
+    try:
+        response = await kg_entity_curation.candidate_pairs(
+            request=request, scope="cross-library", same_type_only=True, top_k=20, db=first
+        )
+        assert response.count == 1
+        pair = response.items[0]
+        assert {pair.entity_a_library_path, pair.entity_b_library_path} == set(databases)
+        assert {pair.entity_a_id, pair.entity_b_id} == {first_entity.id, second_entity.id}
+
+        second.save(
+            EntityResolutionRule(
+                rule_type=EntityResolutionRuleType.suppress,
+                match_canonical_name="Rosario",
+                match_entity_type=EntityType.person,
+                reason="not a reconciliation candidate",
+            )
+        )
+        suppressed = await kg_entity_curation.candidate_pairs(
+            request=request, scope="cross-library", same_type_only=True, top_k=20, db=first
+        )
+        assert suppressed.count == 0
+    finally:
+        first.conn.close()
+        second.conn.close()

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -23701,7 +23701,8 @@
             "schema": {
               "enum": [
                 "library",
-                "folder"
+                "folder",
+                "cross-library"
               ],
               "type": "string",
               "default": "library",


### PR DESCRIPTION
Extends the #3318 scoped-candidates endpoint (kg_entity_curation.py) with scope=cross-library — reconciliation candidates for an entity ACROSS the user's open libraries; user-confirmed merge, persistent curation rules respected. OpenAPI regen synced (scope enum); client builds. 89 curation tests passed. 🤖 Claude (Opus 4.8)