### PR TITLE
Engine: reject masked storage/image-op corruption — raise instead of silent fallback (#3641)

### DIFF
--- a/fichero-engine/src/fichero/image_ops.py
+++ b/fichero-engine/src/fichero/image_ops.py
@@ -107,8 +107,11 @@ def apply_operation(image: Image.Image, op: dict[str, Any]) -> Image.Image:
         )
     if name == "crop":
         base = ImageOps.exif_transpose(image) if bool(params.get("auto_orient", True)) else image
-        left, top = int(params.get("left", 0)), int(params.get("top", 0))
-        width, height = int(params.get("width", base.width)), int(params.get("height", base.height))
+        missing = {key for key in ("left", "top", "width", "height") if key not in params}
+        if missing:
+            raise HTTPException(400, f"Crop operation missing required params: {sorted(missing)}")
+        left, top = int(params["left"]), int(params["top"])
+        width, height = int(params["width"]), int(params["height"])
         right, bottom = min(left + width, base.width), min(top + height, base.height)
         if width <= 0 or height <= 0 or left < 0 or top < 0 or right <= left or bottom <= top:
             raise HTTPException(400, "Crop bounds are invalid")

--- a/fichero-engine/src/fichero/storage.py
+++ b/fichero-engine/src/fichero/storage.py
@@ -466,9 +466,9 @@ def _get_bookmark(doc: "Document") -> bytes | None:
     b64 = doc.metadata.get("bookmark")
     if b64:
         try:
-            return base64.b64decode(b64)
-        except Exception:
-            return None
+            return base64.b64decode(b64, validate=True)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"Document {doc.id} has invalid bookmark metadata") from exc
     return None
 
 

--- a/fichero-engine/tests/unit/test_image_ops.py
+++ b/fichero-engine/tests/unit/test_image_ops.py
@@ -1,4 +1,6 @@
 from PIL import Image
+from fastapi import HTTPException
+import pytest
 
 from fichero.image_ops import apply_operation
 
@@ -36,6 +38,13 @@ def test_auto_crop_border_removes_dark_margin():
         for y in range(2, 8):
             image.putpixel((x, y), (255, 255, 255))
     assert apply_operation(image, {"op": "auto_crop_border", "params": {}}).size == (6, 6)
+
+
+def test_crop_missing_dimensions_raises_instead_of_using_full_image():
+    image = Image.new("RGB", (10, 10), "white")
+
+    with pytest.raises(HTTPException, match="missing required params"):
+        apply_operation(image, {"op": "crop", "params": {"left": 0, "top": 0}})
 
 
 def test_adaptive_binarize_returns_bilevel_image():

--- a/fichero-engine/tests/unit/test_storage.py
+++ b/fichero-engine/tests/unit/test_storage.py
@@ -266,9 +266,9 @@ class TestResolveSource:
         result = resolve_source(doc, library_root=new_root)
         assert result == source
 
-    def test_bookmark_priority(self, tmp_path):
-        """Bookmark should take priority over paths."""
-        from fichero.storage import resolve_source
+    def test_invalid_bookmark_raises_instead_of_falling_back_to_path(self, tmp_path):
+        """Corrupt bookmark metadata must not silently select another source."""
+        from fichero.storage import _get_bookmark
 
         bookmark_file = tmp_path / "bookmark.jpg"
         bookmark_file.touch()
@@ -277,12 +277,12 @@ class TestResolveSource:
         path_file.touch()
 
         doc = Mock()
+        doc.id = "broken-bookmark"
         doc.path = str(path_file)
         doc.metadata = {"bookmark": "invalid_base64"}  # Invalid bookmark
 
-        # Without valid bookmark, should fall back to path
-        result = resolve_source(doc, library_root=tmp_path)
-        assert result == path_file
+        with pytest.raises(ValueError, match="broken-bookmark has invalid bookmark"):
+            _get_bookmark(doc)
 
     def test_remote_bookmark_disabled_prefers_package_path(self, tmp_path, monkeypatch):
         """Remote engines must not resolve Mac bookmarks from by-reference docs."""


### PR DESCRIPTION
Silent-fallback audit found real masking in storage.py + image_ops.py: corruption/failure was being silently swallowed/substituted. Now raises with context (Daniel's HARD prefer-raise-over-silent-fallback rule; silent fallbacks caused #2430). Tests updated to expect the raise; narrow storage+image suite 162 passed. No regen. 🤖 Claude (Opus 4.8)