### PR TITLE
feat(pairing): show the pairing link as copyable text, and explain the Simulator (#3774)

### DIFF
--- a/fichero/fichero/Views/Settings/BackendSettingsRemoteAccessSection.swift
+++ b/fichero/fichero/Views/Settings/BackendSettingsRemoteAccessSection.swift
@@ -376,9 +376,38 @@ private struct PairingCardView: View {
                         .font(.caption)
                     }
 
+                    // The pairing link, as SELECTABLE TEXT (#3774). A QR is useless
+                    // in the iOS Simulator — it has no camera — so manual entry is
+                    // not a fallback there, it is the only way to pair. This is the
+                    // exact same payload the QR encodes, produced by the same
+                    // `RemoteClientPairing.inviteLinkString(from:)` the device's
+                    // "Enter Link Manually" already parses: same SPKI pin, same
+                    // one-time code, same expiry. Showing it changes convenience,
+                    // not trust — the QR beside it already carries it.
+                    if let inviteLink {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Pairing link")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            Text(inviteLink)
+                                .font(.system(.caption, design: .monospaced))
+                                .textSelection(.enabled)
+                                .lineLimit(3)
+                                .truncationMode(.middle)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(6)
+                                .background(Color(.textBackgroundColor))
+                                .clipShape(RoundedRectangle(cornerRadius: 4))
+                                .accessibilityLabel("Pairing link, selectable text")
+                            Text("On the device: Enter Link Manually → paste this.")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+
                     HStack {
                         if let inviteLink {
-                            Button(copiedInvite ? "Invite Copied" : "Copy Invite", action: onCopyInvite)
+                            Button(copiedInvite ? "Pairing Link Copied" : "Copy Pairing Link", action: onCopyInvite)
                             if let shareURL = URL(string: inviteLink) {
                                 ShareLink(item: shareURL) {
                                     Label("Share Link", systemImage: "square.and.arrow.up")
@@ -391,6 +420,17 @@ private struct PairingCardView: View {
                     if inviteLink != nil {
                         Text("This link lets a device connect to your library — share only with people you trust.")
                             .font(.caption)
+                            .foregroundStyle(.secondary)
+
+                        // Saves the next person an hour (#3774): the Simulator runs on
+                        // the Mac's own network stack, so the Mac's loopback engine is
+                        // reachable from it directly. A real iPhone is a different
+                        // machine — 127.0.0.1 there means the phone itself, so it must
+                        // pair to this Mac's LAN address instead.
+                        Text("iOS Simulator: it shares this Mac's network, so it can reach a local "
+                             + "engine directly at https://127.0.0.1:8765. A real iPhone or iPad "
+                             + "cannot — it needs this Mac's address above.")
+                            .font(.caption2)
                             .foregroundStyle(.secondary)
                     }
 


### PR DESCRIPTION
**Unblocks testing the iOS app against a local engine.**

## The gap
iOS **already has** the manual path — the "Enter Link Manually" button (`FicheroApp_iOS.swift:396-403`, from #2350, built for visionOS where there is no camera). But **the Mac never showed the link as text**, only a QR. So the manual path existed on the receiving end with nothing to paste into it.

**The iOS Simulator has no camera.** It cannot scan a QR. Manual entry is therefore not a fallback there — it is the **only** way to pair, which made this a blocker on testing.

## The change
Beside the QR: the pairing link as **selectable, monospaced text** plus a **"Copy Pairing Link"** button, and a line of copy telling the user to use "Enter Link Manually" on the device.

## Same payload, same parser — verified, not assumed
It reuses `RemoteClientPairing.inviteLinkString(from: PairingQRCodePayload)` — and iOS decodes with `PairingQRCodePayloadDecoder.decode(message:)` (`FicheroApp_iOS.swift:481`) from **the same payload type**. So the two paths cannot drift into incompatible formats, which is the one way this feature would silently ship broken.

A round-trip test already exists (`fichero-tests/RemoteClientPairingInviteLinkTests.swift`).

## Security: convenience, not trust
Same SPKI pin, same one-time pair code, same expiry as the QR — which is already displayed on screen beside it. This changes convenience, not the trust model.

## Verification
- `check_accessibility`, `check_tooltips`, `check_observer_pattern`, `check_shell_chrome`, `check_native_controls` → all exit 0
- **Not built by me** — f_manager owns all builds. Swift compile verdict is theirs.

Part of the new milestone **Sharing & Pairing — Dead-Simple UX** (#263).

🤖 Generated with [Claude Code](https://claude.com/claude-code)