### PR TITLE
fix: align entity route contracts and tests (#3768)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/entities.py
+++ b/fichero-engine/src/fichero/api/routes/entities.py
@@ -1407,8 +1407,8 @@ async def entity_drill_down(
 
     return EntityDrillDownResponse(
         entity=entity,
-        documents=documents,
-        co_occurring=co_occurring,
+        documents=documents.items,
+        co_occurring=co_occurring.items,
         claim_excerpts=excerpts,
     )
 

--- a/fichero-engine/tests/integration/test_search_end_to_end.py
+++ b/fichero-engine/tests/integration/test_search_end_to_end.py
@@ -24,10 +24,14 @@ import importlib.util
 from pathlib import Path
 
 import pytest
+from fastapi import Request
 
 from fichero.db_manager import DatabaseManager
 from fichero.models import Artifact, Document
 
+
+def _request() -> Request:
+    return Request({"type": "http", "headers": []})
 
 
 def _real_search_ready() -> bool:
@@ -296,7 +300,9 @@ class TestRouteLevelEnhancedSearch:
         import asyncio
 
         request = SearchRequest(query="Leidy", limit=10)
-        response = asyncio.run(enhanced_search(request, db=search_library))
+        response = asyncio.run(
+            enhanced_search(request, http_request=_request(), db=search_library)
+        )
         assert response.count >= 1
         ids = {r.document_id for r in response.results}
         assert "fix-leidy-001" in ids or "fix-leidy-002" in ids
@@ -309,7 +315,9 @@ class TestRouteLevelEnhancedSearch:
         import asyncio
 
         request = SearchRequest(query="people:Asprilla", limit=10)
-        response = asyncio.run(enhanced_search(request, db=search_library))
+        response = asyncio.run(
+            enhanced_search(request, http_request=_request(), db=search_library)
+        )
         assert response.count >= 1
         # All results should be entity-bridge (the only path that ran).
         for r in response.results:
@@ -322,7 +330,9 @@ class TestRouteLevelEnhancedSearch:
         # 'Leidy "sluice wedged"' — both Leidy docs match Leidy, but
         # only fix-leidy-001 contains the literal "sluice wedged" phrase.
         request = SearchRequest(query='Leidy "sluice wedged"', limit=10)
-        response = asyncio.run(enhanced_search(request, db=search_library))
+        response = asyncio.run(
+            enhanced_search(request, http_request=_request(), db=search_library)
+        )
         ids = {r.document_id for r in response.results}
         assert "fix-leidy-001" in ids
         assert "fix-leidy-002" not in ids
@@ -334,7 +344,9 @@ class TestRouteLevelEnhancedSearch:
         # 'gold' — would normally hit the mining doc. With -mining,
         # it should drop.
         request = SearchRequest(query="gold -mining", limit=10)
-        response = asyncio.run(enhanced_search(request, db=search_library))
+        response = asyncio.run(
+            enhanced_search(request, http_request=_request(), db=search_library)
+        )
         ids = {r.document_id for r in response.results}
         assert "fix-mining-001" not in ids
 
@@ -343,7 +355,9 @@ class TestRouteLevelEnhancedSearch:
         import asyncio
 
         request = SearchRequest(query="", limit=10)
-        response = asyncio.run(enhanced_search(request, db=search_library))
+        response = asyncio.run(
+            enhanced_search(request, http_request=_request(), db=search_library)
+        )
         assert response.search_type == "recent"
         # Returns docs that have non-empty page_content.
         assert response.count >= 1
@@ -356,7 +370,9 @@ class TestRouteLevelEnhancedSearch:
         # Note: requires the artifact planted in _build_library which
         # contains 'Joseph Antonio Asprilla'.
         request = SearchRequest(query="Aspriyaaa_no_real_match", limit=5)
-        response = asyncio.run(enhanced_search(request, db=search_library))
+        response = asyncio.run(
+            enhanced_search(request, http_request=_request(), db=search_library)
+        )
         # Even if some semantic hits sneak in, they'd be filtered by
         # the 0.3 min_score for 'Aspriyaaa_no_real_match' which has
         # no real match. Suggestions should be present.
@@ -406,17 +422,18 @@ class TestKnowledgeGraphRoutes:
 
         # /entities/{id}/documents: Leidy appears in two docs.
         docs = asyncio.run(get_entity_documents("kg-leidy", limit=10, db=search_library))
-        ids = {d.document_id for d in docs}
+        ids = {d.document_id for d in docs.items}
         assert "fix-leidy-001" in ids
         assert "fix-leidy-002" in ids
-        assert all(d.claim_count >= 1 for d in docs)
+        assert docs.count == len(docs.items)
+        assert all(d.claim_count >= 1 for d in docs.items)
 
         # /entities/{id}/co-occurrence: Leidy is in claims with both
         # Quibdó (1 shared) and gold (1 shared). Order may vary.
         cos = asyncio.run(
             get_entity_co_occurrence("kg-leidy", limit=10, db=search_library)
         )
-        related_ids = {c.entity_id for c in cos}
+        related_ids = {c.entity_id for c in cos.items}
         assert "kg-quibdo" in related_ids
         assert "kg-gold" in related_ids
         # Self never appears in co-occurrence — would be nonsensical.
@@ -473,12 +490,13 @@ class TestKnowledgeGraphRoutes:
         ))
 
         rows = asyncio.run(top_entities(limit=10, db=search_library))
-        names = [r.name for r in rows]
+        assert rows.count == len(rows.items)
+        names = [r.name for r in rows.items]
         # 'Frequent' must beat 'Rare' (3 claims vs 1).
         assert names.index("Frequent") < names.index("Rare")
         # Counts reflect input.
-        freq_row = next(r for r in rows if r.name == "Frequent")
-        rare_row = next(r for r in rows if r.name == "Rare")
+        freq_row = next(r for r in rows.items if r.name == "Frequent")
+        rare_row = next(r for r in rows.items if r.name == "Rare")
         assert freq_row.claim_count == 3
         assert rare_row.claim_count == 1
 

--- a/fichero-engine/tests/unit/test_routes_entities.py
+++ b/fichero-engine/tests/unit/test_routes_entities.py
@@ -11,6 +11,7 @@ import logging
 from unittest.mock import patch
 
 from fichero.knowledge_models import EntityType, KnowledgeEntity
+from fichero.models import EntityCoOccurrenceListResponse, EntityDocumentListResponse
 
 
 # ---------------------------------------------------------------------------
@@ -271,8 +272,16 @@ class TestEntityReadLogging:
 
         entity = _make_entity(db, "Alice")
         with (
-            patch.object(entities_routes, "get_entity_documents", return_value=[]),
-            patch.object(entities_routes, "get_entity_co_occurrence", return_value=[]),
+            patch.object(
+                entities_routes,
+                "get_entity_documents",
+                return_value=EntityDocumentListResponse(items=[], count=0),
+            ),
+            patch.object(
+                entities_routes,
+                "get_entity_co_occurrence",
+                return_value=EntityCoOccurrenceListResponse(items=[], count=0),
+            ),
             patch.object(db, "knowledge_claim_excerpts_for_entity", side_effect=RuntimeError("boom")),
             caplog.at_level(logging.WARNING, logger=entities_routes.logger.name),
         ):


### PR DESCRIPTION
Closes #3768

Aligns stale direct route tests with required `Request` and `{items, count}` envelopes. Also corrects `entity_drill_down` to pass envelope `.items` to its list-valued response fields, with typed test doubles covering the route.

Validation:
- ruff on touched files
- search E2E: 26 passed with `FICHERO_RUN_SEARCH_E2E=1`
- full unit + integration: 7,732 passed; the only two failures reproduce on baseline `e44e64de7` (batch activity logging and pre-existing bare array endpoint guard).

Directed-By: Daniel Tubb <dtubb@me.com>