### PR TITLE
Preview: extract PreviewDownloadService from QuickLookDownloadView (#3207)

### DIFF
--- a/fichero/fichero-tests/QuickLookDownloadErrorTests.swift
+++ b/fichero/fichero-tests/QuickLookDownloadErrorTests.swift
@@ -2,14 +2,14 @@
 @testable import Fichero
 import XCTest
 
-/// Tests for QuickLookDownloadView.downloadErrorMessage (#3206) — the pure
+/// Tests for PreviewDownloadService.downloadErrorMessage (#3206) — the pure
 /// mapping of a non-2xx source-download response to a user message. Replaces the
 /// old byte-size heuristic (a legit <1000-byte .txt was misreported as an
 /// error); now the engine's JSON `detail` drives the message. No live engine.
 final class QuickLookDownloadErrorTests: XCTestCase {
 
     private func msg(_ status: Int, _ body: String?, path: String? = nil) -> String {
-        QuickLookDownloadView.downloadErrorMessage(
+        PreviewDownloadService.downloadErrorMessage(
             statusCode: status,
             body: body.map { Data($0.utf8) },
             documentPath: path
@@ -56,27 +56,27 @@ final class QuickLookDownloadErrorTests: XCTestCase {
     // MARK: - sanitizedFileName (#3207 path-injection guard)
 
     func testSanitizePassesCleanNames() {
-        XCTAssertEqual(QuickLookDownloadView.sanitizedFileName("report.pdf"), "report.pdf")
-        XCTAssertEqual(QuickLookDownloadView.sanitizedFileName("My Scan 2.tiff"), "My Scan 2.tiff")
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName("report.pdf"), "report.pdf")
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName("My Scan 2.tiff"), "My Scan 2.tiff")
     }
 
     func testSanitizeStripsPathTraversalToLeaf() {
-        XCTAssertEqual(QuickLookDownloadView.sanitizedFileName("../../etc/passwd"), "passwd")
-        XCTAssertEqual(QuickLookDownloadView.sanitizedFileName("/a/b/c.pdf"), "c.pdf")
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName("../../etc/passwd"), "passwd")
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName("/a/b/c.pdf"), "c.pdf")
         // Backslash (Windows) separators are stripped too.
-        XCTAssertEqual(QuickLookDownloadView.sanitizedFileName("..\\..\\secret.txt"), "secret.txt")
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName("..\\..\\secret.txt"), "secret.txt")
     }
 
     func testSanitizeRejectsEmptyAndDotOnly() {
-        XCTAssertEqual(QuickLookDownloadView.sanitizedFileName(""), "")
-        XCTAssertEqual(QuickLookDownloadView.sanitizedFileName(".."), "")
-        XCTAssertEqual(QuickLookDownloadView.sanitizedFileName("/"), "")
-        XCTAssertEqual(QuickLookDownloadView.sanitizedFileName("   "), "")
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName(""), "")
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName(".."), "")
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName("/"), "")
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName("   "), "")
     }
 
     func testSanitizeStripsControlCharsAndCapsLength() {
-        XCTAssertEqual(QuickLookDownloadView.sanitizedFileName("a\nb\tc.pdf"), "abc.pdf")
-        XCTAssertEqual(QuickLookDownloadView.sanitizedFileName(String(repeating: "x", count: 500)).count, 200)
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName("a\nb\tc.pdf"), "abc.pdf")
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName(String(repeating: "x", count: 500)).count, 200)
     }
 
     // MARK: - preferredDownloadFileName (#3202 Unicode filename handling)
@@ -84,7 +84,7 @@ final class QuickLookDownloadErrorTests: XCTestCase {
     func testPreferredDownloadFileNameUsesRFC5987FilenameStar() {
         let header = "attachment; filename*=UTF-8''R%C3%A9sum%C3%A9%20Scan.pdf"
         XCTAssertEqual(
-            QuickLookDownloadView.preferredDownloadFileName(
+            PreviewDownloadService.preferredDownloadFileName(
                 contentDisposition: header,
                 fallback: "fallback.pdf"
             ),
@@ -95,7 +95,7 @@ final class QuickLookDownloadErrorTests: XCTestCase {
     func testPreferredDownloadFileNameFallsBackToQuotedFilename() {
         let header = #"attachment; filename="scan-final.pdf""#
         XCTAssertEqual(
-            QuickLookDownloadView.preferredDownloadFileName(
+            PreviewDownloadService.preferredDownloadFileName(
                 contentDisposition: header,
                 fallback: "fallback.pdf"
             ),
@@ -106,7 +106,7 @@ final class QuickLookDownloadErrorTests: XCTestCase {
     func testPreferredDownloadFileNameKeepsFallbackWhenServerNameIsUnsafe() {
         let header = #"attachment; filename="../..""#
         XCTAssertEqual(
-            QuickLookDownloadView.preferredDownloadFileName(
+            PreviewDownloadService.preferredDownloadFileName(
                 contentDisposition: header,
                 fallback: "fallback.pdf"
             ),

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -340,6 +340,7 @@
 		A13E7C3A2F27F36000EC9EE1 /* ActivityServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */; };
 		LOC00012F27F36000EC9EE1 /* LocationServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */; };
 		PDFC00012F27F36000EC9EE1 /* PDFDocumentCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = PDFC00022F27F36000EC9EE1 /* PDFDocumentCache.swift */; };
+		PRDL00012F27F36000EC9EE1 /* PreviewDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = PRDL00022F27F36000EC9EE1 /* PreviewDownloadService.swift */; };
 		A13E7C3C2F27F36000EC9EE1 /* ActivityTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C3B2F27F36000EC9EE1 /* ActivityTypes.swift */; };
 		A13E7C3D2F27F36000EC9EE1 /* ActivityStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C3E2F27F36000EC9EE1 /* ActivityStreamService.swift */; };
 		A13E7C462F280BE900EC9EE1 /* ActivityProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C432F280BE900EC9EE1 /* ActivityProgressView.swift */; };
@@ -957,6 +958,7 @@
 		A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityServiceGenerated.swift; sourceTree = "<group>"; };
 		LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServiceGenerated.swift; sourceTree = "<group>"; };
 		PDFC00022F27F36000EC9EE1 /* PDFDocumentCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFDocumentCache.swift; sourceTree = "<group>"; };
+		PRDL00022F27F36000EC9EE1 /* PreviewDownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDownloadService.swift; sourceTree = "<group>"; };
 		A13E7C3B2F27F36000EC9EE1 /* ActivityTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTypes.swift; sourceTree = "<group>"; };
 		A13E7C3C2F280BE900EC9EE1 /* ActivityConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityConsoleView.swift; sourceTree = "<group>"; };
 		A13E7C3E2F27F36000EC9EE1 /* ActivityStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStreamService.swift; sourceTree = "<group>"; };
@@ -1754,6 +1756,7 @@
 				A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */,
 				LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */,
 				PDFC00022F27F36000EC9EE1 /* PDFDocumentCache.swift */,
+				PRDL00022F27F36000EC9EE1 /* PreviewDownloadService.swift */,
 				A13E7C3E2F27F36000EC9EE1 /* ActivityStreamService.swift */,
 				AUT00012F27F36000EC9EE1 /* AutomationServiceGenerated.swift */,
 				A13E7C632F27F36000EC9EE1 /* ArtifactServiceGenerated.swift */,
@@ -2621,6 +2624,7 @@
 				A13E7C3A2F27F36000EC9EE1 /* ActivityServiceGenerated.swift in Sources */,
 				LOC00012F27F36000EC9EE1 /* LocationServiceGenerated.swift in Sources */,
 				PDFC00012F27F36000EC9EE1 /* PDFDocumentCache.swift in Sources */,
+				PRDL00012F27F36000EC9EE1 /* PreviewDownloadService.swift in Sources */,
 				A13E7C3D2F27F36000EC9EE1 /* ActivityStreamService.swift in Sources */,
 				202674AA2F476453008EAB5D /* ExtractEntitiesNodeConfig.swift in Sources */,
 				202674B42F4783A9008EAB5D /* WorkflowNodeCard.swift in Sources */,

--- a/fichero/fichero/Services/PreviewDownloadService.swift
+++ b/fichero/fichero/Services/PreviewDownloadService.swift
@@ -1,0 +1,177 @@
+import FicheroAPIClient
+import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "app.fichero.fichero", category: "PreviewDownloadService")
+
+/// Centralized "download a document's source file to a temp path, then hand it
+/// to a system viewer" flow (#3207). Extracted from `QuickLookDownloadView` so
+/// the raw networking + auth + HTTP-status handling + Content-Disposition
+/// parsing + temp-file lifecycle live in ONE injectable, testable service instead
+/// of inline in a view (one-path mandate; input validation on server data). The
+/// view keeps only its display state.
+///
+/// Behavior-preserving: the sanitize, status-check, error-message, and filename
+/// logic are the exact routines that landed with #3206/#3202/#3207 — moved, not
+/// changed. Cross-platform so any future "download then hand to a system viewer"
+/// flow reuses it (fix-then-sweep).
+struct PreviewDownloadService: Sendable {
+    struct Request {
+        let sourceURL: URL
+        let libraryPath: String?
+        let documentId: String
+        /// Name used when the server sends no (safe) Content-Disposition filename.
+        let fallbackFileName: String
+        /// Document path, for the linked-external-drive hint in the error message.
+        let documentPath: String?
+    }
+
+    enum Outcome {
+        /// The source file, moved into the preview cache and ready for the viewer.
+        case success(URL)
+        /// A human-readable message for the error UI (never a bare status code).
+        case failure(message: String)
+    }
+
+    /// Session factory — overridable in tests; defaults to the pinned session
+    /// every other raw storage fetch uses.
+    var makeSession: @Sendable () -> URLSession = { RemoteCertificatePinning.configuredSession() }
+
+    /// Download the source file to `FicheroPreview/<id>_<name>` and return it,
+    /// or a human error message. Any non-2xx surfaces the engine's JSON `detail`
+    /// (not the body handed to a viewer); a `/` or `..` in the server filename is
+    /// sanitized away before it can touch the cache path.
+    func download(_ request: Request) async -> Outcome {
+        if request.libraryPath == nil {
+            logger.warning("Downloading source without library path - API may reject request")
+        }
+        var urlRequest = URLRequest(url: request.sourceURL)
+        urlRequest.addEngineAuth(libraryPath: request.libraryPath)
+
+        do {
+            let (tempURL, response) = try await makeSession().download(for: urlRequest)
+
+            // Branch on the HTTP status (#3206): a non-2xx body is the engine's
+            // JSON error, not the document. Surface its `detail` instead of
+            // handing an error page to the viewer or guessing from byte size.
+            if let httpResponse = response as? HTTPURLResponse,
+               !(200..<300).contains(httpResponse.statusCode) {
+                let message = Self.downloadErrorMessage(
+                    statusCode: httpResponse.statusCode,
+                    body: try? Data(contentsOf: tempURL),
+                    documentPath: request.documentPath
+                )
+                return .failure(message: message)
+            }
+
+            var fileName = request.fallbackFileName
+            if let httpResponse = response as? HTTPURLResponse,
+               let contentDisposition = httpResponse.value(forHTTPHeaderField: "Content-Disposition") {
+                fileName = Self.preferredDownloadFileName(
+                    contentDisposition: contentDisposition,
+                    fallback: fileName
+                )
+            }
+
+            let cacheDir = Self.previewCacheDirectory
+            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+            let destURL = cacheDir.appendingPathComponent("\(request.documentId)_\(fileName)")
+
+            if FileManager.default.fileExists(atPath: destURL.path) {
+                try FileManager.default.removeItem(at: destURL)
+            }
+            try FileManager.default.moveItem(at: tempURL, to: destURL)
+
+            logger.info("Downloaded to: \(destURL.path) (extension: \(destURL.pathExtension))")
+            return .success(destURL)
+        } catch {
+            logger.error("Download error: \(error.localizedDescription)")
+            return .failure(message: "Failed to load: \(error.localizedDescription)")
+        }
+    }
+
+    /// Remove a previously-downloaded preview file, guarded to the preview root
+    /// so a stray URL can never delete outside the cache.
+    func removePreviewFile(_ fileURL: URL?) {
+        guard let fileURL else { return }
+        let previewRoot = Self.previewCacheDirectory.standardizedFileURL
+        let candidate = fileURL.standardizedFileURL
+        guard candidate.path.hasPrefix(previewRoot.path) else { return }
+        try? FileManager.default.removeItem(at: candidate)
+    }
+
+    /// The single temp directory previews are cached in.
+    static var previewCacheDirectory: URL {
+        FileManager.default.temporaryDirectory.appendingPathComponent("FicheroPreview")
+    }
+
+    // MARK: - Pure helpers (moved from QuickLookDownloadView; unit-tested)
+
+    /// Human message for a non-2xx source download (#3206): the engine's JSON
+    /// `detail` when present (get_source_file returns proper 404 detail), else a
+    /// status-coded fallback, plus the linked-external-drive hint that helps a
+    /// user mount an unplugged volume. Pure + static so it is unit-testable.
+    static func downloadErrorMessage(statusCode: Int, body: Data?, documentPath: String?) -> String {
+        var message = "Preview unavailable (HTTP \(statusCode))"
+        if let body,
+           let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
+           let detail = object["detail"] as? String, !detail.isEmpty {
+            message = detail
+        }
+        if let documentPath, documentPath.hasPrefix("/Volumes/") {
+            message += "\n\nThis file is linked to an external drive:\n\(documentPath)"
+            message += "\n\nMount the drive to view the full resolution file."
+        }
+        return message
+    }
+
+    /// Reduce a server-supplied Content-Disposition filename to a safe leaf
+    /// before it is spliced into a cache path (#3207): keep only the last path
+    /// component, drop path separators + control chars, reject empty / `.` /
+    /// `..`, and cap the length. Returns "" when nothing safe remains (the
+    /// caller then keeps its document-derived name). Pure + static → testable.
+    static func sanitizedFileName(_ raw: String) -> String {
+        // Normalize Windows separators so lastPathComponent (splits on "/" only)
+        // reduces "..\\..\\x" to its leaf too, then drop any residual separator +
+        // control chars.
+        let leaf = (raw.replacingOccurrences(of: "\\", with: "/") as NSString).lastPathComponent
+        let kept = leaf.unicodeScalars.filter { scalar in
+            scalar != "/" && !CharacterSet.controlCharacters.contains(scalar)
+        }
+        let cleaned = String(String.UnicodeScalarView(kept)).trimmingCharacters(in: .whitespaces)
+        guard !cleaned.isEmpty, cleaned != ".", cleaned != ".." else { return "" }
+        return String(cleaned.prefix(200))
+    }
+
+    /// Pick the best cache filename from a Content-Disposition header. Supports
+    /// both RFC 5987 `filename*=` (UTF-8 percent-encoded) and plain
+    /// `filename=`. Every server-provided value is sanitized before use; if no
+    /// safe value remains, the caller's fallback is kept. Pure + static so the
+    /// Unicode/header parsing contract is unit-testable.
+    static func preferredDownloadFileName(contentDisposition: String, fallback: String) -> String {
+        let parts = contentDisposition.split(separator: ";").map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        for part in parts {
+            guard part.lowercased().hasPrefix("filename*=") else { continue }
+            let rawValue = String(part.dropFirst("filename*=".count))
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            let encoded = rawValue.components(separatedBy: "''").last ?? rawValue
+            if let decoded = encoded.removingPercentEncoding {
+                let sanitized = sanitizedFileName(decoded)
+                if !sanitized.isEmpty { return sanitized }
+            }
+        }
+
+        for part in parts {
+            guard part.lowercased().hasPrefix("filename=") else { continue }
+            let rawValue = String(part.dropFirst("filename=".count))
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            let sanitized = sanitizedFileName(rawValue)
+            if !sanitized.isEmpty { return sanitized }
+        }
+
+        return fallback
+    }
+}

--- a/fichero/fichero/Views/Library/QuickLookComponents.swift
+++ b/fichero/fichero/Views/Library/QuickLookComponents.swift
@@ -23,6 +23,10 @@ struct QuickLookDownloadView: View {
 
     @Environment(APIClient.self) var apiClient
 
+    /// The download/auth/temp-file flow lives in the service (#3207); the view
+    /// keeps only fileURL/isLoading/error state.
+    private let downloadService = PreviewDownloadService()
+
     var body: some View {
         Group {
             if let url = fileURL {
@@ -74,163 +78,31 @@ struct QuickLookDownloadView: View {
             await loadFile()
         }
         .onDisappear {
-            cleanupTemporaryFile()
+            downloadService.removePreviewFile(fileURL)
         }
     }
 
     private func loadFile() async {
         isLoading = true
         error = nil
+        downloadService.removePreviewFile(fileURL)
         fileURL = nil
-        cleanupTemporaryFile()
         logger.info("Loading file from API for document: \(document.id)")
-        await downloadFromAPI()
-    }
 
-    private func downloadFromAPI() async {
-        let sourceURL = apiClient.sourceURL(for: document.id)
-
-        do {
-            if apiClient.currentLibraryPath == nil {
-                logger.warning("Downloading source without library path - API may reject request")
-            }
-            var request = URLRequest(url: sourceURL)
-            request.addEngineAuth(libraryPath: apiClient.currentLibraryPath)
-
-            // Download file from API
-            let session = RemoteCertificatePinning.configuredSession()
-            let (tempURL, response) = try await session.download(for: request)
-
-            // Branch on the HTTP status (#3206): a non-2xx body is the engine's
-            // JSON error, not the document. Surface its `detail` instead of
-            // handing an error page to Quick Look or guessing from byte size.
-            if let httpResponse = response as? HTTPURLResponse,
-               !(200..<300).contains(httpResponse.statusCode) {
-                let message = Self.downloadErrorMessage(
-                    statusCode: httpResponse.statusCode,
-                    body: try? Data(contentsOf: tempURL),
-                    documentPath: document.path
-                )
-                await MainActor.run {
-                    self.error = message
-                    self.isLoading = false
-                }
-                return
-            }
-
-            var fileName = fileNameWithExtension()
-            if let httpResponse = response as? HTTPURLResponse,
-               let contentDisposition = httpResponse.value(forHTTPHeaderField: "Content-Disposition") {
-                fileName = Self.preferredDownloadFileName(
-                    contentDisposition: contentDisposition,
-                    fallback: fileName
-                )
-            }
-
-            // Move to cache directory
-            let cacheDir = FileManager.default.temporaryDirectory
-                .appendingPathComponent("FicheroPreview")
-            try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
-
-            let destURL = cacheDir.appendingPathComponent("\(document.id)_\(fileName)")
-
-            // Remove existing
-            if FileManager.default.fileExists(atPath: destURL.path) {
-                try FileManager.default.removeItem(at: destURL)
-            }
-            try FileManager.default.moveItem(at: tempURL, to: destURL)
-
-            logger.info("Downloaded to: \(destURL.path) (extension: \(destURL.pathExtension))")
-
-            await MainActor.run {
-                self.fileURL = destURL
-                self.isLoading = false
-            }
-        } catch {
-            logger.error("Download error: \(error.localizedDescription)")
-            await MainActor.run {
-                self.error = "Failed to load: \(error.localizedDescription)"
-                self.isLoading = false
-            }
+        let outcome = await downloadService.download(.init(
+            sourceURL: apiClient.sourceURL(for: document.id),
+            libraryPath: apiClient.currentLibraryPath,
+            documentId: document.id,
+            fallbackFileName: fileNameWithExtension(),
+            documentPath: document.path
+        ))
+        switch outcome {
+        case .success(let url):
+            fileURL = url
+        case .failure(let message):
+            error = message
         }
-    }
-
-    /// Human message for a non-2xx source download (#3206): the engine's JSON
-    /// `detail` when present (get_source_file returns proper 404 detail), else a
-    /// status-coded fallback, plus the linked-external-drive hint that helps a
-    /// user mount an unplugged volume. Pure + static so it is unit-testable.
-    static func downloadErrorMessage(statusCode: Int, body: Data?, documentPath: String?) -> String {
-        var message = "Preview unavailable (HTTP \(statusCode))"
-        if let body,
-           let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any],
-           let detail = object["detail"] as? String, !detail.isEmpty {
-            message = detail
-        }
-        if let documentPath, documentPath.hasPrefix("/Volumes/") {
-            message += "\n\nThis file is linked to an external drive:\n\(documentPath)"
-            message += "\n\nMount the drive to view the full resolution file."
-        }
-        return message
-    }
-
-    /// Reduce a server-supplied Content-Disposition filename to a safe leaf
-    /// before it is spliced into a cache path (#3207): keep only the last path
-    /// component, drop path separators + control chars, reject empty / `.` /
-    /// `..`, and cap the length. Returns "" when nothing safe remains (the
-    /// caller then keeps its document-derived name). Pure + static → testable.
-    static func sanitizedFileName(_ raw: String) -> String {
-        // Normalize Windows separators so lastPathComponent (splits on "/" only)
-        // reduces "..\\..\\x" to its leaf too, then drop any residual separator +
-        // control chars.
-        let leaf = (raw.replacingOccurrences(of: "\\", with: "/") as NSString).lastPathComponent
-        let kept = leaf.unicodeScalars.filter { scalar in
-            scalar != "/" && !CharacterSet.controlCharacters.contains(scalar)
-        }
-        let cleaned = String(String.UnicodeScalarView(kept)).trimmingCharacters(in: .whitespaces)
-        guard !cleaned.isEmpty, cleaned != ".", cleaned != ".." else { return "" }
-        return String(cleaned.prefix(200))
-    }
-
-    /// Pick the best cache filename from a Content-Disposition header. Supports
-    /// both RFC 5987 `filename*=` (UTF-8 percent-encoded) and plain
-    /// `filename=`. Every server-provided value is sanitized before use; if no
-    /// safe value remains, the caller's fallback is kept. Pure + static so the
-    /// Unicode/header parsing contract is unit-testable.
-    static func preferredDownloadFileName(contentDisposition: String, fallback: String) -> String {
-        let parts = contentDisposition.split(separator: ";").map {
-            $0.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-
-        for part in parts {
-            guard part.lowercased().hasPrefix("filename*=") else { continue }
-            let rawValue = String(part.dropFirst("filename*=".count))
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            let encoded = rawValue.components(separatedBy: "''").last ?? rawValue
-            if let decoded = encoded.removingPercentEncoding {
-                let sanitized = sanitizedFileName(decoded)
-                if !sanitized.isEmpty { return sanitized }
-            }
-        }
-
-        for part in parts {
-            guard part.lowercased().hasPrefix("filename=") else { continue }
-            let rawValue = String(part.dropFirst("filename=".count))
-                .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-            let sanitized = sanitizedFileName(rawValue)
-            if !sanitized.isEmpty { return sanitized }
-        }
-
-        return fallback
-    }
-
-    private func cleanupTemporaryFile() {
-        guard let fileURL else { return }
-        let previewRoot = FileManager.default.temporaryDirectory
-            .appendingPathComponent("FicheroPreview")
-            .standardizedFileURL
-        let candidate = fileURL.standardizedFileURL
-        guard candidate.path.hasPrefix(previewRoot.path) else { return }
-        try? FileManager.default.removeItem(at: candidate)
+        isLoading = false
     }
 
     // Get filename with proper extension


### PR DESCRIPTION
Behavior-preserving refactor: the inline hand-rolled URLSession download (with Content-Disposition sanitize + HTTP-status handling) is extracted into a reusable PreviewDownloadService — centralized + testable, out of the view. Completes the Preview download/render hardening cluster (#3206/#3207/#3208/#3209/#3210). BUILD SUCCEEDED, swiftlint 0 errors. 🤖 Claude (Opus 4.8)