### PR TITLE
test: point the reading-surface hook contract at the shipped controls

### DIFF
--- a/fichero-engine/tests/unit/test_uitest_launch_contract.py
+++ b/fichero-engine/tests/unit/test_uitest_launch_contract.py
@@ -21,15 +21,25 @@ def test_ui_test_launch_uses_isolated_library_hooks() -> None:
 
 
 def test_reading_surface_has_stable_accessibility_hooks() -> None:
+    # The inspector's 10-tab bar is GONE: the Inspector IA reform (#3434/#3454,
+    # b731db520) folded it into a 4-section bar plus a segmented facet sub-picker.
+    # So `inspectorTabBar` / `inspectorTab-<tab>` no longer exist — do not "restore"
+    # them. The hooks below are their shipped successors on the real controls.
     files = [
         ROOT / "fichero" / "fichero" / "Views" / "Library" / "DocumentInspector" / "DocumentInspector.swift",
+        # Per-section hook is declared on the enum, not at the call site.
+        ROOT / "fichero" / "fichero" / "Views" / "Library" / "Inspector" / "InspectorSection.swift",
         ROOT / "fichero" / "fichero" / "Views" / "Library" / "DocumentKGSurface.swift",
         ROOT / "fichero" / "fichero" / "Views" / "Toolbars" / "ReaderToolbar.swift",
     ]
     text = "\n".join(path.read_text(encoding="utf-8") for path in files)
 
-    assert '"inspectorTabBar"' in text
-    assert '"inspectorTab-\\(tab.rawValue)"' in text
+    # Container + per-segment hooks — the successors to inspectorTabBar and
+    # inspectorTab-<tab>, so the switcher stays addressable segment by segment.
+    assert '"inspectorSectionBar"' in text
+    assert '"inspectorSection-\\(rawValue)"' in text
+    # The sub-picker revealed by multi-facet sections (Knowledge / Notes).
+    assert '"inspectorFacetPicker"' in text
     assert '"knowledgeSurfaceContent"' in text
     assert '"pdfPreviousPage"' in text
     assert '"pdfNextPage"' in text


### PR DESCRIPTION
Fixes `test_reading_surface_has_stable_accessibility_hooks`, red on main.

## The test was stale, not the app
The inspector's tab bar **no longer exists**. The Inspector IA reform (#3434/#3454) folded it into a 4-section bar plus a segmented facet sub-picker, so `inspectorTabBar` and `inspectorTab-<tab>` are gone. Nothing in `fichero-ui-tests` referenced them either. The test was asserting a contract for a control we deliberately deleted.

## Retargeted at the real successors — and strengthened
Rather than dropping to a single weaker assertion, it now asserts the actual shipped hooks so the switcher stays addressable **segment by segment**:
- `"inspectorSectionBar"` (container) — `DocumentInspector.swift`
- `"inspectorSection-\(rawValue)"` (per-segment, declared on the enum) — `InspectorSection.swift`
- `"inspectorFacetPicker"` (the sub-picker on multi-facet sections) — `DocumentInspector.swift`

The three still-valid assertions (`knowledgeSurfaceContent`, `pdfPreviousPage`, `pdfNextPage`) are kept. All six identifiers verified present on real controls.

A comment records that the tab bar is gone, so nobody "restores" a control that no longer exists.

## Verification
`test_uitest_launch_contract.py` → 2 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)