### PR TITLE
docs: iOS engine-embed re-review — confirms thin client

### DIFF
--- a/scripts/check_docs_publication_allowlist.json
+++ b/scripts/check_docs_publication_allowlist.json
@@ -46,6 +46,7 @@
     "superpowers/specs/2026-07-12-surface-consistency-design.md",
     "superpowers/specs/2026-07-13-accessibility-voiceover-design.md",
     "superpowers/specs/2026-07-13-drag-drop-engine-audit.md",
+    "superpowers/specs/2026-07-13-ios-engine-embed-rereview.md",
     "superpowers/specs/2026-07-13-library-columns-engine-audit.md",
     "superpowers/specs/2026-07-13-mac-app-store-sandbox-research.md",
     "superpowers/specs/2026-07-13-mas-sandbox-spike-result.md",


### PR DESCRIPTION
Re-review of #3278 at Daniel's request.

**Verdict: yes for the interpreter, no for the stack.** PEP 730 makes embedding CPython in an iOS app process officially supported — so the original review's headline objection (*"iOS has no subprocess API"*) was aimed at the **subprocess** architecture and does not refute **in-process** embedding. That reasoning was wrong.

What *is* decisive: **`pydantic-core` (FastAPI's compiled core) and `duckdb` have no iOS wheels on PyPI**, so a minimal FastAPI + pydantic + DuckDB engine cannot even import.

## Caveat recorded prominently, because it nearly misled us
**"No iOS wheels" is a claim about PYTHON BINDINGS on PyPI — NOT about the databases.** DuckDB runs on iOS. LanceDB ships **native Swift bindings** for iOS/macOS with vector search and graph queries. Do not read this document as "DuckDB doesn't work on iOS" — it does. Daniel caught this, and the doc now says so explicitly.

The consequence is the opposite of alarming: on iOS you don't *need* Python, because the databases are native.

## And the Python backend is not in question
It exists for the AI lane, document processing, workflows and importers — none of which native databases replace. Decision stands: **iPhone/iPad remain thin clients.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)