### PR TITLE
feat: make citation rows draggable (#3704, partial)

### DIFF
--- a/fichero/fichero-tests/CitationExportModelTests.swift
+++ b/fichero/fichero-tests/CitationExportModelTests.swift
@@ -8,6 +8,14 @@ import XCTest
 @MainActor
 final class CitationExportModelTests: XCTestCase {
 
+    func testCitationDragPayloadRoundTripsAcrossTargets() throws {
+        let payload = CitationDragID(id: "citation-1", text: "Ada, 1843")
+        let decoded = try JSONDecoder().decode(CitationDragID.self, from: JSONEncoder().encode(payload))
+
+        XCTAssertEqual(decoded.id, "citation-1")
+        XCTAssertEqual(decoded.text, "Ada, 1843")
+    }
+
     func testReadyWithBibTeX() async {
         let model = CitationExportModel()
         await model.load { "@article{key, title={T}}" }

--- a/fichero/fichero/Views/Library/Inspector/CitationListView.swift
+++ b/fichero/fichero/Views/Library/Inspector/CitationListView.swift
@@ -57,6 +57,7 @@ struct CitationListView: View {
     private func row(for item: CitationItem) -> some View {
         CitationRow(item: item)
             .tag(item.id)
+            .draggable(CitationDragID(id: item.id, text: item.citation.targetCitationText))
             .inspectorListRowTarget()
             .contextMenu {
                 if let onOpenInWindow {

--- a/fichero/fichero/Views/Library/Inspector/FocusedCitation.swift
+++ b/fichero/fichero/Views/Library/Inspector/FocusedCitation.swift
@@ -1,3 +1,4 @@
+import CoreTransferable
 import FicheroAPIClient
 import Foundation
 import Observation
@@ -39,6 +40,18 @@ struct CitationItem: Identifiable, Hashable {
 
     static func == (lhs: CitationItem, rhs: CitationItem) -> Bool { lhs.id == rhs.id }
     func hash(into hasher: inout Hasher) { hasher.combine(id) }
+}
+
+/// The citation identity shared by native drag sources and drop destinations.
+/// Plain text keeps drops useful in editors and other applications.
+struct CitationDragID: Codable, Transferable {
+    let id: String
+    let text: String
+
+    static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: .json)
+        ProxyRepresentation(exporting: \.text)
+    }
 }
 
 /// Shared selection holder for the citations List + detail (#2004, EPIC #2002).


### PR DESCRIPTION
Drag source half of #3704.

`CitationDragID: Transferable` with `CodableRepresentation` (in-app) + `ProxyRepresentation` exporting plain text (drops usefully into editors and other apps). `CitationListView` rows get `.draggable`.

**Partial: the "associate" half is NOT implemented.** There is no `dropDestination` accepting `CitationDragID` anywhere in the app, so a citation cannot yet be dropped onto a target to associate it. #3704 stays open.

## Verification
- `xcodebuild -scheme 'Fichero (Dev Local)' -destination platform=macOS` → BUILD SUCCEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)