### PR TITLE
Engine: silent-fallback audit part 2 — db_manager + kg_predictions raise instead of mask (#3643)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/kg_predictions.py
+++ b/fichero-engine/src/fichero/api/routes/kg_predictions.py
@@ -11,6 +11,7 @@ endpoints. Lives under ``/api/kg/predictions``.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Any
 
@@ -28,6 +29,7 @@ from fichero.knowledge_models import (
 from fichero.models import KGPredictionListResponse
 
 router = APIRouter(prefix="/kg/predictions")
+logger = logging.getLogger(__name__)
 
 KG_CLAIM_EMBEDDINGS_TABLE = "kg_claim_embeddings"
 
@@ -144,8 +146,12 @@ async def generate_heuristic_predictions(
     for claim in all_claims:
         try:
             qv = await db._embed_text_async(claim.text, role="passage")  # type: ignore[attr-defined]
-        except Exception:
-            continue
+        except Exception as exc:
+            logger.exception("Failed to embed claim %s for heuristic predictions", claim.id)
+            raise HTTPException(
+                status_code=503,
+                detail=f"Failed to embed claim {claim.id} for heuristic predictions",
+            ) from exc
         similar = db.search_vectors(
             KG_CLAIM_EMBEDDINGS_TABLE, qv, limit=request.top_k + 1
         )

--- a/fichero-engine/src/fichero/db_manager.py
+++ b/fichero-engine/src/fichero/db_manager.py
@@ -84,28 +84,31 @@ class DatabaseManager:
                 )
 
                 db = Database(path=db_path)
+                try:
+                    migrate_workflow_table(db.conn)
+                    migrate_saved_search_table(db.conn)
+                    migrate_provider_refs_table(db.conn)
+                    migrate_activity_tables(db.conn)
+                    migrate_checkpoint_tables(db.conn)
 
-                migrate_workflow_table(db.conn)
-                migrate_saved_search_table(db.conn)
-                migrate_provider_refs_table(db.conn)
-                migrate_activity_tables(db.conn)
-                migrate_checkpoint_tables(db.conn)
+                    # Seed default workflow presets (Transcribe, Catalogue). Idempotent
+                    # by workflow name — a user who deleted a preset doesn't get it back.
+                    # Tests set FICHERO_SKIP_DEFAULT_WORKFLOWS=1 so fixtures that assert
+                    # on "empty library" keep working without per-test cleanup.
+                    import os
 
-                # Seed default workflow presets (Transcribe, Catalogue). Idempotent
-                # by workflow name — a user who deleted a preset doesn't get it back.
-                # Tests set FICHERO_SKIP_DEFAULT_WORKFLOWS=1 so fixtures that assert
-                # on "empty library" keep working without per-test cleanup.
-                import os
-
-                if os.environ.get("FICHERO_SKIP_DEFAULT_WORKFLOWS") != "1":
-                    try:
+                    if os.environ.get("FICHERO_SKIP_DEFAULT_WORKFLOWS") != "1":
                         seeded = seed_default_workflows(db)
                         if seeded:
                             logger.info(f"Seeded {seeded} default workflow preset(s)")
-                    except Exception as exc:
-                        logger.warning(f"Default workflow seeding skipped: {exc}")
 
-                ensure_inbox_folder(db)
+                    ensure_inbox_folder(db)
+                except Exception as exc:
+                    db.close()
+                    logger.exception("Failed to initialize library database: %s", package_str)
+                    raise RuntimeError(
+                        f"Failed to initialize library database: {package_str}"
+                    ) from exc
 
                 self._databases[cache_key] = db
                 logger.info(f"Database connection created: {db_path}")

--- a/fichero-engine/tests/unit/test_db_manager_threading.py
+++ b/fichero-engine/tests/unit/test_db_manager_threading.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 import os
 import threading
 
+import pytest
+
 os.environ.setdefault("FICHERO_SKIP_DEFAULT_WORKFLOWS", "1")
 
 from fichero.db_manager import DatabaseManager  # noqa: E402
@@ -63,6 +65,33 @@ def test_active_count_counts_packages(tmp_path):
         t.join()
 
         assert mgr.active_count == 1
+    finally:
+        mgr.close_all()
+
+
+def test_initialization_failure_is_loud_and_does_not_leave_a_cached_handle(
+    tmp_path, monkeypatch
+):
+    """A failed default-workflow seed must not leave a partial library open."""
+    pkg = tmp_path / "lib.fichero"
+    pkg.mkdir()
+    mgr = DatabaseManager()
+    monkeypatch.delenv("FICHERO_SKIP_DEFAULT_WORKFLOWS", raising=False)
+
+    def fail_seed(_db):
+        raise RuntimeError("seed failed")
+
+    monkeypatch.setattr(
+        "fichero.workflows.default_workflows.seed_default_workflows", fail_seed
+    )
+    try:
+        with pytest.raises(RuntimeError, match="Failed to initialize library database") as exc:
+            mgr.get_database(pkg)
+
+        assert isinstance(exc.value.__cause__, RuntimeError)
+        assert str(exc.value.__cause__) == "seed failed"
+        assert mgr.active_count == 0
+        assert mgr.open_library_paths() == []
     finally:
         mgr.close_all()
 

--- a/fichero-engine/tests/unit/test_kg_embedding_roles.py
+++ b/fichero-engine/tests/unit/test_kg_embedding_roles.py
@@ -7,9 +7,10 @@ stored passage vectors.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
+from fastapi import HTTPException
 
 from fichero.kg.entity_vectors import find_similar
 
@@ -145,3 +146,36 @@ async def test_heuristic_predictions_uses_passage_role() -> None:
     assert all(r == "passage" for r in captured), (
         f"All heuristic-prediction embeds should use role='passage'; got {captured}"
     )
+
+
+@pytest.mark.anyio
+async def test_heuristic_predictions_raises_when_a_claim_cannot_be_embedded() -> None:
+    """A failed embedding must not silently omit a claim from predictions."""
+    from fichero.api.routes.kg_predictions import (
+        HeuristicRequest,
+        generate_heuristic_predictions,
+    )
+    from fichero.knowledge_models import ClaimCurationState, ClaimType, KnowledgeClaim
+
+    claim = KnowledgeClaim(
+        id="broken-claim",
+        text="Broken vector input.",
+        source_document_id="doc1",
+        claim_type=ClaimType.fact,
+        curation_state=ClaimCurationState.unreviewed,
+        entity_ids=[],
+    )
+    db = MagicMock()
+    db._lance_tables.return_value = ["kg_claim_embeddings"]
+    db.all.side_effect = [[claim], []]
+
+    async def fail_embed(*_args, **_kwargs):
+        raise RuntimeError("embedding backend unavailable")
+
+    db._embed_text_async = fail_embed
+
+    with pytest.raises(HTTPException) as exc:
+        await generate_heuristic_predictions(HeuristicRequest(), db=db)
+
+    assert exc.value.status_code == 503
+    assert "broken-claim" in exc.value.detail


### PR DESCRIPTION
Part 2 (after #3641 storage/image_ops): db_manager.py + kg_predictions.py masked failures now raise with context (missing/closed handle, missing embedding role). Tests updated (test_db_manager_threading, test_kg_embedding_roles). 5 in-file + 741 narrow broader passed. No regen. 🤖 Claude (Opus 4.8)