### PR TITLE
iPad/iPhone parity: cap source-provenance popover width on compact (#3666 slice 4)

### DIFF
--- a/fichero/fichero/Views/Library/Inspector/SourceProvenancePopover.swift
+++ b/fichero/fichero/Views/Library/Inspector/SourceProvenancePopover.swift
@@ -84,7 +84,14 @@ struct SourceProvenanceCard: View {
             .font(.callout)
         }
         .padding(12)
+        // macOS popover wants a fixed width; on iPhone this popover adapts to a
+        // sheet, where a hard 320pt clips on a 320pt device and can't shrink — so
+        // cap instead of fix (#3666). The desktop popover is unchanged.
+        #if os(macOS)
         .frame(width: 320)
+        #else
+        .frame(maxWidth: 320)
+        #endif
     }
 
     /// Prefer the attribution's verbatim quotation; fall back to the claim text.


### PR DESCRIPTION
The source-provenance popover forced a fixed width that overflowed on compact — now caps (maxWidth) so it fits iPhone/iPad-compact. macOS BUILD SUCCEEDED, swiftlint 0 errors. 🤖 Claude (Opus 4.8)