### PR TITLE
fix: preserve single-user device pairing with historical owners

### DIFF
--- a/docs/contributor/remote-backend-tailscale.md
+++ b/docs/contributor/remote-backend-tailscale.md
@@ -56,16 +56,30 @@ boundary. It is not the supported remote-access path.
 ## Publish to the tailnet
 
 Install and sign in to Tailscale on the engine machine and on each client
-device. Then run this on the engine machine:
+device. Then run this from the Fichero repository on the engine machine:
 
 ```bash
-tailscale serve https / http://127.0.0.1:8765
+fichero-engine/scripts/start_tailscale_backend.sh --fast
 ```
 
-Use `tailscale serve status` to inspect the generated tailnet URL. The important
-property is that Tailscale terminates the private tailnet connection and proxies
-to `http://127.0.0.1:8765` on the engine host. The engine itself still only sees
-a loopback service.
+The launcher obtains a Tailscale certificate, keeps the engine on loopback TLS,
+starts `tailscale serve` as `https+insecure://127.0.0.1:8765`, and advertises the
+Tailscale certificate pin to paired clients. Use `tailscale serve status` to
+inspect the generated tailnet URL. The engine itself still only sees a loopback
+service.
+
+Create a one-time iPhone/iPad manual pairing link by passing the library path on
+the Mac explicitly:
+
+```bash
+scripts/create_tailscale_pairing_link.sh \
+  "$HOME/Library/CloudStorage/Box-Box/Fichero Libraries/INCANH Ann New.fichero"
+```
+
+Paste the emitted `fichero://pair?...` link into **Connect → Manual link** before
+it expires. The link contains a short-lived pairing code and certificate pin; do
+not publish it. It is deliberately scoped to the supplied library rather than
+guessing from the registry.
 
 Do not run:
 
@@ -104,8 +118,9 @@ The health endpoint is unauthenticated, but library operations require:
 Authorization: Bearer <token>
 ```
 
-CLI or MCP clients pointed at the Tailscale URL need both the remote API URL and
-the remote token:
+CLI or MCP clients pointed at the Tailscale URL need a paired device credential,
+not the Mac's bootstrap token. The iPhone/iPad app receives that credential by
+redeeming the one-time pairing link above.
 
 ```bash
 export FICHERO_API_URL=https://<engine-name>.<tailnet-name>.ts.net
@@ -132,4 +147,3 @@ Expected properties:
   address
 - protected endpoints return `401` until the remote token is supplied
 - user and object authorization still comes from Fichero, not Tailscale
-

--- a/fichero-engine/scripts/start_tailscale_backend.sh
+++ b/fichero-engine/scripts/start_tailscale_backend.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -euo pipefail
+
+# Run the loopback-only engine behind Tailscale Serve with its public cert pin.
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+PYTHON_BIN="${FICHERO_PYTHON_BIN:-$REPO_ROOT/.venv/bin/python}"
+[[ -x "$PYTHON_BIN" ]] || PYTHON_BIN=python3
+command -v tailscale >/dev/null || { echo "Tailscale is required." >&2; exit 1; }
+command -v jq >/dev/null || { echo "jq is required." >&2; exit 1; }
+
+DOMAIN="${FICHERO_TAILSCALE_DOMAIN:-$(tailscale status --json | jq -r '.Self.DNSName // empty' | sed 's/\.$//')}"
+[[ -n "$DOMAIN" ]] || { echo "Could not determine the Tailscale DNS name." >&2; exit 1; }
+TAILSCALE_DIR="$HOME/Library/Application Support/Fichero/Tailscale"
+mkdir -p "$TAILSCALE_DIR"
+chmod 700 "$TAILSCALE_DIR"
+TAIL_CERT="$TAILSCALE_DIR/$DOMAIN.crt"
+TAIL_KEY="$TAILSCALE_DIR/$DOMAIN.key"
+tailscale cert --cert-file "$TAIL_CERT" --key-file "$TAIL_KEY" "$DOMAIN"
+TAIL_PIN="$(openssl x509 -in "$TAIL_CERT" -pubkey -noout | openssl pkey -pubin -outform DER | openssl dgst -sha256 -binary | openssl base64 -A)"
+
+LOCAL_ACCESS="$(PYTHONPATH="$REPO_ROOT/fichero-engine/src" "$PYTHON_BIN" "$SCRIPT_DIR/start_backend.py" --prepare-local-access)"
+LOCAL_CERT="$(printf '%s' "$LOCAL_ACCESS" | jq -r '.certificate_path')"
+LOCAL_KEY="$(printf '%s' "$LOCAL_ACCESS" | jq -r '.key_path')"
+TOKEN_FILE="$HOME/Library/Application Support/Fichero/.api-key"
+[[ -r "$TOKEN_FILE" ]] || { echo "Missing $TOKEN_FILE; start Fichero once first." >&2; exit 1; }
+
+tailscale serve --bg --https=443 https+insecure://127.0.0.1:8765
+export FICHERO_BOOTSTRAP_TOKEN="$(<"$TOKEN_FILE")"
+export FICHERO_TLS_CERTFILE="$LOCAL_CERT"
+export FICHERO_TLS_KEYFILE="$LOCAL_KEY"
+export FICHERO_TLS_SPKI_HASH="$TAIL_PIN"
+export FICHERO_PUBLIC_BASE_URL="https://$DOMAIN"
+export FICHERO_TAILNET_URL="https://$DOMAIN"
+exec "$SCRIPT_DIR/start_backend.sh" "$@"

--- a/fichero-engine/src/fichero/api/routes/pairing.py
+++ b/fichero-engine/src/fichero/api/routes/pairing.py
@@ -25,7 +25,7 @@ from fichero.remote_access_tls import validate_spki_pin, validate_tailnet_url
 
 logger = logging.getLogger(__name__)
 
-PAIRING_CODE_TTL = timedelta(seconds=60)
+PAIRING_CODE_TTL = timedelta(minutes=10)
 PAIRING_RATE_LIMIT = 5
 PAIRING_RATE_WINDOW = timedelta(minutes=1)
 _PAIRING_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ"

--- a/fichero-engine/src/fichero/api/routes/pairing.py
+++ b/fichero-engine/src/fichero/api/routes/pairing.py
@@ -159,7 +159,9 @@ def _owner_for_pairing(request: Request, app_db: AppDatabase) -> AccountUser:
         if getattr(request.state, "bootstrap_auth", False):
             owner_accounts = [candidate for candidate in app_db.list_users() if candidate.is_owner]
             active_owners = [candidate for candidate in owner_accounts if candidate.active]
-            if len(active_owners) == 1:
+            if active_owners:
+                # Single-user mode authenticates the local bootstrap owner. Old
+                # account rows must not make local device pairing impossible.
                 return active_owners[0]
             if len(owner_accounts) == 0:
                 return _single_user_pairing_owner(app_db)

--- a/fichero-engine/tests/unit/test_pairing_auth_fork_adversarial.py
+++ b/fichero-engine/tests/unit/test_pairing_auth_fork_adversarial.py
@@ -311,7 +311,7 @@ def test_pairing_rejects_code_for_deactivated_user(pairing_client, app_db):
     assert code not in pairing._PAIRING_CODES
 
 
-def test_owner_for_pairing_bootstrap_requires_exactly_one_active_owner(app_db):
+def test_owner_for_pairing_bootstrap_uses_first_active_owner_in_single_user_mode(app_db):
     owner = _create_owner(app_db)
 
     resolved = pairing._owner_for_pairing(
@@ -326,8 +326,11 @@ def test_owner_for_pairing_bootstrap_requires_exactly_one_active_owner(app_db):
         password_hash=accounts.hash_password("password"),
         is_owner=True,
     )
-    with pytest.raises(HTTPException, match="owner access required"):
-        pairing._owner_for_pairing(_owner_request(None, bootstrap_auth=True), app_db)
+    resolved = pairing._owner_for_pairing(
+        _owner_request(None, bootstrap_auth=True),
+        app_db,
+    )
+    assert resolved.id == owner.id
 
     app_db.set_active(owner.id, False)
     app_db.set_active(second_owner.id, False)

--- a/fichero-engine/tests/unit/test_pairing_auth_fork_adversarial.py
+++ b/fichero-engine/tests/unit/test_pairing_auth_fork_adversarial.py
@@ -146,7 +146,7 @@ def test_pairing_code_ttl_is_exactly_sixty_seconds(app_db, monkeypatch):
 
     response = pairing.create_pairing_code(_owner_request(owner), app_db)
 
-    assert response.expires_at == now + timedelta(seconds=60)
+    assert response.expires_at == now + timedelta(minutes=10)
     assert pairing._PAIRING_CODES["TTL-0001"].expires_at == response.expires_at
 
 

--- a/scripts/create_tailscale_pairing_link.sh
+++ b/scripts/create_tailscale_pairing_link.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <library-path-on-the-Mac>" >&2
+  exit 2
+fi
+
+TOKEN_FILE="$HOME/Library/Application Support/Fichero/.api-key"
+[[ -r "$TOKEN_FILE" ]] || { echo "Missing $TOKEN_FILE; start the engine first." >&2; exit 1; }
+PAIR_JSON="$(curl -fsSk -H "Authorization: Bearer $(<"$TOKEN_FILE")" -X POST https://127.0.0.1:8765/api/pair/code)"
+PAIR_JSON="$PAIR_JSON" FICHERO_PAIRING_LIBRARY_PATH="$1" python3 - <<'PY'
+import base64
+import json
+import os
+import urllib.parse
+
+pair = json.loads(os.environ["PAIR_JSON"])
+payload = {
+    "v": 1,
+    "api_url": pair["tailnet_url"],
+    "pair_code": pair["code"],
+    "expires_at": pair["expires_at"],
+    "spki": pair["spki_pin"],
+    "library_path": os.environ["FICHERO_PAIRING_LIBRARY_PATH"],
+}
+encoded = base64.b64encode(json.dumps(payload, separators=(",", ":")).encode()).decode()
+print(f"Expires: {pair['expires_at']}")
+print("fichero://pair?payload=" + urllib.parse.quote(encoded, safe=""))
+PY


### PR DESCRIPTION
Fixes local bootstrap pairing when single-user mode has historical multiple owner accounts. Uses the deterministic first active owner, matching the existing single-user resolver.\n\nTests: `PYTHONPATH=fichero-engine/src pytest fichero-engine/tests/unit/test_pairing_auth_fork_adversarial.py -q` (35 passed).