### PR TITLE
Engine: external-authority reconciliation — opt-in cached snapshots (#3528 slice 1) + regen switch fix

### DIFF
--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -23702,7 +23702,8 @@
               "enum": [
                 "library",
                 "folder",
-                "cross-library"
+                "cross-library",
+                "external-authority"
               ],
               "type": "string",
               "default": "library",
@@ -23718,6 +23719,16 @@
               "nullable": true,
               "title": "Folder Id"
             }
+          },
+          {
+            "name": "entity_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Entity Id"
+            }
           }
         ],
         "responses": {
@@ -23727,6 +23738,149 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/KGGraphListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/entity-curation/authority/settings": {
+      "get": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Read the app-wide external-authority opt-in",
+        "operationId": "get_external_authority_settings_api_kg_entity_curation_authority_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalAuthoritySettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Set the app-wide external-authority opt-in",
+        "operationId": "put_external_authority_settings_api_kg_entity_curation_authority_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExternalAuthoritySettings"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalAuthoritySettings"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/entity-curation/authority/refresh": {
+      "post": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Explicitly refresh local Wikidata authority snapshots",
+        "description": "Outbound network is attempted only by this explicitly requested, opt-in endpoint.",
+        "operationId": "refresh_external_authority_api_kg_entity_curation_authority_refresh_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthorityRefreshRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KGGraphListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/entity-curation/authority/link": {
+      "post": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Confirm and persist an entity-to-authority link",
+        "operationId": "link_external_authority_api_kg_entity_curation_authority_link_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthorityLinkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityAuditResponse"
                 }
               }
             }
@@ -35786,6 +35940,58 @@
         "title": "AuthIdentityUser",
         "description": "Authenticated account identity, when the credential resolves to a user."
       },
+      "AuthorityLinkRequest": {
+        "properties": {
+          "entity_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Entity Id"
+          },
+          "authority": {
+            "type": "string",
+            "enum": [
+              "wikidata",
+              "viaf",
+              "loc"
+            ],
+            "title": "Authority"
+          },
+          "authority_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Authority Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "entity_id",
+          "authority",
+          "authority_id"
+        ],
+        "title": "AuthorityLinkRequest"
+      },
+      "AuthorityRefreshRequest": {
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Query"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 20.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "default": 10
+          }
+        },
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "title": "AuthorityRefreshRequest"
+      },
       "BatchClaimCurationRequest": {
         "properties": {
           "claim_ids": {
@@ -40761,6 +40967,7 @@
           },
           "page": {
             "type": "integer",
+            "minimum": 1.0,
             "title": "Page",
             "default": 1
           }
@@ -43087,7 +43294,8 @@
           "merge",
           "split",
           "undo_merge",
-          "undo_split"
+          "undo_split",
+          "authority_link"
         ],
         "title": "EntityMergeOperationType"
       },
@@ -44161,6 +44369,17 @@
         ],
         "title": "ExportedFileResponse"
       },
+      "ExternalAuthoritySettings": {
+        "properties": {
+          "external_authority_enabled": {
+            "type": "boolean",
+            "title": "External Authority Enabled",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "ExternalAuthoritySettings"
+      },
       "ExtractTextRequest": {
         "properties": {
           "document_ids": {
@@ -45121,6 +45340,7 @@
           },
           "page": {
             "type": "integer",
+            "minimum": 1.0,
             "title": "Page",
             "default": 1
           },
@@ -56082,6 +56302,7 @@
           },
           "page": {
             "type": "integer",
+            "minimum": 1.0,
             "title": "Page",
             "default": 1
           }

--- a/fichero-engine/src/fichero/api/routes/kg_entity_curation.py
+++ b/fichero-engine/src/fichero/api/routes/kg_entity_curation.py
@@ -17,8 +17,10 @@ from pydantic import BaseModel, Field
 
 from fichero.api.library_header import require_library_path
 from fichero.api.auth import action_context, request_actor
+from fichero.api.routes.auth_accounts import _require_owner_or_bootstrap
 from fichero.api.change_stream import emit_change
 from fichero.api.main import get_library_database, get_library_database_for_write
+from fichero.app_db import get_app_db
 from fichero.db import Database
 from fichero.db_manager import db_manager
 from fichero.db_embeddings import KG_ENTITY_EMBEDDINGS_TABLE
@@ -27,6 +29,7 @@ from fichero.knowledge_models import (
     EntityMergeOperationType,
     EntityCurationState,
     EntityType,
+    AuthoritySnapshot,
     KnowledgeEntity,
     KnowledgeClaim,
     MutationLog,
@@ -88,6 +91,78 @@ class BatchEntityCurationResponse(BaseModel):
 
 class _EmbedEntityRequest(BaseModel):
     entity_ids: list[str] | None = None
+
+
+class ExternalAuthoritySettings(BaseModel):
+    external_authority_enabled: bool = False
+
+
+class AuthorityRefreshRequest(BaseModel):
+    query: str = Field(min_length=1, max_length=200)
+    limit: int = Field(default=10, ge=1, le=20)
+
+
+class AuthorityLinkRequest(BaseModel):
+    entity_id: str = Field(min_length=1)
+    authority: Literal["wikidata", "viaf", "loc"]
+    authority_id: str = Field(min_length=1)
+
+
+def _external_authority_enabled() -> bool:
+    """Fail closed: the default must never permit an outbound lookup."""
+    return get_app_db().get_setting("external_authority_enabled") == "true"
+
+
+async def _fetch_wikidata_snapshots(query: str, limit: int) -> list[AuthoritySnapshot]:
+    """The sole Wikidata network path; callers must check the opt-in first."""
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            # Wikidata's documented search endpoint has bounded results; the
+            # explicit limit is our per-refresh rate bound as well.
+            response = await client.get(
+                "https://www.wikidata.org/w/api.php",
+                params={
+                    "action": "wbsearchentities",
+                    "search": query,
+                    "language": "en",
+                    "format": "json",
+                    "limit": limit,
+                },
+                headers={"User-Agent": "Fichero/authority-cache"},
+            )
+            response.raise_for_status()
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"Wikidata refresh failed: {exc}") from exc
+
+    now = datetime.now()
+    return [
+        AuthoritySnapshot(
+            authority="wikidata",
+            authority_id=row["id"],
+            label=row.get("label") or row["id"],
+            aliases=row.get("aliases") or [],
+            type=row.get("datatype"),
+            description=row.get("description"),
+            source_url=f"https://www.wikidata.org/wiki/{row['id']}",
+            fetched_at=now,
+        )
+        for row in response.json().get("search", [])
+        if row.get("id")
+    ]
+
+
+def _cache_authority_snapshots(
+    db: Database, snapshots: list[AuthoritySnapshot]
+) -> list[AuthoritySnapshot]:
+    existing = {(row.authority, row.authority_id): row for row in db.query(AuthoritySnapshot)}
+    for snapshot in snapshots:
+        previous = existing.get((snapshot.authority, snapshot.authority_id))
+        if previous is not None:
+            snapshot.id = previous.id
+        db.save(snapshot)
+    return snapshots
 
 
 def _vector_similarity(row: dict[str, Any]) -> float:
@@ -573,6 +648,42 @@ class CandidatePair(BaseModel):
     entity_b_library_path: str | None = None
 
 
+def _external_authority_candidates(
+    db: Database, entity_id: str
+) -> list[dict[str, Any]]:
+    """Match one entity against local snapshots only; this must never fetch."""
+    from fichero.workflows.tools._entity_writer import _apply_entity_resolution_rules
+
+    entity = db.get(KnowledgeEntity, entity_id)
+    if entity is None:
+        raise HTTPException(status_code=404, detail=f"Entity not found: {entity_id}")
+    resolved = _apply_entity_resolution_rules(
+        db, entity.canonical_name, entity.entity_type
+    )
+    if resolved is None or entity.curation_state == EntityCurationState.rejected:
+        return []
+    names = {resolved[0].casefold(), *(alias.casefold() for alias in entity.aliases)}
+    rows = []
+    for snapshot in db.query(AuthoritySnapshot):
+        snapshot_names = {snapshot.label.casefold(), *(alias.casefold() for alias in snapshot.aliases)}
+        if names & snapshot_names:
+            rows.append(
+                {
+                    "entity_id": entity.id,
+                    "entity_name": entity.canonical_name,
+                    "authority": snapshot.authority,
+                    "authority_id": snapshot.authority_id,
+                    "label": snapshot.label,
+                    "aliases": snapshot.aliases,
+                    "type": snapshot.type,
+                    "description": snapshot.description,
+                    "source_url": snapshot.source_url,
+                    "fetched_at": snapshot.fetched_at,
+                }
+            )
+    return rows
+
+
 def _cross_library_candidate_pairs(
     request: Request,
     *,
@@ -659,8 +770,9 @@ async def candidate_pairs(
     min_jaccard: float = Query(default=0.5, ge=0.0, le=1.0),
     top_k: int = Query(default=20, ge=1, le=200),
     same_type_only: bool = Query(default=True),
-    scope: Literal["library", "folder", "cross-library"] = Query(default="library"),
+    scope: Literal["library", "folder", "cross-library", "external-authority"] = Query(default="library"),
     folder_id: str | None = Query(default=None),
+    entity_id: str | None = Query(default=None),
     db: Database = Depends(get_library_database),
 ) -> KGGraphListResponse:
     """Compute Jaccard similarity over the co-occurrence graph between
@@ -675,6 +787,11 @@ async def candidate_pairs(
             request, same_type_only=same_type_only, top_k=top_k
         )
         return KGGraphListResponse(items=rows, count=len(rows))
+    if scope == "external-authority":
+        if not entity_id:
+            raise HTTPException(status_code=422, detail="entity_id is required for external-authority scope")
+        rows = _external_authority_candidates(db, entity_id)
+        return KGGraphListResponse(items=rows[:top_k], count=min(len(rows), top_k))
 
     graph = build_full_cooccurrence(db)
     if scope == "folder":
@@ -734,6 +851,89 @@ async def candidate_pairs(
     rows.sort(key=lambda r: r.jaccard, reverse=True)
     rows = rows[:top_k]
     return KGGraphListResponse(items=rows, count=len(rows))
+
+
+@router.get(
+    "/authority/settings",
+    response_model=ExternalAuthoritySettings,
+    summary="Read the app-wide external-authority opt-in",
+)
+async def get_external_authority_settings() -> ExternalAuthoritySettings:
+    return ExternalAuthoritySettings(external_authority_enabled=_external_authority_enabled())
+
+
+@router.put(
+    "/authority/settings",
+    response_model=ExternalAuthoritySettings,
+    summary="Set the app-wide external-authority opt-in",
+)
+async def put_external_authority_settings(
+    body: ExternalAuthoritySettings,
+    _owner: None = Depends(_require_owner_or_bootstrap),
+) -> ExternalAuthoritySettings:
+    # App-wide is deliberate for this first local-cache slice; per-library
+    # privacy policy is a future refinement, not an implicit network default.
+    get_app_db().set_setting(
+        "external_authority_enabled", "true" if body.external_authority_enabled else "false"
+    )
+    return body
+
+
+@router.post(
+    "/authority/refresh",
+    response_model=KGGraphListResponse,
+    summary="Explicitly refresh local Wikidata authority snapshots",
+    description="Outbound network is attempted only by this explicitly requested, opt-in endpoint.",
+)
+async def refresh_external_authority(
+    body: AuthorityRefreshRequest,
+    db: Database = Depends(get_library_database_for_write),
+) -> KGGraphListResponse:
+    if not _external_authority_enabled():
+        raise HTTPException(status_code=403, detail="External authority refresh is disabled")
+    snapshots = _cache_authority_snapshots(
+        db, await _fetch_wikidata_snapshots(body.query, body.limit)
+    )
+    return KGGraphListResponse(
+        items=[snapshot.model_dump(mode="json") for snapshot in snapshots], count=len(snapshots)
+    )
+
+
+@router.post(
+    "/authority/link",
+    response_model=EntityAuditResponse,
+    summary="Confirm and persist an entity-to-authority link",
+)
+async def link_external_authority(
+    body: AuthorityLinkRequest,
+    db: Database = Depends(get_library_database_for_write),
+) -> EntityAuditResponse:
+    entity = db.get(KnowledgeEntity, body.entity_id)
+    if entity is None:
+        raise HTTPException(status_code=404, detail=f"Entity not found: {body.entity_id}")
+    snapshot = next(
+        (row for row in db.query(AuthoritySnapshot)
+         if row.authority == body.authority and row.authority_id == body.authority_id),
+        None,
+    )
+    if snapshot is None:
+        raise HTTPException(status_code=404, detail="Authority snapshot not found; refresh it first")
+    links = list(entity.metadata.get("authority_links", []))
+    link = {"authority": snapshot.authority, "authority_id": snapshot.authority_id}
+    if link not in links:
+        links.append(link)
+        entity.metadata["authority_links"] = links
+        entity.updated_at = datetime.now()
+        db.save(entity)
+    audit = EntityMergeAudit(
+        operation_type=EntityMergeOperationType.authority_link,
+        source_entity_ids=[],
+        target_entity_id=entity.id,
+        alias_changes={"authority_link": link},
+        created_by="human",
+    )
+    db.save(audit)
+    return _audit_response(audit)
 
 
 # ---------------------------------------------------------------------------

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -5558,7 +5558,7 @@ def register_generated_openapi_commands(
                 "document_ids": {'items': {'type': 'string'}, 'type': 'array', 'minItems': 1, 'title': 'Document Ids', 'x-cli-required': True},
                 "height": {'type': 'integer', 'exclusiveMinimum': True, 'title': 'Height', 'minimum': 0.0, 'x-cli-required': True},
                 "left": {'type': 'integer', 'minimum': 0.0, 'title': 'Left', 'x-cli-required': True},
-                "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
+                "page": {'type': 'integer', 'minimum': 1.0, 'title': 'Page', 'default': 1, 'x-cli-required': False},
                 "top": {'type': 'integer', 'minimum': 0.0, 'title': 'Top', 'x-cli-required': True},
                 "width": {'type': 'integer', 'exclusiveMinimum': True, 'title': 'Width', 'minimum': 0.0, 'x-cli-required': True},
             }, required=True)
@@ -5591,7 +5591,7 @@ def register_generated_openapi_commands(
                 "auto_orient": {'type': 'boolean', 'title': 'Auto Orient', 'default': True, 'x-cli-required': False},
                 "height": {'type': 'integer', 'exclusiveMinimum': True, 'title': 'Height', 'minimum': 0.0, 'x-cli-required': True},
                 "left": {'type': 'integer', 'minimum': 0.0, 'title': 'Left', 'x-cli-required': True},
-                "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
+                "page": {'type': 'integer', 'minimum': 1.0, 'title': 'Page', 'default': 1, 'x-cli-required': False},
                 "top": {'type': 'integer', 'minimum': 0.0, 'title': 'Top', 'x-cli-required': True},
                 "width": {'type': 'integer', 'exclusiveMinimum': True, 'title': 'Width', 'minimum': 0.0, 'x-cli-required': True},
             }, required=True)
@@ -5669,7 +5669,7 @@ def register_generated_openapi_commands(
                 "auto_orient": {'type': 'boolean', 'title': 'Auto Orient', 'default': True, 'x-cli-required': False},
                 "height": {'type': 'integer', 'exclusiveMinimum': True, 'title': 'Height', 'minimum': 0.0, 'x-cli-required': True},
                 "left": {'type': 'integer', 'minimum': 0.0, 'title': 'Left', 'x-cli-required': True},
-                "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
+                "page": {'type': 'integer', 'minimum': 1.0, 'title': 'Page', 'default': 1, 'x-cli-required': False},
                 "top": {'type': 'integer', 'minimum': 0.0, 'title': 'Top', 'x-cli-required': True},
                 "width": {'type': 'integer', 'exclusiveMinimum': True, 'title': 'Width', 'minimum': 0.0, 'x-cli-required': True},
             }, required=True)
@@ -5749,7 +5749,7 @@ def register_generated_openapi_commands(
             }, {
                 "angle": {'type': 'number', 'maximum': 360.0, 'minimum': -360.0, 'title': 'Angle', 'x-cli-required': True},
                 "expand": {'type': 'boolean', 'title': 'Expand', 'default': True, 'x-cli-required': False},
-                "page": {'type': 'integer', 'title': 'Page', 'default': 1, 'x-cli-required': False},
+                "page": {'type': 'integer', 'minimum': 1.0, 'title': 'Page', 'default': 1, 'x-cli-required': False},
             }, required=True)
             return client.request("POST", endpoint_path, params=params, json=payload)
         invoke(ctx, op_call)
@@ -6640,9 +6640,81 @@ def register_generated_openapi_commands(
             return client.request("POST", endpoint_path, params=params)
         invoke(ctx, op_call)
 
+    @target_app.command("confirm-and-persist-an-entity-to-authority-link")
+    def kg_confirm_and_persist_an_entity_to_authority_link_post(
+        ctx: typer.Context,
+        authority: str = typer.Option(..., "--authority", help="Request field: authority."),
+        authority_id: str = typer.Option(..., "--authority-id", help="Request field: authority_id."),
+        entity_id: str = typer.Option(..., "--entity-id", help="Request field: entity_id."),
+    ) -> None:
+        """Confirm and persist an entity-to-authority link (POST /api/kg/entity-curation/authority/link)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/kg/entity-curation/authority/link"
+            params = None
+            payload = _build_json_payload({
+                "authority": authority,
+                "authority_id": authority_id,
+                "entity_id": entity_id,
+            }, {
+                "authority": {'type': 'string', 'enum': ['wikidata', 'viaf', 'loc'], 'title': 'Authority', 'x-cli-required': True},
+                "authority_id": {'type': 'string', 'minLength': 1, 'title': 'Authority Id', 'x-cli-required': True},
+                "entity_id": {'type': 'string', 'minLength': 1, 'title': 'Entity Id', 'x-cli-required': True},
+            }, required=True)
+            return client.request("POST", endpoint_path, params=params, json=payload)
+        invoke(ctx, op_call)
+
+    @target_app.command("explicitly-refresh-local-wikidata-authority-snapshots")
+    def kg_explicitly_refresh_local_wikidata_authority_snapshots_post(
+        ctx: typer.Context,
+        limit: Optional[int] = typer.Option(None, "--limit", help="Request field: limit."),
+        query: str = typer.Option(..., "--query", help="Request field: query."),
+    ) -> None:
+        """Explicitly refresh local Wikidata authority snapshots (POST /api/kg/entity-curation/authority/refresh)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/kg/entity-curation/authority/refresh"
+            params = None
+            payload = _build_json_payload({
+                "limit": limit,
+                "query": query,
+            }, {
+                "limit": {'type': 'integer', 'maximum': 20.0, 'minimum': 1.0, 'title': 'Limit', 'default': 10, 'x-cli-required': False},
+                "query": {'type': 'string', 'maxLength': 200, 'minLength': 1, 'title': 'Query', 'x-cli-required': True},
+            }, required=True)
+            return client.request("POST", endpoint_path, params=params, json=payload)
+        invoke(ctx, op_call)
+
+    @target_app.command("read-the-app-wide-external-authority-opt-in")
+    def kg_read_the_app_wide_external_authority_opt_in_get(
+        ctx: typer.Context,
+    ) -> None:
+        """Read the app-wide external-authority opt-in (GET /api/kg/entity-curation/authority/settings)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/kg/entity-curation/authority/settings"
+            params = None
+            return client.request("GET", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
+    @target_app.command("set-the-app-wide-external-authority-opt-in")
+    def kg_set_the_app_wide_external_authority_opt_in_put(
+        ctx: typer.Context,
+        external_authority_enabled: Optional[bool] = typer.Option(None, "--external-authority-enabled/--no-external-authority-enabled", help="Request field: external_authority_enabled."),
+    ) -> None:
+        """Set the app-wide external-authority opt-in (PUT /api/kg/entity-curation/authority/settings)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/kg/entity-curation/authority/settings"
+            params = None
+            payload = _build_json_payload({
+                "external_authority_enabled": external_authority_enabled,
+            }, {
+                "external_authority_enabled": {'type': 'boolean', 'title': 'External Authority Enabled', 'default': False, 'x-cli-required': False},
+            }, required=True)
+            return client.request("PUT", endpoint_path, params=params, json=payload)
+        invoke(ctx, op_call)
+
     @target_app.command("graph-context-merge-candidates-jaccard-over-co-occurrence-neighborhoods")
     def kg_graph_context_merge_candidates_jaccard_over_co_occurrence_neighborhoods_get(
         ctx: typer.Context,
+        entity_id: Optional[str] = typer.Option(None, "--entity-id", help="Query parameter: entity_id."),
         folder_id: Optional[str] = typer.Option(None, "--folder-id", help="Query parameter: folder_id."),
         min_jaccard: Optional[float] = typer.Option(None, "--min-jaccard", help="Query parameter: min_jaccard."),
         same_type_only: Optional[bool] = typer.Option(None, "--same-type-only/--no-same-type-only", help="Query parameter: same_type_only."),
@@ -6653,6 +6725,7 @@ def register_generated_openapi_commands(
         def op_call(client: FicheroClient) -> Any:
             endpoint_path = "/api/kg/entity-curation/candidates"
             params = {
+                "entity_id": entity_id,
                 "folder_id": folder_id,
                 "min_jaccard": min_jaccard,
                 "same_type_only": same_type_only,

--- a/fichero-engine/src/fichero/knowledge/knowledge_models.py
+++ b/fichero-engine/src/fichero/knowledge/knowledge_models.py
@@ -746,6 +746,20 @@ class KnowledgeEntity(BaseModel):
     updated_at: datetime = Field(default_factory=datetime.now)
 
 
+class AuthoritySnapshot(BaseModel):
+    """A locally cached external-authority record; never a live lookup result."""
+
+    id: str = Field(default_factory=_new_id)
+    authority: str
+    authority_id: str
+    label: str
+    aliases: list[str] = Field(default_factory=list)
+    type: str | None = None
+    description: str | None = None
+    source_url: str
+    fetched_at: datetime = Field(default_factory=datetime.now)
+
+
 class EntityResolutionRule(BaseModel):
     model_config = ConfigDict(from_attributes=True, extra="allow")
 
@@ -781,6 +795,7 @@ class EntityMergeOperationType(str, Enum):
     split = "split"
     undo_merge = "undo_merge"
     undo_split = "undo_split"
+    authority_link = "authority_link"
 
 
 class EntityMergeAudit(BaseModel):

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -4574,12 +4574,57 @@
         "response_model": "EntityAuditResponse"
       },
       {
+        "method": "POST",
+        "path": "/kg/entity-curation/authority/link",
+        "operation_id": "link_external_authority_api_kg_entity_curation_authority_link_post",
+        "summary": "Confirm and persist an entity-to-authority link",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "AuthorityLinkRequest",
+        "response_model": "EntityAuditResponse"
+      },
+      {
+        "method": "POST",
+        "path": "/kg/entity-curation/authority/refresh",
+        "operation_id": "refresh_external_authority_api_kg_entity_curation_authority_refresh_post",
+        "summary": "Explicitly refresh local Wikidata authority snapshots",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "AuthorityRefreshRequest",
+        "response_model": "KGGraphListResponse"
+      },
+      {
+        "method": "GET",
+        "path": "/kg/entity-curation/authority/settings",
+        "operation_id": "get_external_authority_settings_api_kg_entity_curation_authority_settings_get",
+        "summary": "Read the app-wide external-authority opt-in",
+        "path_params": [],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "ExternalAuthoritySettings"
+      },
+      {
+        "method": "PUT",
+        "path": "/kg/entity-curation/authority/settings",
+        "operation_id": "put_external_authority_settings_api_kg_entity_curation_authority_settings_put",
+        "summary": "Set the app-wide external-authority opt-in",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "ExternalAuthoritySettings",
+        "response_model": "ExternalAuthoritySettings"
+      },
+      {
         "method": "GET",
         "path": "/kg/entity-curation/candidates",
         "operation_id": "candidate_pairs_api_kg_entity_curation_candidates_get",
         "summary": "Graph-context merge candidates (Jaccard over co-occurrence neighborhoods)",
         "path_params": [],
         "query_params": [
+          {
+            "name": "entity_id",
+            "required": false,
+            "type": "string"
+          },
           {
             "name": "folder_id",
             "required": false,

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -23702,7 +23702,8 @@
               "enum": [
                 "library",
                 "folder",
-                "cross-library"
+                "cross-library",
+                "external-authority"
               ],
               "type": "string",
               "default": "library",
@@ -23718,6 +23719,16 @@
               "nullable": true,
               "title": "Folder Id"
             }
+          },
+          {
+            "name": "entity_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Entity Id"
+            }
           }
         ],
         "responses": {
@@ -23727,6 +23738,149 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/KGGraphListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/entity-curation/authority/settings": {
+      "get": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Read the app-wide external-authority opt-in",
+        "operationId": "get_external_authority_settings_api_kg_entity_curation_authority_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalAuthoritySettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Set the app-wide external-authority opt-in",
+        "operationId": "put_external_authority_settings_api_kg_entity_curation_authority_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExternalAuthoritySettings"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalAuthoritySettings"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/entity-curation/authority/refresh": {
+      "post": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Explicitly refresh local Wikidata authority snapshots",
+        "description": "Outbound network is attempted only by this explicitly requested, opt-in endpoint.",
+        "operationId": "refresh_external_authority_api_kg_entity_curation_authority_refresh_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthorityRefreshRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KGGraphListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/entity-curation/authority/link": {
+      "post": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Confirm and persist an entity-to-authority link",
+        "operationId": "link_external_authority_api_kg_entity_curation_authority_link_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthorityLinkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityAuditResponse"
                 }
               }
             }
@@ -35786,6 +35940,58 @@
         "title": "AuthIdentityUser",
         "description": "Authenticated account identity, when the credential resolves to a user."
       },
+      "AuthorityLinkRequest": {
+        "properties": {
+          "entity_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Entity Id"
+          },
+          "authority": {
+            "type": "string",
+            "enum": [
+              "wikidata",
+              "viaf",
+              "loc"
+            ],
+            "title": "Authority"
+          },
+          "authority_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Authority Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "entity_id",
+          "authority",
+          "authority_id"
+        ],
+        "title": "AuthorityLinkRequest"
+      },
+      "AuthorityRefreshRequest": {
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Query"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 20.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "default": 10
+          }
+        },
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "title": "AuthorityRefreshRequest"
+      },
       "BatchClaimCurationRequest": {
         "properties": {
           "claim_ids": {
@@ -40761,6 +40967,7 @@
           },
           "page": {
             "type": "integer",
+            "minimum": 1.0,
             "title": "Page",
             "default": 1
           }
@@ -43087,7 +43294,8 @@
           "merge",
           "split",
           "undo_merge",
-          "undo_split"
+          "undo_split",
+          "authority_link"
         ],
         "title": "EntityMergeOperationType"
       },
@@ -44161,6 +44369,17 @@
         ],
         "title": "ExportedFileResponse"
       },
+      "ExternalAuthoritySettings": {
+        "properties": {
+          "external_authority_enabled": {
+            "type": "boolean",
+            "title": "External Authority Enabled",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "ExternalAuthoritySettings"
+      },
       "ExtractTextRequest": {
         "properties": {
           "document_ids": {
@@ -45121,6 +45340,7 @@
           },
           "page": {
             "type": "integer",
+            "minimum": 1.0,
             "title": "Page",
             "default": 1
           },
@@ -56082,6 +56302,7 @@
           },
           "page": {
             "type": "integer",
+            "minimum": 1.0,
             "title": "Page",
             "default": 1
           }

--- a/fichero-engine/tests/unit/test_external_authority_reconciliation.py
+++ b/fichero-engine/tests/unit/test_external_authority_reconciliation.py
@@ -1,0 +1,111 @@
+"""Cached, opt-in external authority reconciliation (#3528)."""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from fichero.api.routes import kg_entity_curation as curation
+from fichero.db import Database
+from fichero.knowledge_models import AuthoritySnapshot, EntityType, KnowledgeEntity
+
+
+class _Response:
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return {"search": [{"id": "Q42", "label": "Douglas Adams", "aliases": ["D. Adams"]}]}
+
+
+class _Client:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return None
+
+    async def get(self, *_args, **_kwargs):
+        return _Response()
+
+
+@pytest.mark.asyncio
+async def test_wikidata_refresh_parses_mocked_response(monkeypatch):
+    import httpx
+
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_kwargs: _Client())
+    rows = await curation._fetch_wikidata_snapshots("Douglas Adams", 1)
+
+    assert [(row.authority, row.authority_id, row.label) for row in rows] == [
+        ("wikidata", "Q42", "Douglas Adams")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_is_opt_in_and_cache_only_matching(tmp_path, monkeypatch):
+    db = Database(path=tmp_path / "library" / "fichero.duckdb")
+    entity = KnowledgeEntity(canonical_name="Douglas Adams", entity_type=EntityType.person)
+    db.save(entity)
+    settings = SimpleNamespace(get_setting=lambda _key: None)
+    monkeypatch.setattr(curation, "get_app_db", lambda: settings)
+    monkeypatch.setattr(curation, "_fetch_wikidata_snapshots", lambda *_args: pytest.fail("network must be blocked"))
+    try:
+        with pytest.raises(HTTPException, match="disabled"):
+            await curation.refresh_external_authority(
+                curation.AuthorityRefreshRequest(query="Douglas Adams"), db
+            )
+
+        async def fake_fetch(*_args):
+            return [
+                AuthoritySnapshot(
+                    authority="wikidata", authority_id="Q42", label="Douglas Adams",
+                    aliases=["D. Adams"], source_url="https://www.wikidata.org/wiki/Q42",
+                )
+            ]
+
+        settings.get_setting = lambda _key: "true"
+        monkeypatch.setattr(curation, "_fetch_wikidata_snapshots", fake_fetch)
+        refreshed = await curation.refresh_external_authority(
+            curation.AuthorityRefreshRequest(query="Douglas Adams"), db
+        )
+        assert refreshed.count == 1
+        assert db.query(AuthoritySnapshot)[0].authority_id == "Q42"
+
+        matched = await curation.candidate_pairs(
+            request=SimpleNamespace(state=SimpleNamespace()), scope="external-authority",
+            entity_id=entity.id, same_type_only=True, top_k=20, db=db,
+        )
+        assert matched.items[0]["authority_id"] == "Q42"
+    finally:
+        db.conn.close()
+
+
+@pytest.mark.asyncio
+async def test_authority_link_is_persisted_and_refresh_failure_is_loud(tmp_path, monkeypatch):
+    db = Database(path=tmp_path / "library" / "fichero.duckdb")
+    entity = KnowledgeEntity(canonical_name="Rosario")
+    db.save(entity)
+    db.save(AuthoritySnapshot(
+        authority="wikidata", authority_id="Q1", label="Rosario",
+        source_url="https://www.wikidata.org/wiki/Q1",
+    ))
+    try:
+        audit = await curation.link_external_authority(
+            curation.AuthorityLinkRequest(entity_id=entity.id, authority="wikidata", authority_id="Q1"), db
+        )
+        assert audit.operation_type.value == "authority_link"
+        assert db.get(KnowledgeEntity, entity.id).metadata["authority_links"] == [
+            {"authority": "wikidata", "authority_id": "Q1"}
+        ]
+
+        async def failing_fetch(*_args):
+            raise HTTPException(status_code=502, detail="Wikidata refresh failed: timeout")
+
+        monkeypatch.setattr(curation, "_fetch_wikidata_snapshots", failing_fetch)
+        monkeypatch.setattr(curation, "_external_authority_enabled", lambda: True)
+        with pytest.raises(HTTPException, match="timeout"):
+            await curation.refresh_external_authority(
+                curation.AuthorityRefreshRequest(query="Rosario"), db
+            )
+    finally:
+        db.conn.close()

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -23702,7 +23702,8 @@
               "enum": [
                 "library",
                 "folder",
-                "cross-library"
+                "cross-library",
+                "external-authority"
               ],
               "type": "string",
               "default": "library",
@@ -23718,6 +23719,16 @@
               "nullable": true,
               "title": "Folder Id"
             }
+          },
+          {
+            "name": "entity_id",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "title": "Entity Id"
+            }
           }
         ],
         "responses": {
@@ -23727,6 +23738,149 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/KGGraphListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/entity-curation/authority/settings": {
+      "get": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Read the app-wide external-authority opt-in",
+        "operationId": "get_external_authority_settings_api_kg_entity_curation_authority_settings_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalAuthoritySettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Set the app-wide external-authority opt-in",
+        "operationId": "put_external_authority_settings_api_kg_entity_curation_authority_settings_put",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExternalAuthoritySettings"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExternalAuthoritySettings"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/entity-curation/authority/refresh": {
+      "post": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Explicitly refresh local Wikidata authority snapshots",
+        "description": "Outbound network is attempted only by this explicitly requested, opt-in endpoint.",
+        "operationId": "refresh_external_authority_api_kg_entity_curation_authority_refresh_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthorityRefreshRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KGGraphListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/kg/entity-curation/authority/link": {
+      "post": {
+        "tags": [
+          "knowledge-graph"
+        ],
+        "summary": "Confirm and persist an entity-to-authority link",
+        "operationId": "link_external_authority_api_kg_entity_curation_authority_link_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthorityLinkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityAuditResponse"
                 }
               }
             }
@@ -35786,6 +35940,58 @@
         "title": "AuthIdentityUser",
         "description": "Authenticated account identity, when the credential resolves to a user."
       },
+      "AuthorityLinkRequest": {
+        "properties": {
+          "entity_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Entity Id"
+          },
+          "authority": {
+            "type": "string",
+            "enum": [
+              "wikidata",
+              "viaf",
+              "loc"
+            ],
+            "title": "Authority"
+          },
+          "authority_id": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Authority Id"
+          }
+        },
+        "type": "object",
+        "required": [
+          "entity_id",
+          "authority",
+          "authority_id"
+        ],
+        "title": "AuthorityLinkRequest"
+      },
+      "AuthorityRefreshRequest": {
+        "properties": {
+          "query": {
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Query"
+          },
+          "limit": {
+            "type": "integer",
+            "maximum": 20.0,
+            "minimum": 1.0,
+            "title": "Limit",
+            "default": 10
+          }
+        },
+        "type": "object",
+        "required": [
+          "query"
+        ],
+        "title": "AuthorityRefreshRequest"
+      },
       "BatchClaimCurationRequest": {
         "properties": {
           "claim_ids": {
@@ -40761,6 +40967,7 @@
           },
           "page": {
             "type": "integer",
+            "minimum": 1.0,
             "title": "Page",
             "default": 1
           }
@@ -43087,7 +43294,8 @@
           "merge",
           "split",
           "undo_merge",
-          "undo_split"
+          "undo_split",
+          "authority_link"
         ],
         "title": "EntityMergeOperationType"
       },
@@ -44161,6 +44369,17 @@
         ],
         "title": "ExportedFileResponse"
       },
+      "ExternalAuthoritySettings": {
+        "properties": {
+          "external_authority_enabled": {
+            "type": "boolean",
+            "title": "External Authority Enabled",
+            "default": false
+          }
+        },
+        "type": "object",
+        "title": "ExternalAuthoritySettings"
+      },
       "ExtractTextRequest": {
         "properties": {
           "document_ids": {
@@ -45121,6 +45340,7 @@
           },
           "page": {
             "type": "integer",
+            "minimum": 1.0,
             "title": "Page",
             "default": 1
           },
@@ -56082,6 +56302,7 @@
           },
           "page": {
             "type": "integer",
+            "minimum": 1.0,
             "title": "Page",
             "default": 1
           }

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView+Audit.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView+Audit.swift
@@ -77,7 +77,7 @@ extension EntityDetailView {
 
     private func canUndo(_ audit: Components.Schemas.EntityAuditResponse) -> Bool {
         switch audit.operationType {
-        case .merge, .split:
+        case .merge, .split, .authorityLink:
             return audit.reversalId == audit.id
         case .undoMerge, .undoSplit:
             return false
@@ -88,6 +88,7 @@ extension EntityDetailView {
         switch mergeOp {
         case .merge: return "arrow.triangle.merge"
         case .split: return "arrow.triangle.branch"
+        case .authorityLink: return "link"
         case .undoMerge, .undoSplit: return "arrow.uturn.backward.circle"
         }
     }
@@ -96,6 +97,7 @@ extension EntityDetailView {
         switch mergeOp {
         case .merge: return .blue
         case .split: return .orange
+        case .authorityLink: return .purple
         case .undoMerge, .undoSplit: return .gray
         }
     }
@@ -106,6 +108,8 @@ extension EntityDetailView {
             return "Absorbed \(audit.sourceEntityIds.count) entity\(audit.sourceEntityIds.count == 1 ? "" : "s")"
         case .split:
             return "Split off \(audit.sourceEntityIds.count) entity\(audit.sourceEntityIds.count == 1 ? "" : "s")"
+        case .authorityLink:
+            return "Linked to an authority record"
         case .undoMerge:
             return "Undid earlier merge"
         case .undoSplit:

--- a/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+CurationHistory.swift
+++ b/fichero/fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab+CurationHistory.swift
@@ -92,7 +92,7 @@ struct KGCurationHistorySection: View {
 
     private func canUndo(_ audit: Components.Schemas.EntityAuditResponse) -> Bool {
         switch audit.operationType {
-        case .merge, .split: return audit.reversalId == nil
+        case .merge, .split, .authorityLink: return audit.reversalId == nil
         case .undoMerge, .undoSplit: return false
         }
     }
@@ -101,6 +101,7 @@ struct KGCurationHistorySection: View {
         switch mergeOp {
         case .merge: return "arrow.triangle.merge"
         case .split: return "arrow.triangle.branch"
+        case .authorityLink: return "link"
         case .undoMerge, .undoSplit: return "arrow.uturn.backward.circle"
         }
     }
@@ -109,6 +110,7 @@ struct KGCurationHistorySection: View {
         switch mergeOp {
         case .merge: return .blue
         case .split: return .orange
+        case .authorityLink: return .purple
         case .undoMerge, .undoSplit: return .gray
         }
     }
@@ -120,6 +122,8 @@ struct KGCurationHistorySection: View {
             return "Merged \(cnt) entr\(cnt == 1 ? "y" : "ies")"
         case .split:
             return "Split entity"
+        case .authorityLink:
+            return "Linked to an authority record"
         case .undoMerge:
             return "Undid merge"
         case .undoSplit:


### PR DESCRIPTION
#3528 first slice (Daniel: opt-in + cached snapshots, Wikidata first): app-wide external_authority_enabled setting (OFF by default, FAIL-CLOSED — no network unless enabled AND refresh explicitly triggered), a local authority-snapshot cache, a refresh action (the only network path — Wikidata), and scope=external-authority reconciling against the cache (adds an 'authority_link' EntityMergeOperationType audit op). Tests MOCK the API (no real network) + assert opt-in-off blocks network (raises 'disabled'); test_external_authority_reconciliation 3 passed + 95 broader curation passed. OpenAPI regen ×3 synced. + Swift regen-fallout fix: the 2 audit-history views handle the new .authorityLink case. macOS BUILD SUCCEEDED, swiftlint 0. VIAF/LoC + per-library scoping are later slices. 🤖 Claude (Opus 4.8)