### PR TITLE
fix: rehash native-controls baseline entry shifted by #3705

### DIFF
--- a/scripts/check_native_controls.py
+++ b/scripts/check_native_controls.py
@@ -30,7 +30,7 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     "KnowledgeGraph/OntologyBrowser/HeuristicReviewSheet.swift#aa939bcbf4": "#1912 baseline",
     "KnowledgeGraph/OntologyBrowser/SpeakerComparisonView.swift#ffffcf8a29": "#1912 baseline",
     "Library/ImageEditor/ImageEditChainPanel.swift#83a0175036": "#1912 baseline",
-    "Library/LibraryView+DisplayModes.swift#ac36d057da": "#1912 baseline",
+    "Library/LibraryView+DisplayModes.swift#1a99669c78": "#1912 baseline (rehashed: #3705 added .draggable to the rows; the collection itself is unchanged)",
     "Library/Workspace/WorkspaceItemPicker.swift#2e87b93a6b": "#1912 baseline",
     "Research/ResearchTasksPane.swift#1d731da4e7": "#1912 baseline (shifted by store migration)",
     "Research/ResearchTasksPane.swift#f50acbd404": "#1912 baseline (shifted by store migration)",


### PR DESCRIPTION
Last green→red regression from today's merges.

`#3705` added `.draggable(...)` to the library rows, changing the content hash of an **existing** hand-rolled row collection in `LibraryView+DisplayModes.swift`. `check_native_controls.py` keys `KNOWN_VIOLATIONS` by hash, so the same unchanged violation re-presented as "1 new" while the old entry simultaneously reported as "now clean" — a hash rebase, not a new violation.

Rehashed in place (`ac36d057da` → `1a99669c78`), matching the existing "shifted by store migration" precedent on `ResearchTasksPane`. Still 11 known / 11 found; `check_native_controls.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)