### PR TITLE
Image editing: client-side Core Image live-preview LiveEditPreview (#3673, hybrid #3213)

### DIFF
--- a/fichero/fichero-tests/LiveEditPreviewTests.swift
+++ b/fichero/fichero-tests/LiveEditPreviewTests.swift
@@ -1,0 +1,71 @@
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
+@testable import Fichero
+import CoreGraphics
+import Foundation
+import Testing
+
+/// Client-side Core Image live preview (#3673): composites in-progress slider
+/// values over the original with NO backend, and the model resyncs to the
+/// server frame on commit (ImageEditChain stays the sole source of truth).
+@MainActor
+@Suite("LiveEditPreview")
+struct LiveEditPreviewTests {
+
+    /// A small solid-colour bitmap, wrapped as the platform image type.
+    private static func testImage(_ side: Int = 8) -> PlatformImage {
+        let space = CGColorSpaceCreateDeviceRGB()
+        let context = CGContext(
+            data: nil, width: side, height: side, bitsPerComponent: 8, bytesPerRow: 0,
+            space: space, bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )!
+        context.setFillColor(CGColor(red: 0.5, green: 0.5, blue: 0.5, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: side, height: side))
+        let cgImage = context.makeImage()!
+        #if canImport(AppKit)
+        return NSImage(cgImage: cgImage, size: NSSize(width: side, height: side))
+        #else
+        return UIImage(cgImage: cgImage)
+        #endif
+    }
+
+    @Test("composites a frame for given slider values, with no backend call")
+    func rendersCompositedFrame() {
+        let live = LiveEditPreview(original: Self.testImage())
+        #expect(live != nil)
+
+        let frame = live?.render(brightness: 1.5, contrast: 1.2, sharpen: 1.3, angleDegrees: 0)
+        #expect(frame != nil)
+        #expect(frame?.pixelSize.width ?? 0 > 0)
+        #expect(frame?.pixelSize.height ?? 0 > 0)
+    }
+
+    @Test("neutral values still return a valid frame")
+    func neutralRenders() {
+        let frame = LiveEditPreview(original: Self.testImage())?
+            .render(brightness: 1, contrast: 1, sharpen: 1, angleDegrees: 0)
+        #expect(frame != nil)
+    }
+
+    @Test("model: live edit sets a provisional frame, discard resyncs to the server preview")
+    func liveEditThenDiscardResyncs() {
+        let model = ImageEditorModel()
+        let original = PreviewImage(image: Self.testImage(), pixelSize: CGSize(width: 8, height: 8))
+        let edited = PreviewImage(image: Self.testImage(), pixelSize: CGSize(width: 8, height: 8))
+        model.originalPreview = original
+        model.editedPreview = edited
+        model.showEdited = true
+        model.preview = edited
+
+        model.previewLiveEdit(brightness: 1.6, contrast: 1, sharpen: 1)
+        // A provisional Core Image frame replaced the server preview...
+        #expect(model.preview?.image !== edited.image)
+
+        model.discardLiveEdit()
+        // ...and discarding restores the authoritative (server) edited preview.
+        #expect(model.preview?.image === edited.image)
+    }
+}

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		35B42F6B063872E635AD5362 /* WindowSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE84D175FC1F5C5644EB914 /* WindowSeed.swift */; };
 		35CD189B6E6257ACC5F97863 /* SidebarItemRow+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47244E304896B65E6F12976C /* SidebarItemRow+Preview.swift */; };
 		36C67BBF07CCFEAF928943C9 /* ImageEditorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF014F0FAEFCA5233DCB114F /* ImageEditorModel.swift */; };
+		LIVE00012F27F36000EC9EE1 /* LiveEditPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = LIVE00022F27F36000EC9EE1 /* LiveEditPreview.swift */; };
 		37125B13A36AF61C3B5868C3 /* NodeComparisonSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D455270E3396946CF4F1939 /* NodeComparisonSheet.swift */; };
 		37B827A97DAB87AADDC8642A /* CanvasScene3DRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A8D1A3FCF024827D89665 /* CanvasScene3DRenderer.swift */; };
 		3D3445F0B90D093149C9A7D6 /* DocumentInspectorContentTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36234E44A7E494963A441CDC /* DocumentInspectorContentTab.swift */; };
@@ -1191,6 +1192,7 @@
 		EE609F48196839FAA6981CFF /* SearchStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchStore.swift; sourceTree = "<group>"; };
 		EEFD8D2157AA0C0F66955D78 /* IdentityStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IdentityStore.swift; sourceTree = "<group>"; };
 		EF014F0FAEFCA5233DCB114F /* ImageEditorModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageEditorModel.swift; sourceTree = "<group>"; };
+		LIVE00022F27F36000EC9EE1 /* LiveEditPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveEditPreview.swift; sourceTree = "<group>"; };
 		EF8C2AF12DD3E6EAB64C68B4 /* WorkspaceItemPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceItemPicker.swift; sourceTree = "<group>"; };
 		EFA65406167827DCB144E3E2 /* NoteStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NoteStore.swift; sourceTree = "<group>"; };
 		F01276A4ABA0F672CF1D8067 /* DocumentInspectorInfoTab+Bibliography.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentInspectorInfoTab+Bibliography.swift"; sourceTree = "<group>"; };
@@ -2126,6 +2128,7 @@
 			isa = PBXGroup;
 			children = (
 				EF014F0FAEFCA5233DCB114F /* ImageEditorModel.swift */,
+				LIVE00022F27F36000EC9EE1 /* LiveEditPreview.swift */,
 				95706A3222B50B478F15D83D /* ImageEditChainPanel.swift */,
 				5C8EFF7D9BC634BAE18E0F47 /* ImageEditorView.swift */,
 				72D05E0BE3C8D1AEA1AA3A8D /* ImageMarqueeOverlay.swift */,
@@ -2857,6 +2860,7 @@
 				E16CECCFD4B4BCE53B2FEC36 /* KGTimelineView.swift in Sources */,
 				54A07EFB77CACCF2E0ADDD84 /* ImageEditingServiceGenerated.swift in Sources */,
 				36C67BBF07CCFEAF928943C9 /* ImageEditorModel.swift in Sources */,
+				LIVE00012F27F36000EC9EE1 /* LiveEditPreview.swift in Sources */,
 				7800350961E1C38A10D02D54 /* ImageEditChainPanel.swift in Sources */,
 				F23CD14AC5C36398DB6CCC74 /* ImageEditorView.swift in Sources */,
 				F272CFE1FADD5F15F71CFC23 /* ImageMarqueeOverlay.swift in Sources */,

--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditorModel.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditorModel.swift
@@ -48,6 +48,12 @@ final class ImageEditorModel {
     private var service: ImageEditingServiceGenerated?
     private(set) var documentId: String = ""
 
+    /// Client-side Core Image live-preview compositor (#3673). Built lazily from
+    /// `originalPreview`, cached, and evicted on document change / chain reset.
+    /// PROVISIONAL only — the server render replaces its frame on commit; the
+    /// `ImageEditChain` stays the sole source of truth. Never observed directly.
+    @ObservationIgnored private var liveEditPreview: LiveEditPreview?
+
     /// In-flight original↔edited toggle. Tracked so rapid taps coalesce to the
     /// latest intended state instead of running out of order (#1508).
     private var toggleTask: Task<Void, Never>?
@@ -71,7 +77,43 @@ final class ImageEditorModel {
         self.preview = nil
         self.originalPreview = nil
         self.editedPreview = nil
+        // Drop the client live-preview cache — the original bytes belong to the
+        // previous document (#3673). It rebuilds lazily on the next slider drag.
+        self.liveEditPreview = nil
         await reload()
+    }
+
+    // MARK: - Client-side live preview (#3673)
+
+    /// Composite an in-progress enhance/rotate LOCALLY (no backend) for a
+    /// continuously-dragged slider, so it previews at ~60fps. Sets `preview` to a
+    /// provisional Core Image frame over the ORIGINAL bytes; the next commit
+    /// (`enhance`/`rotate`) resyncs it from the server. A no-op until the original
+    /// has loaded. This never touches the chain and adds no network call.
+    func previewLiveEdit(
+        brightness: Double = 1,
+        contrast: Double = 1,
+        sharpen: Double = 1,
+        angleDegrees: Double = 0
+    ) {
+        if liveEditPreview == nil, let original = originalPreview?.image {
+            liveEditPreview = LiveEditPreview(original: original)
+        }
+        guard let liveEditPreview,
+              let frame = liveEditPreview.render(
+                  brightness: brightness,
+                  contrast: contrast,
+                  sharpen: sharpen,
+                  angleDegrees: angleDegrees
+              )
+        else { return }
+        preview = frame
+    }
+
+    /// Discard the provisional live frame and restore the authoritative preview —
+    /// e.g. when the user dismisses a slider without committing (#3673).
+    func discardLiveEdit() {
+        preview = showEdited ? editedPreview : originalPreview
     }
 
     /// Reload both the chain and the current preview.

--- a/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/ImageEditorView.swift
@@ -46,6 +46,9 @@ struct ImageEditorView: View {
     @State private var contrast: Double = 1.0
     @State private var sharpen: Double = 1.0
     @State private var showEnhancePopover = false
+    /// True once Apply/Auto-Levels kicked off a commit, so dismissing the popover
+    /// doesn't discard the live frame the server render is about to replace (#3673).
+    @State private var enhanceCommitted = false
 
     /// Marquee selection in normalized image space (0…1); nil when none (#1265).
     @State private var marqueeSelection: CGRect?
@@ -384,11 +387,13 @@ private extension ImageEditorView {
             enhanceSlider("Sharpen", value: $sharpen)
             HStack {
                 Button("Auto Levels") {
+                    enhanceCommitted = true
                     Task { await model.enhance(brightness: 1, contrast: 1, sharpen: 1, autoLevels: true) }
                     showEnhancePopover = false
                 }
                 Spacer()
                 Button("Apply") {
+                    enhanceCommitted = true
                     Task {
                         await model.enhance(
                             brightness: brightness,
@@ -405,6 +410,23 @@ private extension ImageEditorView {
         }
         .padding(16)
         .frame(width: 260)
+        // Live client-side preview while dragging (#3673): composite the slider
+        // values over the original via Core Image — no backend — so the canvas
+        // updates at 60fps. On commit (Apply/Auto-Levels) the server render
+        // replaces it; on dismiss-without-commit the provisional frame is dropped.
+        .onChange(of: brightness) { previewLiveEnhance() }
+        .onChange(of: contrast) { previewLiveEnhance() }
+        .onChange(of: sharpen) { previewLiveEnhance() }
+        .onDisappear {
+            if !enhanceCommitted { model.discardLiveEdit() }
+            enhanceCommitted = false
+        }
+    }
+
+    /// Push the current enhance-slider values to the model's client-side live
+    /// preview (#3673) — provisional, replaced by the server render on commit.
+    private func previewLiveEnhance() {
+        model.previewLiveEdit(brightness: brightness, contrast: contrast, sharpen: sharpen)
     }
 
     private func enhanceSlider(_ label: String, value: Binding<Double>) -> some View {

--- a/fichero/fichero/Views/Library/ImageEditor/LiveEditPreview.swift
+++ b/fichero/fichero/Views/Library/ImageEditor/LiveEditPreview.swift
@@ -1,0 +1,97 @@
+#if canImport(AppKit)
+import AppKit
+#elseif canImport(UIKit)
+import UIKit
+#endif
+import CoreImage
+import CoreImage.CIFilterBuiltins
+import Foundation
+
+/// Client-side Core Image live preview for continuously-dragged image-edit
+/// sliders (#3673 — the client half of the hybrid #3213). Composites the
+/// ALREADY-FETCHED original image with the in-progress slider values through a
+/// GPU `CIContext` — with NO backend call — so brightness/contrast/sharpen/
+/// rotate-angle preview at ~60fps with no network chatter.
+///
+/// This is a LATENCY OPTIMISATION ONLY, never a source of truth. The frame it
+/// produces is PROVISIONAL: on slider release the editor POSTs the op, the engine
+/// appends it to the `ImageEditChain` (the sole source of truth), and the server
+/// bytes replace this frame — so the two can't diverge more than one round-trip.
+/// The values are the editor's 1.0-neutral multipliers; the mapping onto Core
+/// Image's parameters is approximate on purpose — exactness comes from the server
+/// resync, not this frame. Cross-platform (Core Image is AppKit/UIKit).
+struct LiveEditPreview {
+    private let source: CIImage
+    private let context: CIContext
+
+    /// Build from the original preview's decoded image, captured once. Callers
+    /// evict + rebuild on document change / chain reset. Returns nil if the image
+    /// has no backing `CGImage`.
+    init?(original: PlatformImage) {
+        guard let cgImage = original.liveEditCGImage else { return nil }
+        self.source = CIImage(cgImage: cgImage)
+        self.context = CIContext(options: [.useSoftwareRenderer: false])
+    }
+
+    /// Composite the ABSOLUTE slider values over the fixed original (never
+    /// compounding between frames). All-neutral (1.0 / 0°) returns the original.
+    func render(
+        brightness: Double = 1,
+        contrast: Double = 1,
+        sharpen: Double = 1,
+        angleDegrees: Double = 0
+    ) -> PreviewImage? {
+        var image = source
+
+        // colorControls: the editor's brightness is a 1.0-neutral MULTIPLIER;
+        // Core Image's inputBrightness is ADDITIVE (0 neutral), so shift by -1.
+        // Contrast maps ~directly (1.0 neutral on both sides).
+        if brightness != 1.0 || contrast != 1.0 {
+            let filter = CIFilter.colorControls()
+            filter.inputImage = image
+            filter.brightness = Float(brightness - 1.0)
+            filter.contrast = Float(contrast)
+            filter.saturation = 1.0
+            if let output = filter.outputImage { image = output }
+        }
+
+        // sharpen: editor 1.0 neutral → 0 sharpness; > 1.0 sharpens.
+        if sharpen > 1.0 {
+            let filter = CIFilter.sharpenLuminance()
+            filter.inputImage = image
+            filter.sharpness = Float(sharpen - 1.0)
+            if let output = filter.outputImage { image = output }
+        }
+
+        // rotate-angle: straightenFilter rotates about the centre (radians) and
+        // crops to fill, matching the editor's straighten/rotate-angle slider.
+        if angleDegrees != 0 {
+            let filter = CIFilter.straighten()
+            filter.inputImage = image
+            filter.angle = Float(angleDegrees * .pi / 180)
+            if let output = filter.outputImage { image = output }
+        }
+
+        guard let cgImage = context.createCGImage(image, from: image.extent) else { return nil }
+        let pixelSize = CGSize(width: cgImage.width, height: cgImage.height)
+        #if canImport(AppKit)
+        return PreviewImage(
+            image: NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height)),
+            pixelSize: pixelSize
+        )
+        #elseif canImport(UIKit)
+        return PreviewImage(image: UIImage(cgImage: cgImage), pixelSize: pixelSize)
+        #endif
+    }
+}
+
+private extension PlatformImage {
+    /// The backing `CGImage`, cross-platform.
+    var liveEditCGImage: CGImage? {
+        #if canImport(AppKit)
+        return cgImage(forProposedRect: nil, context: nil, hints: nil)
+        #elseif canImport(UIKit)
+        return cgImage
+        #endif
+    }
+}


### PR DESCRIPTION
Implements the client half of the hybrid architecture (design doc §Decision, #3213): a new LiveEditPreview composites brightness/contrast/sharpen over the cached original CGImage via a GPU CIContext with NO backend call — 60fps slider feedback. On commit the existing server flow is unchanged and the provisional frame is discarded/resynced to the server render (backend ImageEditChain stays the sole source of truth). Properly platform-guarded (AppKit/UIKit → NSImage/UIImage, CGImage output — cross-platform). + LiveEditPreviewTests. macOS BUILD SUCCEEDED, swiftlint 0 errors, iOS-safe by construction. 🤖 Claude (Opus 4.8)