### PR TITLE
Engine: external-authority reconciliation — VIAF + LoC fetchers (#3528 slice 2)

### DIFF
--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -35984,6 +35984,19 @@
             "minimum": 1.0,
             "title": "Limit",
             "default": 10
+          },
+          "authorities": {
+            "items": {
+              "type": "string",
+              "enum": [
+                "wikidata",
+                "viaf",
+                "loc"
+              ]
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Authorities"
           }
         },
         "type": "object",

--- a/fichero-engine/src/fichero/api/routes/kg_entity_curation.py
+++ b/fichero-engine/src/fichero/api/routes/kg_entity_curation.py
@@ -100,6 +100,9 @@ class ExternalAuthoritySettings(BaseModel):
 class AuthorityRefreshRequest(BaseModel):
     query: str = Field(min_length=1, max_length=200)
     limit: int = Field(default=10, ge=1, le=20)
+    authorities: list[Literal["wikidata", "viaf", "loc"]] = Field(
+        default_factory=lambda: ["wikidata", "viaf", "loc"], min_length=1
+    )
 
 
 class AuthorityLinkRequest(BaseModel):
@@ -115,26 +118,11 @@ def _external_authority_enabled() -> bool:
 
 async def _fetch_wikidata_snapshots(query: str, limit: int) -> list[AuthoritySnapshot]:
     """The sole Wikidata network path; callers must check the opt-in first."""
-    import httpx
-
-    try:
-        async with httpx.AsyncClient(timeout=5.0) as client:
-            # Wikidata's documented search endpoint has bounded results; the
-            # explicit limit is our per-refresh rate bound as well.
-            response = await client.get(
-                "https://www.wikidata.org/w/api.php",
-                params={
-                    "action": "wbsearchentities",
-                    "search": query,
-                    "language": "en",
-                    "format": "json",
-                    "limit": limit,
-                },
-                headers={"User-Agent": "Fichero/authority-cache"},
-            )
-            response.raise_for_status()
-    except Exception as exc:
-        raise HTTPException(status_code=502, detail=f"Wikidata refresh failed: {exc}") from exc
+    payload = await _authority_json(
+        "Wikidata",
+        "https://www.wikidata.org/w/api.php",
+        {"action": "wbsearchentities", "search": query, "language": "en", "format": "json", "limit": limit},
+    )
 
     now = datetime.now()
     return [
@@ -148,9 +136,79 @@ async def _fetch_wikidata_snapshots(query: str, limit: int) -> list[AuthoritySna
             source_url=f"https://www.wikidata.org/wiki/{row['id']}",
             fetched_at=now,
         )
-        for row in response.json().get("search", [])
+        for row in payload.get("search", [])
         if row.get("id")
     ]
+
+
+async def _authority_json(name: str, url: str, params: dict[str, Any]) -> dict[str, Any]:
+    """Bounded JSON request shared by the explicit authority refreshers."""
+    import httpx
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            response = await client.get(
+                url, params=params, headers={"User-Agent": "Fichero/authority-cache"}
+            )
+            response.raise_for_status()
+            return response.json()
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=f"{name} refresh failed: {exc}") from exc
+
+
+async def _fetch_viaf_snapshots(query: str, limit: int) -> list[AuthoritySnapshot]:
+    payload = await _authority_json(
+        "VIAF", "https://viaf.org/viaf/AutoSuggest", {"query": query}
+    )
+    now = datetime.now()
+    return [
+        AuthoritySnapshot(
+            authority="viaf",
+            authority_id=str(row["viafid"]),
+            label=row.get("term") or str(row["viafid"]),
+            type=row.get("nametype"),
+            source_url=f"https://viaf.org/viaf/{row['viafid']}",
+            fetched_at=now,
+        )
+        for row in payload.get("result", [])[:limit]
+        if row.get("viafid")
+    ]
+
+
+async def _fetch_loc_snapshots(query: str, limit: int) -> list[AuthoritySnapshot]:
+    payload = await _authority_json(
+        "LoC", "https://id.loc.gov/authorities/suggest2/", {"q": query}
+    )
+    now = datetime.now()
+    return [
+        AuthoritySnapshot(
+            authority="loc",
+            authority_id=row["uri"].rstrip("/").rsplit("/", 1)[-1],
+            label=row.get("a") or row["uri"],
+            type=row.get("type"),
+            source_url=row["uri"],
+            fetched_at=now,
+        )
+        for row in payload.get("hits", [])[:limit]
+        if row.get("uri")
+    ]
+
+
+async def _fetch_authority_snapshots(
+    query: str, limit: int, authorities: list[str]
+) -> list[AuthoritySnapshot]:
+    fetchers = {
+        "wikidata": _fetch_wikidata_snapshots,
+        "viaf": _fetch_viaf_snapshots,
+        "loc": _fetch_loc_snapshots,
+    }
+    snapshots: list[AuthoritySnapshot] = []
+    for authority in dict.fromkeys(authorities):
+        # The refresh is sequential and bounded, keeping each explicit request
+        # polite to public authorities without introducing a second scheduler.
+        snapshots.extend(await fetchers[authority](query, limit))
+        await asyncio.sleep(0.1)
+    return snapshots
 
 
 def _cache_authority_snapshots(
@@ -892,7 +950,7 @@ async def refresh_external_authority(
     if not _external_authority_enabled():
         raise HTTPException(status_code=403, detail="External authority refresh is disabled")
     snapshots = _cache_authority_snapshots(
-        db, await _fetch_wikidata_snapshots(body.query, body.limit)
+        db, await _fetch_authority_snapshots(body.query, body.limit, body.authorities)
     )
     return KGGraphListResponse(
         items=[snapshot.model_dump(mode="json") for snapshot in snapshots], count=len(snapshots)

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -6666,6 +6666,7 @@ def register_generated_openapi_commands(
     @target_app.command("explicitly-refresh-local-wikidata-authority-snapshots")
     def kg_explicitly_refresh_local_wikidata_authority_snapshots_post(
         ctx: typer.Context,
+        authorities: Optional[str] = typer.Option(None, "--authorities", help="Request field: authorities."),
         limit: Optional[int] = typer.Option(None, "--limit", help="Request field: limit."),
         query: str = typer.Option(..., "--query", help="Request field: query."),
     ) -> None:
@@ -6674,9 +6675,11 @@ def register_generated_openapi_commands(
             endpoint_path = "/api/kg/entity-curation/authority/refresh"
             params = None
             payload = _build_json_payload({
+                "authorities": authorities,
                 "limit": limit,
                 "query": query,
             }, {
+                "authorities": {'items': {'type': 'string', 'enum': ['wikidata', 'viaf', 'loc']}, 'type': 'array', 'minItems': 1, 'title': 'Authorities', 'x-cli-required': False},
                 "limit": {'type': 'integer', 'maximum': 20.0, 'minimum': 1.0, 'title': 'Limit', 'default': 10, 'x-cli-required': False},
                 "query": {'type': 'string', 'maxLength': 200, 'minLength': 1, 'title': 'Query', 'x-cli-required': True},
             }, required=True)

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -35984,6 +35984,19 @@
             "minimum": 1.0,
             "title": "Limit",
             "default": 10
+          },
+          "authorities": {
+            "items": {
+              "type": "string",
+              "enum": [
+                "wikidata",
+                "viaf",
+                "loc"
+              ]
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Authorities"
           }
         },
         "type": "object",

--- a/fichero-engine/tests/unit/test_external_authority_reconciliation.py
+++ b/fichero-engine/tests/unit/test_external_authority_reconciliation.py
@@ -42,13 +42,29 @@ async def test_wikidata_refresh_parses_mocked_response(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_viaf_and_loc_refresh_parse_mocked_responses(monkeypatch):
+    async def fake_json(name, *_args):
+        if name == "VIAF":
+            return {"result": [{"viafid": "123", "term": "Rosario", "nametype": "Personal"}]}
+        return {"hits": [{"uri": "https://id.loc.gov/authorities/names/n123", "a": "Rosario"}]}
+
+    monkeypatch.setattr(curation, "_authority_json", fake_json)
+    viaf = await curation._fetch_viaf_snapshots("Rosario", 1)
+    loc = await curation._fetch_loc_snapshots("Rosario", 1)
+
+    assert [(row.authority, row.authority_id) for row in viaf + loc] == [
+        ("viaf", "123"), ("loc", "n123")
+    ]
+
+
+@pytest.mark.asyncio
 async def test_refresh_is_opt_in_and_cache_only_matching(tmp_path, monkeypatch):
     db = Database(path=tmp_path / "library" / "fichero.duckdb")
     entity = KnowledgeEntity(canonical_name="Douglas Adams", entity_type=EntityType.person)
     db.save(entity)
     settings = SimpleNamespace(get_setting=lambda _key: None)
     monkeypatch.setattr(curation, "get_app_db", lambda: settings)
-    monkeypatch.setattr(curation, "_fetch_wikidata_snapshots", lambda *_args: pytest.fail("network must be blocked"))
+    monkeypatch.setattr(curation, "_fetch_authority_snapshots", lambda *_args: pytest.fail("network must be blocked"))
     try:
         with pytest.raises(HTTPException, match="disabled"):
             await curation.refresh_external_authority(
@@ -64,7 +80,7 @@ async def test_refresh_is_opt_in_and_cache_only_matching(tmp_path, monkeypatch):
             ]
 
         settings.get_setting = lambda _key: "true"
-        monkeypatch.setattr(curation, "_fetch_wikidata_snapshots", fake_fetch)
+        monkeypatch.setattr(curation, "_fetch_authority_snapshots", fake_fetch)
         refreshed = await curation.refresh_external_authority(
             curation.AuthorityRefreshRequest(query="Douglas Adams"), db
         )
@@ -101,7 +117,7 @@ async def test_authority_link_is_persisted_and_refresh_failure_is_loud(tmp_path,
         async def failing_fetch(*_args):
             raise HTTPException(status_code=502, detail="Wikidata refresh failed: timeout")
 
-        monkeypatch.setattr(curation, "_fetch_wikidata_snapshots", failing_fetch)
+        monkeypatch.setattr(curation, "_fetch_authority_snapshots", failing_fetch)
         monkeypatch.setattr(curation, "_external_authority_enabled", lambda: True)
         with pytest.raises(HTTPException, match="timeout"):
             await curation.refresh_external_authority(

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -35984,6 +35984,19 @@
             "minimum": 1.0,
             "title": "Limit",
             "default": 10
+          },
+          "authorities": {
+            "items": {
+              "type": "string",
+              "enum": [
+                "wikidata",
+                "viaf",
+                "loc"
+              ]
+            },
+            "type": "array",
+            "minItems": 1,
+            "title": "Authorities"
           }
         },
         "type": "object",


### PR DESCRIPTION
Adds VIAF (Virtual International Authority File) + LoC (Library of Congress) fetchers into the same opt-in/cached-snapshot/refresh path as Wikidata (slice 1). authorities param = [wikidata, viaf, loc]. Fail-closed unchanged; tests MOCK the VIAF/LoC APIs. test_external_authority_reconciliation 4 passed + 96 broader curation passed; regen synced (input enum, no output-enum Swift-switch fallout); macOS build green. Per-library scoping = slice 3 (in flight). 🤖 Claude (Opus 4.8)