### PR TITLE
Engine: silent-fallback audit part 3 — record workflow + IIIF parsing failures (#3646)

### DIFF
--- a/fichero-engine/src/fichero/execution/batch.py
+++ b/fichero-engine/src/fichero/execution/batch.py
@@ -603,9 +603,12 @@ class BatchManager:
                         # complete_run_documents (centralised for both paths,
                         # #2518) — no per-caller emit needed here.
                     except Exception as completion_exc:
-                        logger.warning(
-                            f"Batch {batch_id} item {item.item_index} "
-                            f"completion failed: {completion_exc}"
+                        item.status = BatchItemStatus.FAILED
+                        item.error = f"Document completion failed: {completion_exc}"
+                        logger.exception(
+                            "Batch %s item %s document completion failed",
+                            batch_id,
+                            item.item_index,
                         )
 
                 except Exception as e:

--- a/fichero-engine/src/fichero/importers/iiif_import.py
+++ b/fichero-engine/src/fichero/importers/iiif_import.py
@@ -272,8 +272,8 @@ def _load_json_documents(root: Path) -> list[tuple[Path, dict[str, Any]]]:
     for path in paths:
         try:
             data = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            continue
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"Failed to parse IIIF JSON: {path}") from exc
         if isinstance(data, dict):
             data.setdefault("_fichero_source_path", str(path))
             docs.append((path, data))

--- a/fichero-engine/tests/unit/test_iiif_import.py
+++ b/fichero-engine/tests/unit/test_iiif_import.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
 from typer.testing import CliRunner
 
 from fichero import __main__ as cli
@@ -171,6 +172,16 @@ def test_parse_iiif_directory_normalizes_nodes_and_annotation_jobs(tmp_path):
     assert page["images"][0]["source_path"] == str(tmp_path / "page_001.jpg")
     assert page["entities"][0]["canonical_name"] == "Marshall"
     assert len(parsed.annotation_jobs) == 2
+
+
+def test_parse_iiif_directory_raises_for_invalid_json(tmp_path):
+    broken = tmp_path / "broken.json"
+    broken.write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Failed to parse IIIF JSON") as exc:
+        parse_iiif_directory(broken)
+
+    assert str(broken) in str(exc.value)
 
 
 def test_import_iiif_scopes_entities_to_page_and_preserves_text_annotations(

--- a/fichero-engine/tests/unit/test_workflow_code_bugs.py
+++ b/fichero-engine/tests/unit/test_workflow_code_bugs.py
@@ -252,6 +252,50 @@ async def test_batch_item_execution_accepts_string_db_path(tmp_path, monkeypatch
     assert persisted.completed_items == 1
 
 
+@pytest.mark.asyncio
+async def test_batch_records_document_completion_failure(tmp_path, monkeypatch):
+    """A completed graph is not a completed batch item until documents persist."""
+    manager = BatchManager(str(tmp_path / "batch_completion_failure.duckdb"))
+    batch = await manager.create_batch(workflow_id="wf-1", items_inputs=[{"value": 1}])
+
+    class FakeGraph:
+        async def astream(self, initial_state, config):
+            yield {"node-1": {"completed_nodes": ["node-1"]}}
+
+        async def aget_state(self, config):
+            return SimpleNamespace(values={})
+
+    monkeypatch.setattr(
+        "fichero.workflows.batch.create_compiled_app",
+        lambda *a, **k: (FakeGraph(), None),
+    )
+    monkeypatch.setattr(
+        "fichero.workflows.completion.collect_processed_document_ids", lambda values: []
+    )
+    monkeypatch.setattr(
+        "fichero.db_manager.db_manager.get_database", lambda path: SimpleNamespace()
+    )
+
+    def fail_completion(*_args, **_kwargs):
+        raise RuntimeError("document write failed")
+
+    monkeypatch.setattr(
+        "fichero.workflows.completion.complete_run_documents", fail_completion
+    )
+
+    events = [
+        event.event_type
+        async for event in manager.execute_batch(batch.batch_id, SyncWorkflowStore(_workflow()))
+    ]
+    persisted = await manager.get_batch(batch.batch_id)
+
+    assert "item_failed" in events
+    assert persisted is not None
+    assert persisted.status.value == "failed"
+    assert persisted.items[0].status.value == "failed"
+    assert "Document completion failed: document write failed" == persisted.items[0].error
+
+
 def test_batch_cache_is_bounded(tmp_path):
     """#2136: batch cache cannot grow without bound."""
     manager = BatchManager(str(tmp_path / "batch_cache.duckdb"))


### PR DESCRIPTION
Final silent-fallback pass (data-processing): batch.py workflow steps + iiif_import.py parsing now RECORD failures (raise/log with context) instead of silently swallowing/skipping. Tests updated (test_workflow_code_bugs, test_iiif_import). 5 in-file passed; narrow broader 1920 passed (the 1 fail — transcribe PDF-text-layer — is PRE-EXISTING at baseline in isolation, unrelated; filed separately). No regen. 🤖 Claude (Opus 4.8)