### PR TITLE
feat(reader): restore the real WebKit transcript, delete Source, paper-card pages (#3765/#3226)

### DIFF
--- a/fichero-engine/src/fichero/api/templates/document_view.html
+++ b/fichero-engine/src/fichero/api/templates/document_view.html
@@ -116,12 +116,34 @@
         }
 
         .transcript {
-            white-space: pre-wrap;
             /* Reader body text derives from the Swift-injected semantic base
                size (--reader-base-size); the 14px fallback keeps it readable in
                a plain browser. The Reader font-size setting scales the var (#3681). */
             font-size: var(--reader-base-size, 14px);
             line-height: 1.6;
+            display: grid;
+            gap: 1em;
+        }
+
+        .transcript-page {
+            scroll-margin-block-start: 0.75em;
+            background: var(--panel);
+            border: 1px solid var(--line);
+            border-radius: 0.8em;
+            box-shadow: 0 0.15em 0.6em var(--line);
+            padding: 1.25em;
+        }
+
+        .page-marker {
+            color: var(--muted);
+            font: 600 0.72em/1 var(--font-system);
+            letter-spacing: 0.08em;
+            margin-bottom: 1em;
+            text-transform: uppercase;
+        }
+
+        .transcript-page-body {
+            white-space: pre-wrap;
         }
 
         .transcript mark {
@@ -602,17 +624,19 @@ function groupedClaims() {
     return Array.from(groups.values()).filter((group) => group.claims.length > 0);
 }
 
-function highlightedTranscript() {
+function transcriptPages() {
     const transcript = documentData.page_content || "";
-    const activeClaim = claims.find((claim) => claim.id === state.activeClaimId);
-    const excerpt = activeClaim?.source_excerpt;
-    if (!excerpt || !transcript.includes(excerpt)) {
-        return escapeHtml(transcript);
+    const markers = [...transcript.matchAll(/^Page\s+(\d+)\s*\n/gm)];
+    if (!markers.length) {
+        return [{ number: 1, content: transcript }];
     }
-    return escapeHtml(transcript).replace(
-        escapeRegExpHtml(excerpt),
-        `<mark data-highlight="claim">${escapeHtml(excerpt)}</mark>`
-    );
+    return markers.map((marker, index) => ({
+        number: marker[1],
+        content: transcript.slice(
+            marker.index + marker[0].length,
+            markers[index + 1]?.index
+        ),
+    }));
 }
 
 function escapeHtml(text) {
@@ -622,10 +646,6 @@ function escapeHtml(text) {
         .replaceAll(">", "&gt;");
 }
 
-function escapeRegExpHtml(text) {
-    return escapeHtml(text).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 function renderTranscript() {
     const panel = document.getElementById("transcript-panel");
     if (!documentData.page_content) {
@@ -633,7 +653,12 @@ function renderTranscript() {
         return;
     }
     panel.innerHTML = `
-        <div class="transcript">${highlightedTranscript()}</div>
+        <div class="transcript">${transcriptPages().map((page) => `
+            <article class="transcript-page" data-page="${page.number}">
+                <div class="page-marker">Page ${page.number}</div>
+                <div class="transcript-page-body">${escapeHtml(page.content)}</div>
+            </article>
+        `).join("")}</div>
     `;
 }
 

--- a/fichero-engine/tests/unit/test_document_view_template.py
+++ b/fichero-engine/tests/unit/test_document_view_template.py
@@ -49,3 +49,11 @@ def test_graph_neighborhood_fetch_uses_relative_api_path() -> None:
 
     assert "fetch(`/api/kg/graph/neighborhood/${entityId}`" in source
     assert "http://localhost:8765/api/kg/graph/neighborhood" not in source
+
+
+def test_transcript_page_cards_keep_scroll_sync_anchors() -> None:
+    source = _template_source()
+
+    assert "function transcriptPages()" in source
+    assert 'class="transcript-page" data-page="${page.number}"' in source
+    assert "scroll-margin-block-start" in source

--- a/fichero/fichero/Views/Library/Reading/ReaderTabBar.swift
+++ b/fichero/fichero/Views/Library/Reading/ReaderTabBar.swift
@@ -51,41 +51,6 @@ enum ReaderTab: String, CaseIterable, Identifiable, SurfaceTab {
     }
 }
 
-/// Page-tab layout (#3502): read the source (image / PDF page) alone, the
-/// transcript alone, or the two side by side. "Read the source" is one tab, so
-/// image ↔ transcript is a layout toggle inside Page rather than separate modes.
-enum ReaderPageLayout: String, CaseIterable, Identifiable {
-    case source
-    case split
-    case transcript
-
-    var id: String { rawValue }
-
-    var title: String {
-        switch self {
-        case .source: return "Source"
-        case .split: return "Split"
-        case .transcript: return "Transcript"
-        }
-    }
-
-    var icon: String {
-        switch self {
-        case .source: return "photo"
-        case .split: return "rectangle.split.2x1"
-        case .transcript: return "text.alignleft"
-        }
-    }
-
-    var help: String {
-        switch self {
-        case .source: return "Show the page image / source only"
-        case .split: return "Show the source and transcript side by side"
-        case .transcript: return "Show the transcript only"
-        }
-    }
-}
-
 /// Notes-tab sub-mode (#3513): the anchored reading marks (highlights / notes /
 /// bookmarks) or free-text document notes. Both live under Notes so the reading
 /// layer and loose notes share one tab.

--- a/fichero/fichero/Views/Library/Reading/ReadingPaneView.swift
+++ b/fichero/fichero/Views/Library/Reading/ReadingPaneView.swift
@@ -53,9 +53,10 @@ struct ReadingPaneView: View {
     @State private var pinnedActivePageNumber: Int?
     @State private var pinnedPageCount: Int?
     @State private var webZoom: Double = 1.0
-    // The KG surface sub-mode. Defaults to Graph — transcript moved to the Page
-    // tab, so the Knowledge surface opens on a "what we know" view.
-    @State private var activeTab: KGSurfaceTab = .graph
+    // The KG surface sub-mode. Defaults to Entities — the entities WITH the
+    // statements made about them, i.e. the "what we know" reading, NOT the graph
+    // visualisation (Daniel 2026-07-14, #3765 Q6).
+    @State private var activeTab: KGSurfaceTab = .entities
     /// The reader's top-level tab (Page/Knowledge/Notes) — the reader IA fold
     /// (2026-07-11 design). Per-window via @SceneStorage. Defaults to Page: the
     /// reader reads the source first (Daniel 2026-07-12); Knowledge and Notes

--- a/fichero/fichero/Views/Library/Reading/ReadingPaneView.swift
+++ b/fichero/fichero/Views/Library/Reading/ReadingPaneView.swift
@@ -26,7 +26,6 @@ struct ReadingPaneView: View {
     /// Drives the compact (iPhone) collapse of the side-by-side page split — a
     /// fixed-width transcript beside the source doesn't fit at compact width
     /// (#3666). Always `.regular` on macOS, so the desktop layout is unchanged.
-    @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     /// Per-window source-navigation bus (#2105/#3437). A reveal brings the reader
     /// to the Page tab so the highlighted source is visible (#3521).
     @Environment(ClaimSourceNavigationState.self) private var claimSourceNavigationState: ClaimSourceNavigationState?
@@ -58,28 +57,14 @@ struct ReadingPaneView: View {
     // visualisation (Daniel 2026-07-14, #3765 Q6).
     @State private var activeTab: KGSurfaceTab = .entities
     /// The reader's top-level tab (Page/Knowledge/Notes) — the reader IA fold
-    /// (2026-07-11 design). Per-window via @SceneStorage. Defaults to Page: the
-    /// reader reads the source first (Daniel 2026-07-12); Knowledge and Notes
-    /// are secondary top tabs.
+    /// (2026-07-11 design). Per-window via @SceneStorage. Page hosts the REAL
+    /// multi-page WebKit transcript (#3765); the old "reader reads the source
+    /// first" note is retired — the source lives in Preview, never here.
     @SceneStorage("reader.topTab") private var readerTabRaw = ReaderTab.page.rawValue
     private var readerTab: ReaderTab { ReaderTab(rawValue: readerTabRaw) ?? .page }
     private var readerTabBinding: Binding<ReaderTab> {
         Binding(get: { readerTab }, set: { readerTabRaw = $0.rawValue })
     }
-    /// Page-tab layout: source / split / transcript (#3502). Per-window.
-    @SceneStorage("reader.page.layout") private var pageLayoutRaw = ReaderPageLayout.source.rawValue
-    private var pageLayout: ReaderPageLayout { ReaderPageLayout(rawValue: pageLayoutRaw) ?? .source }
-    private var pageLayoutBinding: Binding<ReaderPageLayout> {
-        Binding(get: { pageLayout }, set: { pageLayoutRaw = $0.rawValue })
-    }
-    /// Page-turn animation for image-sequence navigation in the Page tab (#2485).
-    /// Shares the reader.pageTurnAnimated key with the immersive reader so the
-    /// setting is unified; reduce-motion falls back to a crossfade.
-    @AppStorage("reader.pageTurnAnimated") private var pageTurnAnimated = true
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    /// Direction of the last page change, tracked from the page sequence so the
-    /// image swap curls the right way.
-    @State private var pageTurnForward = true
 
     private var effectiveDocument: Document? { isPinned ? pinnedDocument : liveDocument }
     private var effectivePageNumber: Int? { isPinned ? pinnedActivePageNumber : liveActivePageNumber }
@@ -215,7 +200,7 @@ struct ReadingPaneView: View {
         // A source reveal (#2105) brings the reader to the Page tab so the
         // highlighted / scrolled-to source is actually visible (#3521).
         .onChange(of: claimSourceNavigationState?.requestID) { _, newID in
-            if newID != nil { revealSourceInPageTab() }
+            if newID != nil { revealInTranscript() }
         }
     }
 
@@ -231,15 +216,12 @@ struct ReadingPaneView: View {
         WindowOpener.open(libraryId: libraryId, documentId: documentId, asTab: asTab, using: openWindow)
     }
 
-    /// Switch the reader to the Page tab and, if it's showing only the source,
-    /// split in the transcript — so a revealed claim/entity source shows with
-    /// its highlight + scroll-to-anchor. The transcript highlight and scroll
-    /// come from PageContentPane observing ClaimFocusState (#3511 on appear,
-    /// #3226 anchor); the PDF page scroll comes from the reveal's
-    /// `.ficheroNavigateToPage`.
-    private func revealSourceInPageTab() {
+    /// Bring the Reader to the Page tab so a revealed claim/entity lands on the
+    /// transcript, which scrolls to the page anchor (#3226). There is no longer a
+    /// source layout to switch: the source is Preview's job (#3765 Q4), and the
+    /// reveal drives that pane separately via `.ficheroNavigateToPage`.
+    private func revealInTranscript() {
         if readerTab != .page { readerTabRaw = ReaderTab.page.rawValue }
-        if pageLayout == .source { pageLayoutRaw = ReaderPageLayout.split.rawValue }
     }
 
     @ViewBuilder
@@ -359,7 +341,7 @@ struct ReadingPaneView: View {
 
             Divider()
 
-            surfaceView
+            surfaceView(tab: effectiveKnowledgeTab)
         }
     }
 
@@ -387,90 +369,22 @@ struct ReadingPaneView: View {
         (Self.knowledgeVizModes.contains(activeTab) || activeTab == .digest) ? activeTab : .entities
     }
 
-    /// Page tab — read the source. A source/split/transcript toggle (#3502) lays
-    /// out the page image and its transcript alone or side by side. The source is
-    /// a PDF page in the native `PDFPageWithToolbar` (bottom loupe #2419 + page
-    /// nav) or an image via `DocumentCanvas` (storage HTTP, never a local path);
-    /// the transcript is the annotatable `PageContentPane`.
+    /// Page tab — the REAL multi-page WebKit transcript (#3765).
+    ///
+    /// This is the whole point of the Reader. The engine assembles the
+    /// `page_content` of EVERY child page, in sequence, into one transcript
+    /// (`views.py:37-49`), serves it into `document_view.html`, and
+    /// `DocumentKGSurface` renders it in the shared WKWebView with per-page
+    /// anchors driving scroll↔page sync (#3226). That capability was UNREACHABLE:
+    /// the Knowledge surface excluded `.transcript`, and what the Reader called
+    /// "Transcript" was a different, single-page NATIVE pane — the name lied.
+    ///
+    /// The source is NOT here and never will be: source is always Preview
+    /// (Daniel 2026-07-14, #3765 Q4). Reading the transcript beside the page is
+    /// TWO PANES — Reader + Preview — not an embedded source view.
     @ViewBuilder
     private var pageTabContent: some View {
-        if let doc = effectiveDocument {
-            VStack(spacing: 0) {
-                Picker("Page layout", selection: pageLayoutBinding) {  // #3502
-                    ForEach(ReaderPageLayout.allCases) { layout in
-                        Label(layout.title, systemImage: layout.icon)
-                            .help(layout.help)
-                            .tag(layout)
-                    }
-                }
-                .pickerStyle(.segmented)
-                .labelStyle(.iconOnly)
-                .fixedSize()
-                .padding(.horizontal, 8)
-                .padding(.vertical, 4)
-                .accessibilityIdentifier("readerPageLayout")
-
-                Divider()
-
-                switch pageLayout {
-                case .source:
-                    pageSource(for: doc)
-                case .transcript:
-                    PageContentPane(document: doc)
-                case .split:
-                    if horizontalSizeClass == .compact {
-                        // A 320pt transcript beside the source can't fit on an
-                        // iPhone (#3666) — the source would collapse to a sliver.
-                        // Show the source full-width; the layout picker still
-                        // offers the transcript-only view for the text.
-                        pageSource(for: doc)
-                            .frame(maxWidth: .infinity)
-                    } else {
-                        HStack(spacing: 0) {
-                            pageSource(for: doc)
-                                .frame(maxWidth: .infinity)
-                            Divider()
-                            PageContentPane(document: doc)
-                                .frame(width: 320)
-                        }
-                    }
-                }
-            }
-            // Track page-turn direction from the sequence so the image swap
-            // curls the right way (#2485).
-            .onChange(of: doc.sequence ?? -1) { oldSeq, newSeq in
-                if oldSeq != -1, newSeq != -1 { pageTurnForward = newSeq >= oldSeq }
-            }
-        } else {
-            readerEmptyState
-        }
-    }
-
-    /// The page's source rendering: a PDF page (loupe #2419 + page nav via
-    /// `PDFPageWithToolbar`), an image (`DocumentCanvas`, storage HTTP), or the
-    /// transcript as a last resort for text-only documents.
-    ///
-    /// The page-turn (#2485) rides only the image branch: each image page is its
-    /// own document, so an id-swap animates cleanly. PDFs page *inside*
-    /// `PDFPageWithToolbar` (PDFKit owns rendering) — forcing an id-swap there
-    /// would reload the whole PDF each turn, so it keeps stable identity.
-    @ViewBuilder
-    private func pageSource(for doc: Document) -> some View {
-        if doc.docType == .page, let parentId = doc.parentId {
-            PDFPageWithToolbar(documentId: parentId, pageIndex: max(0, (doc.sequence ?? 1) - 1))
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if doc.fileType == .pdf {
-            PDFPageWithToolbar(documentId: doc.id, pageIndex: 0)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        } else if doc.fileType == .image {
-            DocumentCanvas(content: .imageStorageDisplay(documentId: doc.id))
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .id(doc.id)
-                .transition(pageTurnTransition)
-                .animation(pageTurnAnimation, value: doc.id)
-        } else {
-            PageContentPane(document: doc)
-        }
+        surfaceView(tab: .transcript)
     }
 
     /// Notes tab — the human reading layer. A sub-mode toggle (#3513) switches
@@ -517,26 +431,12 @@ struct ReadingPaneView: View {
         }
     }
 
-    /// Annotation scope for the focused document — page / folder / document.
     private func annotationScope(for doc: Document) -> AnnotationScope {
         switch doc.docType {
         case .folder: return .folder(doc.id)
         case .page: return .page(doc.id)
         default: return .document(doc.id)
         }
-    }
-
-    /// Page-turn transition for the Page tab's image navigation (#2485). Off ⇒
-    /// no transition; reduce-motion ⇒ crossfade; otherwise the 3D page-turn.
-    private var pageTurnTransition: AnyTransition {
-        guard pageTurnAnimated else { return .identity }
-        guard !reduceMotion else { return .opacity }
-        return .pageTurn(forward: pageTurnForward)
-    }
-
-    private var pageTurnAnimation: Animation? {
-        guard pageTurnAnimated else { return nil }
-        return .easeInOut(duration: reduceMotion ? 0.2 : 0.45)
     }
 
     private var readerEmptyState: some View {
@@ -547,8 +447,11 @@ struct ReadingPaneView: View {
             .background(Color(.textBackgroundColor))
     }
 
+    /// The shared WebKit surface, driven by an explicit tab. The Page tab passes
+    /// `.transcript` (the assembled multi-page transcript) and the Knowledge tab
+    /// passes its viz sub-mode — one WKWebView, two readings of the same document.
     @ViewBuilder
-    private var surfaceView: some View {
+    private func surfaceView(tab: KGSurfaceTab) -> some View {
         if let doc = effectiveDocument,
            let libraryPath = apiClient.currentLibraryPath, !libraryPath.isEmpty {
             let kgDocId = (doc.docType == .page && doc.parentId != nil) ? doc.parentId! : doc.id
@@ -563,16 +466,16 @@ struct ReadingPaneView: View {
                 onPageSelected: isPinned ? { _ in } : onPageSelected,
                 scrollSync: scrollSync,
                 zoom: webZoom,
-                externalActiveTab: effectiveKnowledgeTab,
-                onTabSelected: { activeTab = $0 },
+                externalActiveTab: tab,
+                // Only the Knowledge tab owns the sub-mode. A tab change published
+                // while the transcript is showing must not silently rewrite it.
+                onTabSelected: { newTab in
+                    if tab != .transcript { activeTab = newTab }
+                },
                 document: doc
             )
         } else {
-            Text("No selection")
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color(.textBackgroundColor))
+            readerEmptyState
         }
     }
 }


### PR DESCRIPTION
**The Reader is a reading surface again.** Three commits.

## 1. Restore the REAL multi-page WebKit transcript; DELETE Source (#3765)
The multi-page transcript — *the whole point of the Reader* — was **unreachable in the app**. The engine capability was intact (`views.py:37-49` concatenates every child page in sequence); the client had orphaned it, and the thing labelled "Transcript" was a different, single-page **native** pane. The name lied.

Now restored as the Reader's primary content, and the **Source view is deleted** — not demoted.

**Daniel, authoritative:** *"Source is always in preview. It's never inside the reader."* The source-beside-transcript experience is **two panes** (Reader + Preview), never an embedded source. The Page tab's Source view also literally duplicated Preview, down to the same `PDFPageWithToolbar`.

Net **−132 lines** — the source/split/transcript third mode level is gone, not worked around.

## 2. Knowledge opens on Entities-with-statements (#3765 Q6)
Not `.graph` (flashy, least information-dense first paint) and **not `.digest`** — the worker proposed Digest and was corrected: Daniel said *"Digest — not sure what that is"*, so we do not design around it. It is left untouched, and what it actually *is* remains an open question.

## 3. Transcript pages render as paper cards (#3226)
Each page is a paper-like card with a page marker and the SF system font stack, driven from the CSS variables Swift already injects (`--bg`, `--panel`, `--text`, `--reader-base-size`, `--font-system`) so it follows light/dark and the user's Reader font-size. Elevated surface in dark mode — not a white light-bomb.

**The risk here was silently breaking scroll↔page sync.** The Swift side scrolls to `.transcript [data-page]` anchors (`DocumentKGWebPane.swift:339,412`). The restyle **keeps them**, and codex added `test_transcript_page_cards_keep_scroll_sync_anchors` asserting exactly that — so a future restyle cannot quietly break it.

## Verification
- Guardrails: accessibility, tooltips, observer_pattern, shell_chrome, native_controls, view_endpoint_access, dead_files, canonical_renderers → **all exit 0**
- `test_document_view_template.py` → 5 passed · `test_routes_views.py` → 9 passed
- **Not built by me** — f_manager owns all builds; the Swift compile verdict is theirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)