### PR TITLE
Fix SwiftLint identifier_name (b→cropBounds) in PDFPageView — unblocks iOS archive

### DIFF
--- a/fichero/fichero/Views/Library/Reading/PDFPageView.swift
+++ b/fichero/fichero/Views/Library/Reading/PDFPageView.swift
@@ -501,12 +501,12 @@ private func applyHighlightSpan(
     // highlight directly, flipping y into PDFKit's bottom-left page space so the
     // highlight lands exactly where the crop was taken (#2105/#3449).
     if let bbox = info["bbox"] as? [Double], bbox.count == 4 {
-        let b = page.bounds(for: .cropBox)
+        let cropBounds = page.bounds(for: .cropBox)
         let rect = CGRect(
-            x: b.minX + bbox[0] * b.width,
-            y: b.minY + (1 - bbox[1] - bbox[3]) * b.height,
-            width: bbox[2] * b.width,
-            height: bbox[3] * b.height
+            x: cropBounds.minX + bbox[0] * cropBounds.width,
+            y: cropBounds.minY + (1 - bbox[1] - bbox[3]) * cropBounds.height,
+            width: bbox[2] * cropBounds.width,
+            height: bbox[3] * cropBounds.height
         )
         let annotation = PDFAnnotation(bounds: rect, forType: .highlight, withProperties: nil)
         #if canImport(AppKit)
@@ -837,12 +837,12 @@ private func applyHighlightSpan(
     // highlight directly, flipping y into PDFKit's bottom-left page space so the
     // highlight lands exactly where the crop was taken (#2105/#3449).
     if let bbox = info["bbox"] as? [Double], bbox.count == 4 {
-        let b = page.bounds(for: .cropBox)
+        let cropBounds = page.bounds(for: .cropBox)
         let rect = CGRect(
-            x: b.minX + bbox[0] * b.width,
-            y: b.minY + (1 - bbox[1] - bbox[3]) * b.height,
-            width: bbox[2] * b.width,
-            height: bbox[3] * b.height
+            x: cropBounds.minX + bbox[0] * cropBounds.width,
+            y: cropBounds.minY + (1 - bbox[1] - bbox[3]) * cropBounds.height,
+            width: bbox[2] * cropBounds.width,
+            height: bbox[3] * cropBounds.height
         )
         let annotation = PDFAnnotation(bounds: rect, forType: .highlight, withProperties: nil)
         #if canImport(AppKit)


### PR DESCRIPTION
RELEASE-BLOCKER: the iOS TestFlight archive failed on SwiftLint identifier_name errors (var 'b') at PDFPageView.swift 502/836 — SwiftLint is a hard error in the Release/archive build. Renamed 'b' → 'cropBounds' (both occurrences + all usages). Verified: 0 'let b', 2 'cropBounds', swiftlint 0 errors, BUILD SUCCEEDED. 🤖 Claude (Opus 4.8)