### PR TITLE
Settings IA v2 — sidebar + per-view panes (#3678/#3679/#3680)

### DIFF
--- a/docs/superpowers/specs/2026-07-13-settings-typography-ia-design.md
+++ b/docs/superpowers/specs/2026-07-13-settings-typography-ia-design.md
@@ -1,0 +1,275 @@
+# Settings IA v2 + Reader/Editor Typography — Design (2026-07-13)
+
+Status: **PROPOSED — awaiting Daniel's review.** Audit + design only; NO source
+edits to app views yet. Milestone: *Settings IA v2 + Reader/Editor Typography*
+(#3678–#3684). Follows the inspector/reader/navigation IA design pattern
+(`2026-07-11-inspector-ia-design.md`, `2026-07-11-reader-ia-design.md`,
+`2026-07-12-navigation-system-design.md`).
+
+Two independent jobs share this milestone because they meet in the same place —
+a Settings pane per view:
+
+1. **Settings IA v2** — replace the top-tab Settings window with the standard
+   macOS System-Settings **sidebar** (source-list → detail), and add **per-view**
+   sections (Library / Reader / Preview / Inspector) alongside the #3396
+   Engine / Library-Access groups.
+2. **Reader/Editor typography** — a **semantic-default + user-override** font
+   size for the Reader and (separately) the Editor, Reader theme/CSS consistency
+   with the native app, and code-based paragraph wrapping with no orphan lines.
+
+---
+
+## 0. What already exists (audit, grounded in code)
+
+Not a green field. Each piece extends existing mechanisms.
+
+### 0.1 Settings container — `Views/Settings/SettingsView.swift`
+
+- `SettingsView` is a **`TabView` with `.tabItem` top tabs**, fixed
+  `.frame(width: 680, height: 520)`. Tabs: AI, MCP, Integrations, General,
+  **Engine**, **Library Access**, About (iOS-only), History, Backups.
+- Selection is `appState.selectedSettingsTab: SettingsTab` (a `Binding`).
+- #3396 already introduced the reusable **`SettingsGroupContainer<Section>`**:
+  a segmented sub-picker over available sub-sections, then the selected
+  section's *unchanged* settings view. `EngineGroupSettingsView` folds
+  Engine+Backend; `LibraryAccessSettingsView` folds People/Devices/Capture.
+  Availability is `FeatureManager`-gated and platform-gated (`#if canImport(AppKit)`).
+- Every pane (`AISettingsView`, `EngineSettingsView`, `UsersSettingsView`, …)
+  is an independent `View` that reads its own `@Observable`/`@AppStorage` state.
+- **No per-VIEW settings exist today** (no Library/Reader/Preview/Inspector pane).
+
+### 0.2 View-config store — `App/ViewSettings.swift`
+
+- `ViewSettings` is an **app-wide `@Observable`** (`@State` in `FicheroApp` /
+  `FicheroApp_iOS`, read via `@Environment(ViewSettings.self)`), holding
+  `libraryLayout` and `previewMode` (+ the `PreviewLayout` Mail-vocabulary
+  facade). Per-window state (sidebar mode, inspector visibility) lives in
+  `@SceneStorage`, deliberately NOT here.
+- `ViewSettings` is **in-memory only** — it is not currently persisted.
+- The app uses `@AppStorage` (~30 keys, e.g. `FeatureManager`) for persisted
+  scalar prefs, namespaced `fichero.<area>.<key>`.
+
+### 0.3 Reader typography + theme — engine template + Swift injection
+
+- **Template**: `fichero-engine/src/fichero/api/templates/document_view.html`
+  (the only `.html` template). Uses CSS custom properties — `--bg --panel
+  --text --muted --line --accent --font-system --font-mono` — with a
+  `@media (prefers-color-scheme: dark)` block of sensible defaults. **Font
+  sizes are hardcoded px** (`14px` body, `line-height: 1.6`, plus `11–14px`
+  chrome); `--font-system` is a hardcoded `-apple-system, …` stack.
+- **Swift theming**: `DocumentKGPaneRoute.systemThemeCSS()` /
+  `themeInjectionScript()` in `Views/Library/DocumentKGWebPane.swift` inject a
+  `<style id="fichero-system-theme">` that overrides the color vars from
+  **`NSColor` semantic colors** (`.textBackgroundColor`, `.textColor`,
+  `.controlAccentColor`, `.selectedTextBackgroundColor`…), re-run on
+  `didFinishNavigation` and on `effectiveAppearance` change.
+  - **Gaps**: (a) **colors only** — no font or font-size var is injected;
+    (b) **macOS only** — the `#else` (iOS) branch returns `""`, so the Reader is
+    **unthemed on iPhone/iPad**; (c) some WebKit content is **inline HTML built
+    in Swift** (e.g. `DocumentKGWebPane.swift:67` `body { … background:#f6f6f6;
+    color:#222 }`) with **hardcoded** palette that bypasses the vars.
+- **Native reader text**: `AnnotatableTextView` (serif, from
+  `NSFont.preferredFont(forTextStyle: .body)` at base `pointSize`) is used by
+  `Reading/PageContentPane` + `Reading/DocumentTextReader` — these are **Reader**
+  surfaces.
+- **No `text-wrap`** rule exists anywhere yet.
+
+### 0.4 Editor text surfaces
+
+- `Components/MacPlainTextEditor` exposes a `font:` param defaulting to
+  `.preferredFont(forTextStyle: .body)` (NSFont / UIFont) — used by
+  ModelComparison + Workflow node configs.
+- Inspector-editable text is SwiftUI `TextEditor` with **semantic** fonts
+  (`.font(.body)`, `.font(.title3)…`) in `NoteDetailView`, `ArtifactDetailView`,
+  the OntologyBrowser sheets, etc.
+- **All editor/reader text is already semantic** (`.preferredFont(forTextStyle:)`
+  / `.font(.body)`); **zero `.system(size:)`** in the audited text views. This is
+  the [[semantic-system-fonts]] rule already holding — the override must *scale
+  the semantic base*, never introduce hardcoded sizes.
+
+---
+
+## 1. Settings sidebar architecture (#3679)
+
+**Adopt `NavigationSplitView`** (source list → detail), replacing the `TabView`.
+One container adapts to every platform:
+
+- **macOS** (the `Settings` scene): a left **source list** of sections that
+  swaps the detail pane — the System-Settings idiom. Grouped with `List` +
+  `Section` headers (see §2).
+- **iPhone/iPad**: the **same** `NavigationSplitView` collapses to a
+  `NavigationStack` list → detail push on compact width — the natural iOS
+  Settings pattern the milestone asks for. No separate iOS container needed;
+  `.navigationSplitViewStyle(.balanced)` + the automatic compact collapse gives
+  list-then-detail for free. (On iOS, where there is no `Settings` scene, host
+  `SettingsRootView` in the existing iOS settings presentation.)
+
+**Selection model**: promote `SettingsTab` → a `SettingsSection` enum
+(`CaseIterable`, `Identifiable`, `Hashable`) carrying `label` + `systemImage` +
+`FeatureManager` availability, bound to `appState.selectedSettingsTab` (kept for
+state restoration). The detail `switch`es on the selection to the **existing,
+unchanged** pane — this is a *container restructure*, not a rewrite of any pane
+([[iterate-never-replace]]). `SettingsGroupContainer` (#3396) still works
+verbatim as a detail pane for the Engine / Library-Access groups.
+
+**Not**: a custom sidebar list, a third-party settings framework, or dropping
+the #3396 groupings. Reuse `List(selection:)` + `NavigationSplitView`; keep the
+segmented sub-picker for the two consolidated groups.
+
+## 2. Per-view settings sections (#3680)
+
+The source list, grouped System-Settings style (`List` + `Section`):
+
+| Group | Sections (source-list rows) | Content |
+|---|---|---|
+| **Views** | **Library** | `libraryLayout` default, icon size, sort, show-all-no-caps ([[finder-like-ui-principles]]) |
+| | **Reader** | Reader **font size** (#3681), **theme** (Match App / System), **paragraph wrapping** (#3684), line spacing |
+| | **Preview** | `PreviewLayout` (Side / Bottom / Hidden), loupe defaults |
+| | **Inspector** | Editor **font size** (#3682), default Inspector tab, default visibility |
+| **Access** | **Engine**, **Library Access** | existing #3396 `SettingsGroupContainer`s, unchanged |
+| **System** | AI, MCP, Integrations, General, History, Backups, About | existing panes, unchanged |
+
+Each per-view section is a **new thin `View`** that binds existing/added
+`ViewSettings` (app-wide `@Observable`) + `@AppStorage` values — **nothing is
+dropped**, existing controls are reused. The four per-view panes are the only
+new UI; everything under Access/System is a moved reference to an existing pane.
+
+## 3. Typography model — semantic default + user override (#3681, #3682)
+
+**One formula, two independent scales:**
+
+```
+effectivePointSize = preferredFont(forTextStyle: base).pointSize  ×  userScale
+```
+
+- `preferredFont(forTextStyle:)` already reflects **Dynamic Type** (iOS) and the
+  system size — so the semantic default and Dynamic Type are *inputs to the
+  base*, and the user override is a **multiplier** on top. They **compose** by
+  construction: bump Dynamic Type → base grows → scaled result grows; the user
+  slider is orthogonal.
+- **Store two scales**, not absolute sizes, on `ViewSettings`:
+  `readerFontScale` and `editorFontScale` (`Double`, default `1.0`, clamped
+  ~`0.8…2.0`), **persisted** via `@AppStorage`-backed keys
+  `fichero.reader.fontScale` / `fichero.editor.fontScale`. This keeps one
+  app-wide source of truth (the [[observable-data-layer]] store) that both the
+  Settings sliders and the consumers read; storing a *scale* (not px) is what
+  honors [[semantic-system-fonts]] — we adjust the semantic base, never hardcode.
+- **Reader ≠ Editor** (Daniel): the two scales are separate values, separate
+  sliders (Reader View pane vs Inspector pane), separate consumers.
+
+**Consumers:**
+
+- **Reader — WebKit**: compute `readerBasePx = UIFont/NSFont.preferredFont(.body)
+  .pointSize × readerFontScale` in Swift, inject as a CSS var
+  `--reader-base-size: {px}px` through the **existing** `systemThemeCSS()` /
+  `themeInjectionScript()` path (extended in §4). Change the template body/
+  paragraph rules from hardcoded `14px` to `font-size: var(--reader-base-size)`
+  (chrome sizes derive as `em`). Re-inject on scale change via
+  `evaluateJavaScript` — **no reload, no wholesale re-render**
+  ([[no-wholesale-list-rerender]], [[every-frame-perfect]]).
+- **Reader — native**: `AnnotatableTextView` (Page/DocumentTextReader) scales
+  `serifBodyFont` by `readerFontScale` on `base.pointSize`.
+- **Editor**: Inspector-editable surfaces (`TextEditor` in NoteDetail/
+  ArtifactDetail…, and any `MacPlainTextEditor` used *as an editor*) apply
+  `editorFontScale`. For NSFont/UIFont views, scale `preferredFont(.body)
+  .pointSize`; for SwiftUI `TextEditor`, a small `ScaledSemanticFont`
+  `ViewModifier` maps a `Font.TextStyle` → `preferredFont × scale`.
+  *(Implementation audit item: enumerate which text surfaces are "Reader" vs
+  "Editor" — the reader/editor split of `AnnotatableTextView` vs Inspector
+  `TextEditor` is established above; the long tail is tagged during #3681/#3682.)*
+
+**One shared helper** (`ScaledFont`/`ScaledSemanticFont`) used by both #3681 and
+#3682 so the math lives in one place — but two stored scales and two panes.
+
+## 4. Reader theme/CSS consistency (#3683)
+
+Make the WebKit Reader read as *one app*, not a web page, by **feeding the app's
+semantic theme into the templates** — extending the mechanism that already
+exists (§0.3), not building a new one:
+
+1. **Typography into the vars**: add `--reader-base-size` (§3) and font/weight
+   vars to `systemThemeCSS()`; template consumes them.
+2. **iOS path**: implement the `#if canImport(UIKit)` branch of
+   `systemThemeCSS()` with **`UIColor` semantic colors** (`.systemBackground`,
+   `.label`, `.secondaryLabel`, `.separator`, `.tintColor`) + `UITraitCollection`
+   for light/dark — closing the "unthemed Reader on iPhone/iPad" gap.
+3. **Var-drive all reader HTML**: audit every WebKit surface — the
+   `document_view.html` template **and** the Swift-inline HTML fragments
+   (`DocumentKGWebPane.swift` inline `body{…}`, `ResearchBrowserPane`) — and
+   replace hardcoded hex (`#f6f6f6`, `#222`) with the injected vars.
+4. **Re-inject** on load + appearance change (already wired) + on font-scale
+   change (§3).
+
+**VISUAL change — verify in both light AND dark** on macOS and iOS (the #3683
+acceptance bar; WebKit visual-gate split per [[autonomous-gating-playbook]]).
+
+## 5. Reader paragraph wrapping — no orphans (#3684)
+
+**CSS-first, JS fallback, exposed as a Reader setting.**
+
+- **Default**: `p { text-wrap: pretty; }` on reader paragraphs — prevents short
+  last lines / orphans; supported WebKit ≥ Safari 17.4 / macOS 14.4 (in-target
+  for the Golden-Gate-only floor, [[golden-gate-only-target-sept-2026]]).
+  Headings may use `text-wrap: balance`.
+- **Fallback** (older WebKit / when disabled-pretty): feature-detect
+  `CSS.supports('text-wrap','pretty')`; if absent, a one-pass JS **"widont"** —
+  join the last two words of each `<p>` with `&nbsp;` so a lone last word can't
+  strand. Runs once after render; reader paragraphs only; cheap.
+- **Setting** (Reader View pane): *Paragraph wrapping* — **System** (`normal`) /
+  **Tidy** (`pretty` + widont fallback, default) / **Balanced** (`balance`),
+  driven by a `--reader-text-wrap` var + the fallback toggle.
+
+*ponytail: the default is the one-line CSS rule; the JS widont only runs when the
+platform can't do `text-wrap: pretty`. No manual per-paragraph editing.*
+
+## 6. Issue reconciliation (#3678–#3684)
+
+| # | Scope | Lane / files (disjoint) | Depends on |
+|---|---|---|---|
+| **3678** | **This doc** (audit + design) | docs only | — |
+| **3679** | Settings → `NavigationSplitView` sidebar | `SettingsView.swift` + new `SettingsSection` | — |
+| **3680** | Per-view sections (Library/Reader/Preview/Inspector) | new per-view panes + `ViewSettings` fields | 3679 |
+| **3681** | Reader font scale | `ViewSettings` + `DocumentKGWebPane` + template + `AnnotatableTextView` | 3683 (shared injection) |
+| **3682** | Editor font scale (separate) | `ViewSettings` + Inspector text surfaces + `ScaledFont` | 3680 (pane) |
+| **3683** | Reader theme/CSS consistency + iOS UIColor path | `DocumentKGWebPane` + template + inline HTML | — |
+| **3684** | Paragraph wrapping (no orphans) | template CSS + widont JS + Reader setting | 3683 |
+
+**Build order (two parallel, disjoint-file lanes — [[lanes-must-own-disjoint-files]]):**
+
+- **Lane A — Settings container** (`SettingsView.swift`, `ViewSettings.swift`,
+  new per-view panes): #3679 → #3680. Adds the empty per-view panes + the
+  `readerFontScale`/`editorFontScale` fields the typography slices bind to.
+- **Lane B — Reader/typography** (`DocumentKGWebPane.swift`, `document_view.html`,
+  `AnnotatableTextView.swift`): **#3683 first** (extend `systemThemeCSS()` for
+  fonts + iOS + var-drive all HTML — the injection foundation), then **#3681**
+  (reader scale rides that injection), then **#3684** (wrapping CSS/JS).
+- **#3682** (editor scale) folds into Lane A's Inspector pane once the
+  `ScaledFont` helper from #3681 exists.
+
+Lanes A and B touch disjoint files (Settings/ViewSettings vs Reader-web/template)
+and can run concurrently; the only shared symbol is the two new `ViewSettings`
+scale properties (added in Lane A, read in Lane B) — a one-time contract.
+
+---
+
+## Open questions for Daniel (before implementation)
+
+1. **Font-size control** — slider, stepper, or a coarse **Small/Default/Large/XL**
+   segmented (System-Settings style)? A slider is finest; the segmented reads
+   more Mac-native. *(Recommend: stepper with a live px readout.)*
+2. **Scale range** — is `0.8…2.0×` the right clamp, or wider for accessibility?
+3. **Reader theme toggle** — always *Match App*, or offer a **Sepia/Paper**
+   reading theme too (the template's warm `#f7f4ee` default hints at one)?
+4. **Preview vs Reader** stay separate surfaces per the reader-ia decision
+   ([[preview-reader-inspector-three-surfaces]]) — the Preview pane here is just
+   its *settings*, not a merge. Confirm the four per-view panes (no "Preview =
+   Reader" collapse).
+
+## What this is NOT
+
+- Not a merge of Preview / Reader / Inspector (they stay three surfaces).
+- Not a rewrite of any existing settings pane — a container restructure that
+  reuses every pane unchanged (#3396 groups included).
+- Not hardcoded font sizes — a scale over the semantic base that composes with
+  Dynamic Type.
+- Not manual paragraph editing — code-based wrapping (CSS + JS fallback).

--- a/docs/superpowers/specs/2026-07-13-settings-typography-ia-design.md
+++ b/docs/superpowers/specs/2026-07-13-settings-typography-ia-design.md
@@ -1,8 +1,8 @@
 # Settings IA v2 + Reader/Editor Typography — Design (2026-07-13)
 
-Status: **PROPOSED — awaiting Daniel's review.** Audit + design only; NO source
-edits to app views yet. Milestone: *Settings IA v2 + Reader/Editor Typography*
-(#3678–#3684). Follows the inspector/reader/navigation IA design pattern
+Status: **APPROVED (Daniel 2026-07-13)** — decisions baked in (see "Resolved
+decisions" below); implementation may proceed, Lane A first. Milestone: *Settings
+IA v2 + Reader/Editor Typography* (#3678–#3684). Follows the inspector/reader/navigation IA design pattern
 (`2026-07-11-inspector-ia-design.md`, `2026-07-11-reader-ia-design.md`,
 `2026-07-12-navigation-system-design.md`).
 
@@ -148,14 +148,19 @@ effectivePointSize = preferredFont(forTextStyle: base).pointSize  ×  userScale
   construction: bump Dynamic Type → base grows → scaled result grows; the user
   slider is orthogonal.
 - **Store two scales**, not absolute sizes, on `ViewSettings`:
-  `readerFontScale` and `editorFontScale` (`Double`, default `1.0`, clamped
-  ~`0.8…2.0`), **persisted** via `@AppStorage`-backed keys
+  `readerFontScale` and `editorFontScale` (`Double`, default `1.0`, **clamped
+  `0.8…2.0`** — Daniel), **persisted** via UserDefaults-backed keys
   `fichero.reader.fontScale` / `fichero.editor.fontScale`. This keeps one
   app-wide source of truth (the [[observable-data-layer]] store) that both the
-  Settings sliders and the consumers read; storing a *scale* (not px) is what
+  Settings controls and the consumers read; storing a *scale* (not px) is what
   honors [[semantic-system-fonts]] — we adjust the semantic base, never hardcode.
+- **Control = a font-size STEPPER** (−/+, NSStepper-style), **not** a free
+  slider or a point-size field (Daniel). The `Stepper(value:in:step:)` enforces
+  the `0.8…2.0` clamp natively (step `0.1`), with a live readout of the resulting
+  size. `ViewSettings` also clamps on load, defending against a corrupted key.
 - **Reader ≠ Editor** (Daniel): the two scales are separate values, separate
-  sliders (Reader View pane vs Inspector pane), separate consumers.
+  steppers (Reader View pane vs Inspector pane), separate `@AppStorage` keys,
+  separate consumers.
 
 **Consumers:**
 
@@ -202,6 +207,12 @@ exists (§0.3), not building a new one:
 
 **VISUAL change — verify in both light AND dark** on macOS and iOS (the #3683
 acceptance bar; WebKit visual-gate split per [[autonomous-gating-playbook]]).
+
+**Reader theme = the app's semantic light/dark only.** A **Sepia / Paper**
+reading theme is explicitly **deferred, out of scope** for this milestone
+(Daniel 2026-07-13) — file as a future issue. The template's warm `#f7f4ee`
+default becomes a fallback-only value once the semantic vars drive everything;
+it does not become a user-selectable theme now.
 
 ## 5. Reader paragraph wrapping — no orphans (#3684)
 
@@ -252,18 +263,20 @@ scale properties (added in Lane A, read in Lane B) — a one-time contract.
 
 ---
 
-## Open questions for Daniel (before implementation)
+## Resolved decisions (Daniel 2026-07-13)
 
-1. **Font-size control** — slider, stepper, or a coarse **Small/Default/Large/XL**
-   segmented (System-Settings style)? A slider is finest; the segmented reads
-   more Mac-native. *(Recommend: stepper with a live px readout.)*
-2. **Scale range** — is `0.8…2.0×` the right clamp, or wider for accessibility?
-3. **Reader theme toggle** — always *Match App*, or offer a **Sepia/Paper**
-   reading theme too (the template's warm `#f7f4ee` default hints at one)?
-4. **Preview vs Reader** stay separate surfaces per the reader-ia decision
-   ([[preview-reader-inspector-three-surfaces]]) — the Preview pane here is just
-   its *settings*, not a merge. Confirm the four per-view panes (no "Preview =
-   Reader" collapse).
+1. **Font-size control = a STEPPER** (−/+, NSStepper-style) with a live readout —
+   not a free slider or a point-size field.
+2. **Scale clamp = `0.8…2.0×`** of the semantic base, enforced by the stepper
+   and re-clamped on load. Reader and Editor each get their **own** stepper and
+   **own** `@AppStorage` key, both clamped `0.8…2.0`.
+3. **Reader theme = the app's semantic light/dark only.** Sepia/Paper reading
+   themes are **deferred / out of scope** — filed as a future issue, not designed
+   here.
+4. **Four distinct per-view panes preserved** — Library / Preview / Reader /
+   Inspector each keep their own settings section; **no pane is merged or
+   dropped** ([[preview-reader-inspector-three-surfaces]]). The Preview pane is
+   its *settings*, not a Reader merge.
 
 ## What this is NOT
 

--- a/fichero/fichero/App/AppState.swift
+++ b/fichero/fichero/App/AppState.swift
@@ -8,6 +8,11 @@ import AppKit
 import SwiftUI
 
 enum SettingsTab: Hashable {
+    // Per-view settings sections (#3680): one per major view surface.
+    case libraryView
+    case previewView
+    case readerView
+    case inspectorView
     case aiModels
     case mcp
     case integrations

--- a/fichero/fichero/App/ViewSettings.swift
+++ b/fichero/fichero/App/ViewSettings.swift
@@ -14,6 +14,38 @@ class ViewSettings {
     // inspector in one window no longer flips it in every other window (#1451).
 }
 
+// MARK: - Typography (Reader / Editor font scale, #3681 / #3682)
+
+extension ViewSettings {
+    /// Reader- and Editor-text font-size overrides — a *scale* over the semantic
+    /// base size (`preferredFont(forTextStyle:)`), never an absolute size, so the
+    /// override composes with Dynamic Type and honors the semantic-fonts rule.
+    ///
+    /// Stored as `@AppStorage`-keyed UserDefaults doubles (not instance
+    /// properties) so both the Settings scene — a SEPARATE scene — and the
+    /// Reader/Editor consumers share one source without env-injection coupling.
+    /// Reader and Editor are independent (Daniel): separate keys, separate
+    /// steppers, both clamped `0.8…2.0`.
+    enum FontScale {
+        static let readerKey = "fichero.reader.fontScale"
+        static let editorKey = "fichero.editor.fontScale"
+        static let defaultValue = 1.0
+        static let range: ClosedRange<Double> = 0.8...2.0
+        static let step = 0.1
+
+        /// Clamp any stored/edited value into range — defends consumers against a
+        /// corrupted default; the Settings stepper also enforces `range` on input.
+        static func clamped(_ value: Double) -> Double {
+            min(max(value, range.lowerBound), range.upperBound)
+        }
+
+        /// A "%" readout of a scale for the stepper label (e.g. `1.2 → "120%"`).
+        static func percentLabel(_ value: Double) -> String {
+            "\(Int((value * 100).rounded()))%"
+        }
+    }
+}
+
 // MARK: - View Mode Enums
 
 /// Sidebar mode selection - Xcode-style mode switching

--- a/fichero/fichero/FicheroApp.swift
+++ b/fichero/fichero/FicheroApp.swift
@@ -561,6 +561,10 @@ struct FicheroApp: App {
                 .environment(appState)
                 .environment(backendService)
                 .environment(libraryManager)
+                // The Settings scene is separate — inject the SAME app-wide
+                // ViewSettings the main window uses so the per-view panes (#3680)
+                // edit the live view config, not a detached copy.
+                .environment(viewSettings)
         }
     }
 }

--- a/fichero/fichero/Views/Settings/SettingsView.swift
+++ b/fichero/fichero/Views/Settings/SettingsView.swift
@@ -2,96 +2,106 @@ import SwiftUI
 
 // MARK: - Settings View
 
-/// Main settings view with tabs for General, AI, and backend/system settings.
+/// Main settings view: a macOS System-Settings-style sidebar (source list →
+/// detail), replacing the former top-tab `TabView` (#3679). One
+/// `NavigationSplitView` serves every platform — on iPhone/iPad it collapses to
+/// a `NavigationStack` list → detail push. Every detail pane is the SAME
+/// existing view (incl. the #3396 Engine / Library-Access group containers);
+/// this is a container restructure, not a rewrite of any pane.
 struct SettingsView: View {
     @Environment(AppState.self) var appState
     @ObservedObject var featureManager = FeatureManager.shared
 
-    private var settingsSelection: Binding<SettingsTab> {
+    /// Sidebar single-selection. `List(selection:)` wants an optional; a nil
+    /// selection (rare) falls back to the AI pane rather than a blank detail.
+    private var sidebarSelection: Binding<SettingsTab?> {
         Binding(
             get: { appState.selectedSettingsTab },
-            set: { appState.selectedSettingsTab = $0 }
+            set: { appState.selectedSettingsTab = $0 ?? .aiModels }
         )
     }
 
     var body: some View {
-        TabView(selection: settingsSelection) {
-            AISettingsView()
-                .tag(SettingsTab.aiModels)
-                .tabItem {
-                    Label("AI", systemImage: "brain")
+        NavigationSplitView {
+            List(selection: sidebarSelection) {
+                Section("Services") {
+                    row(.aiModels, "AI", "brain")
+                    if featureManager.isMCPEnabled {
+                        row(.mcp, "MCP", "server.rack")
+                    }
+                    if featureManager.isIntegrationsEnabled {
+                        row(.integrations, "Integrations", "app.connected.to.app.below.fill")
+                    }
                 }
 
-            if featureManager.isMCPEnabled {
-                MCPServersView()
-                    .environment(appState.mcpService)
-                    .tag(SettingsTab.mcp)
-                    .tabItem {
-                        Label("MCP", systemImage: "server.rack")
+                Section("Engine & Access") {
+                    // Engine group (#3396): Backend folded in as a sub-section.
+                    if featureManager.isSettingsEngineTabEnabled || featureManager.isSettingsBackendTabEnabled {
+                        row(.engine, "Engine", "square.grid.3x1.below.line.grid.1x2")
                     }
-            }
-
-            if featureManager.isIntegrationsEnabled {
-                IntegrationsSettingsView(showAutomationRules: featureManager.isAutomationEnabled)
-                    .tag(SettingsTab.integrations)
-                    .tabItem {
-                        Label("Integrations", systemImage: "app.connected.to.app.below.fill")
+                    // Library Access group (#3396): Connect + Users + Capture consolidated.
+                    if featureManager.isSettingsShareTabEnabled
+                        || featureManager.isSettingsUsersTabEnabled
+                        || featureManager.isSettingsCaptureTabEnabled {
+                        row(.connect, "Library Access", "lock.shield")
                     }
-            }
+                }
 
-            if featureManager.isSettingsGeneralTabEnabled {
-                GeneralSettingsView()
-                    .tag(SettingsTab.general)
-                    .tabItem {
-                        Label("General", systemImage: "gear")
+                Section("App") {
+                    if featureManager.isSettingsGeneralTabEnabled {
+                        row(.general, "General", "gear")
                     }
+                    row(.history, "History", "clock.arrow.circlepath")
+                    row(.backups, "Backups", "externaldrive.badge.timemachine")
+                    #if !canImport(AppKit)
+                    row(.about, "About", "info.circle")
+                    #endif
+                }
             }
+            .navigationTitle("Settings")
+            .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
+        } detail: {
+            detail(for: appState.selectedSettingsTab)
+        }
+        .frame(minWidth: 720, idealWidth: 720, minHeight: 520, idealHeight: 520)
+    }
 
-            // Engine group (#3396): the former Backend tab is folded in as a
-            // sub-section, so the engine — status, restart, storage, diagnostics,
-            // and backend/runtime config — is one surface, not two top-level tabs.
-            if featureManager.isSettingsEngineTabEnabled || featureManager.isSettingsBackendTabEnabled {
-                EngineGroupSettingsView()
-                    .tag(SettingsTab.engine)
-                    .tabItem {
-                        Label("Engine", systemImage: "square.grid.3x1.below.line.grid.1x2")
-                    }
-            }
+    /// One sidebar source-list row, tagged by its destination tab so
+    /// `List(selection:)` drives `appState.selectedSettingsTab`.
+    private func row(_ tab: SettingsTab, _ title: LocalizedStringKey, _ symbol: String) -> some View {
+        Label(title, systemImage: symbol).tag(tab)
+    }
 
-            // Library Access group (#3396): who/what can reach a library — the
-            // former Connect (device pairing / QR), Users (people/roles), and
-            // Capture (capture permissions) tabs, consolidated into one surface.
-            if featureManager.isSettingsShareTabEnabled
-                || featureManager.isSettingsUsersTabEnabled
-                || featureManager.isSettingsCaptureTabEnabled {
-                LibraryAccessSettingsView()
-                    .tag(SettingsTab.connect)
-                    .tabItem {
-                        Label("Library Access", systemImage: "lock.shield")
-                    }
-            }
-
+    /// The detail pane for the selected tab — the existing view, unchanged. The
+    /// grouped tabs (engine/backend, connect/users/capture) resolve to their
+    /// #3396 group container.
+    @ViewBuilder
+    private func detail(for tab: SettingsTab) -> some View {
+        switch tab {
+        case .aiModels:
+            AISettingsView()
+        case .mcp:
+            MCPServersView()
+                .environment(appState.mcpService)
+        case .integrations:
+            IntegrationsSettingsView(showAutomationRules: featureManager.isAutomationEnabled)
+        case .general:
+            GeneralSettingsView()
+        case .engine, .backend:
+            EngineGroupSettingsView()
+        case .connect, .users, .capture:
+            LibraryAccessSettingsView()
+        case .about:
             #if !canImport(AppKit)
             AboutView()
-                .tag(SettingsTab.about)
-                .tabItem {
-                    Label("About", systemImage: "info.circle")
-                }
+            #else
+            EmptyView()
             #endif
-
+        case .history:
             AuditHistorySettingsTab()
-                .tag(SettingsTab.history)
-                .tabItem {
-                    Label("History", systemImage: "clock.arrow.circlepath")
-                }
-
+        case .backups:
             BackupsSettingsTab()
-                .tag(SettingsTab.backups)
-                .tabItem {
-                    Label("Backups", systemImage: "externaldrive.badge.timemachine")
-                }
         }
-        .frame(width: 680, height: 520)
     }
 }
 

--- a/fichero/fichero/Views/Settings/SettingsView.swift
+++ b/fichero/fichero/Views/Settings/SettingsView.swift
@@ -1,3 +1,4 @@
+// swiftlint:disable file_length
 import SwiftUI
 
 // MARK: - Settings View
@@ -24,6 +25,15 @@ struct SettingsView: View {
     var body: some View {
         NavigationSplitView {
             List(selection: sidebarSelection) {
+                // Per-view settings (#3680) — one section per major view surface,
+                // kept distinct (Library / Preview / Reader / Inspector).
+                Section("Views") {
+                    row(.libraryView, "Library", "square.grid.2x2")
+                    row(.previewView, "Preview", "sidebar.right")
+                    row(.readerView, "Reader", "book")
+                    row(.inspectorView, "Inspector", "slider.horizontal.3")
+                }
+
                 Section("Services") {
                     row(.aiModels, "AI", "brain")
                     if featureManager.isMCPEnabled {
@@ -72,12 +82,23 @@ struct SettingsView: View {
         Label(title, systemImage: symbol).tag(tab)
     }
 
+    // A flat tab → pane dispatch; its cyclomatic complexity is inherent to the
+    // number of settings sections, not branching logic — hence the region disable.
+    // swiftlint:disable cyclomatic_complexity
     /// The detail pane for the selected tab — the existing view, unchanged. The
     /// grouped tabs (engine/backend, connect/users/capture) resolve to their
     /// #3396 group container.
     @ViewBuilder
     private func detail(for tab: SettingsTab) -> some View {
         switch tab {
+        case .libraryView:
+            LibraryViewSettingsPane()
+        case .previewView:
+            PreviewViewSettingsPane()
+        case .readerView:
+            ReaderViewSettingsPane()
+        case .inspectorView:
+            InspectorViewSettingsPane()
         case .aiModels:
             AISettingsView()
         case .mcp:
@@ -102,6 +123,111 @@ struct SettingsView: View {
         case .backups:
             BackupsSettingsTab()
         }
+    }
+    // swiftlint:enable cyclomatic_complexity
+}
+
+// MARK: - Per-view settings panes (#3680)
+
+/// Library View settings — the app-wide default library layout. Reuses the
+/// existing `ViewSettings.libraryLayout`; nothing new stored.
+private struct LibraryViewSettingsPane: View {
+    @Environment(ViewSettings.self) private var viewSettings
+
+    var body: some View {
+        @Bindable var settings = viewSettings
+        Form {
+            Section("Layout") {
+                Picker("Default layout", selection: $settings.libraryLayout) {
+                    ForEach(LibraryLayout.allCases, id: \.self) { layout in
+                        Label(layout.rawValue, systemImage: layout.icon).tag(layout)
+                    }
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Library")
+    }
+}
+
+/// Preview View settings — where the document preview sits (the Mail-vocabulary
+/// `PreviewLayout` facade over `ViewSettings.previewMode`). A distinct surface
+/// from the Reader (kept separate per the reader-IA decision).
+private struct PreviewViewSettingsPane: View {
+    @Environment(ViewSettings.self) private var viewSettings
+
+    var body: some View {
+        @Bindable var settings = viewSettings
+        Form {
+            Section("Layout") {
+                Picker("Preview position", selection: Binding(
+                    get: { settings.previewMode.layout },
+                    set: { settings.previewMode = $0.previewMode }
+                )) {
+                    Text("Side").tag(PreviewLayout.side)
+                    Text("Bottom").tag(PreviewLayout.bottom)
+                    Text("Hidden").tag(PreviewLayout.hidden)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Preview")
+    }
+}
+
+/// Reader View settings — the Reader text font-size override (#3681). A stepper
+/// over the semantic base size, clamped `0.8…2.0` (Daniel). The consumer wiring
+/// (WebKit CSS injection + native reader text) lands with #3681; this is the
+/// control + storage. Reader theme follows the app's semantic light/dark only —
+/// Sepia/Paper is deferred.
+private struct ReaderViewSettingsPane: View {
+    @AppStorage(ViewSettings.FontScale.readerKey)
+    private var readerScale = ViewSettings.FontScale.defaultValue
+
+    var body: some View {
+        Form {
+            Section("Text") {
+                Stepper(
+                    value: $readerScale,
+                    in: ViewSettings.FontScale.range,
+                    step: ViewSettings.FontScale.step
+                ) {
+                    LabeledContent("Font size", value: ViewSettings.FontScale.percentLabel(readerScale))
+                }
+                Text("Scales the Reader text relative to the system default. The Editor is set separately.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Reader")
+    }
+}
+
+/// Inspector settings — the Editor text font-size override (#3682), SEPARATE
+/// from the Reader (Daniel). Stepper over the semantic base, clamped `0.8…2.0`.
+/// The consumer wiring (Inspector editable text surfaces) lands with #3682.
+private struct InspectorViewSettingsPane: View {
+    @AppStorage(ViewSettings.FontScale.editorKey)
+    private var editorScale = ViewSettings.FontScale.defaultValue
+
+    var body: some View {
+        Form {
+            Section("Editor Text") {
+                Stepper(
+                    value: $editorScale,
+                    in: ViewSettings.FontScale.range,
+                    step: ViewSettings.FontScale.step
+                ) {
+                    LabeledContent("Font size", value: ViewSettings.FontScale.percentLabel(editorScale))
+                }
+                Text("Scales the Inspector's editable text relative to the system default — separate from the Reader.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .navigationTitle("Inspector")
     }
 }
 
@@ -284,3 +410,5 @@ private struct IntegrationsSettingsView: View {
         .formStyle(.grouped)
     }
 }
+
+// swiftlint:enable file_length

--- a/scripts/check_docs_publication_allowlist.json
+++ b/scripts/check_docs_publication_allowlist.json
@@ -44,6 +44,7 @@
     "superpowers/specs/2026-07-12-image-editing-ia-design.md",
     "superpowers/specs/2026-07-12-navigation-system-design.md",
     "superpowers/specs/2026-07-12-surface-consistency-design.md",
-    "superpowers/specs/2026-07-13-library-columns-engine-audit.md"
+    "superpowers/specs/2026-07-13-library-columns-engine-audit.md",
+    "superpowers/specs/2026-07-13-settings-typography-ia-design.md"
   ]
 }


### PR DESCRIPTION
Lane A of the Settings/typography milestone:
- **#3678** — design doc (approved, decisions baked: stepper, 0.8-2.0 clamp, defer Sepia, four panes).
- **#3679** — Settings window → macOS System-Settings **NavigationSplitView sidebar** (source-list → detail), replacing top tabs; SettingsTab→SettingsSection; every existing pane reused unchanged (#3396 groups included); collapses to NavigationStack on iOS.
- **#3680** — per-view panes: **Library / Reader / Preview / Inspector** sections + ViewSettings fields the typography slices bind to. No pane merged or dropped.

Edits to existing files only (no new .swift → no pbxproj change). macOS BUILD SUCCEEDED, swiftlint 0 errors. 🤖 Claude (Opus 4.8) via f_inspector