### PR TITLE
★ EVERY FRAME PERFECT: shared FrameAnimation constants across key transitions (#3619)

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		A1BFB2F02F043FA100EAA55A /* BackendConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2EF2F043FA100EAA55A /* BackendConnectionView.swift */; };
 		A1BFB2F32F045C8A00EAA55A /* LibraryImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2F22F045C8A00EAA55A /* LibraryImageView.swift */; };
 		SKEL00012F045C8A00EAA55A /* SkeletonPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = SKEL00022F045C8A00EAA55A /* SkeletonPlaceholder.swift */; };
+		ANIM00012F045C8A00EAA55A /* FrameAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ANIM00022F045C8A00EAA55A /* FrameAnimation.swift */; };
 		A1BFB4032F057B9300EAA55A /* QuickLookComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB3FF2F057B9300EAA55A /* QuickLookComponents.swift */; };
 		A1BFB4052F057B9300EAA55A /* FolderAccessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB3FB2F057B9300EAA55A /* FolderAccessManager.swift */; };
 		A1BFB4092F057BAC00EAA55A /* ViewMenuCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4082F057BAC00EAA55A /* ViewMenuCommands.swift */; };
@@ -1021,6 +1022,7 @@
 		A1BFB2EF2F043FA100EAA55A /* BackendConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendConnectionView.swift; sourceTree = "<group>"; };
 		A1BFB2F22F045C8A00EAA55A /* LibraryImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryImageView.swift; sourceTree = "<group>"; };
 		SKEL00022F045C8A00EAA55A /* SkeletonPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonPlaceholder.swift; sourceTree = "<group>"; };
+		ANIM00022F045C8A00EAA55A /* FrameAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameAnimation.swift; sourceTree = "<group>"; };
 		A1BFB3FB2F057B9300EAA55A /* FolderAccessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderAccessManager.swift; sourceTree = "<group>"; };
 		A1BFB3FF2F057B9300EAA55A /* QuickLookComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookComponents.swift; sourceTree = "<group>"; };
 		A1BFB4082F057BAC00EAA55A /* ViewMenuCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMenuCommands.swift; sourceTree = "<group>"; };
@@ -1974,6 +1976,7 @@
 				A3CD4902A47A5787D61C6D72 /* FlowLayout.swift */,
 				A1BFB2F22F045C8A00EAA55A /* LibraryImageView.swift */,
 				SKEL00022F045C8A00EAA55A /* SkeletonPlaceholder.swift */,
+				ANIM00022F045C8A00EAA55A /* FrameAnimation.swift */,
 				A1BFB2D42F042C6D00EAA55A /* ProviderLogoView.swift */,
 				A1BFB2D52F042C6D00EAA55A /* StatusBadge.swift */,
 				A1BFB4F12F30000100EAA55A /* MacPlainTextEditor.swift */,
@@ -2668,6 +2671,7 @@
 				A1BFB4612F0AADC000EAA55A /* LayoutMode.swift in Sources */,
 				A1BFB2F32F045C8A00EAA55A /* LibraryImageView.swift in Sources */,
 				SKEL00012F045C8A00EAA55A /* SkeletonPlaceholder.swift in Sources */,
+				ANIM00012F045C8A00EAA55A /* FrameAnimation.swift in Sources */,
 				202674952F475B1D008EAB5D /* NodeConfigView.swift in Sources */,
 				202674D22F478A13008EAB5D /* LibraryView+DisplayModes.swift in Sources */,
 				AA112233001122AA /* LibraryView+Sorting.swift in Sources */,

--- a/fichero/fichero/Views/Components/FrameAnimation.swift
+++ b/fichero/fichero/Views/Components/FrameAnimation.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// ★ EVERY FRAME PERFECT (#3619): one place for transition timing so animations
+/// feel intentional and consistent instead of ad-hoc per view. Great start + end
+/// frames aren't enough — standardizing the curve keeps the frames BETWEEN smooth
+/// and matched across surfaces.
+///
+/// Two tiers, both pure SwiftUI `Animation` values (no new framework),
+/// cross-platform:
+///
+/// - ``snappy`` — chrome & selection movement (tab switch, pane/sidebar reveal,
+///   inspector present). A quick, minimal-overshoot spring so a control feels
+///   responsive without bouncing.
+/// - ``crossfade`` — content opacity swaps (skeleton → image #3616, edit-mode
+///   overtake of the Preview #3593, content replace). A calm, bounce-free curve
+///   so pixels dissolve rather than jump-cut.
+enum FrameAnimation {
+    /// Shared base duration. Keep any manual `.transition`/`withAnimation` timing
+    /// in step with this rather than inventing a per-view number.
+    static let duration: Double = 0.25
+
+    /// Chrome & selection movement — tabs, pane/sidebar reveal, present/dismiss.
+    static let snappy: Animation = .snappy(duration: duration)
+
+    /// Content opacity cross-fades — skeleton → image, mode overtake, replace.
+    static let crossfade: Animation = .easeInOut(duration: duration)
+}

--- a/fichero/fichero/Views/Components/LibraryImageView.swift
+++ b/fichero/fichero/Views/Components/LibraryImageView.swift
@@ -45,7 +45,7 @@ struct LibraryImageView: View {
         }
         // Cross-fade the branch swap: the skeleton fades out as the loaded image
         // fades in, keyed to image presence (feeds #3619's precise transitions).
-        .animation(.easeOut(duration: 0.25), value: image == nil)
+        .animation(FrameAnimation.crossfade, value: image == nil)
         .task(id: loadKey) {
             guard !Task.isCancelled else { return }
             await loadImage(for: loadKey)

--- a/fichero/fichero/Views/ContentView+Actions.swift
+++ b/fichero/fichero/Views/ContentView+Actions.swift
@@ -237,7 +237,7 @@ extension ContentView {
         if horizontalSizeClass == .compact || shouldUseRuntimeSidebarCollapse {
             return
         }
-        withAnimation {
+        withAnimation(FrameAnimation.snappy) {
             showSidebar.toggle()
             updateColumnVisibility()
         }

--- a/fichero/fichero/Views/ContentView+State.swift
+++ b/fichero/fichero/Views/ContentView+State.swift
@@ -596,7 +596,7 @@ extension ContentView {
         }
 
         if currentLayoutMode != newLayoutMode {
-            withAnimation {
+            withAnimation(FrameAnimation.snappy) {
                 currentLayoutMode = newLayoutMode
             }
         }

--- a/fichero/fichero/Views/ContentView.swift
+++ b/fichero/fichero/Views/ContentView.swift
@@ -860,7 +860,7 @@ extension ContentView {
 
     private var inspectorToggleButton: some View {
         Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
+            withAnimation(FrameAnimation.snappy) {
                 showInspectorSidebar.toggle()
             }
         } label: {

--- a/fichero/fichero/Views/Library/DocumentCanvas.swift
+++ b/fichero/fichero/Views/Library/DocumentCanvas.swift
@@ -124,7 +124,7 @@ private struct StorageDisplayImageCanvas: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         // Cross-fade the branch swap as the loaded image replaces the skeleton.
-        .animation(.easeOut(duration: 0.25), value: image == nil)
+        .animation(FrameAnimation.crossfade, value: image == nil)
         .task(id: documentId) { await loadImage() }
     }
 

--- a/fichero/fichero/Views/Library/EditorView.swift
+++ b/fichero/fichero/Views/Library/EditorView.swift
@@ -62,6 +62,10 @@ struct EditorView: View {
                 Divider()
             }
             previewContent(doc)
+                // ★ EVERY FRAME PERFECT (#3619): cross-fade when edit mode
+                // overtakes the Preview (#3593) — the source canvas dissolves into
+                // the editor canvas instead of a jump-cut, with the shared timing.
+                .animation(FrameAnimation.crossfade, value: isEditing)
         }
     }
 

--- a/fichero/fichero/Views/Library/Reading/PDFThumbnailView.swift
+++ b/fichero/fichero/Views/Library/Reading/PDFThumbnailView.swift
@@ -34,7 +34,7 @@ struct PDFThumbnailView: View {
                     SkeletonPlaceholder(cornerRadius: 4)
                 }
             }
-            .animation(.easeOut(duration: 0.25), value: image == nil)
+            .animation(FrameAnimation.crossfade, value: image == nil)
             // Multi-page badge (#946) — paper-stack icon + page count
             // sitting bottom-right, drawn only when the PDF has more
             // than one page AND we're showing page 0 (the parent doc).

--- a/fichero/fichero/Views/SurfaceChrome/SurfaceTabBar.swift
+++ b/fichero/fichero/Views/SurfaceChrome/SurfaceTabBar.swift
@@ -53,6 +53,9 @@ struct SurfaceTabBar<Tab: SurfaceTab>: View {
         .padding(.horizontal, 8)
         .padding(.vertical, 6)
         .frame(height: MiniToolbar<EmptyView, EmptyView>.standardHeight)
+        // ★ EVERY FRAME PERFECT (#3619): glide the active-tab highlight + divider
+        // fade between tabs instead of a jump-cut, with the shared chrome timing.
+        .animation(FrameAnimation.snappy, value: selection)
         .accessibilityIdentifier(accessibilityID)
     }
 


### PR DESCRIPTION
New FrameAnimation constants (standard duration/easing tiers) applied to SurfaceTabBar tab switch, pane/edit-overtake (EditorView), canvas/thumbnail/skeleton cross-fade, ContentView transitions — consistent, de-janked timing instead of ad-hoc per-view animations. BUILD SUCCEEDED. 🤖 Claude (Opus 4.8)