### PR TITLE
Fix pre-existing transcribe test red — mock DB after db_manager hardening (#3649)

### DIFF
--- a/fichero-engine/tests/unit/test_workflow_tools.py
+++ b/fichero-engine/tests/unit/test_workflow_tools.py
@@ -457,17 +457,19 @@ class TestTranscribeTool:
 
         with patch("fichero.workflows.tools.vision_base._try_pdf_text_layer", return_value=["Digital PDF text"]) as mock_pdf_layer:
             with patch("fichero.workflows.tools.vision_base.save_artifact", save_artifact_mock):
-                with patch("fichero.llm.vision", new_callable=AsyncMock) as mock_vision:
-                    result = await transcribe(
-                        {
-                            "files": [str(test_pdf)],
-                            "documents": [{"id": "doc123", "path": str(test_pdf)}],
-                            "save_to_db": True,
-                            "vision_mode": "apple",
-                        },
-                        mock_state,
-                        mock_llm_config,
-                    )
+                with patch("fichero.db.db_manager.get_database") as get_database:
+                    get_database.return_value.get.return_value = None
+                    with patch("fichero.llm.vision", new_callable=AsyncMock) as mock_vision:
+                        result = await transcribe(
+                            {
+                                "files": [str(test_pdf)],
+                                "documents": [{"id": "doc123", "path": str(test_pdf)}],
+                                "save_to_db": True,
+                                "vision_mode": "apple",
+                            },
+                            mock_state,
+                            mock_llm_config,
+                        )
 
         assert result["text"] == "Digital PDF text"
         mock_pdf_layer.assert_called_once_with(str(test_pdf))


### PR DESCRIPTION
test_transcribe_labels_pdf_text_layer_as_pdf_text failed because it didn't mock db_manager.get_database — after the #3643 silent-fallback hardening (db_manager raises on missing handle instead of masking), the unmocked DB access surfaced. Added the proper DB mock so the test reaches its labeling assertion. Test-only; production labeling was correct. test_workflow_tools.py green. 🤖 Claude (Opus 4.8)