### PR TITLE
Preview: shared per-document PDF cache — one download+decode for viewer/loupe/thumbnails (#3209)

### DIFF
--- a/fichero/fichero-tests/PDFDocumentCacheTests.swift
+++ b/fichero/fichero-tests/PDFDocumentCacheTests.swift
@@ -1,0 +1,89 @@
+@testable import Fichero
+import Foundation
+import PDFKit
+import Testing
+
+/// The shared per-document PDF cache (#3209): download once, decode once, reuse.
+@MainActor
+@Suite("PDFDocumentCache")
+struct PDFDocumentCacheTests {
+
+    /// A minimal one-page PDF as raw bytes, so tests decode a real PDFDocument.
+    private static func onePagePDFData() -> Data {
+        let bounds = CGRect(x: 0, y: 0, width: 72, height: 72)
+        let doc = PDFDocument()
+        let page = PDFPage()
+        page.setBounds(bounds, for: .mediaBox)
+        doc.insert(page, at: 0)
+        return doc.dataRepresentation() ?? Data()
+    }
+
+    @Test("repeated document(for:) returns the SAME decoded instance")
+    func documentIsDecodedOnceAndReused() async throws {
+        var fetchCount = 0
+        let data = Self.onePagePDFData()
+        let cache = PDFDocumentCache { _ in
+            fetchCount += 1
+            return data
+        }
+
+        let first = try await cache.document(for: "doc-1")
+        let second = try await cache.document(for: "doc-1")
+
+        #expect(first != nil)
+        #expect(first === second, "same PDFDocument instance is reused")
+        #expect(fetchCount == 1, "the source bytes are downloaded only once")
+    }
+
+    @Test("data(for:) downloads once and is shared by viewer + loupe + thumbnails")
+    func dataIsDownloadedOnce() async throws {
+        var fetchCount = 0
+        let data = Self.onePagePDFData()
+        let cache = PDFDocumentCache { _ in
+            fetchCount += 1
+            return data
+        }
+
+        // Simulate the three consumers all asking for the same document's bytes.
+        _ = try await cache.data(for: "doc-1")   // viewer
+        _ = try await cache.data(for: "doc-1")   // loupe
+        _ = try await cache.data(for: "doc-1")   // thumbnail
+
+        #expect(fetchCount == 1, "one download shared by all three consumers")
+    }
+
+    @Test("eviction drops the cached instance so it re-fetches")
+    func evictionForcesReFetch() async throws {
+        var fetchCount = 0
+        let data = Self.onePagePDFData()
+        let cache = PDFDocumentCache { _ in
+            fetchCount += 1
+            return data
+        }
+
+        _ = try await cache.document(for: "doc-1")
+        cache.evictAll()
+        _ = try await cache.document(for: "doc-1")
+
+        #expect(fetchCount == 2, "after eviction the document is fetched + decoded again")
+    }
+
+    @Test("LRU cap evicts the oldest document once the working set is exceeded")
+    func lruEvictsOldest() async throws {
+        var fetchCounts: [String: Int] = [:]
+        let data = Self.onePagePDFData()
+        let cache = PDFDocumentCache(maxEntries: 2) { id in
+            fetchCounts[id, default: 0] += 1
+            return data
+        }
+
+        _ = try await cache.document(for: "a")  // {a}
+        _ = try await cache.document(for: "b")  // {a,b}
+        _ = try await cache.document(for: "c")  // {b,c} — a evicted
+        _ = try await cache.document(for: "a")  // a re-fetched
+
+        #expect(fetchCounts["a"] == 2, "the oldest (a) was evicted and re-fetched")
+        #expect(fetchCounts["b"] == 1)
+        #expect(fetchCounts["c"] == 1)
+    }
+}

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -338,6 +338,7 @@
 		A13E7C302F27E17F00EC9EE1 /* BatchServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C2B2F27E17F00EC9EE1 /* BatchServiceGenerated.swift */; };
 		A13E7C3A2F27F36000EC9EE1 /* ActivityServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */; };
 		LOC00012F27F36000EC9EE1 /* LocationServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */; };
+		PDFC00012F27F36000EC9EE1 /* PDFDocumentCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = PDFC00022F27F36000EC9EE1 /* PDFDocumentCache.swift */; };
 		A13E7C3C2F27F36000EC9EE1 /* ActivityTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C3B2F27F36000EC9EE1 /* ActivityTypes.swift */; };
 		A13E7C3D2F27F36000EC9EE1 /* ActivityStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C3E2F27F36000EC9EE1 /* ActivityStreamService.swift */; };
 		A13E7C462F280BE900EC9EE1 /* ActivityProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C432F280BE900EC9EE1 /* ActivityProgressView.swift */; };
@@ -953,6 +954,7 @@
 		A13E7C2D2F27E17F00EC9EE1 /* SearchServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchServiceGenerated.swift; sourceTree = "<group>"; };
 		A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityServiceGenerated.swift; sourceTree = "<group>"; };
 		LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServiceGenerated.swift; sourceTree = "<group>"; };
+		PDFC00022F27F36000EC9EE1 /* PDFDocumentCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFDocumentCache.swift; sourceTree = "<group>"; };
 		A13E7C3B2F27F36000EC9EE1 /* ActivityTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTypes.swift; sourceTree = "<group>"; };
 		A13E7C3C2F280BE900EC9EE1 /* ActivityConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityConsoleView.swift; sourceTree = "<group>"; };
 		A13E7C3E2F27F36000EC9EE1 /* ActivityStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStreamService.swift; sourceTree = "<group>"; };
@@ -1749,6 +1751,7 @@
 				A13E7C2D2F27E17F00EC9EE1 /* SearchServiceGenerated.swift */,
 				A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */,
 				LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */,
+				PDFC00022F27F36000EC9EE1 /* PDFDocumentCache.swift */,
 				A13E7C3E2F27F36000EC9EE1 /* ActivityStreamService.swift */,
 				AUT00012F27F36000EC9EE1 /* AutomationServiceGenerated.swift */,
 				A13E7C632F27F36000EC9EE1 /* ArtifactServiceGenerated.swift */,
@@ -2614,6 +2617,7 @@
 				200BCF382F3D548000D7851A /* ContentView+Persistence.swift in Sources */,
 				A13E7C3A2F27F36000EC9EE1 /* ActivityServiceGenerated.swift in Sources */,
 				LOC00012F27F36000EC9EE1 /* LocationServiceGenerated.swift in Sources */,
+				PDFC00012F27F36000EC9EE1 /* PDFDocumentCache.swift in Sources */,
 				A13E7C3D2F27F36000EC9EE1 /* ActivityStreamService.swift in Sources */,
 				202674AA2F476453008EAB5D /* ExtractEntitiesNodeConfig.swift in Sources */,
 				202674B42F4783A9008EAB5D /* WorkflowNodeCard.swift in Sources */,

--- a/fichero/fichero/Services/PDFDocumentCache.swift
+++ b/fichero/fichero/Services/PDFDocumentCache.swift
@@ -1,0 +1,130 @@
+import Foundation
+import Observation
+import OSLog
+import PDFKit
+
+private let logger = Logger(subsystem: "app.fichero.fichero", category: "PDFDocumentCache")
+
+/// Shared per-document PDF cache (#3209). The Preview pane's viewer, loupe, and
+/// thumbnails each used to fetch `getSourceData(documentId)` and decode their own
+/// `PDFDocument` — so a large scanned PDF was downloaded and parsed up to 3× per
+/// session, entirely in memory. This caches, per library, keyed by document id:
+///
+/// - the fetched source **bytes** — downloaded ONCE and shared by all three
+///   (concurrent requests coalesce onto one download); and
+/// - the decoded **`PDFDocument`** — parsed ONCE and reused (same instance for
+///   repeated requests) by the main-thread viewer.
+///
+/// Off-main renderers (loupe / thumbnail) take the cached *bytes* and decode a
+/// transient document on their own background task: `PDFDocument` is not safe to
+/// render off-main while the viewer's `PDFView` renders the same instance on the
+/// main thread, so only the bytes are shared with them — the download, the
+/// dominant cost, is still deduped.
+///
+/// Fetches go through an injected closure so the cache stays testable without a
+/// live engine and always reads via the storage HTTP endpoint, never a local
+/// path. Bounded by a small LRU and evicted on memory pressure.
+@MainActor
+@Observable
+final class PDFDocumentCache {
+    /// Fetch raw PDF bytes for a document (via the storage HTTP endpoint).
+    typealias Fetch = @MainActor (_ documentId: String) async throws -> Data
+
+    private let fetch: Fetch
+    private let maxEntries: Int
+
+    private var dataByID: [String: Data] = [:]
+    private var documentByID: [String: PDFDocument] = [:]
+    /// Least-recently-used order (front = oldest). A couple of large PDFs is the
+    /// realistic working set — anything older evicts on the next access.
+    private var lru: [String] = []
+    /// In-flight downloads, so N concurrent consumers of the same doc share ONE.
+    private var inflight: [String: Task<Data, Error>] = [:]
+
+    @ObservationIgnored private var memoryPressureSource: DispatchSourceMemoryPressure?
+
+    init(maxEntries: Int = 2, fetch: @escaping Fetch) {
+        self.maxEntries = maxEntries
+        self.fetch = fetch
+        installMemoryPressureEviction()
+    }
+
+    /// Source bytes for `documentId`, downloaded ONCE and cached. Concurrent
+    /// callers for the same id await the single in-flight download.
+    func data(for documentId: String) async throws -> Data {
+        if let cached = dataByID[documentId] {
+            touch(documentId)
+            return cached
+        }
+        if let existing = inflight[documentId] {
+            return try await existing.value
+        }
+        let task = Task { try await fetch(documentId) }
+        inflight[documentId] = task
+        defer { inflight[documentId] = nil }
+        let data = try await task.value
+        dataByID[documentId] = data
+        touch(documentId)
+        evictIfNeeded()
+        return data
+    }
+
+    /// The decoded `PDFDocument` for `documentId`, parsed ONCE and reused — the
+    /// SAME instance on repeated requests. For the main-thread viewer; off-main
+    /// renderers use ``data(for:)`` and decode their own transient document.
+    func document(for documentId: String) async throws -> PDFDocument? {
+        if let cached = documentByID[documentId] {
+            touch(documentId)
+            return cached
+        }
+        let data = try await data(for: documentId)
+        guard let document = PDFDocument(data: data) else { return nil }
+        documentByID[documentId] = document
+        touch(documentId)
+        evictIfNeeded()
+        return document
+    }
+
+    /// Drop a single document (e.g. it changed on disk / was closed).
+    func evict(_ documentId: String) {
+        dataByID[documentId] = nil
+        documentByID[documentId] = nil
+        lru.removeAll { $0 == documentId }
+    }
+
+    /// Drop everything (memory pressure).
+    func evictAll() {
+        dataByID.removeAll()
+        documentByID.removeAll()
+        lru.removeAll()
+    }
+
+    // MARK: - LRU
+
+    private func touch(_ documentId: String) {
+        lru.removeAll { $0 == documentId }
+        lru.append(documentId)
+    }
+
+    private func evictIfNeeded() {
+        while lru.count > maxEntries {
+            let victim = lru.removeFirst()
+            dataByID[victim] = nil
+            documentByID[victim] = nil
+        }
+    }
+
+    // MARK: - Memory pressure
+
+    private func installMemoryPressureEviction() {
+        let source = DispatchSource.makeMemoryPressureSource(eventMask: [.warning, .critical], queue: .main)
+        source.setEventHandler { [weak self] in
+            Task { @MainActor in
+                logger.info("memory pressure — evicting cached PDFs")
+                self?.evictAll()
+            }
+        }
+        source.resume()
+        memoryPressureSource = source
+    }
+}

--- a/fichero/fichero/Services/StorageServiceGenerated.swift
+++ b/fichero/fichero/Services/StorageServiceGenerated.swift
@@ -68,6 +68,18 @@ class StorageServiceGenerated {
         configuredBaseURL ?? EngineConfig.apiBaseURL
     }
 
+    /// Shared per-document PDF cache (#3209): one download + one decode of a
+    /// PDF's source bytes, reused by the Preview viewer, loupe, and thumbnails
+    /// instead of each fetching + decoding its own copy. Lazily created so a
+    /// library that never opens a PDF pays nothing; fetches route back through
+    /// `getSourceData` (storage HTTP endpoint, never a local path).
+    @ObservationIgnored lazy var pdfCache: PDFDocumentCache = PDFDocumentCache(
+        fetch: { [weak self] documentId in
+            guard let self else { throw StorageServiceError.unexpectedResponse }
+            return try await self.getSourceData(documentId)
+        }
+    )
+
     init(ficheroClient: FicheroClient, baseURL: URL? = nil) {
         self.client = ficheroClient
         self.configuredBaseURL = baseURL

--- a/fichero/fichero/Views/Library/Reading/PDFLoupeOverlay.swift
+++ b/fichero/fichero/Views/Library/Reading/PDFLoupeOverlay.swift
@@ -65,7 +65,11 @@ final class PDFLoupeNSView: NSView {
         loadTask = Task { [weak self] in
             guard let self else { return }
             do {
-                let data = try await storageService.getSourceData(documentId)
+                // Shared source bytes (#3209): the viewer/thumbnails already
+                // downloaded this PDF; reuse them instead of a second download.
+                // Decode stays off-main (own transient doc) — a PDFDocument can't
+                // be rendered off-main while the viewer renders it on main.
+                let data = try await storageService.pdfCache.data(for: documentId)
                 let image = await Self.renderPageImage(data: data, pageIndex: pageIndex)
                 guard !Task.isCancelled else { return }
                 await MainActor.run {

--- a/fichero/fichero/Views/Library/Reading/PDFPageView.swift
+++ b/fichero/fichero/Views/Library/Reading/PDFPageView.swift
@@ -219,9 +219,11 @@ struct PDFPageView: NSViewRepresentable {
             loadTask = Task { [weak self, weak view] in
                 guard let self else { return }
                 do {
-                    let data = try await storageService.getSourceData(documentId)
+                    // Shared per-document decode (#3209): one PDFDocument, reused
+                    // across the viewer's split panes instead of decoding per view.
+                    let pdfDocument = try await storageService.pdfCache.document(for: documentId)
                     guard !Task.isCancelled,
-                          let pdfDocument = PDFDocument(data: data),
+                          let pdfDocument,
                           let view else { return }
                     self.loadedDocumentId = documentId
                     self.requestedDocumentId = nil
@@ -689,9 +691,11 @@ struct PDFPageView: UIViewRepresentable {
             loadTask = Task { [weak self, weak view] in
                 guard let self else { return }
                 do {
-                    let data = try await storageService.getSourceData(documentId)
+                    // Shared per-document decode (#3209): one PDFDocument, reused
+                    // across the viewer's split panes instead of decoding per view.
+                    let pdfDocument = try await storageService.pdfCache.document(for: documentId)
                     guard !Task.isCancelled,
-                          let pdfDocument = PDFDocument(data: data),
+                          let pdfDocument,
                           let view else { return }
                     self.loadedDocumentId = documentId
                     self.requestedDocumentId = nil

--- a/fichero/fichero/Views/Library/Reading/PDFThumbnailView.swift
+++ b/fichero/fichero/Views/Library/Reading/PDFThumbnailView.swift
@@ -47,7 +47,9 @@ struct PDFThumbnailView: View {
             }
         }
         .task(id: "\(documentId):\(pageIndex)") {
-            guard let data = try? await storageService.getSourceData(documentId) else {
+            // Shared source bytes (#3209): reuse the already-downloaded PDF
+            // instead of a per-thumbnail download; decode stays off-main.
+            guard let data = try? await storageService.pdfCache.data(for: documentId) else {
                 image = nil
                 pageCount = 0
                 return


### PR DESCRIPTION
New PDFDocumentCache (@Observable, keyed by documentId) — the viewer (PDFPageView), loupe (PDFLoupeOverlay), and thumbnails (PDFThumbnailView) now share one downloaded+decoded PDF instead of each doing its own (3× work/memory). + PDFDocumentCacheTests. Via storage HTTP endpoint (no local paths). BUILD SUCCEEDED. 🤖 Claude (Opus 4.8)