### PR TITLE
fix: unify release versioning and Mac TestFlight target

### DIFF
--- a/scripts/build-release-dmg.sh
+++ b/scripts/build-release-dmg.sh
@@ -29,8 +29,8 @@ done
 # Every release auto-stamps TODAY's date (set-release-version.sh with no arg);
 # a second build the same day bumps a sub-number. Opt out by exporting
 # FICHERO_RELEASE_VERSION (the operator has stamped a specific version already).
-# Channel defaults to beta (the current distribution channel); set
-# FICHERO_RELEASE_BETA=0 for a stable stamp. Skipped when not rebuilding the app.
+# Channel defaults to the numeric release version; set
+# FICHERO_RELEASE_BETA=1 only for an explicitly requested prerelease suffix.
 if [ "$SKIP_APP_BUILD" = true ]; then
   echo "[0/6] Skipping version stamp (--skip-app-build; using already-built app)"
 elif [ -n "${FICHERO_RELEASE_VERSION:-}" ]; then
@@ -38,7 +38,7 @@ elif [ -n "${FICHERO_RELEASE_VERSION:-}" ]; then
 else
   echo "[0/6] Auto-stamp dated release version"
   STAMP_ARGS=()
-  [ "${FICHERO_RELEASE_BETA:-1}" != "0" ] && STAMP_ARGS+=(--beta)
+  [ "${FICHERO_RELEASE_BETA:-0}" = "1" ] && STAMP_ARGS+=(--beta)
   "$ROOT_DIR/scripts/set-release-version.sh" "${STAMP_ARGS[@]+"${STAMP_ARGS[@]}"}"
 fi
 

--- a/scripts/release-all.sh
+++ b/scripts/release-all.sh
@@ -142,7 +142,8 @@ echo "Sparkle feed: $SPARKLE_FEED_URL"
 # Stamp TODAY's date across frontend + backend before any build path runs, so
 # both the DMG and the TestFlight archive carry the same auto-incremented dated
 # version. Opt out by exporting FICHERO_RELEASE_VERSION (operator controls it);
-# channel defaults to beta — set FICHERO_RELEASE_BETA=0 for a stable stamp. We
+# channel defaults to the numeric release version. Set FICHERO_RELEASE_BETA=1
+# only for an explicitly requested prerelease suffix. We
 # export FICHERO_RELEASE_VERSION afterward so the nested build-release-dmg.sh
 # sees the version already set and does not re-stamp.
 if [ -n "${FICHERO_RELEASE_VERSION:-}" ]; then
@@ -152,7 +153,7 @@ else
   echo
   echo "── Version: auto-stamp dated release ──"
   STAMP_ARGS=()
-  [ "${FICHERO_RELEASE_BETA:-1}" != "0" ] && STAMP_ARGS+=(--beta)
+  [ "${FICHERO_RELEASE_BETA:-0}" = "1" ] && STAMP_ARGS+=(--beta)
   "$ROOT_DIR/scripts/set-release-version.sh" "${STAMP_ARGS[@]+"${STAMP_ARGS[@]}"}"
   # Pin the just-stamped MARKETING_VERSION so downstream scripts don't re-stamp.
   export FICHERO_RELEASE_VERSION="$(project_setting MARKETING_VERSION)"
@@ -217,8 +218,8 @@ if [ "$RUN_MAC_TESTFLIGHT" = true ]; then
   install_mac_app_store_profile
 
   if ! xcodebuild -project "$ROOT_DIR/fichero/fichero.xcodeproj" \
-    -scheme "$MAC_SCHEME" \
-    -configuration "$MAC_CONFIG" \
+    -scheme "$MAC_APP_STORE_SCHEME" \
+    -configuration "$MAC_APP_STORE_CONFIG" \
     -destination "platform=macOS,arch=arm64" \
     -archivePath "$MAC_ARCHIVE_PATH" \
     -skipPackagePluginValidation \

--- a/scripts/tier_build_map.sh
+++ b/scripts/tier_build_map.sh
@@ -40,4 +40,8 @@ case "$TIER" in
     IOS_SCHEME="Fichero (Release Local iOS)"; IOS_CONFIG="Release Local"
     ;;
 esac
-export FICHERO_RELEASE_TIER="$TIER" MAC_SCHEME MAC_CONFIG IOS_SCHEME IOS_CONFIG
+# TestFlight uses the sandboxed App Store target. DMG builds keep MAC_SCHEME.
+MAC_APP_STORE_SCHEME="Fichero (App Store)"
+MAC_APP_STORE_CONFIG="Release"
+export FICHERO_RELEASE_TIER="$TIER" MAC_SCHEME MAC_CONFIG IOS_SCHEME IOS_CONFIG \
+  MAC_APP_STORE_SCHEME MAC_APP_STORE_CONFIG


### PR DESCRIPTION
Closes #3748

Uses the sandboxed App Store scheme for Mac TestFlight while retaining the Sparkle DMG scheme. Numeric dated release versions are now the default across all channels; beta suffix is opt-in.