### PR TITLE
SwiftLint archive-error sweep: x/y→insetX/insetY + empty_count disable (unblocks archive)

### DIFF
--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorContentV2.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorContentV2.swift
@@ -516,6 +516,10 @@ struct SourceOutlineView: View {
             Text(row.label)
                 .lineLimit(1)
             Spacer(minLength: 4)
+            // `row.count` is a generated Int field (child/item count) on the
+            // OpenAPI DocumentOutlineRow, not a collection — there is no
+            // `isEmpty`, so the empty_count rule is a false positive here.
+            // swiftlint:disable:next empty_count
             if row.count > 0 {
                 Text("\(row.count)")
                     .font(.caption2)

--- a/fichero/fichero/Views/Library/ImageViewer/ImageWithCursorTracking.swift
+++ b/fichero/fichero/Views/Library/ImageViewer/ImageWithCursorTracking.swift
@@ -883,9 +883,9 @@ struct ImageWithCursorTracking: UIViewRepresentable {
             let scaledW = imageSize.width * zoom
             let scaledH = imageSize.height * zoom
 
-            let x = max(0, (viewSize.width - scaledW) / 2)
-            let y = max(0, (viewSize.height - scaledH) / 2)
-            scrollView.contentInset = UIEdgeInsets(top: y, left: x, bottom: y, right: x)
+            let insetX = max(0, (viewSize.width - scaledW) / 2)
+            let insetY = max(0, (viewSize.height - scaledH) / 2)
+            scrollView.contentInset = UIEdgeInsets(top: insetY, left: insetX, bottom: insetY, right: insetX)
         }
 
         func updateVisibleRect() {


### PR DESCRIPTION
Release-readiness SwiftLint ERROR sweep (SwiftLint is a hard error in the Release/archive build). Fixed the remaining archive-blocking errors: ImageWithCursorTracking x/y insets → insetX/insetY (identifier_name); DocumentInspectorContentV2 count scoped-disable (empty_count). swiftlint 0 errors on both files, BUILD SUCCEEDED. Archive SwiftLint gate should now be clean beyond PDFPageView. 🤖 Claude (Opus 4.8)