### PR TITLE
Preview: stream audio/video via AVPlayer instead of downloading the whole file (#3208)

### DIFF
--- a/fichero/fichero-tests/MediaStreamPreviewTests.swift
+++ b/fichero/fichero-tests/MediaStreamPreviewTests.swift
@@ -1,0 +1,43 @@
+@testable import Fichero
+import Foundation
+import Testing
+
+/// #3208: audio/video stream via AVPlayer; formats AVFoundation can't play fall
+/// back to the QuickLook download. `canStream` is the gate that decides which.
+@MainActor
+@Suite("MediaStreamPreview.canStream")
+struct MediaStreamPreviewTests {
+
+    private func doc(_ name: String, _ type: FileType) -> Document {
+        var d = Document(id: "d", parentId: "root", docType: .file, name: name)
+        d.fileType = type
+        return d
+    }
+
+    @Test("AVFoundation-native audio streams")
+    func nativeAudioStreams() {
+        #expect(MediaStreamPreview.canStream(doc("recording.mp3", .audio)))
+        #expect(MediaStreamPreview.canStream(doc("voice.m4a", .audio)))
+        #expect(MediaStreamPreview.canStream(doc("take.wav", .audio)))
+    }
+
+    @Test("AVFoundation-native video streams")
+    func nativeVideoStreams() {
+        #expect(MediaStreamPreview.canStream(doc("clip.mp4", .video)))
+        #expect(MediaStreamPreview.canStream(doc("scene.mov", .video)))
+    }
+
+    @Test("containers AVFoundation can't play fall back (not streamable)")
+    func unsupportedFallsBack() {
+        #expect(!MediaStreamPreview.canStream(doc("movie.mkv", .video)))
+        #expect(!MediaStreamPreview.canStream(doc("old.avi", .video)))
+        #expect(!MediaStreamPreview.canStream(doc("clip.webm", .video)))
+        #expect(!MediaStreamPreview.canStream(doc("song.ogg", .audio)))
+    }
+
+    @Test("extension match is case-insensitive")
+    func caseInsensitive() {
+        #expect(MediaStreamPreview.canStream(doc("LOUD.MP3", .audio)))
+        #expect(MediaStreamPreview.canStream(doc("Clip.MP4", .video)))
+    }
+}

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		186AB9CF6F951F8878BC81AF /* EntityKindChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986AE09BC3B5DC9ECD5820A5 /* EntityKindChartView.swift */; };
 		19F0E17B6ABA9BAF96D135C5 /* AnnotationsInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA6DF64867F557144B14A23 /* AnnotationsInspectorPane.swift */; };
 		1AA8D13CBE8E1D392BDDD4CF /* DocumentCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E4C1042F69F06267FA6CCD /* DocumentCanvas.swift */; };
+		MEDIA0012F69F06267FA6CCD /* MediaStreamPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = MEDIA0022F69F06267FA6CCD /* MediaStreamPreview.swift */; };
 		1ACCE61BCF118B415F1E457E /* OntologyBrowser+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849CA4F172401769E6140F13 /* OntologyBrowser+Toolbar.swift */; };
 		1BA428828543A7D4091C0A98 /* ActivityOverviewView+Cards.swift in Sources */ = {isa = PBXBuildFile; fileRef = D661A54EFC8800F710E16A23 /* ActivityOverviewView+Cards.swift */; };
 		1BD8C58F169EE984D4CF90A4 /* EntitySplitSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3FE2F360EADE051A3D2D51 /* EntitySplitSheet.swift */; };
@@ -907,6 +908,7 @@
 		7FDDBCA3101A6E468A3105D2 /* DocumentInspectorArtifactsTab+Shared.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentInspectorArtifactsTab+Shared.swift"; sourceTree = "<group>"; };
 		80920949B39DD526745B0BF2 /* CanvasDetailTier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CanvasDetailTier.swift; sourceTree = "<group>"; };
 		80E4C1042F69F06267FA6CCD /* DocumentCanvas.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DocumentCanvas.swift; sourceTree = "<group>"; };
+		MEDIA0022F69F06267FA6CCD /* MediaStreamPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MediaStreamPreview.swift; sourceTree = "<group>"; };
 		811A6E6F398CBE8A81AEB7CE /* ActivityMonitorWindow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityMonitorWindow.swift; sourceTree = "<group>"; };
 		82E8622F0305ED125BEDB904 /* EntityDetailView+Audit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "EntityDetailView+Audit.swift"; sourceTree = "<group>"; };
 		849CA4F172401769E6140F13 /* OntologyBrowser+Toolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "OntologyBrowser+Toolbar.swift"; sourceTree = "<group>"; };
@@ -2093,6 +2095,7 @@
 				A9CC1872944150E583173CB8 /* ImageEditor */,
 				A5C119BA4657FD54B0F01D6C /* DocumentKGSurface.swift */,
 				80E4C1042F69F06267FA6CCD /* DocumentCanvas.swift */,
+				MEDIA0022F69F06267FA6CCD /* MediaStreamPreview.swift */,
 				99857D7C99E753A3405778FC /* LibraryToolbarState.swift */,
 				E25A2C92607779F4D928B8E3 /* ArtifactRichTextCodec.swift */,
 				4D11FC06A71EAC1E8C4F6897 /* NodeClassPicker.swift */,
@@ -2874,6 +2877,7 @@
 				699D8A080D56300C542DEE87 /* ContradictionTriageSheet.swift in Sources */,
 				861B6FECAB63CDE10DBC5D7E /* EntityDigestView.swift in Sources */,
 				1AA8D13CBE8E1D392BDDD4CF /* DocumentCanvas.swift in Sources */,
+				MEDIA0012F69F06267FA6CCD /* MediaStreamPreview.swift in Sources */,
 				37125B13A36AF61C3B5868C3 /* NodeComparisonSheet.swift in Sources */,
 				286700373FC6B54B843E8DA5 /* NodePopover+Comparison.swift in Sources */,
 				0C6B1EE6EDE444C4F95ED9FD /* NoteService.swift in Sources */,

--- a/fichero/fichero/Views/Library/EditorView.swift
+++ b/fichero/fichero/Views/Library/EditorView.swift
@@ -138,6 +138,8 @@ struct EditorView: View {
         case storageDisplay(documentId: String)
         case imageEditor(documentId: String)
         case text(content: String)
+        /// Audio/video streamed via AVPlayer against the storage endpoint (#3208).
+        case media(documentId: String)
         case quickLook
 
         var usesImageEditingPreviewForViewing: Bool {
@@ -171,6 +173,12 @@ struct EditorView: View {
                 return .imageEditor(documentId: doc.id)
             }
             return .storageDisplay(documentId: doc.id)
+        }
+        // Audio/video stream progressively via AVPlayer (#3208) instead of the
+        // whole-file QuickLook download. Formats AVFoundation can't play
+        // (mkv/avi/…) fall through to the QuickLook fallback below.
+        if doc.fileType == .audio || doc.fileType == .video, MediaStreamPreview.canStream(doc) {
+            return .media(documentId: doc.id)
         }
         // Text-bearing documents (txt / docx / md) render as annotatable text
         // so highlight + note work on the body (#2458 slice 3). Falls back to
@@ -231,6 +239,9 @@ struct EditorView: View {
             )
         case .text(let content):
             DocumentTextReader(document: doc, content: content)
+        case .media(let documentId):
+            MediaStreamPreview(document: doc)
+                .id(documentId)
         case .quickLook:
             QuickLookDownloadView(document: doc)
         }

--- a/fichero/fichero/Views/Library/MediaStreamPreview.swift
+++ b/fichero/fichero/Views/Library/MediaStreamPreview.swift
@@ -1,0 +1,84 @@
+import AVFoundation
+import AVKit
+import OSLog
+import SwiftUI
+
+private let logger = Logger(subsystem: "app.fichero.fichero", category: "MediaStreamPreview")
+
+/// Streams an audio/video document via `AVPlayer` against the storage HTTP
+/// endpoint (#3208), instead of `QuickLookDownloadView` which downloads the WHOLE
+/// file to a temp path before showing anything — minutes of blank pane and
+/// gigabytes duplicated for large recordings.
+///
+/// The player points an `AVURLAsset` at `apiClient.sourceURL(for:)` and carries
+/// the SAME auth as every other storage fetch (`Authorization: Bearer` +
+/// `X-Fichero-Library-Path`) via `AVURLAssetHTTPHeaderFieldsKey` — the headers
+/// stay inside the asset's request options, no bare token in the URL, no local
+/// path. AVFoundation then fetches progressively (Range requests) rather than up
+/// front. Cross-platform (AVKit on macOS + iOS).
+///
+/// `canStream(_:)` gates this to formats AVFoundation actually plays; anything
+/// else (mkv / avi / …) stays on the QuickLook download fallback.
+struct MediaStreamPreview: View {
+    let document: Document
+
+    @Environment(APIClient.self) private var apiClient
+    @State private var player: AVPlayer?
+
+    var body: some View {
+        Group {
+            if let player {
+                VideoPlayer(player: player)
+            } else {
+                // Brief — only while the player is being constructed; playback
+                // itself streams, so this is not the old whole-file download wait.
+                ProgressView()
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(Color(platformColor: .windowBackgroundColor))
+        .task(id: document.id) { makePlayer() }
+        .onDisappear { player?.pause() }
+    }
+
+    private func makePlayer() {
+        let url = apiClient.sourceURL(for: document.id)
+        // Reuse the exact auth headers every other storage fetch uses, rather
+        // than re-deriving them — keeps the token out of the URL and in step
+        // with the middleware (#742/#3076).
+        var request = URLRequest(url: url)
+        request.addEngineAuth(libraryPath: apiClient.currentLibraryPath)
+        let headers = request.allHTTPHeaderFields ?? [:]
+
+        // The header-fields option key isn't surfaced as a Swift symbol on this
+        // SDK; its stable underlying string value carries the auth headers into
+        // AVFoundation's own networking.
+        let asset = AVURLAsset(url: url, options: ["AVURLAssetHTTPHeaderFieldsKey": headers])
+        let item = AVPlayerItem(asset: asset)
+        logger.info("Streaming media for document: \(document.id, privacy: .public)")
+        player = AVPlayer(playerItem: item)
+    }
+
+    // MARK: - Format gating
+
+    /// Whether AVFoundation can stream this document. Containers it can't play
+    /// (mkv / avi / wmv / flv / webm / ogg) fall back to the QuickLook download
+    /// path so nothing regresses to a broken player.
+    static func canStream(_ document: Document) -> Bool {
+        streamableExtensions.contains(mediaExtension(for: document))
+    }
+
+    private static let streamableExtensions: Set<String> = [
+        // Audio AVFoundation plays natively.
+        "mp3", "m4a", "aac", "wav", "aif", "aiff", "caf", "au", "m4b",
+        // Video AVFoundation plays natively.
+        "mp4", "m4v", "mov"
+    ]
+
+    /// Extension from the document name (or its path when present) — a *format*
+    /// decision, not rendering from a local file path.
+    private static func mediaExtension(for document: Document) -> String {
+        let source = (document.path?.isEmpty == false) ? document.path! : document.name
+        return (source as NSString).pathExtension.lowercased()
+    }
+}


### PR DESCRIPTION
New MediaStreamPreview uses AVPlayer/AVURLAsset against the storage HTTP endpoint (Starlette FileResponse already serves HTTP Range/206, so progressive streaming works with no engine change) instead of downloading the full file first. + MediaStreamPreviewTests. Authed storage URL, no bare token, no local paths. BUILD SUCCEEDED. Completes the Preview download/render hardening cluster (#3206/#3207-partial/#3208/#3209/#3210). 🤖 Claude (Opus 4.8)