### PR TITLE
refactor: KGQueryStore leaves the view layer + one derivation of engine auth headers

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -304,6 +304,7 @@
 		898AABCC531843909C0C6AA8 /* TriggerEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75371C597B1E4689B6E1803F /* TriggerEditorView.swift */; };
 		89A148373109E3D71999629D /* FocusedDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8609BBFA7EF7B54ED73C59A1 /* FocusedDocument.swift */; };
 		8B136BE0DDA41615174E4AF4 /* SessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4FE6FA42E3E4887451FB21 /* SessionStore.swift */; };
+		7C3A91E4B2D14F0A9E5C1A70 /* KGQueryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A91E4B2D14F0A9E5C1A71 /* KGQueryStore.swift */; };
 		8C35E319E4B9A46AB0383C10 /* TriggerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C69898938F25CFEA64385A16 /* TriggerDetailView.swift */; };
 		8C55B492C37B1BBED91F2B9B /* NotesInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F1C6302A9E0863FB1E6775 /* NotesInspectorPane.swift */; };
 		8D462745B97D9C6E1A8EDEB0 /* ArtifactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA5F6DA59D0A499D28F3C75 /* ArtifactDetailView.swift */; };
@@ -1157,6 +1158,7 @@
 		CAA77E9001736B77957513A4 /* NotesBrowserView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotesBrowserView.swift; sourceTree = "<group>"; };
 		CAAFE05184A40A50ADFC54A9 /* QuickLookPreviewViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickLookPreviewViews.swift; sourceTree = "<group>"; };
 		CB4FE6FA42E3E4887451FB21 /* SessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SessionStore.swift; sourceTree = "<group>"; };
+		7C3A91E4B2D14F0A9E5C1A71 /* KGQueryStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KGQueryStore.swift; sourceTree = "<group>"; };
 		CC02D722B13BC58D4D4B37B7 /* MiniToolbarComponents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MiniToolbarComponents.swift; sourceTree = "<group>"; };
 		CD5D9E12155EC0A6E738B878 /* UsersSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UsersSettingsView.swift; sourceTree = "<group>"; };
 		CE7785FFCD6AB43D36199856 /* ArtifactPanel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArtifactPanel.swift; sourceTree = "<group>"; };
@@ -1717,6 +1719,7 @@
 				5D870DB81D42B1614D58CE3F /* BoundingBoxGeometry.swift */,
 				66ADB5B1F77763C5F3295611 /* PDFRegionGeometry.swift */,
 				CB4FE6FA42E3E4887451FB21 /* SessionStore.swift */,
+				7C3A91E4B2D14F0A9E5C1A71 /* KGQueryStore.swift */,
 				36B2292335F30622AB8F0ABE /* BackendHost.swift */,
 				626E23DB6F8B778F70AF3B35 /* SpaceTheme.swift */,
 				EEFD8D2157AA0C0F66955D78 /* IdentityStore.swift */,
@@ -3016,6 +3019,7 @@
 				CC8B35B398A7393E4D687941 /* BookmarkServiceGenerated.swift in Sources */,
 				04EC79C508ADFCB840661C01 /* BookmarksView.swift in Sources */,
 				8B136BE0DDA41615174E4AF4 /* SessionStore.swift in Sources */,
+				7C3A91E4B2D14F0A9E5C1A70 /* KGQueryStore.swift in Sources */,
 				7F7BE70A69F9550AE8D82690 /* AuthGateView.swift in Sources */,
 				8F7C131CEB5C672DD1E4813A /* BackendRootGate.swift in Sources */,
 				28510D794CAA15808E28CB6C /* BackendHost.swift in Sources */,

--- a/fichero/fichero/App/AppState.swift
+++ b/fichero/fichero/App/AppState.swift
@@ -136,6 +136,7 @@ class AppState {
     let identityStore: IdentityStore  // Public for the access UX (F5): who am I / owner?
     let localInferenceStore: LocalInferenceStore  // Public for Settings → Local LLM tab (#3120)
     let appleAvailabilityStore: AppleAvailabilityStore  // Public for FirstRun + provider rows (#3121/#3118)
+    let kgQueryStore: KGQueryStore  // Public for the SPARQL console (#3298); the store is the only endpoint accessor (#1863)
     private let logger = Logger(subsystem: "app.fichero.fichero", category: "AppState")
 
     // MARK: - Initialization
@@ -151,6 +152,7 @@ class AppState {
         self.identityStore = IdentityStore(client: ficheroClient)
         self.localInferenceStore = LocalInferenceStore(client: ficheroClient)
         self.appleAvailabilityStore = AppleAvailabilityStore(client: ficheroClient)
+        self.kgQueryStore = KGQueryStore(client: ficheroClient)
         logger.info("⏱ AppState.init services ready")
         // #2960: engine is `@Observable`; the computed backend shims read
         // `engine.phase` directly, so views observing them track the engine

--- a/fichero/fichero/Models/KGQueryStore.swift
+++ b/fichero/fichero/Models/KGQueryStore.swift
@@ -1,0 +1,76 @@
+import FicheroAPIClient
+import Foundation
+import Observation
+
+/// Observable store for the W3C SPARQL query layer (#3298). Wraps the typed
+/// `POST /api/kg/query/sparql` (5s soft-timeout, #3297) and
+/// `GET /api/kg/query/examples` ops — the query surface exists precisely so
+/// this console can seed and run it. Never hand-rolls a URL.
+@MainActor
+@Observable
+final class KGQueryStore {
+    private(set) var response: Components.Schemas.SparqlResponse?
+    private(set) var examples: [Components.Schemas.SparqlExampleQuery] = []
+    private(set) var isRunning = false
+    private(set) var errorMessage: String?
+
+    private let client: FicheroClient
+
+    init(client: FicheroClient) {
+        self.client = client
+    }
+
+    func loadExamples() async {
+        guard examples.isEmpty else { return }
+        do {
+            if case .ok(let response) = try await client.api.sparqlExamplesApiKgQueryExamplesGet() {
+                examples = try response.body.json.examples
+            }
+        } catch {
+            // Examples are an optional seed — a failure just leaves the menu empty.
+        }
+    }
+
+    func run(query: String, limit: Int = 200) async {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        isRunning = true
+        errorMessage = nil
+        defer { isRunning = false }
+        do {
+            let output = try await client.api.sparqlQueryApiKgQuerySparqlPost(
+                body: .json(.init(query: trimmed, limit: limit))
+            )
+            switch output {
+            case .ok(let success):
+                response = try success.body.json
+            case .unprocessableContent(let error):
+                response = nil
+                errorMessage = (try? error.body.json)?.detail?.description ?? "Invalid query"
+            case .undocumented(let code, _):
+                response = nil
+                errorMessage = "Query failed (HTTP \(code))"
+            }
+        } catch {
+            response = nil
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    /// Column names across all result rows (union of binding variables), sorted —
+    /// the SPARQL projection isn't known until the query runs.
+    static func columnKeys(_ rows: [Components.Schemas.SparqlResponseRow]) -> [String] {
+        var keys = Set<String>()
+        for row in rows {
+            for key in row.bindings.additionalProperties.value.keys {
+                keys.insert(key)
+            }
+        }
+        return keys.sorted()
+    }
+
+    static func value(_ row: Components.Schemas.SparqlResponseRow, forKey key: String) -> String {
+        guard let raw = row.bindings.additionalProperties.value[key], let raw else { return "" }
+        return String(describing: raw)
+    }
+}

--- a/fichero/fichero/Services/APIClient+Types.swift
+++ b/fichero/fichero/Services/APIClient+Types.swift
@@ -37,31 +37,48 @@ enum APIError: LocalizedError {
 
 // MARK: - URLRequest engine-auth helper
 
+/// The engine auth headers for `url` — `Authorization: Bearer <token>` (#742)
+/// and, when given, the per-library `X-Fichero-Library-Path` (#2648/#3076).
+///
+/// The ONE derivation of those headers. `URLRequest.addEngineAuth` applies them
+/// to a request; callers that must hand headers to a framework which does its
+/// own networking (AVFoundation's `AVURLAsset`, which range-requests a media
+/// stream and cannot be routed through the generated client) take the dictionary
+/// directly, instead of building a throwaway `URLRequest` just to read its
+/// headers back out.
+///
+/// Health endpoint never needs auth and is the only one we deliberately skip —
+/// see `AuthTokenMiddleware.unauthenticatedPaths`.
+func engineAuthHeaders(for url: URL?, libraryPath: String? = nil) -> [String: String] {
+    var headers: [String: String] = [:]
+    let path = url?.path ?? ""
+    // Resolve the token for THIS request's host (#2866), not the global
+    // default — raw requests can target any of the backends the app holds.
+    if !AuthTokenMiddleware.isUnauthenticatedPath(path),
+       let token = AuthTokenMiddleware.waitForTokenBlocking(hostString: url?.absoluteString) {
+        headers["Authorization"] = "Bearer \(token)"
+    }
+    if let libraryPath {
+        // NFC-normalize before encoding (#3076) so raw-URLSession callsites
+        // carry the same canonical bytes as the middleware choke point.
+        let normalized = libraryPath.nfcNormalized
+        // Percent-encode non-ASCII paths (#2648) so header transport stays
+        // lossless. The engine unquotes on read, and pure-ASCII paths are
+        // unchanged, so this is a no-op unless encoding is actually needed.
+        let encoded = normalized.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? normalized
+        headers["X-Fichero-Library-Path"] = encoded
+    }
+    return headers
+}
+
 extension URLRequest {
     /// Attach `Authorization: Bearer <token>` (#742) and, if provided, the
     /// per-library `X-Fichero-Library-Path` header. Use on every raw
     /// URLSession callsite that does not flow through the OpenAPI middleware
     /// (FicheroClient) or `APIClient.configureRequest`.
-    ///
-    /// Health endpoint never needs auth and is the only one we deliberately
-    /// skip — see `AuthTokenMiddleware.unauthenticatedPaths`.
     mutating func addEngineAuth(libraryPath: String? = nil) {
-        let path = url?.path ?? ""
-        // Resolve the token for THIS request's host (#2866), not the global
-        // default — raw requests can target any of the backends the app holds.
-        if !AuthTokenMiddleware.isUnauthenticatedPath(path),
-           let token = AuthTokenMiddleware.waitForTokenBlocking(hostString: url?.absoluteString) {
-            setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-        }
-        if let libraryPath {
-            // NFC-normalize before encoding (#3076) so raw-URLSession callsites
-            // carry the same canonical bytes as the middleware choke point.
-            let normalized = libraryPath.nfcNormalized
-            // Percent-encode non-ASCII paths (#2648) so header transport stays
-            // lossless. The engine unquotes on read, and pure-ASCII paths are
-            // unchanged, so this is a no-op unless encoding is actually needed.
-            let encoded = normalized.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? normalized
-            setValue(encoded, forHTTPHeaderField: "X-Fichero-Library-Path")
+        for (field, value) in engineAuthHeaders(for: url, libraryPath: libraryPath) {
+            setValue(value, forHTTPHeaderField: field)
         }
     }
 }

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/OntologyBrowser+Sheets.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/OntologyBrowser+Sheets.swift
@@ -34,9 +34,7 @@ struct OntologySheetsModifier: ViewModifier {
                 get: { browser.showSparqlConsole },
                 set: { browser.showSparqlConsole = $0 }
             )) {
-                if let client = LibraryManager.shared.globalLibrary?.apiClient.client {
-                    KGQueryConsoleView(client: client)
-                }
+                KGQueryConsoleView()
             }
     }
 }
@@ -126,94 +124,18 @@ private struct OntologyMergeSplitSheetsModifier: ViewModifier {
 
 // MARK: - SPARQL query console (#3298)
 
-/// Observable store for the W3C SPARQL query layer (#3298). Wraps the typed
-/// `POST /api/kg/query/sparql` (5s soft-timeout, #3297) and
-/// `GET /api/kg/query/examples` ops — the query surface exists precisely so
-/// this console can seed and run it. Never hand-rolls a URL.
-@MainActor
-@Observable
-final class KGQueryStore {
-    private(set) var response: Components.Schemas.SparqlResponse?
-    private(set) var examples: [Components.Schemas.SparqlExampleQuery] = []
-    private(set) var isRunning = false
-    private(set) var errorMessage: String?
-
-    private let client: FicheroClient
-
-    init(client: FicheroClient) {
-        self.client = client
-    }
-
-    func loadExamples() async {
-        guard examples.isEmpty else { return }
-        do {
-            if case .ok(let ok) = try await client.api.sparqlExamplesApiKgQueryExamplesGet() {
-                examples = try ok.body.json.examples
-            }
-        } catch {
-            // Examples are an optional seed — a failure just leaves the menu empty.
-        }
-    }
-
-    func run(query: String, limit: Int = 200) async {
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        isRunning = true
-        errorMessage = nil
-        defer { isRunning = false }
-        do {
-            let output = try await client.api.sparqlQueryApiKgQuerySparqlPost(
-                body: .json(.init(query: trimmed, limit: limit))
-            )
-            switch output {
-            case .ok(let ok):
-                response = try ok.body.json
-            case .unprocessableContent(let error):
-                response = nil
-                errorMessage = (try? error.body.json)?.detail?.description ?? "Invalid query"
-            case .undocumented(let code, _):
-                response = nil
-                errorMessage = "Query failed (HTTP \(code))"
-            }
-        } catch {
-            response = nil
-            errorMessage = error.localizedDescription
-        }
-    }
-
-    /// Column names across all result rows (union of binding variables), sorted —
-    /// the SPARQL projection isn't known until the query runs.
-    static func columnKeys(_ rows: [Components.Schemas.SparqlResponseRow]) -> [String] {
-        var keys = Set<String>()
-        for row in rows {
-            for key in row.bindings.additionalProperties.value.keys {
-                keys.insert(key)
-            }
-        }
-        return keys.sorted()
-    }
-
-    static func value(_ row: Components.Schemas.SparqlResponseRow, forKey key: String) -> String {
-        guard let raw = row.bindings.additionalProperties.value[key], let raw else { return "" }
-        return String(describing: raw)
-    }
-}
-
 /// The W3C SPARQL query console (#3298): a monospaced query editor seeded from
 /// the server's example queries, ⌘↩ to run, results in a native grid with a
 /// truncation badge. Makes the built-and-tested kg_sparql/rdflib layer visible
 /// — it is a query surface, not dead code.
 struct KGQueryConsoleView: View {
-    let client: FicheroClient
+    /// The store is the ONLY endpoint accessor (#1863) — injected, not built
+    /// here from a scraped client, so this console observes the same instance
+    /// the rest of the app does.
+    @Environment(KGQueryStore.self) private var store
 
     @Environment(\.dismiss) private var dismiss
-    @State private var store: KGQueryStore
     @State private var queryText = "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 25"
-
-    init(client: FicheroClient) {
-        self.client = client
-        _store = State(initialValue: KGQueryStore(client: client))
-    }
 
     var body: some View {
         VStack(spacing: 0) {

--- a/fichero/fichero/Views/Library/MediaStreamPreview.swift
+++ b/fichero/fichero/Views/Library/MediaStreamPreview.swift
@@ -45,10 +45,11 @@ struct MediaStreamPreview: View {
         let url = apiClient.sourceURL(for: document.id)
         // Reuse the exact auth headers every other storage fetch uses, rather
         // than re-deriving them — keeps the token out of the URL and in step
-        // with the middleware (#742/#3076).
-        var request = URLRequest(url: url)
-        request.addEngineAuth(libraryPath: apiClient.currentLibraryPath)
-        let headers = request.allHTTPHeaderFields ?? [:]
+        // with the middleware (#742/#3076). AVFoundation does its own
+        // range-requested streaming, so it takes the headers directly; there is
+        // no request for us to build (and no generated-client op that could
+        // stream this without downloading the whole file first).
+        let headers = engineAuthHeaders(for: url, libraryPath: apiClient.currentLibraryPath)
 
         // The header-fields option key isn't surfaced as a Swift symbol on this
         // SDK; its stable underlying string value carries the auth headers into

--- a/fichero/fichero/Views/Shell/DocumentTabView.swift
+++ b/fichero/fichero/Views/Shell/DocumentTabView.swift
@@ -166,6 +166,10 @@ struct DocumentTabView: View {
                     .environment(artifactStore)
                     .environment(entityStore)
                     .environment(claimStore)
+                    // SPARQL console store (#3298/#1863): the console reads it
+                    // from the environment instead of scraping a client off
+                    // LibraryManager.shared.
+                    .environment(appState.kgQueryStore)
                     // These app-/library-scoped @Observable focus + substrate
                     // services are also read directly by ContentView. Forward
                     // them here so switching into Research / KG / claim-focused

--- a/scripts/check_swift_hand_rolled_urls.py
+++ b/scripts/check_swift_hand_rolled_urls.py
@@ -89,7 +89,6 @@ KNOWN_VIOLATIONS: dict[str, str] = {
         "the shared pinned transport — so the KG/reader WKWebView validates the "
         "engine's pinned HTTPS cert like every other call site (#2538)."
     ),
-    "Views/Library/QuickLookComponents.swift#59d9159ae2": "§6b baseline — hand-built URLRequest(url:)",
 }
 
 


### PR DESCRIPTION
Two Swift guardrail fixes, held pending a build gate and now build-verified.

## KGQueryStore leaves the view layer (`2029e5e54`)
`OntologyBrowser+Sheets.swift` was calling `client.api.*` **directly from a view** and reaching for `LibraryManager.shared.globalLibrary` — a straight violation of the observable-data-layer rule (views observe `@Observable` stores; the store is the only endpoint accessor). Routed through `KGQueryStore`. New file correctly registered in `project.pbxproj` (app target is a non-synchronized group).

→ `check_observer_pattern` and `check_view_endpoint_access` both go green.

## One derivation of the engine auth headers (`b50aa30eb`)
`MediaStreamPreview.swift` hand-built a `URLRequest` purely to extract auth headers. Replaced with a shared `engineAuthHeaders(...)` derivation. AVFoundation does its own range-requested streaming, so it takes headers directly — documented in place, since no generated-client op can stream without downloading the whole file first.

Also **removes** the now-stale `QuickLookComponents.swift` entry from the hand-rolled-URL allowlist rather than leaning on it — tightening the ratchet (part of #3726).

→ `check_swift_hand_rolled_urls` goes green.

## Not included
An intermediate `FeatureManager` change swapped `.shared` for `@EnvironmentObject` (legacy `ObservableObject`), which regressed `check_observer_pattern` green→red. It was reverted; the net batch is these two commits. It will be redone with `@Environment(FeatureManager.self)`.

## Verification
- `xcodebuild -scheme 'Fichero (Dev Local)' -destination platform=macOS` → **BUILD SUCCEEDED**, 0 errors
- `check_observer_pattern`, `check_view_endpoint_access`, `check_swift_hand_rolled_urls`, `check_tooltips`, `check_native_controls` → all exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)