### PR TITLE
Engine: remove stale native-controls baseline (#3652 census)

### DIFF
--- a/scripts/check_native_controls.py
+++ b/scripts/check_native_controls.py
@@ -31,7 +31,6 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     "KnowledgeGraph/OntologyBrowser/SpeakerComparisonView.swift#ffffcf8a29": "#1912 baseline",
     "Library/ImageEditor/ImageEditChainPanel.swift#83a0175036": "#1912 baseline",
     "Library/LibraryView+DisplayModes.swift#ac36d057da": "#1912 baseline",
-    "Library/Reading/PDFReadingView.swift#12a18b04b8": "#1912 baseline",
     "Library/Workspace/WorkspaceItemPicker.swift#2e87b93a6b": "#1912 baseline",
     "Research/ResearchTasksPane.swift#1d731da4e7": "#1912 baseline (shifted by store migration)",
     "Research/ResearchTasksPane.swift#f50acbd404": "#1912 baseline (shifted by store migration)",


### PR DESCRIPTION
Pre-existing red census (#3652): check_native_controls.py had a stale baseline entry (PDFReadingView.swift#12a18b04b8 '#1912 baseline') keyed to an outdated file hash. Removed it; check_native_controls now passes. Census result: 377 root tests green across actions/API/app-DB/image-op; no other hidden reds (Workflow/KG just need file-scoped batching for timeouts). 🤖 Claude (Opus 4.8)