### PR TITLE
fix: tooltip on the citations export button (check_tooltips)

### DIFF
--- a/fichero/fichero/Views/Library/Inspector/CitationsInspectorPane.swift
+++ b/fichero/fichero/Views/Library/Inspector/CitationsInspectorPane.swift
@@ -51,6 +51,7 @@ struct CitationsInspectorPane: View {
                     CitationExportButton(fetch: { try await store.exportBibTeX() })
                         .labelStyle(.iconOnly)
                         .id(document.id)
+                        .help("Export citations as BibTeX — copy, share, or drag out")
                         .accessibilityLabel("Export citations as BibTeX")
                 }
 


### PR DESCRIPTION
Adds the missing `.help(...)` on the icon-only citations export toolbar button — the last `check_tooltips.py` offender.

`check_tooltips.py` → exit 0. swiftlint clean. One-line modifier; no behaviour change.

Part of the standing guardrail-debt batch (#3726).

🤖 Generated with [Claude Code](https://claude.com/claude-code)