### PR TITLE
iPad/iPhone parity: no forced 500pt sheet width on iPhone (#3666 slice 2)

### DIFF
--- a/fichero/fichero/Views/Sheets/DocumentPickerSheet.swift
+++ b/fichero/fichero/Views/Sheets/DocumentPickerSheet.swift
@@ -129,7 +129,11 @@ struct DocumentPickerSheet: View {
             }
             .padding()
         }
+        // macOS sheets need an explicit size; on iPhone a fixed 500pt width
+        // overflows the ~390pt screen, so let iOS use natural sheet sizing (#3666).
+        #if os(macOS)
         .frame(width: 500, height: 600)
+        #endif
     }
 
     private func runBatch() {

--- a/fichero/fichero/Views/Sheets/WorkflowPickerSheet.swift
+++ b/fichero/fichero/Views/Sheets/WorkflowPickerSheet.swift
@@ -105,7 +105,11 @@ struct WorkflowPickerSheet: View {
             }
             .padding()
         }
+        // macOS sheets need an explicit size; on iPhone a fixed 500pt width
+        // overflows the ~390pt screen, so let iOS use natural sheet sizing (#3666).
+        #if os(macOS)
         .frame(width: 500, height: 600)
+        #endif
     }
 }
 


### PR DESCRIPTION
DocumentPickerSheet + WorkflowPickerSheet no longer force a 500pt width on iPhone (compact) — they size to the compact presentation instead of overflowing. macOS BUILD SUCCEEDED, swiftlint 0 errors; no macOS-only API touched (iOS-safe conditional sizing). 🤖 Claude (Opus 4.8)