### PR TITLE
fix: emit document group changes (check_emit_change_coverage)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/documents.py
+++ b/fichero-engine/src/fichero/api/routes/documents.py
@@ -2796,6 +2796,11 @@ async def create_document_group(
     for child in children:
         child.parent_id = group.id
         db.save(child)
+    emit_change(
+        str(db.path.parent),
+        type="document.updated",
+        document_ids=[group.id, *child_ids],
+    )
     return group
 
 
@@ -2819,4 +2824,9 @@ async def ungroup_document(
         db.save(child)
         restored.append(child)
     db.delete(group)
+    emit_change(
+        str(db.path.parent),
+        type="document.updated",
+        document_ids=[group.id, *(child.id for child in restored)],
+    )
     return restored

--- a/fichero-engine/tests/unit/test_document_groups.py
+++ b/fichero-engine/tests/unit/test_document_groups.py
@@ -1,7 +1,14 @@
+from fichero.api.routes import documents as document_routes
 from fichero.models import DocType, Document
 
 
-def test_group_and_ungroup_restore_each_child_parent_and_order(client, db):
+def test_group_and_ungroup_restore_each_child_parent_and_order(client, db, monkeypatch):
+    emitted: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        document_routes,
+        "emit_change",
+        lambda library_path, **event: emitted.append({"library_path": library_path, **event}),
+    )
     left_parent = Document(name="Left", doc_type=DocType.folder)
     right_parent = Document(name="Right", doc_type=DocType.folder)
     first = Document(name="Page one", parent_id=left_parent.id, sort_order=3)
@@ -13,6 +20,11 @@ def test_group_and_ungroup_restore_each_child_parent_and_order(client, db):
     assert grouped.status_code == 200
     group_id = grouped.json()["id"]
     assert db.get(Document, first.id).parent_id == group_id
+    assert emitted == [{
+        "library_path": str(db.path.parent),
+        "type": "document.updated",
+        "document_ids": [group_id, first.id, second.id],
+    }]
 
     ungrouped = client.post(f"/api/documents/groups/{group_id}/ungroup")
     assert ungrouped.status_code == 200
@@ -21,3 +33,8 @@ def test_group_and_ungroup_restore_each_child_parent_and_order(client, db):
     assert db.get(Document, second.id).parent_id == right_parent.id
     assert db.get(Document, second.id).sort_order == 7
     assert db.get(Document, group_id) is None
+    assert emitted[1] == {
+        "library_path": str(db.path.parent),
+        "type": "document.updated",
+        "document_ids": [group_id, first.id, second.id],
+    }


### PR DESCRIPTION
**Two real bugs, not lint.** `create_document_group` and `ungroup_document` mutated state without emitting a change event — so the app never reactively refreshed after a group or ungroup. That breaks the observable-data-layer contract (views observe stores; stores need the change stream).

Both now emit `document.updated` for the group **and every affected child**, so the whole affected set refreshes rather than just the parent.

The test asserts the exact emitted payload (type + document_ids), not merely that *something* fired — so it will actually catch a regression.

→ `check_emit_change_coverage` exits 0.

## Verification
`test_document_groups.py` + `tests/contracts` → 10 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)