### PR TITLE
fix: green the contracts suite — regen coverage matrix + document the sandbox endpoint

### DIFF
--- a/docs/contributor/api-reference/index.md
+++ b/docs/contributor/api-reference/index.md
@@ -230,5 +230,26 @@ non-image batch ids return `404`.
     `bash fichero-engine/scripts/start_backend.sh` and open
     `https://127.0.0.1:8765/docs` (Swagger UI) or `/redoc`.
 
+## Sandbox (Mac App Store)
+
+### `POST /api/sandbox/security-scoped-access`
+
+Grants the **running engine process** access to a security-scoped library folder.
+
+Under the Mac App Store's App Sandbox, a child process inherits only the parent's
+**static** entitlements. The user's folder grant (from `NSOpenPanel`) is a **dynamic**
+Powerbox extension, and dynamic rights are **not inherited** — so the sandboxed engine
+cannot open the user's library on its own. The app therefore hands the engine an
+app-scoped **security-scoped bookmark**, which this endpoint resolves on the live engine
+process and calls `startAccessingSecurityScopedResource()` against.
+
+Returns whether the grant was already held (so the bookmark was not resolved twice).
+
+**On failure it returns 400 and the engine refuses the library** — a malformed bookmark,
+or a refusal from `startAccessingSecurityScopedResource()`, means the engine genuinely
+cannot read that library, and the app must say so rather than open it and fail later.
+
+See `docs/superpowers/specs/2026-07-13-mac-app-store-sandbox-research.md` (#3747).
+
 <redoc spec-url="openapi.json" hide-download-button></redoc>
 <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>

--- a/fichero-engine/tests/contracts/coverage_matrix.json
+++ b/fichero-engine/tests/contracts/coverage_matrix.json
@@ -638,6 +638,18 @@
       "cli_coverage": 1.0
     },
     {
+      "domain": "sandbox",
+      "total": 1,
+      "swiftui_wired": 1,
+      "swiftui_unwired": 0,
+      "swiftui_allowlisted": 0,
+      "swiftui_coverage": 1.0,
+      "cli_wired": 1,
+      "cli_untested": 0,
+      "cli_allowlisted": 0,
+      "cli_coverage": 1.0
+    },
+    {
       "domain": "schedules",
       "total": 6,
       "swiftui_wired": 6,


### PR DESCRIPTION
**Two contract tests were red on main. Neither is a functional regression, but main should not be red.**

## 1. `test_per_domain_coverage_only_improves`
`coverage_matrix.json` had drifted. Regenerated with `scripts/check_ui_wiring.py --matrix`.

## 2. `test_every_public_openapi_path_is_documented_or_allowlisted`
**`POST /api/sandbox/security-scoped-access` shipped undocumented** with the Mac App Store signing work (#3747/#3749).

**Documented properly rather than allowlisted** — it is a real, load-bearing endpoint, and the docs-coverage guardrail exists precisely so new public API surface does not appear silently.

What it does, and why it must exist: under App Sandbox, a child process inherits only the parent's **static** entitlements. The user's folder grant from `NSOpenPanel` is a **dynamic** Powerbox extension and is **not inherited** — so the sandboxed engine **cannot open the user's library on its own**. The app hands it an app-scoped **security-scoped bookmark**, which this endpoint resolves on the live engine process via `startAccessingSecurityScopedResource()`.

**On failure it returns 400 and the engine refuses the library** — rather than opening it and failing later. That is the right shape: fail loudly at the boundary.

## Verification
`tests/contracts` → **9 passed, 0 failed.**

## My mistake, recorded
I merged PR #3798 (the owner-identity fix) while these were red — an `&&` chain carried through a failing suite. The owner fix itself is sound (22 tests green), but I should not have pushed with contracts red. Fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)