### PR TITLE
fix: tolerate legacy Lance FTS schemas (#3718)

### DIFF
--- a/fichero-engine/src/fichero/db.py
+++ b/fichero-engine/src/fichero/db.py
@@ -3124,6 +3124,11 @@ class Database(DatabaseEmbeddingMixin):
             return {str(getattr(field, "name", field)) for field in fields}
         return set()
 
+    def _lance_select_existing_fields(self, table, fields: list[str]) -> list[str]:
+        """Keep Lance projections compatible with persisted table schemas."""
+        available = self._lance_table_field_names(table)
+        return [field for field in fields if not available or field in available]
+
     def _coerce_vectors_to_existing_schema(
         self, table_name: str, table, data: list[dict]
     ) -> list[dict]:
@@ -3825,7 +3830,9 @@ class Database(DatabaseEmbeddingMixin):
                             raw_fulltext_hits = (
                                 table.search(query, query_type="fts", fts_columns="text")
                                 .select(
-                                    [
+                                    self._lance_select_existing_fields(
+                                        table,
+                                        [
                                         "document_id",
                                         "id",
                                         "text",
@@ -3839,7 +3846,8 @@ class Database(DatabaseEmbeddingMixin):
                                         "page_id",
                                         "char_start",
                                         "char_end",
-                                    ]
+                                        ],
+                                    )
                                 )
                                 .limit(candidate_limit)
                                 .to_list()

--- a/fichero-engine/tests/unit/test_search_scoring.py
+++ b/fichero-engine/tests/unit/test_search_scoring.py
@@ -17,8 +17,6 @@ from __future__ import annotations
 import math
 from types import SimpleNamespace
 
-import pandas as pd
-
 from fichero.db import (
     EMBEDDINGS_TABLE,
     Database,
@@ -202,7 +200,9 @@ class TestHybridRanking:
             def __init__(self, rows):
                 self.rows = rows
 
-            def select(self, _columns):
+            def select(self, columns):
+                assert "created_at" not in columns
+                assert "updated_at" not in columns
                 return self
 
             def limit(self, _limit):
@@ -212,6 +212,13 @@ class TestHybridRanking:
                 return self.rows
 
         class FakeTable:
+            schema = SimpleNamespace(
+                names=[
+                    "document_id", "id", "text", "name", "doc_type", "file_type",
+                    "embedding_scope", "passage_id", "page_id", "char_start", "char_end",
+                ]
+            )
+
             def search(self, _query, query_type="auto", fts_columns=None):
                 assert query_type == "fts"
                 assert fts_columns == "text"


### PR DESCRIPTION
Closes #3718

Legacy Lance tables may not contain `created_at` / `updated_at`; the FTS projection now selects only fields present in the persisted schema.

Validation:
- `ruff check fichero-engine/src/fichero/db.py fichero-engine/tests/unit/test_search_scoring.py`
- `pytest fichero-engine/tests/unit/test_search_scoring.py -q` (35 passed)
- Full `pytest fichero-engine/tests` started with `FICHERO_RUN_SEARCH_E2E=1`, but baseline integration failures blocked completion. The directly relevant search E2E file is 10 failures on `origin/main` and 9 failures on this branch; the removed failure is the legacy FTS schema case.

Directed-By: Daniel Tubb <dtubb@me.com>