### PR TITLE
test: preserve the multiuser direct-action deny boundary (#263)

### DIFF
--- a/fichero-engine/tests/unit/test_multiuser.py
+++ b/fichero-engine/tests/unit/test_multiuser.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from fichero import authz
 from fichero.api.auth import _use_multiuser_auth
 from fichero.multiuser import multiuser_enabled
@@ -45,6 +47,13 @@ def test_multiuser_enabled_by_persisted_setting(monkeypatch, app_db):
     assert multiuser_enabled() is True
     assert _use_multiuser_auth() is True
     assert authz.multiuser_enabled() is True
+
+
+def test_multiuser_denies_unresolved_direct_action_actor(monkeypatch, tmp_path):
+    monkeypatch.setenv("FICHERO_MULTIUSER", "1")
+
+    with pytest.raises(authz.AuthorizationError, match="write access denied"):
+        authz.assert_can_write("ui", tmp_path / "test.fichero")
 
 
 def test_multiuser_not_enabled_by_existing_accounts(monkeypatch, app_db):


### PR DESCRIPTION
Locks in a boundary that **blocks part of Daniel's sharing design** — recording it as a test so nobody flips the flag and discovers it the hard way.

## The finding
Daniel's design: *"multi-user always on, default one user."*

**Always-on is NOT safe today.** `FICHERO_MULTIUSER` is a real gate (`multiuser.py:15-39`, default off). With it on, **direct-action contexts have no resolvable actor**, and authz denies them (`authz.py:235-253`).

`test_multiuser_denies_unresolved_direct_action_actor` asserts exactly that: with `FICHERO_MULTIUSER=1`, `authz.assert_can_write("ui", …)` raises *"write access denied"*.

So flipping multi-user to always-on **would break direct actions** until every action context resolves an actor. That work has to happen first.

## Verification
`test_multiuser.py` + `test_api_auth.py` → **21 passed, 0 failed.**

The worker correctly **did not claim the full suite green** — its run returned no terminal summary, and it said so rather than asserting success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)