### PR TITLE
fix: distinguish mounted workspace routes

### DIFF
--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -7662,7 +7662,7 @@
           "documents"
         ],
         "summary": "List Workspaces",
-        "description": "List all workspace documents (is_workspace=True).\n\nSurfaces curated-items workspaces so the UI can show a \"Workspaces\" section\nand let the user open / create them (#1617). Declared before the `/{doc_id}`\nroute so the literal path isn't captured as a document id.",
+        "description": "List document workspaces, excluding agent-session workspaces.\n\nSurfaces curated-items workspaces so the UI can show a \"Workspaces\" section\nand let the user open / create them (#1617). Declared before the `/{doc_id}`\nroute so the literal path isn't captured as a document id.",
         "operationId": "list_workspaces_api_documents_workspaces_get",
         "responses": {
           "200": {

--- a/fichero-engine/src/fichero/api/routes/documents.py
+++ b/fichero-engine/src/fichero/api/routes/documents.py
@@ -533,13 +533,18 @@ async def list_roots(
 async def list_workspaces(
     db: Database = Depends(get_library_database),
 ) -> DocumentListResponse:
-    """List all workspace documents (is_workspace=True).
+    """List document workspaces, excluding agent-session workspaces.
 
     Surfaces curated-items workspaces so the UI can show a "Workspaces" section
     and let the user open / create them (#1617). Declared before the `/{doc_id}`
     route so the literal path isn't captured as a document id.
     """
-    items = _ordered_by_sort_order(_list_documents(db, is_workspace=True))
+    items = _ordered_by_sort_order(
+        document
+        for document in _list_documents(db, is_workspace=True)
+        if not isinstance(document.metadata, dict)
+        or document.metadata.get("workspace_kind") != "agent"
+    )
     return DocumentListResponse(items=items, count=len(items))
 
 

--- a/fichero-engine/tests/contracts/duplicate_paths_allowlist.json
+++ b/fichero-engine/tests/contracts/duplicate_paths_allowlist.json
@@ -31,17 +31,9 @@
       "workflows/tools/extractors.py::_write_kg_rows",
       "workflows/tools/merge_dedup_only.py::merge_dedup_only"
     ],
-    "route:DELETE /notes/{note_id}": [
-      "api/routes/mind_palace.py::delete_note",
-      "api/routes/notes.py::delete_note"
-    ],
     "route:DELETE /projects/{project_id}": [
       "api/routes/projects.py::delete_project",
       "api/routes/research_crud.py::delete_project"
-    ],
-    "route:GET /notes": [
-      "api/routes/mind_palace.py::list_notes",
-      "api/routes/notes.py::list_notes"
     ],
     "route:GET /notes/{note_id}": [
       "api/routes/mind_palace.py::get_note",
@@ -56,10 +48,6 @@
       "api/routes/projects.py::get_project",
       "api/routes/research_crud.py::get_project"
     ],
-    "route:GET /stats": [
-      "api/routes/search.py::search_stats",
-      "api/routes/storage.py::storage_stats"
-    ],
     "route:GET /tasks/{task_id}": [
       "api/routes/research_crud.py::get_task",
       "api/routes/tasks.py::get_task"
@@ -73,10 +61,6 @@
       "api/routes/projects.py::patch_project",
       "api/routes/research_crud.py::update_project"
     ],
-    "route:POST /import": [
-      "api/routes/documents.py::import_file",
-      "api/routes/workflows.py::import_workflow"
-    ],
     "route:POST /notes": [
       "api/routes/mind_palace.py::create_note",
       "api/routes/notes.py::create_note",
@@ -85,10 +69,6 @@
     "route:POST /projects": [
       "api/routes/projects.py::create_project",
       "api/routes/research_crud.py::create_project"
-    ],
-    "route:POST /reorder": [
-      "api/routes/documents.py::reorder_documents",
-      "api/routes/workflows.py::reorder_workflows"
     ]
   }
 }

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -7662,7 +7662,7 @@
           "documents"
         ],
         "summary": "List Workspaces",
-        "description": "List all workspace documents (is_workspace=True).\n\nSurfaces curated-items workspaces so the UI can show a \"Workspaces\" section\nand let the user open / create them (#1617). Declared before the `/{doc_id}`\nroute so the literal path isn't captured as a document id.",
+        "description": "List document workspaces, excluding agent-session workspaces.\n\nSurfaces curated-items workspaces so the UI can show a \"Workspaces\" section\nand let the user open / create them (#1617). Declared before the `/{doc_id}`\nroute so the literal path isn't captured as a document id.",
         "operationId": "list_workspaces_api_documents_workspaces_get",
         "responses": {
           "200": {

--- a/fichero-engine/tests/unit/test_check_duplicate_paths.py
+++ b/fichero-engine/tests/unit/test_check_duplicate_paths.py
@@ -41,6 +41,37 @@ def create_b():
     assert "kg_write:KnowledgeEntity" in violations
 
 
+def test_duplicate_detector_uses_application_mount_prefixes(tmp_path):
+    src = tmp_path / "src"
+    routes = src / "api" / "routes"
+    routes.mkdir(parents=True)
+    for name in ("chat", "documents"):
+        (routes / f"{name}.py").write_text(
+            """
+from fastapi import APIRouter
+router = APIRouter()
+
+@router.get("/workspaces")
+def list_workspaces():
+    return {}
+""",
+            encoding="utf-8",
+        )
+    (src / "api" / "main.py").write_text(
+        """
+_CORE_ROUTE_SPECS = [
+    (chat.router, "/api/chat", ["chat"]),
+    (documents.router, "/api/documents", ["documents"]),
+]
+""",
+        encoding="utf-8",
+    )
+
+    concerns = check_duplicate_paths.collect(src)
+    assert len(concerns["route:GET /api/chat/workspaces"]) == 1
+    assert len(concerns["route:GET /api/documents/workspaces"]) == 1
+
+
 def test_repo_duplicate_gate_has_no_unallowlisted_concerns():
     violations = check_duplicate_paths.find_violations()
     assert violations == {}

--- a/fichero-engine/tests/unit/test_routes_documents_workspace.py
+++ b/fichero-engine/tests/unit/test_routes_documents_workspace.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fichero.models import DocType, Document
+from fichero.models import Conversation, DocType, Document
 
 
 def test_workspace_patch_add_remove_reorder_items(client, db):
@@ -73,3 +73,35 @@ def test_list_workspaces_returns_only_workspace_docs(client, db):
     ids = {item["id"] for item in payload["items"]}
     assert ids == {"ws-a", "ws-b"}
     assert payload["count"] == 2
+
+
+def test_document_and_agent_workspaces_have_distinct_endpoints(client, db):
+    document_workspace = Document(
+        id="document-workspace",
+        name="Document workspace",
+        doc_type=DocType.folder,
+        is_workspace=True,
+    )
+    conversation = Conversation(
+        id="agent-workspace-conversation",
+        title="Agent workspace",
+        messages=[{"role": "user", "content": "Investigate this."}],
+    )
+    db.save(document_workspace)
+    db.save(conversation)
+
+    saved_agent_workspace = client.post(
+        f"/api/chat/conversations/{conversation.id}/workspace", json={}
+    )
+    assert saved_agent_workspace.status_code == 200
+    agent_workspace_id = saved_agent_workspace.json()["id"]
+
+    document_response = client.get("/api/documents/workspaces")
+    agent_response = client.get("/api/chat/workspaces")
+
+    assert document_response.status_code == 200
+    assert [item["id"] for item in document_response.json()["items"]] == [
+        document_workspace.id
+    ]
+    assert agent_response.status_code == 200
+    assert [item["id"] for item in agent_response.json()["items"]] == [agent_workspace_id]

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -7662,7 +7662,7 @@
           "documents"
         ],
         "summary": "List Workspaces",
-        "description": "List all workspace documents (is_workspace=True).\n\nSurfaces curated-items workspaces so the UI can show a \"Workspaces\" section\nand let the user open / create them (#1617). Declared before the `/{doc_id}`\nroute so the literal path isn't captured as a document id.",
+        "description": "List document workspaces, excluding agent-session workspaces.\n\nSurfaces curated-items workspaces so the UI can show a \"Workspaces\" section\nand let the user open / create them (#1617). Declared before the `/{doc_id}`\nroute so the literal path isn't captured as a document id.",
         "operationId": "list_workspaces_api_documents_workspaces_get",
         "responses": {
           "200": {

--- a/scripts/check_duplicate_paths.py
+++ b/scripts/check_duplicate_paths.py
@@ -100,7 +100,52 @@ def _route_decorator_concern(dec: ast.expr, prefixes: dict[str, str]) -> str | N
     return f"route:{method.upper()} {path}"
 
 
-def _function_occurrences(tree: ast.AST, rel_file: str) -> list[Occurrence]:
+def _mounted_route_prefixes(root: Path) -> dict[str, str]:
+    """Return module prefixes declared by the application's route specs."""
+    main = root / "api" / "main.py"
+    if not main.exists():
+        return {}
+    try:
+        tree = ast.parse(main.read_text(encoding="utf-8"), filename=str(main))
+    except SyntaxError:
+        return {}
+
+    prefixes: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value = node.value
+        else:
+            continue
+        if not isinstance(value, ast.List):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == "_CORE_ROUTE_SPECS"
+            for target in targets
+        ):
+            continue
+        for spec in value.elts:
+            if not isinstance(spec, ast.Tuple) or len(spec.elts) < 2:
+                continue
+            router, prefix = spec.elts[:2]
+            if (
+                not isinstance(router, ast.Attribute)
+                or not isinstance(router.value, ast.Name)
+                or router.attr != "router"
+                or not isinstance(prefix, ast.Constant)
+                or not isinstance(prefix.value, str)
+            ):
+                continue
+            prefixes[f"api/routes/{router.value.id}.py"] = prefix.value
+    return prefixes
+
+
+def _function_occurrences(
+    tree: ast.AST, rel_file: str, mounted_prefix: str = ""
+) -> list[Occurrence]:
     found: list[Occurrence] = []
     prefixes = _extract_router_prefixes(tree)
     for node in ast.walk(tree):
@@ -111,8 +156,15 @@ def _function_occurrences(tree: ast.AST, rel_file: str) -> list[Occurrence]:
         for dec in node.decorator_list:
             concern = _route_decorator_concern(dec, prefixes)
             if concern:
+                method_path = concern.removeprefix("route:")
+                method, path = method_path.split(" ", maxsplit=1)
                 found.append(
-                    Occurrence(concern=concern, symbol=symbol, file=rel_file, line=node.lineno)
+                    Occurrence(
+                        concern=f"route:{method} {mounted_prefix}{path}",
+                        symbol=symbol,
+                        file=rel_file,
+                        line=node.lineno,
+                    )
                 )
 
         names = {
@@ -144,13 +196,14 @@ def _function_occurrences(tree: ast.AST, rel_file: str) -> list[Occurrence]:
 
 def collect(root: Path = ENGINE_SRC) -> dict[str, list[Occurrence]]:
     by_concern: dict[str, list[Occurrence]] = defaultdict(list)
+    mounted_prefixes = _mounted_route_prefixes(root)
     for path in _py_files(root):
         rel = str(path.relative_to(root))
         try:
             tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         except SyntaxError:
             continue
-        for occ in _function_occurrences(tree, rel):
+        for occ in _function_occurrences(tree, rel, mounted_prefixes.get(rel, "")):
             by_concern[occ.concern].append(occ)
     return by_concern
 


### PR DESCRIPTION
Fixes the duplicate-path guard to account for canonical router mount prefixes. Adds regression coverage that `/api/documents/workspaces` and `/api/chat/workspaces` remain distinct, and excludes agent-session workspaces from the document workspace response.\n\nFocused tests: 39 passed; ruff and duplicate-path guard pass.