### PR TITLE
fix: write-authorize POST /api/library-items/columns

### DIFF
--- a/fichero-engine/src/fichero/api/routes/library_items.py
+++ b/fichero-engine/src/fichero/api/routes/library_items.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 
-from fichero.api.main import get_library_database
+from fichero.api.main import get_library_database_for_write
 from fichero.db import Database
 from fichero.knowledge_models import Annotation, KnowledgeClaim, KnowledgeEntity, Note
 from fichero.models import Document
@@ -78,7 +78,7 @@ def _scopes(item_ids: list[str], documents: list[Document], descendants: bool) -
 )
 async def library_item_columns(
     request: LibraryItemColumnsRequest,
-    db: Database = Depends(get_library_database),
+    db: Database = Depends(get_library_database_for_write),
 ) -> LibraryItemColumnsResponse:
     item_ids = list(dict.fromkeys(request.item_ids))
     if not item_ids:


### PR DESCRIPTION
**Security fix.** `POST /api/library-items/columns` is a *mutating* route but took the read-only `get_library_database` dependency, so it was shipping **without write authorization**. Same class as #3597 / #3565 / #3604.

Swaps it to `get_library_database_for_write`.

## Sweep
`test_all_mutating_routes_use_write_authorized_db_dependency` scans **every** mutating route in `api/routes/`, so its passing is a class-wide assertion, not a spot check — no sibling offenders remain.

## Verification
- `test_route_write_authz_guardrail.py` + `tests/contracts` → 13 passed, 0 failed
- `test_library_item_columns.py` → 2 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)