### PR TITLE
Engine: validate image page indices + location bboxes at the API boundary (#3656)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/image_editing.py
+++ b/fichero-engine/src/fichero/api/routes/image_editing.py
@@ -47,13 +47,13 @@ class CropOperationRequest(BaseModel):
     width: int = Field(gt=0)
     height: int = Field(gt=0)
     auto_orient: bool = True
-    page: int = 1
+    page: int = Field(1, ge=1)
 
 
 class RotateOperationRequest(BaseModel):
     angle: float = Field(ge=-360.0, le=360.0)
     expand: bool = True
-    page: int = 1
+    page: int = Field(1, ge=1)
 
 
 class StraightenOperationRequest(BaseModel):

--- a/fichero-engine/src/fichero/api/routes/locations.py
+++ b/fichero-engine/src/fichero/api/routes/locations.py
@@ -44,7 +44,7 @@ class Location(BaseModel):
 
     @model_validator(mode="after")
     def valid_bbox(self):
-        if self.bbox and (any(v < 0 or v > 1 for v in self.bbox) or self.bbox[0] + self.bbox[2] > 1 or self.bbox[1] + self.bbox[3] > 1):
+        if self.bbox and (any(v < 0 or v > 1 for v in self.bbox) or self.bbox[2] <= 0 or self.bbox[3] <= 0 or self.bbox[0] + self.bbox[2] > 1 or self.bbox[1] + self.bbox[3] > 1):
             raise ValueError("bbox must be normalized [x,y,w,h] within 0..1")
         return self
 

--- a/fichero-engine/tests/unit/test_locations.py
+++ b/fichero-engine/tests/unit/test_locations.py
@@ -26,6 +26,8 @@ def test_rejects_invalid_document_page_and_bbox(db):
         asyncio.run(resolve_location(Location(documentId="missing"), db))
     with pytest.raises(ValueError, match="bbox"):
         Location(documentId="x", bbox=[0, 0, 2, 1])
+    with pytest.raises(ValueError, match="bbox"):
+        Location(documentId="x", bbox=[0, 0, 0, 1])
 
 
 @pytest.mark.parametrize("surface", list(LocationSurface))

--- a/fichero-engine/tests/unit/test_routes_image_editing.py
+++ b/fichero-engine/tests/unit/test_routes_image_editing.py
@@ -160,6 +160,15 @@ class TestImageEditChainRoutes:
         assert ops[0]["params"] == {"angle": 90.0, "expand": True}
         assert "derived_path" not in ops[0]
 
+    def test_crop_and_rotate_reject_nonpositive_page(self, client, db, tmp_path):
+        doc = _make_image_doc(db, tmp_path)
+        for operation, body in (
+            ("crop", {"left": 0, "top": 0, "width": 1, "height": 1, "page": 0}),
+            ("rotate", {"angle": 90, "page": -1}),
+        ):
+            response = client.post(f"/api/images/{doc.id}/operations/{operation}", json=body)
+            assert response.status_code == 422
+
     def test_enhance_operation_appends_chain(self, client, db, tmp_path):
         doc = _make_gray_image_doc(db, tmp_path)
         enhance = client.post(


### PR DESCRIPTION
Input-validation audit: image-editing page indices and location-resolve bboxes now validated (bounds/range) → clear 422 on bad input instead of a 500 or silently-wrong result. test_locations + test_routes_image_editing 8 passed; narrow image_editing/location/storage suite 183 passed. No regen (validation logic, same schema). 🤖 Claude (Opus 4.8)