### PR TITLE
MAS prep (additive): App Sandbox entitlements + Sparkle-hide guard (#3340)

### DIFF
--- a/fichero/fichero/FicheroApp.swift
+++ b/fichero/fichero/FicheroApp.swift
@@ -335,7 +335,12 @@ struct FicheroApp: App {
             }
             #endif
             CommandGroup(after: .appInfo) {
-                #if os(macOS)
+                // Sparkle auto-update is the DMG/Developer-ID channel only. The
+                // Mac App Store forbids Sparkle's helpers and does its own
+                // updates, so the MAS build (which defines APP_STORE and doesn't
+                // link Sparkle) hides this item (#3340). No-op on Dev/Release,
+                // which never define APP_STORE — those keep the update item.
+                #if os(macOS) && !APP_STORE
                 Button("Check for Updates...") {
                     SparkleUpdater.shared.checkForUpdates()
                 }

--- a/fichero/fichero/FicheroAppStore.entitlements
+++ b/fichero/fichero/FicheroAppStore.entitlements
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Mac App Store entitlements (#3340). Distinct from FicheroRelease.entitlements
+  (the DMG / Developer ID channel, which is NOT sandboxed). The MAS build MUST
+  enable App Sandbox on the app and every nested executable, or the upload is
+  rejected (code 90296).
+
+  Only the App-side entitlements live here. The embedded engine's sandbox is set
+  by Briefcase in fichero-engine/pyproject.toml (deliberately NOT wired yet — see
+  #3340 HOLD note: sandboxing the shared engine build risks the DMG engine and
+  needs security-scoped-bookmark plumbing validated first).
+-->
+<plist version="1.0">
+<dict>
+	<!-- App Sandbox — required for the Mac App Store. -->
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+
+	<!-- The app talks to its embedded engine over loopback (client) and the
+	     engine binds a loopback port (server). Both are needed under the sandbox. -->
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+
+	<!-- Open a .fichero library the user picked. -->
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+
+	<!-- Persist access to previously-opened libraries across launches via
+	     security-scoped bookmarks. app-scope is the app's own recents; the
+	     runtime plumbing that HANDS these bookmarks to the sandboxed engine is
+	     the remaining work held for Daniel (#3340). -->
+	<key>com.apple.security.files.bookmarks.app-scope</key>
+	<true/>
+	<key>com.apple.security.files.bookmarks.document-scope</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
Mac App Store prep, ADDITIVE + safe: new standalone FicheroAppStore.entitlements (App Sandbox + capabilities) NOT wired into any target yet (the DMG's FicheroRelease.entitlements is untouched, stays un-sandboxed — active TestFlight/DMG archive UNAFFECTED); FicheroApp guards the Sparkle 'Check for Updates' menu (Sparkle isn't allowed on MAS). Foundation only — wiring the MAS target + verifying the sandboxed embedded engine is a later slice (HOLD if sandbox breaks the loopback engine). macOS BUILD SUCCEEDED, swiftlint 0 errors, Dev/Release schemes unaffected. 🤖 Claude (Opus 4.8)