### PR TITLE
feat: route the preview download through the generated client (#3726)

### DIFF
--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -17855,6 +17855,14 @@
                   "format": "binary"
                 }
               }
+            },
+            "headers": {
+              "Content-Disposition": {
+                "description": "inline; filename=... (RFC 5987 filename* when non-ASCII). The client names the cached preview file from this, and the extension selects the QuickLook renderer.",
+                "schema": {
+                  "type": "string"
+                }
+              }
             }
           },
           "404": {

--- a/fichero-engine/src/fichero/api/routes/storage.py
+++ b/fichero-engine/src/fichero/api/routes/storage.py
@@ -231,6 +231,20 @@ async def get_display_image(
                 "*/*": {"schema": {"type": "string", "format": "binary"}}
             },
             "description": "Original source file bytes",
+            # Declared so the GENERATED client can read it (#3726). The handler has
+            # always sent this header, but an undeclared response header is dropped
+            # by swift-openapi-generator — which is why the Swift preview download
+            # had to stay on raw URLSession to learn the file's real name.
+            "headers": {
+                "Content-Disposition": {
+                    "description": (
+                        "inline; filename=... (RFC 5987 filename* when non-ASCII). "
+                        "The client names the cached preview file from this, and the "
+                        "extension selects the QuickLook renderer."
+                    ),
+                    "schema": {"type": "string"},
+                }
+            },
         },
         404: {"model": NotFoundResponse, "description": "Document or source file not found"},
     },

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -17855,6 +17855,14 @@
                   "format": "binary"
                 }
               }
+            },
+            "headers": {
+              "Content-Disposition": {
+                "description": "inline; filename=... (RFC 5987 filename* when non-ASCII). The client names the cached preview file from this, and the extension selects the QuickLook renderer.",
+                "schema": {
+                  "type": "string"
+                }
+              }
             }
           },
           "404": {

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -17855,6 +17855,14 @@
                   "format": "binary"
                 }
               }
+            },
+            "headers": {
+              "Content-Disposition": {
+                "description": "inline; filename=... (RFC 5987 filename* when non-ASCII). The client names the cached preview file from this, and the extension selects the QuickLook renderer.",
+                "schema": {
+                  "type": "string"
+                }
+              }
             }
           },
           "404": {

--- a/fichero/fichero-tests/PreviewDownloadFileNameTests.swift
+++ b/fichero/fichero-tests/PreviewDownloadFileNameTests.swift
@@ -1,0 +1,80 @@
+#if os(macOS)
+@testable import Fichero
+import XCTest
+
+/// The Content-Disposition → cache-filename rules (#3207/#3726). These matter more
+/// now that the download routes through the generated client: the header is the
+/// only thing that carries the file's REAL name, and the cached file's extension
+/// is what selects the QuickLook renderer. A server-supplied string is also the
+/// one attacker-controllable component of the cache path, so it is sanitized.
+final class PreviewDownloadFileNameTests: XCTestCase {
+
+    private func name(_ header: String, fallback: String = "doc.pdf") -> String {
+        PreviewDownloadService.preferredDownloadFileName(contentDisposition: header, fallback: fallback)
+    }
+
+    // MARK: - The header names the file
+
+    func testPlainFilenameWins() {
+        XCTAssertEqual(name("inline; filename=\"scan 12.tiff\""), "scan 12.tiff")
+    }
+
+    /// RFC 5987 `filename*` (percent-encoded UTF-8) — the engine emits this for
+    /// non-ASCII names, and it takes precedence over the ASCII fallback.
+    func testRFC5987FilenameIsDecodedAndPreferred() {
+        let header = "inline; filename=\"diario.pdf\"; filename*=UTF-8''diario%20de%20Marshall.pdf"
+        XCTAssertEqual(name(header), "diario de Marshall.pdf")
+    }
+
+    func testFallbackWhenHeaderCarriesNoFilename() {
+        XCTAssertEqual(name("inline"), "doc.pdf")
+    }
+
+    // MARK: - The extension must survive (QuickLook picks the renderer from it)
+
+    func testExtensionIsPreserved() {
+        XCTAssertEqual((name("inline; filename=\"notes.md\"") as NSString).pathExtension, "md")
+    }
+
+    // MARK: - A server-supplied name can never escape the cache directory
+
+    func testPathTraversalIsStrippedToItsLeaf() {
+        XCTAssertEqual(name("inline; filename=\"../../etc/passwd\""), "passwd")
+    }
+
+    func testWindowsSeparatorsAreAlsoReducedToTheLeaf() {
+        XCTAssertEqual(name("inline; filename=\"..\\\\..\\\\secret.txt\""), "secret.txt")
+    }
+
+    /// Nothing safe left in the server value → the caller's document-derived name
+    /// is kept, rather than an empty or dotted path component.
+    func testDotDotAloneFallsBack() {
+        XCTAssertEqual(name("inline; filename=\"..\""), "doc.pdf")
+    }
+
+    func testEmptyFilenameFallsBack() {
+        XCTAssertEqual(name("inline; filename=\"\""), "doc.pdf")
+    }
+
+    func testBareSlashFallsBack() {
+        XCTAssertEqual(name("inline; filename=\"/\""), "doc.pdf")
+    }
+
+    func testOverlongNameIsCapped() {
+        let long = String(repeating: "a", count: 500) + ".pdf"
+        XCTAssertEqual(name("inline; filename=\"\(long)\"").count, 200)
+    }
+
+    func testControlCharactersAreDropped() {
+        XCTAssertEqual(name("inline; filename=\"ev\u{0007}il.pdf\""), "evil.pdf")
+    }
+
+    // MARK: - sanitizedFileName directly
+
+    func testSanitizeReturnsEmptyWhenNothingSafeRemains() {
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName("/"), "")
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName("."), "")
+        XCTAssertEqual(PreviewDownloadService.sanitizedFileName(".."), "")
+    }
+}
+#endif

--- a/fichero/fichero/Services/PreviewDownloadService.swift
+++ b/fichero/fichero/Services/PreviewDownloadService.swift
@@ -5,20 +5,17 @@ import OSLog
 private let logger = Logger(subsystem: "app.fichero.fichero", category: "PreviewDownloadService")
 
 /// Centralized "download a document's source file to a temp path, then hand it
-/// to a system viewer" flow (#3207). Extracted from `QuickLookDownloadView` so
-/// the raw networking + auth + HTTP-status handling + Content-Disposition
-/// parsing + temp-file lifecycle live in ONE injectable, testable service instead
-/// of inline in a view (one-path mandate; input validation on server data). The
-/// view keeps only its display state.
+/// to a system viewer" flow (#3207). Transport now goes through the generated
+/// OpenAPI client via `StorageServiceGenerated.fetchSourceFile` (#3726) — no raw
+/// URLSession, no hand-built URLRequest, so auth / pinning / library-path
+/// middleware stay central. This service owns what is left: the Content-Disposition
+/// filename rules, the HTTP-status → human message mapping, and the preview-cache
+/// file lifecycle.
 ///
-/// Behavior-preserving: the sanitize, status-check, error-message, and filename
-/// logic are the exact routines that landed with #3206/#3202/#3207 — moved, not
-/// changed. Cross-platform so any future "download then hand to a system viewer"
-/// flow reuses it (fix-then-sweep).
+/// The sanitize, status-check, error-message, and filename routines are unchanged
+/// from #3206/#3202/#3207 — only the transport beneath them moved.
 struct PreviewDownloadService: Sendable {
     struct Request {
-        let sourceURL: URL
-        let libraryPath: String?
         let documentId: String
         /// Name used when the server sends no (safe) Content-Disposition filename.
         let fallbackFileName: String
@@ -33,40 +30,20 @@ struct PreviewDownloadService: Sendable {
         case failure(message: String)
     }
 
-    /// Session factory — overridable in tests; defaults to the pinned session
-    /// every other raw storage fetch uses.
-    var makeSession: @Sendable () -> URLSession = { RemoteCertificatePinning.configuredSession() }
+    /// The generated-client storage service does the transport (#3726). This
+    /// service owns only the preview-cache lifecycle and the filename rules.
+    let storage: StorageServiceGenerated
 
     /// Download the source file to `FicheroPreview/<id>_<name>` and return it,
     /// or a human error message. Any non-2xx surfaces the engine's JSON `detail`
     /// (not the body handed to a viewer); a `/` or `..` in the server filename is
     /// sanitized away before it can touch the cache path.
     func download(_ request: Request) async -> Outcome {
-        if request.libraryPath == nil {
-            logger.warning("Downloading source without library path - API may reject request")
-        }
-        var urlRequest = URLRequest(url: request.sourceURL)
-        urlRequest.addEngineAuth(libraryPath: request.libraryPath)
-
         do {
-            let (tempURL, response) = try await makeSession().download(for: urlRequest)
-
-            // Branch on the HTTP status (#3206): a non-2xx body is the engine's
-            // JSON error, not the document. Surface its `detail` instead of
-            // handing an error page to the viewer or guessing from byte size.
-            if let httpResponse = response as? HTTPURLResponse,
-               !(200..<300).contains(httpResponse.statusCode) {
-                let message = Self.downloadErrorMessage(
-                    statusCode: httpResponse.statusCode,
-                    body: try? Data(contentsOf: tempURL),
-                    documentPath: request.documentPath
-                )
-                return .failure(message: message)
-            }
+            let (tempURL, contentDisposition) = try await storage.fetchSourceFile(request.documentId)
 
             var fileName = request.fallbackFileName
-            if let httpResponse = response as? HTTPURLResponse,
-               let contentDisposition = httpResponse.value(forHTTPHeaderField: "Content-Disposition") {
+            if let contentDisposition {
                 fileName = Self.preferredDownloadFileName(
                     contentDisposition: contentDisposition,
                     fallback: fileName
@@ -84,6 +61,14 @@ struct PreviewDownloadService: Sendable {
 
             logger.info("Downloaded to: \(destURL.path) (extension: \(destURL.pathExtension))")
             return .success(destURL)
+        } catch let error as SourceFileTransportError {
+            // A non-2xx body is the engine's JSON error, not the document (#3206):
+            // surface its `detail` rather than handing an error page to the viewer.
+            return .failure(message: Self.downloadErrorMessage(
+                statusCode: error.statusCode,
+                body: error.body,
+                documentPath: request.documentPath
+            ))
         } catch {
             logger.error("Download error: \(error.localizedDescription)")
             return .failure(message: "Failed to load: \(error.localizedDescription)")

--- a/fichero/fichero/Services/StorageServiceGenerated.swift
+++ b/fichero/fichero/Services/StorageServiceGenerated.swift
@@ -357,6 +357,59 @@ class StorageServiceGenerated {
         }
     }
 
+}
+
+// MARK: - Error Types
+
+// MARK: - Source file (#3726)
+
+extension StorageServiceGenerated {
+    /// The source file streamed to a temp path, plus the server's
+    /// `Content-Disposition` (#3726). Same op as `downloadSourceFile`, but it
+    /// surfaces the header — the preview cache names the file from it, and the
+    /// extension is what selects the QuickLook renderer, so the caller cannot
+    /// just invent a name.
+    ///
+    /// Non-2xx raises `SourceFileTransportError` carrying the status + raw body
+    /// so the caller can surface the engine's JSON `detail` (#3206) rather than a
+    /// bare status code. Bytes stream chunk-by-chunk — a scan or a large PDF is
+    /// never held whole in memory.
+    func fetchSourceFile(_ docId: String) async throws -> (fileURL: URL, contentDisposition: String?) {
+        isLoading = true
+        defer { isLoading = false }
+
+        let response = try await client.api.getSourceFileApiStorageSourceDocIdGet(.init(
+            path: .init(docId: docId)
+        ))
+        switch response {
+        case .ok(let okResponse):
+            let tempURL = FileManager.default.temporaryDirectory
+                .appendingPathComponent(UUID().uuidString)
+                .appendingPathExtension("fichero")
+            FileManager.default.createFile(atPath: tempURL.path, contents: nil, attributes: nil)
+            let handle = try FileHandle(forWritingTo: tempURL)
+            defer { try? handle.close() }
+            let body = try okResponse.body.any
+            for try await chunk in body {
+                handle.write(Data(chunk))
+            }
+            return (tempURL, okResponse.headers.contentDisposition)
+        case .notFound(let notFound):
+            // Re-encode the typed detail as the `{"detail": ...}` body the shared
+            // message builder already parses, so 404 and every other status take
+            // one path.
+            let detail = (try? notFound.body.json.detail) ?? "Source file not available"
+            let body = try? JSONSerialization.data(withJSONObject: ["detail": detail])
+            throw SourceFileTransportError(statusCode: 404, body: body)
+        case .undocumented(let statusCode, let payload):
+            var body: Data?
+            if let payloadBody = payload.body {
+                body = try? await Data(collecting: payloadBody, upTo: 64 * 1024)
+            }
+            throw SourceFileTransportError(statusCode: statusCode, body: body)
+        }
+    }
+
     // MARK: - Storage Stats
 
     /// Get storage statistics
@@ -399,7 +452,13 @@ class StorageServiceGenerated {
     }
 }
 
-// MARK: - Error Types
+/// A non-2xx from the source-file op, carrying the status and the raw body so the
+/// caller can surface the engine's JSON `detail` (#3206/#3726) instead of a bare
+/// status code.
+struct SourceFileTransportError: Error {
+    let statusCode: Int
+    let body: Data?
+}
 
 enum StorageServiceError: Error, LocalizedError {
     case invalidImageData

--- a/fichero/fichero/Services/StorageServiceGenerated.swift
+++ b/fichero/fichero/Services/StorageServiceGenerated.swift
@@ -401,6 +401,13 @@ extension StorageServiceGenerated {
             let detail = (try? notFound.body.json.detail) ?? "Source file not available"
             let body = try? JSONSerialization.data(withJSONObject: ["detail": detail])
             throw SourceFileTransportError(statusCode: 404, body: body)
+        case .unprocessableContent(let error):
+            // A 422 means the request genuinely failed validation — it must surface
+            // as a thrown, user-visible error, never a silent fallback. Same path as
+            // 404 so the engine's detail reaches the error UI (#3206).
+            let detail = (try? error.body.json)?.detail?.description ?? "Validation error"
+            let body = try? JSONSerialization.data(withJSONObject: ["detail": detail])
+            throw SourceFileTransportError(statusCode: 422, body: body)
         case .undocumented(let statusCode, let payload):
             var body: Data?
             if let payloadBody = payload.body {

--- a/fichero/fichero/Views/Library/QuickLookComponents.swift
+++ b/fichero/fichero/Views/Library/QuickLookComponents.swift
@@ -21,11 +21,14 @@ struct QuickLookDownloadView: View {
     @State private var isLoading = true
     @State private var error: String?
 
-    @Environment(APIClient.self) var apiClient
+    @Environment(StorageServiceGenerated.self) var storageService
 
-    /// The download/auth/temp-file flow lives in the service (#3207); the view
-    /// keeps only fileURL/isLoading/error state.
-    private let downloadService = PreviewDownloadService()
+    /// The download/temp-file flow lives in the service (#3207/#3726); the view
+    /// keeps only fileURL/isLoading/error state. Built from the environment's
+    /// storage service so transport stays on the generated client.
+    private var downloadService: PreviewDownloadService {
+        PreviewDownloadService(storage: storageService)
+    }
 
     var body: some View {
         Group {
@@ -90,8 +93,6 @@ struct QuickLookDownloadView: View {
         logger.info("Loading file from API for document: \(document.id)")
 
         let outcome = await downloadService.download(.init(
-            sourceURL: apiClient.sourceURL(for: document.id),
-            libraryPath: apiClient.currentLibraryPath,
             documentId: document.id,
             fallbackFileName: fileNameWithExtension(),
             documentPath: document.path

--- a/scripts/check_no_raw_urlsession_app.py
+++ b/scripts/check_no_raw_urlsession_app.py
@@ -50,7 +50,13 @@ GRANDFATHERED_FILES: set[str] = {
     # KEEP
     "Services/EngineReadinessProbe.swift",      # readiness bootstrap: probes health/registry over RemoteCertificatePinning before the generated client is usable (#3106)
     "Models/DocumentStore+CRUD.swift",          # multipart import upload
-    "Views/Library/QuickLookComponents.swift",  # binary source bytes for QuickLook
+    # FALSE POSITIVES of the `.data(for:` pattern — these call
+    # PDFDocumentCache.data(for:) (the shared #3209 PDF byte cache, which itself
+    # fetches through StorageServiceGenerated), NOT URLSession.data(for:). Neither
+    # file imports or touches URLSession. Listed so the ratchet stays green without
+    # loosening the regex for everyone else.
+    "Views/Library/Reading/PDFLoupeOverlay.swift",
+    "Views/Library/Reading/PDFThumbnailView.swift",
     "Services/ActivityStreamService.swift",     # SSE
     "Services/ChangeStreamTransport.swift",     # SSE
     "Services/WorkflowStreamService.swift",     # SSE


### PR DESCRIPTION
Closes the last easy Swift guardrail pair.

`PreviewDownloadService` hand-built a `URLRequest` and used raw `URLSession`, bypassing the one-OpenAPI-backed-path rule. Now routed through `StorageServiceGenerated` / the generated `FicheroAPIClient`.

The `.unprocessableContent` (422) case throws with the engine's own detail rather than a `default:` that would swallow it — a failed download must surface, never silently fall back.

Also **removes** the stale `QuickLookComponents.swift` allowlist entry. Two new entries are added for `PDFLoupeOverlay` / `PDFThumbnailView`, which are genuine false positives of the `.data(for:` regex — both call `storageService.pdfCache.data(for:)` and neither references `URLSession` at all (verified). Documenting them beats loosening the regex for everyone else.

→ `check_service_consistency` and `check_no_raw_urlsession_app` both go green.

## Verification
- `xcodebuild -scheme 'Fichero (Dev Local)' -destination platform=macOS` → **BUILD SUCCEEDED**, 0 errors
- 7 guardrails exit 0: service_consistency, no_raw_urlsession_app, swift_hand_rolled_urls, observer_pattern, view_endpoint_access, native_controls, tooltips

🤖 Generated with [Claude Code](https://claude.com/claude-code)