### PR TITLE
Engine: scope external-authority opt-in per-library (#3528 slice 3)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/kg_entity_curation.py
+++ b/fichero-engine/src/fichero/api/routes/kg_entity_curation.py
@@ -20,7 +20,6 @@ from fichero.api.auth import action_context, request_actor
 from fichero.api.routes.auth_accounts import _require_owner_or_bootstrap
 from fichero.api.change_stream import emit_change
 from fichero.api.main import get_library_database, get_library_database_for_write
-from fichero.app_db import get_app_db
 from fichero.db import Database
 from fichero.db_manager import db_manager
 from fichero.db_embeddings import KG_ENTITY_EMBEDDINGS_TABLE
@@ -30,6 +29,7 @@ from fichero.knowledge_models import (
     EntityCurationState,
     EntityType,
     AuthoritySnapshot,
+    LibrarySetting,
     KnowledgeEntity,
     KnowledgeClaim,
     MutationLog,
@@ -111,9 +111,13 @@ class AuthorityLinkRequest(BaseModel):
     authority_id: str = Field(min_length=1)
 
 
-def _external_authority_enabled() -> bool:
-    """Fail closed: the default must never permit an outbound lookup."""
-    return get_app_db().get_setting("external_authority_enabled") == "true"
+_EXTERNAL_AUTHORITY_SETTING_ID = "external_authority_enabled"
+
+
+def _external_authority_enabled(db: Database) -> bool:
+    """Fail closed per library; the legacy app-wide key is intentionally ignored."""
+    setting = db.get(LibrarySetting, _EXTERNAL_AUTHORITY_SETTING_ID)
+    return setting is not None and setting.value == "true"
 
 
 async def _fetch_wikidata_snapshots(query: str, limit: int) -> list[AuthoritySnapshot]:
@@ -916,8 +920,10 @@ async def candidate_pairs(
     response_model=ExternalAuthoritySettings,
     summary="Read the app-wide external-authority opt-in",
 )
-async def get_external_authority_settings() -> ExternalAuthoritySettings:
-    return ExternalAuthoritySettings(external_authority_enabled=_external_authority_enabled())
+async def get_external_authority_settings(
+    db: Database = Depends(get_library_database),
+) -> ExternalAuthoritySettings:
+    return ExternalAuthoritySettings(external_authority_enabled=_external_authority_enabled(db))
 
 
 @router.put(
@@ -928,11 +934,13 @@ async def get_external_authority_settings() -> ExternalAuthoritySettings:
 async def put_external_authority_settings(
     body: ExternalAuthoritySettings,
     _owner: None = Depends(_require_owner_or_bootstrap),
+    db: Database = Depends(get_library_database_for_write),
 ) -> ExternalAuthoritySettings:
-    # App-wide is deliberate for this first local-cache slice; per-library
-    # privacy policy is a future refinement, not an implicit network default.
-    get_app_db().set_setting(
-        "external_authority_enabled", "true" if body.external_authority_enabled else "false"
+    db.save(
+        LibrarySetting(
+            id=_EXTERNAL_AUTHORITY_SETTING_ID,
+            value="true" if body.external_authority_enabled else "false",
+        )
     )
     return body
 
@@ -947,7 +955,7 @@ async def refresh_external_authority(
     body: AuthorityRefreshRequest,
     db: Database = Depends(get_library_database_for_write),
 ) -> KGGraphListResponse:
-    if not _external_authority_enabled():
+    if not _external_authority_enabled(db):
         raise HTTPException(status_code=403, detail="External authority refresh is disabled")
     snapshots = _cache_authority_snapshots(
         db, await _fetch_authority_snapshots(body.query, body.limit, body.authorities)

--- a/fichero-engine/src/fichero/knowledge/knowledge_models.py
+++ b/fichero-engine/src/fichero/knowledge/knowledge_models.py
@@ -760,6 +760,14 @@ class AuthoritySnapshot(BaseModel):
     fetched_at: datetime = Field(default_factory=datetime.now)
 
 
+class LibrarySetting(BaseModel):
+    """A setting scoped to one library database, never the app registry."""
+
+    id: str
+    value: str
+    updated_at: datetime = Field(default_factory=datetime.now)
+
+
 class EntityResolutionRule(BaseModel):
     model_config = ConfigDict(from_attributes=True, extra="allow")
 

--- a/fichero-engine/tests/unit/test_external_authority_reconciliation.py
+++ b/fichero-engine/tests/unit/test_external_authority_reconciliation.py
@@ -1,13 +1,16 @@
 """Cached, opt-in external authority reconciliation (#3528)."""
 
-from types import SimpleNamespace
-
 import pytest
 from fastapi import HTTPException
 
 from fichero.api.routes import kg_entity_curation as curation
 from fichero.db import Database
-from fichero.knowledge_models import AuthoritySnapshot, EntityType, KnowledgeEntity
+from fichero.knowledge_models import (
+    AuthoritySnapshot,
+    EntityType,
+    KnowledgeEntity,
+    LibrarySetting,
+)
 
 
 class _Response:
@@ -59,16 +62,17 @@ async def test_viaf_and_loc_refresh_parse_mocked_responses(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_refresh_is_opt_in_and_cache_only_matching(tmp_path, monkeypatch):
-    db = Database(path=tmp_path / "library" / "fichero.duckdb")
+    enabled_db = Database(path=tmp_path / "enabled" / "fichero.duckdb")
+    disabled_db = Database(path=tmp_path / "disabled" / "fichero.duckdb")
     entity = KnowledgeEntity(canonical_name="Douglas Adams", entity_type=EntityType.person)
-    db.save(entity)
-    settings = SimpleNamespace(get_setting=lambda _key: None)
-    monkeypatch.setattr(curation, "get_app_db", lambda: settings)
+    enabled_db.save(entity)
+    enabled_db.save(LibrarySetting(id="external_authority_enabled", value="true"))
     monkeypatch.setattr(curation, "_fetch_authority_snapshots", lambda *_args: pytest.fail("network must be blocked"))
     try:
+        assert not (await curation.get_external_authority_settings(disabled_db)).external_authority_enabled
         with pytest.raises(HTTPException, match="disabled"):
             await curation.refresh_external_authority(
-                curation.AuthorityRefreshRequest(query="Douglas Adams"), db
+                curation.AuthorityRefreshRequest(query="Douglas Adams"), disabled_db
             )
 
         async def fake_fetch(*_args):
@@ -79,21 +83,22 @@ async def test_refresh_is_opt_in_and_cache_only_matching(tmp_path, monkeypatch):
                 )
             ]
 
-        settings.get_setting = lambda _key: "true"
         monkeypatch.setattr(curation, "_fetch_authority_snapshots", fake_fetch)
         refreshed = await curation.refresh_external_authority(
-            curation.AuthorityRefreshRequest(query="Douglas Adams"), db
+            curation.AuthorityRefreshRequest(query="Douglas Adams"), enabled_db
         )
         assert refreshed.count == 1
-        assert db.query(AuthoritySnapshot)[0].authority_id == "Q42"
+        assert enabled_db.query(AuthoritySnapshot)[0].authority_id == "Q42"
+        assert disabled_db.query(AuthoritySnapshot) == []
 
         matched = await curation.candidate_pairs(
-            request=SimpleNamespace(state=SimpleNamespace()), scope="external-authority",
-            entity_id=entity.id, same_type_only=True, top_k=20, db=db,
+            request=None, scope="external-authority",
+            entity_id=entity.id, same_type_only=True, top_k=20, db=enabled_db,
         )
         assert matched.items[0]["authority_id"] == "Q42"
     finally:
-        db.conn.close()
+        enabled_db.conn.close()
+        disabled_db.conn.close()
 
 
 @pytest.mark.asyncio
@@ -118,7 +123,7 @@ async def test_authority_link_is_persisted_and_refresh_failure_is_loud(tmp_path,
             raise HTTPException(status_code=502, detail="Wikidata refresh failed: timeout")
 
         monkeypatch.setattr(curation, "_fetch_authority_snapshots", failing_fetch)
-        monkeypatch.setattr(curation, "_external_authority_enabled", lambda: True)
+        monkeypatch.setattr(curation, "_external_authority_enabled", lambda *_args: True)
         with pytest.raises(HTTPException, match="timeout"):
             await curation.refresh_external_authority(
                 curation.AuthorityRefreshRequest(query="Rosario"), db


### PR DESCRIPTION
Slice 3 of #3528: the external-authority opt-in is now PER-LIBRARY (default-off), replacing the app-wide flag from slice 1. Each library's opt-in lives in its own DuckDB `LibrarySetting` — library A enabling it does not enable it for library B (verified: enabled/disabled DB pair, snapshot never leaks, fail-closed HTTPException when off, network blocked when off). 4 focused tests green, no OpenAPI change. 🤖 Claude (Opus 4.8) via codex