### PR TITLE
★ EVERY FRAME PERFECT: detail-window empty↔content crossfade — closing audit (#3614)

### DIFF
--- a/fichero/fichero/Views/Library/Inspector/FocusedDocument.swift
+++ b/fichero/fichero/Views/Library/Inspector/FocusedDocument.swift
@@ -66,6 +66,11 @@ struct DocumentDetailWindow: View {
                 )
             }
         }
+        // ★ EVERY FRAME PERFECT (#3614): the empty ↔ document swap sits on the
+        // semantic surface (no bare-white gap) and cross-fades with the shared
+        // timing instead of a jump-cut when the followed document changes.
+        .background(Color(platformColor: .windowBackgroundColor))
+        .animation(FrameAnimation.crossfade, value: shownDocument?.id)
         .navigationTitle(shownDocument?.name ?? "Document")
         .navigationSubtitle(activeLibrary?.displayName ?? "")
         .toolbar {


### PR DESCRIPTION
Closing EFP audit: swept the remaining transitions; the one residual found — the document detail window's empty↔content swap flashed — now uses the surface-base + crossfade pattern. Rest of the transitions are clean (built on the shared SkeletonPlaceholder/FrameAnimation/surface-base work from #3615-#3619). BUILD SUCCEEDED, swiftlint 0 errors. Completes the ★ EVERY FRAME PERFECT milestone (6/6). 🤖 Claude (Opus 4.8)