### PR TITLE
feat: citation associate-on-drop (#3704) + library item rows draggable (#3705)

### DIFF
--- a/fichero/fichero-tests/CitationExportModelTests.swift
+++ b/fichero/fichero-tests/CitationExportModelTests.swift
@@ -8,12 +8,19 @@ import XCTest
 @MainActor
 final class CitationExportModelTests: XCTestCase {
 
-    func testCitationDragPayloadRoundTripsAcrossTargets() throws {
-        let payload = CitationDragID(id: "citation-1", text: "Ada, 1843")
-        let decoded = try JSONDecoder().decode(CitationDragID.self, from: JSONEncoder().encode(payload))
+    func testCitationDropAssociatesOnlyNewPersistedCitations() {
+        let ids = CitationStore.associationIDs(
+            from: [
+                .init(id: "citation-1", sourceDocumentId: "source", targetDocumentId: nil, text: "Ada, 1843"),
+                .init(id: "citation-1", sourceDocumentId: "source", targetDocumentId: nil, text: "duplicate"),
+                .init(id: "", sourceDocumentId: "source", targetDocumentId: nil, text: "unsaved"),
+                .init(id: "citation-2", sourceDocumentId: "target", targetDocumentId: nil, text: "self"),
+                .init(id: "citation-3", sourceDocumentId: "source", targetDocumentId: "target", text: "already associated")
+            ],
+            targetDocumentId: "target"
+        )
 
-        XCTAssertEqual(decoded.id, "citation-1")
-        XCTAssertEqual(decoded.text, "Ada, 1843")
+        XCTAssertEqual(ids, ["citation-1"])
     }
 
     func testReadyWithBibTeX() async {

--- a/fichero/fichero-tests/LibraryItemDragTests.swift
+++ b/fichero/fichero-tests/LibraryItemDragTests.swift
@@ -1,0 +1,30 @@
+@testable import Fichero
+import XCTest
+
+final class LibraryItemDragTests: XCTestCase {
+
+    func testLibraryItemDragExportsReadableText() {
+        let item = LibraryItemDrag(kind: .annotation, id: "annotation-1", documentId: "page-1", text: "Important")
+
+        XCTAssertEqual(item.exportText, "Annotation: Important")
+    }
+
+    func testLibrarySurfacesUseCommonDragPayload() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("fichero")
+        let surfaces = [
+            ("Views/Library/LibraryView+DisplayModes.swift", ".draggable(libraryItemDrag(for: doc))"),
+            ("Views/Library/Inspector/ArtifactListView.swift", ".draggable(LibraryItemDrag("),
+            ("Views/Library/Inspector/AnnotationListView.swift", ".draggable(LibraryItemDrag("),
+            ("Views/Notes/NoteListView.swift", ".draggable(LibraryItemDrag("),
+            ("Views/Library/LibraryView+TableMapViews.swift", ".draggable(libraryItemDrag(for: page))")
+        ]
+
+        for (path, marker) in surfaces {
+            let source = try String(contentsOf: root.appendingPathComponent(path), encoding: .utf8)
+            XCTAssertTrue(source.contains(marker), path)
+        }
+    }
+}

--- a/fichero/fichero/Models/CitationStore.swift
+++ b/fichero/fichero/Models/CitationStore.swift
@@ -85,6 +85,35 @@ final class CitationStore: ObservableDomainStore {
         return try await entityService.exportCitationsBibtex(documentIds: [documentId])
     }
 
+    /// Persisted citations eligible to associate with `targetDocumentId`.
+    static func associationIDs(
+        from payloads: [CitationDragID],
+        targetDocumentId: String
+    ) -> [String] {
+        Array(Set(payloads.compactMap { payload in
+            guard !payload.id.isEmpty,
+                  payload.sourceDocumentId != targetDocumentId,
+                  payload.targetDocumentId != targetDocumentId else { return nil }
+            return payload.id
+        })).sorted()
+    }
+
+    /// Associate dropped citations through the existing audited patch action.
+    func associate(citationIds: [String], with targetDocumentId: String) async {
+        do {
+            for citationId in citationIds {
+                _ = try await entityService.patchCitation(
+                    citationId,
+                    targetDocumentId: targetDocumentId
+                )
+            }
+            await reload()
+        } catch {
+            loadError = "Couldn't associate citation."
+            log.error("Citation association failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
     // MARK: - ObservableDomainStore
 
     nonisolated var changeDomain: String { "citation" }

--- a/fichero/fichero/Models/Document.swift
+++ b/fichero/fichero/Models/Document.swift
@@ -1,6 +1,8 @@
+import CoreTransferable
 // swiftlint:disable file_length
 import FicheroAPIClient
 import Foundation
+import UniformTypeIdentifiers
 
 // MARK: - Document Types
 
@@ -108,6 +110,37 @@ enum Status: String, Codable, CaseIterable {
 }
 
 // MARK: - Document Model
+
+/// Common drag payload for library items. The text file makes each row useful
+/// outside Fichero while JSON preserves its identity for in-app destinations.
+struct LibraryItemDrag: Codable, Transferable {
+    enum Kind: String, Codable {
+        case document
+        case page
+        case group
+        case artifact
+        case note
+        case annotation
+    }
+
+    let kind: Kind
+    let id: String
+    let documentId: String?
+    let text: String
+
+    var exportText: String { "\(kind.rawValue.capitalized): \(text)" }
+
+    static var transferRepresentation: some TransferRepresentation {
+        CodableRepresentation(contentType: .json)
+        ProxyRepresentation(exporting: \.text)
+        FileRepresentation(exportedContentType: .plainText) { item in
+            let url = FileManager.default.temporaryDirectory
+                .appendingPathComponent("fichero-\(item.kind.rawValue)-\(UUID().uuidString).txt")
+            try item.exportText.write(to: url, atomically: true, encoding: .utf8)
+            return SentTransferredFile(url)
+        }
+    }
+}
 
 /// Main document model matching Python Document (Pydantic)
 struct Document: Identifiable, Codable, Hashable, @unchecked Sendable {

--- a/fichero/fichero/Services/ArtifactServiceGenerated.swift
+++ b/fichero/fichero/Services/ArtifactServiceGenerated.swift
@@ -4,9 +4,9 @@
 // [[feedback_swift_file_sync]]). Splitting would require pbxproj
 // surgery; suppressing here is the lower-risk path until we decide
 // to move the entity service into its own file.
-import Observation
 import FicheroAPIClient
 import Foundation
+import Observation
 import OpenAPIRuntime
 import OSLog
 
@@ -1236,6 +1236,30 @@ final class EntityServiceGenerated {
     }
 
     // MARK: - Citation graph (#974 hook-up)
+
+    /// Associate an existing citation with a document through the audited
+    /// `citation.patch` action.
+    @discardableResult
+    func patchCitation(
+        _ citationId: String,
+        targetDocumentId: String
+    ) async throws -> Components.Schemas.DocumentCitation {
+        var body = Components.Schemas.CitationPatchRequest()
+        body.targetDocumentId = targetDocumentId
+        let response = try await client.api.patchCitationApiCitationsGraphCitationIdPatch(
+            path: .init(citationId: citationId),
+            body: .json(body)
+        )
+        switch response {
+        case .ok(let okResponse):
+            return try okResponse.body.json
+        case .unprocessableContent(let error):
+            let detail = try? error.body.json
+            throw ServiceError.validationError(detail?.detail?.description ?? "Validation error")
+        case .undocumented(let code, _):
+            throw ServiceError.unexpectedResponse(code)
+        }
+    }
 
     /// Get inbound citations for a document — i.e. other documents that
     /// cite this one. Backed by

--- a/fichero/fichero/Views/Library/Inspector/AnnotationListView.swift
+++ b/fichero/fichero/Views/Library/Inspector/AnnotationListView.swift
@@ -84,6 +84,12 @@ struct AnnotationListView: View {
     @ViewBuilder
     private func row(for annotation: DocumentAnnotation) -> some View {
         AnnotationRow(annotation: annotation)
+            .draggable(LibraryItemDrag(
+                kind: .annotation,
+                id: annotation.id,
+                documentId: annotation.documentId,
+                text: annotation.text?.isEmpty == false ? annotation.text ?? annotation.kind.label : annotation.kind.label
+            ))
             .inspectorListRowTarget()
     }
 

--- a/fichero/fichero/Views/Library/Inspector/ArtifactListView.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactListView.swift
@@ -135,6 +135,14 @@ struct ArtifactListView: View {
             )
         )
             .tag(artifact.id)
+            .draggable(LibraryItemDrag(
+                kind: .artifact,
+                id: artifact.id,
+                documentId: artifact.documentId,
+                text: artifact.content?.isEmpty == false
+                    ? artifact.content ?? artifact.artifactTypeDisplayName
+                    : artifact.artifactTypeDisplayName
+            ))
             .inspectorListRowTarget()
             .onTapGesture(count: 2) {
                 guard let onOpenInWindow else { return }

--- a/fichero/fichero/Views/Library/Inspector/CitationListView.swift
+++ b/fichero/fichero/Views/Library/Inspector/CitationListView.swift
@@ -55,9 +55,15 @@ struct CitationListView: View {
 
     @ViewBuilder
     private func row(for item: CitationItem) -> some View {
+        let citation = item.citation
         CitationRow(item: item)
             .tag(item.id)
-            .draggable(CitationDragID(id: item.id, text: item.citation.targetCitationText))
+            .draggable(CitationDragID(
+                id: citation.id ?? "",
+                sourceDocumentId: citation.sourceDocumentId,
+                targetDocumentId: citation.targetDocumentId,
+                text: citation.targetCitationText
+            ))
             .inspectorListRowTarget()
             .contextMenu {
                 if let onOpenInWindow {

--- a/fichero/fichero/Views/Library/Inspector/CitationsInspectorPane.swift
+++ b/fichero/fichero/Views/Library/Inspector/CitationsInspectorPane.swift
@@ -94,6 +94,15 @@ struct CitationsInspectorPane: View {
         }
         .onChange(of: store.outbound) { _, _ in focused.resolve(in: items) }
         .onChange(of: store.inbound) { _, _ in focused.resolve(in: items) }
+        .dropDestination(for: CitationDragID.self) { payloads, _ in
+            let citationIds = CitationStore.associationIDs(
+                from: payloads,
+                targetDocumentId: document.id
+            )
+            guard !citationIds.isEmpty else { return false }
+            Task { await store.associate(citationIds: citationIds, with: document.id) }
+            return true
+        }
     }
 
     private var citationsToolbarStatusText: String {

--- a/fichero/fichero/Views/Library/Inspector/FocusedCitation.swift
+++ b/fichero/fichero/Views/Library/Inspector/FocusedCitation.swift
@@ -46,6 +46,8 @@ struct CitationItem: Identifiable, Hashable {
 /// Plain text keeps drops useful in editors and other applications.
 struct CitationDragID: Codable, Transferable {
     let id: String
+    let sourceDocumentId: String
+    let targetDocumentId: String?
     let text: String
 
     static var transferRepresentation: some TransferRepresentation {

--- a/fichero/fichero/Views/Library/LibraryView+DisplayModes.swift
+++ b/fichero/fichero/Views/Library/LibraryView+DisplayModes.swift
@@ -57,7 +57,7 @@ extension LibraryView {
                                     scale: CGFloat(iconViewScale)
                                 )
                                 .id(doc.id)
-                                .draggable(doc.id)
+                                .draggable(libraryItemDrag(for: doc))
                                 .onTapGesture(count: 2) {
                                     handleDoubleClick(doc)
                                 }
@@ -279,7 +279,7 @@ extension LibraryView {
                                 showFilterBar = true
                             }
                             .id(doc.id)
-                            .draggable(doc.id)
+                            .draggable(libraryItemDrag(for: doc))
                             .padding(.horizontal, 12)
                             .padding(.vertical, 8)
                             .background(selection.contains(doc.id) ? selectionTint.opacity(0.12) : Color.clear)

--- a/fichero/fichero/Views/Library/LibraryView+FilterAndBatch.swift
+++ b/fichero/fichero/Views/Library/LibraryView+FilterAndBatch.swift
@@ -6,6 +6,20 @@ import SwiftUI
 // MARK: - Filter, Selection, and Batch Extension
 
 extension LibraryView {
+
+    func libraryItemDrag(for document: Document) -> LibraryItemDrag {
+        let kind: LibraryItemDrag.Kind = switch document.docType {
+        case .page: .page
+        case .group: .group
+        default: .document
+        }
+        return LibraryItemDrag(
+            kind: kind,
+            id: document.id,
+            documentId: document.id,
+            text: document.pageContent?.isEmpty == false ? document.pageContent ?? document.name : document.name
+        )
+    }
     private var logger: Logger {
         Logger(subsystem: "app.fichero.fichero", category: "LibraryView")
     }

--- a/fichero/fichero/Views/Library/LibraryView+TableMapViews.swift
+++ b/fichero/fichero/Views/Library/LibraryView+TableMapViews.swift
@@ -385,6 +385,12 @@ extension LibraryView {
             Label(type.groupLabel(count: node.count), systemImage: type.systemImage)
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
+                .draggable(LibraryItemDrag(
+                    kind: .group,
+                    id: node.id,
+                    documentId: node.document.id,
+                    text: type.groupLabel(count: node.count)
+                ))
         case .pageItem(let page):
             Label(
                 page.pageThumbnailLabel.map { "Page \($0)" } ?? page.name,
@@ -392,6 +398,7 @@ extension LibraryView {
             )
             .font(.subheadline)
             .foregroundStyle(.primary)
+            .draggable(libraryItemDrag(for: page))
         case .artifactItem(let artifact):
             Label(
                 artifact.stepName ?? artifact.artifactType,
@@ -399,6 +406,14 @@ extension LibraryView {
             )
             .font(.subheadline)
             .foregroundStyle(.primary)
+            .draggable(LibraryItemDrag(
+                kind: .artifact,
+                id: artifact.id,
+                documentId: artifact.documentId,
+                text: artifact.content?.isEmpty == false
+                    ? artifact.content ?? artifact.artifactTypeDisplayName
+                    : artifact.artifactTypeDisplayName
+            ))
         case .entityItem(let entity):
             Label(entity.canonicalName, systemImage: "person.crop.circle")
                 .font(.subheadline)

--- a/fichero/fichero/Views/Notes/NoteListView.swift
+++ b/fichero/fichero/Views/Notes/NoteListView.swift
@@ -108,6 +108,12 @@ struct NoteListView: View {
     @ViewBuilder
     private func row(for item: NoteSelectionItem) -> some View {
         NoteRow(item: item)
+            .draggable(LibraryItemDrag(
+                kind: .note,
+                id: item.note.id ?? "",
+                documentId: item.note.pageId ?? item.note.folderId,
+                text: item.note.body?.isEmpty == false ? item.note.body ?? item.title : item.title
+            ))
             .inspectorListRowTarget()
     }
 


### PR DESCRIPTION
## #3704 — associate half (completes the issue)
`dropDestination(for: CitationDragID.self)` on the citations inspector pane. Routes through the existing audited `citation.patch` action via `CitationStore.associate` (store layer owns the endpoint call, per the observable-data-layer rule). Self-drops are filtered out; failures surface a user-visible error rather than failing silently.

## #3705 — all library items draggable
`LibraryItemDrag: Transferable` applied to documents, artifacts, pages, annotations and notes. `CodableRepresentation` (in-app) + `ProxyRepresentation` (plain text) + `FileRepresentation` (drag out to Finder).

## Verification
- `xcodebuild -scheme 'Fichero (Dev Local)' -destination platform=macOS` → **BUILD SUCCEEDED**
- `check_service_consistency.py` / `check_no_raw_urlsession_app.py` → output **byte-identical to origin/main baseline**; both are already red on main (pre-existing debt, see below), so this adds no new violation.

## Pre-existing, not from this PR
Both service guardrails exit 1 on clean main today (`PreviewDownloadService.swift` hand-built URLRequest; a stale `QuickLookComponents.swift` allowlist entry). Filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)