### PR TITLE
settings: one host-side pairing surface + a real users pane (#3777/#3787)

### DIFF
--- a/fichero/fichero/Views/Settings/BackendSettingsRemoteAccessSection.swift
+++ b/fichero/fichero/Views/Settings/BackendSettingsRemoteAccessSection.swift
@@ -1,381 +1,31 @@
 #if canImport(AppKit)
-// swiftlint:disable file_length
-import CoreImage
-import CoreImage.CIFilterBuiltins
 import FicheroAPIClient
 import SwiftUI
 
-private let hostedRemoteAccessHelpText = """
-Use a private reachable URL such as a literal IP address, .local hostname, or Tailscale .ts.net hostname.
-Bonjour only announces that this Mac is available; the QR code still carries the URL the client should call.
-"""
-
-// swiftlint:disable:next type_body_length
-struct BackendSettingsRemoteAccessSection: View {
-    @Bindable private var appState: AppState
-    @Bindable private var backendService: EmbeddedBackendService
-    @Bindable private var libraryManager: LibraryManager
-    @AppStorage(EngineConfig.userDefaultsKey) private var engineHost = EngineConfig.defaultHostString
-    @AppStorage(RemoteAccessConfig.hostingEnabledKey) private var hostingEnabled = false
-    @AppStorage(RemoteAccessConfig.bonjourEnabledKey) private var bonjourEnabled = false
-    @AppStorage(RemoteAccessConfig.publicBaseURLKey) private var publicBaseURL = ""
-
-    @State private var pairingCode: PairingCodeRecord?
-    @State private var pairedDevices: [PairedDeviceRecord] = []
-    @State private var pairingError: String?
-    @State private var isRestartingHost = false
-    @State private var isGeneratingPairingCode = false
-    @State private var isLoadingDevices = false
-    @State private var didBootstrapPairingCard = false
-    @State private var spkiPin = ""
-    @State private var copiedInvite = false
-
-    init(
-        appState: AppState,
-        backendService: EmbeddedBackendService,
-        libraryManager: LibraryManager
-    ) {
-        self._appState = Bindable(wrappedValue: appState)
-        self._backendService = Bindable(wrappedValue: backendService)
-        self._libraryManager = Bindable(wrappedValue: libraryManager)
-    }
-
-    private let qrContext = CIContext()
-
-    var body: some View {
-        Section("Share This Mac") {
-            TextField("Sharing address", text: $publicBaseURL)
-                .autocorrectionDisabled()
-                .disabled(!hostingEnabled)
-
-            PairingCardView(
-                pairingCode: pairingCode,
-                qrCodeImage: qrCodeImage,
-                publicURL: validatedPublicURL?.absoluteString,
-                inviteLink: inviteLinkString,
-                isGeneratingPairingCode: isGeneratingPairingCode,
-                blocker: pairingBlocker,
-                errorMessage: pairingError,
-                isResolving: isRestartingHost,
-                onResolve: { blocker in Task { await resolve(blocker) } },
-                copiedInvite: copiedInvite,
-                onCopyInvite: copyInvite
-            )
-
-            PairedDevicesSectionView(
-                devices: activePairedDevices(from: pairedDevices),
-                isLoading: isLoadingDevices,
-                canHostRemoteAccess: canHostRemoteAccess,
-                onRefresh: { Task { await refreshPairedDevices() } },
-                onRevoke: { deviceID in Task { await revoke(deviceID: deviceID) } }
-            )
-
-            AdvancedRemoteAccessSection(
-                hostingEnabled: $hostingEnabled,
-                bonjourEnabled: $bonjourEnabled,
-                publicBaseURL: $publicBaseURL,
-                canHostRemoteAccess: canHostRemoteAccess,
-                isRestartingHost: isRestartingHost,
-                isRefreshingInvite: isGeneratingPairingCode,
-                canResetInvite: pairingBlocker == nil,
-                onResetInvite: { Task { await refreshPairingCard() } },
-                onApply: { Task { await applyHostingChanges() } }
-            )
-        }
-        .task {
-            loadAdvertisedSPKIPin()
-            if !canHostRemoteAccess {
-                pairedDevices = []
-            } else if hostingEnabled, appState.isBackendRunning {
-                await refreshPairedDevices()
-            }
-            didBootstrapPairingCard = true
-        }
-        .task(id: pairingRefreshKey) {
-            guard didBootstrapPairingCard else { return }
-            await refreshPairingCard()
-        }
-        .onChange(of: publicBaseURL) { _, _ in
-            loadAdvertisedSPKIPin()
-        }
-    }
-
-    private var canHostRemoteAccess: Bool {
-        EngineConfig.engineIsLocal
-    }
-
-    private var ownerPairingService: PairingService? {
-        guard canHostRemoteAccess else { return nil }
-        return PairingService(apiRoot: EngineConfig.host)
-    }
-
-    private var advertisedPairingService: PairingService? {
-        guard let publicURL = try? validatedHostedRemoteURL(from: publicBaseURL) else { return nil }
-        return PairingService(apiRoot: publicURL)
-    }
-
-    private var hasValidSPKIPin: Bool {
-        (try? RemoteCertificatePinning.validatedSPKIPin(spkiPin)) != nil
-    }
-
-    private var validatedPublicURL: URL? {
-        try? validatedHostedRemoteURL(from: publicBaseURL)
-    }
-
-    private var pairingRefreshKey: String {
-        [
-            hostingEnabled.description,
-            publicBaseURL,
-            spkiPin,
-            engineHost,
-            appState.isBackendRunning.description,
-            didBootstrapPairingCard.description
-        ].joined(separator: "|")
-    }
-
-    private var inviteLinkString: String? {
-        guard let pairingCode, let advertisedPairingService else { return nil }
-        guard let normalizedSPKIPin = try? RemoteCertificatePinning.validatedSPKIPin(spkiPin) else {
-            return nil
-        }
-        let payload = advertisedPairingService.buildQRCodePayload(
-            from: pairingCode,
-            spki: normalizedSPKIPin,
-            libraryPath: sharedLibraryPath
-        )
-        return try? RemoteClientPairing.inviteLinkString(from: payload)
-    }
-
-    private var qrCodeImage: PlatformImage? {
-        guard let pairingCode, let advertisedPairingService else { return nil }
-        guard let normalizedSPKIPin = try? RemoteCertificatePinning.validatedSPKIPin(spkiPin) else {
-            return nil
-        }
-
-        let payload = advertisedPairingService.buildQRCodePayload(
-            from: pairingCode,
-            spki: normalizedSPKIPin,
-            libraryPath: sharedLibraryPath
-        )
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        guard let data = try? encoder.encode(payload) else { return nil }
-
-        let filter = CIFilter.qrCodeGenerator()
-        filter.message = data
-        filter.correctionLevel = "M"
-        guard let output = filter.outputImage?.transformed(by: CGAffineTransform(scaleX: 12, y: 12)),
-              let cgImage = qrContext.createCGImage(output, from: output.extent) else {
-            return nil
-        }
-        return PlatformImage(cgImage: cgImage, size: .zero)
-    }
-
-    /// Why the pairing card cannot show a QR right now — each precondition named
-    /// HONESTLY, with the fix the app can perform itself (#3776/#3769).
-    ///
-    /// The old chain returned one `String?` and the card printed a fixed headline
-    /// ("Secure sharing needs HTTPS") over ALL of them — so a stopped engine was
-    /// reported as an HTTPS problem. And three separate causes shared one message
-    /// that named no place and offered no button. Both are fixed here: the card
-    /// asks the blocker for its own headline, and offers `actionTitle` when the app
-    /// can cure it without the user doing setup by hand.
-    private var pairingBlocker: PairingBlocker? {
-        guard canHostRemoteAccess else { return .engineIsRemote }
-        guard appState.isBackendRunning else { return .engineNotRunning }
-        guard hostingEnabled else { return .sharingNotStarted }
-
-        do {
-            _ = try validatedHostedRemoteURL(from: publicBaseURL)
-        } catch let error as RemoteURLValidationError {
-            switch error {
-            case .blank: return .addressMissing
-            case .insecureRemoteTransport: return .addressInsecure
-            default: return .addressInvalid(error.localizedDescription)
-            }
-        } catch {
-            return .addressInvalid(error.localizedDescription)
-        }
-
-        // THE TRAP (#3776 review): the pin is derived, not typed — and the
-        // derivation is optional. If it comes back nil the card used to go blank,
-        // which is the very disease #3769 is about. The app CAN fix this itself:
-        // restarting the engine mints the TLS material and re-derives the pin.
-        guard hasValidSPKIPin else { return .pinNotDerived }
-        return nil
-    }
-
-    /// Perform the blocker's own cure. Only offered where the app can genuinely do
-    /// the setup itself — the whole point of the design is that it does, rather
-    /// than telling the user to go and do it.
-    private func resolve(_ blocker: PairingBlocker) async {
-        switch blocker {
-        case .engineNotRunning:
-            // Mark busy so the button disables — without this a double-tap races a
-            // second start(). (start() has its own re-entrancy guard, #3108, but the
-            // UI should not invite the race.)
-            isRestartingHost = true
-            defer { isRestartingHost = false }
-            do { try await backendService.start() } catch {
-                pairingError = error.localizedDescription
-            }
-            loadAdvertisedSPKIPin()
-        case .sharingNotStarted:
-            hostingEnabled = true
-            await applyHostingChanges()
-        case .pinNotDerived:
-            // Restart mints TLS material and re-derives the pin (applyHostingChanges
-            // → backendService.start() → loadAdvertisedSPKIPin()).
-            await applyHostingChanges()
-            await refreshPairingCard()
-        case .engineIsRemote, .addressMissing, .addressInsecure, .addressInvalid:
-            break  // no button offered — see PairingBlocker.actionTitle
-        }
-    }
-
-    private var sharedLibraryPath: String? {
-        if let currentLibraryId = libraryManager.currentLibraryId,
-           let library = libraryManager.getLibrary(id: currentLibraryId) {
-            return library.url.path
-        }
-        return libraryManager.globalLibrary?.url.path
-    }
-
-    private func applyHostingChanges() async {
-        isRestartingHost = true
-        defer { isRestartingHost = false }
-
-        if hostingEnabled {
-            do {
-                guard canHostRemoteAccess else {
-                    pairingError = "Use the embedded engine on this Mac to host remotely."
-                    return
-                }
-                _ = try validatedHostedRemoteURL(from: publicBaseURL)
-            } catch {
-                pairingError = error.localizedDescription
-                return
-            }
-        } else {
-            RemoteCertificatePinning.clearAdvertisedSPKIPin(hostString: publicBaseURL)
-            RemoteCertificatePinning.clearPersistedSPKIPin(hostString: publicBaseURL)
-            loadAdvertisedSPKIPin()
-        }
-
-        if backendService.isUsingExternalBackend {
-            await appState.checkBackendHealth()
-            appState.reconfigureGeneratedClientsForCurrentHost()
-            libraryManager.reconfigureGeneratedClientsForCurrentHost()
-            if hostingEnabled {
-                await refreshPairedDevices()
-            }
-            return
-        }
-
-        backendService.stop()
-        do {
-            try await backendService.start()
-            loadAdvertisedSPKIPin()
-            await appState.checkBackendHealth()
-            appState.reconfigureGeneratedClientsForCurrentHost()
-            libraryManager.reconfigureGeneratedClientsForCurrentHost()
-            if hostingEnabled {
-                await refreshPairedDevices()
-            }
-        } catch {
-            pairingError = error.localizedDescription
-        }
-    }
-
-    private func refreshPairingCard() async {
-        pairingError = nil
-        pairingCode = nil
-
-        guard pairingBlocker == nil else {
-            return
-        }
-
-        isGeneratingPairingCode = true
-        defer { isGeneratingPairingCode = false }
-
-        do {
-            try await Task.sleep(for: .milliseconds(200))
-            try Task.checkCancellation()
-
-            guard let ownerPairingService else {
-                pairingError = "Use a reachable HTTPS URL to show the QR."
-                return
-            }
-            let code = try await ownerPairingService.createPairingCode()
-            pairingCode = code
-        } catch {
-            if error is CancellationError {
-                return
-            }
-            pairingError = error.localizedDescription
-        }
-    }
-
-    private func refreshPairedDevices() async {
-        isLoadingDevices = true
-        defer { isLoadingDevices = false }
-
-        do {
-            guard canHostRemoteAccess else {
-                return
-            }
-            guard let ownerPairingService else {
-                pairingError = "Use the embedded engine on this Mac to load devices."
-                return
-            }
-            pairedDevices = try await ownerPairingService.listDevices()
-        } catch {
-            pairingError = error.localizedDescription
-        }
-    }
-
-    private func revoke(deviceID: String) async {
-        pairingError = nil
-        do {
-            guard canHostRemoteAccess else {
-                return
-            }
-            guard let ownerPairingService else {
-                pairingError = "Use the embedded engine on this Mac to revoke devices."
-                return
-            }
-            try await ownerPairingService.revokeDevice(id: deviceID)
-            await refreshPairedDevices()
-        } catch {
-            pairingError = error.localizedDescription
-        }
-    }
-
-    private func loadAdvertisedSPKIPin() {
-        spkiPin = RemoteAccessConfig.hostedBackendSPKIPin(hostString: publicBaseURL) ?? ""
-    }
-
-    private func copyInvite() {
-        guard let inviteLinkString else { return }
-        PlatformPasteboard.writeString(inviteLinkString)
-        copiedInvite = true
-        Task {
-            try? await Task.sleep(for: .seconds(2))
-            copiedInvite = false
-        }
-    }
-}
-
-func activePairedDevices(from devices: [PairedDeviceRecord]) -> [PairedDeviceRecord] {
-    devices.filter { !$0.revoked }
-}
+// The pairing card, its blocker vocabulary, and the connected-devices list.
+//
+// This file used to ALSO hold `BackendSettingsRemoteAccessSection` — a second,
+// parallel host-side pairing UI ("Share This Mac") living under Engine → Backend,
+// with its own toggle, its own hand-typed URL, its own editable SPKI pin field and
+// its own device list, all sharing the same @AppStorage keys as Library Access →
+// Devices. Two surfaces that disagree is why pairing felt incoherent and why "the
+// QR vanished" (#3769) had two different sets of causes (#3777).
+//
+// There is now ONE host-side pairing surface: `ShareSettingsView`
+// (Settings → Library Access → Devices). What survives here are the pieces that
+// surface worth keeping — the honest blocker vocabulary and the copyable pairing
+// link (#3774/#3776) — which `ShareSettingsView` now renders.
+//
+// ponytail: the file keeps its old name so its Xcode target membership is
+// untouched; renaming it to PairingCard.swift is a project-file change, not a
+// code change.
 
 /// Why the pairing card cannot show a QR, as a value rather than a lone string
 /// (#3776/#3769). Each case carries its OWN headline — the card no longer prints
 /// "Secure sharing needs HTTPS" over a stopped engine — and its own cure, so a
 /// blocker is never a dead end. Non-negotiable: never a blank space, never a
 /// dead control; if we cannot proceed, say why and offer the fix.
-private enum PairingBlocker: Equatable {
+enum PairingBlocker: Equatable {
     /// The library is served by an engine on ANOTHER machine, so this Mac has
     /// nothing to share. Nothing the app can do here — that is honest, not a dead end.
     case engineIsRemote
@@ -384,9 +34,9 @@ private enum PairingBlocker: Equatable {
     /// Sharing has not been started yet. The app can start it — the user does not
     /// "enable a subsystem" first, they just share.
     case sharingNotStarted
-    /// No reachable address for this Mac yet. The app cannot DISCOVER one today
-    /// (there is no Bonjour/.local/Tailscale self-lookup — see #3776 comment), so
-    /// this one honestly asks for it instead of pretending.
+    /// No reachable address for this Mac yet. Sharing derives one automatically
+    /// (`https://<hostname>.local:<port>`), so this should be unreachable in
+    /// practice — it only appears if someone cleared the address under Advanced.
     case addressMissing
     case addressInsecure
     case addressInvalid(String)
@@ -411,15 +61,15 @@ private enum PairingBlocker: Equatable {
     var detail: String {
         switch self {
         case .engineIsRemote:
-            return "Share This Mac works on the Mac that hosts the library. This one is connected to an engine elsewhere."
+            return "Sharing happens on the Mac that hosts the library. This one is connected to an engine elsewhere."
         case .engineNotRunning:
             return "The QR code needs a running engine to pair against."
         case .sharingNotStarted:
-            return "Start sharing and Fichero will prepare the certificate and the invite for you."
+            return "Turn sharing on and Fichero will prepare the address, the certificate and the invite for you."
         case .addressMissing:
-            return "Enter the address other devices can reach this Mac on — an IP, a .local name, or a Tailscale hostname — under Advanced."
+            return "Fichero normally works this out itself. Restore the automatic address under Advanced."
         case .addressInsecure:
-            return "Devices pair over HTTPS so the connection can be pinned. Use an https:// address under Advanced."
+            return "Devices pair over HTTPS so the connection can be pinned. Restore the automatic address under Advanced."
         case .addressInvalid(let reason):
             return reason
         case .pinNotDerived:
@@ -433,14 +83,21 @@ private enum PairingBlocker: Equatable {
     var actionTitle: String? {
         switch self {
         case .engineNotRunning: return "Start Engine"
-        case .sharingNotStarted: return "Start Sharing"
+        case .sharingNotStarted: return "Turn On Sharing"
         case .pinNotDerived: return "Prepare Certificate"
         case .engineIsRemote, .addressMissing, .addressInsecure, .addressInvalid: return nil
         }
     }
 }
 
-private struct PairingCardView: View {
+func activePairedDevices(from devices: [PairedDeviceRecord]) -> [PairedDeviceRecord] {
+    devices.filter { !$0.revoked }
+}
+
+/// The one pairing card. Four states, none of them blank: READY (QR + link),
+/// PREPARING (progress), BLOCKED (named cause + its cure), and — only ever
+/// alongside one of those — an error line.
+struct PairingCardView: View {
     let pairingCode: PairingCodeRecord?
     let qrCodeImage: PlatformImage?
     let publicURL: String?
@@ -455,125 +112,156 @@ private struct PairingCardView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Show a QR code so iPhone, iPad, Vision Pro, or another Mac can connect to this library.")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
             if let pairingCode {
-                VStack(alignment: .leading, spacing: 12) {
-                    if let image = qrCodeImage {
-                        Image(platformImage: image)
-                            .interpolation(.none)
-                            .resizable()
-                            .frame(width: 180, height: 180)
-                            .accessibilityLabel("Pairing QR code")
-                    }
-
-                    Text("Scan this with Fichero on another device.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-
-                    if let publicURL {
-                        LabeledContent("Address") {
-                            Text(publicURL)
-                                .textSelection(.enabled)
-                        }
-                        .font(.caption)
-                    }
-
-                    // The pairing link, as SELECTABLE TEXT (#3774). A QR is useless
-                    // in the iOS Simulator — it has no camera — so manual entry is
-                    // not a fallback there, it is the only way to pair. This is the
-                    // exact same payload the QR encodes, produced by the same
-                    // `RemoteClientPairing.inviteLinkString(from:)` the device's
-                    // "Enter Link Manually" already parses: same SPKI pin, same
-                    // one-time code, same expiry. Showing it changes convenience,
-                    // not trust — the QR beside it already carries it.
-                    if let inviteLink {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Pairing link")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            Text(inviteLink)
-                                .font(.system(.caption, design: .monospaced))
-                                .textSelection(.enabled)
-                                .lineLimit(3)
-                                .truncationMode(.middle)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(6)
-                                .background(Color(.textBackgroundColor))
-                                .clipShape(RoundedRectangle(cornerRadius: 4))
-                                .accessibilityLabel("Pairing link, selectable text")
-                            Text("On the device: Enter Link Manually → paste this.")
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-
-                    HStack {
-                        if let inviteLink {
-                            Button(copiedInvite ? "Pairing Link Copied" : "Copy Pairing Link", action: onCopyInvite)
-                            if let shareURL = URL(string: inviteLink) {
-                                ShareLink(item: shareURL) {
-                                    Label("Share Link", systemImage: "square.and.arrow.up")
-                                }
-                            }
-                        }
-                    }
-                    .buttonStyle(.bordered)
-
-                    if inviteLink != nil {
-                        Text("This link lets a device connect to your library — share only with people you trust.")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-
-                        // Saves the next person an hour (#3774): the Simulator runs on
-                        // the Mac's own network stack, so the Mac's loopback engine is
-                        // reachable from it directly. A real iPhone is a different
-                        // machine — 127.0.0.1 there means the phone itself, so it must
-                        // pair to this Mac's LAN address instead.
-                        Text("iOS Simulator: it shares this Mac's network, so it can reach a local "
-                             + "engine directly at https://127.0.0.1:8765. A real iPhone or iPad "
-                             + "cannot — it needs this Mac's address above.")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-
-                    Text("Expires \(pairingCode.expiresAt.formatted(date: .omitted, time: .shortened))")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
+                readyCard(pairingCode)
             } else if isGeneratingPairingCode {
                 ProgressView("Preparing QR code…")
             } else if let blocker {
-                // Each cause states ITSELF and offers its cure. The old code printed
-                // "Secure sharing needs HTTPS" over every blocker — so a stopped
-                // engine was reported as an HTTPS problem, which is simply false.
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(blocker.headline)
-                        .font(.headline)
-                    Text(blocker.detail)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                    if let actionTitle = blocker.actionTitle {
-                        Button(isResolving ? "Working…" : actionTitle) {
-                            onResolve(blocker)
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .disabled(isResolving)
-                    }
-                    if let errorMessage {
-                        Label(errorMessage, systemImage: "exclamationmark.triangle")
-                            .font(.caption)
-                            .foregroundStyle(.orange)
-                    }
-                }
+                blockedCard(blocker)
+            } else if let errorMessage {
+                // Belt and braces: an error with no blocker and no code still says
+                // something. The card is never empty.
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
             }
         }
         .padding(.vertical, 4)
     }
+
+    @ViewBuilder
+    private func readyCard(_ pairingCode: PairingCodeRecord) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let image = qrCodeImage {
+                HStack {
+                    Spacer(minLength: 0)
+                    Image(platformImage: image)
+                        .interpolation(.none)
+                        .resizable()
+                        .frame(width: 220, height: 220)
+                        .accessibilityLabel("Pairing QR code")
+                    Spacer(minLength: 0)
+                }
+                Text("Scan this with Fichero on another device to connect.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                // The QR encoder can fail even when everything else is ready. Say so
+                // rather than printing "Scan this" beside nothing (#3769).
+                Label(
+                    "Fichero couldn't draw the QR code. Use the pairing link below — it carries the same invite.",
+                    systemImage: "exclamationmark.triangle"
+                )
+                .font(.caption)
+                .foregroundStyle(.orange)
+            }
+
+            if let publicURL {
+                LabeledContent("Address") {
+                    Text(publicURL)
+                        .textSelection(.enabled)
+                }
+                .font(.caption)
+            }
+
+            if let inviteLink {
+                inviteLinkBlock(inviteLink)
+            }
+
+            Text("Expires \(pairingCode.expiresAt.formatted(date: .omitted, time: .shortened))")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
+
+    /// The pairing link, as SELECTABLE TEXT (#3774). A QR is useless in the iOS
+    /// Simulator — it has no camera — so manual entry is not a fallback there, it is
+    /// the only way to pair. This is the exact same payload the QR encodes, produced
+    /// by the same `RemoteClientPairing.inviteLinkString(from:)` the device's "Enter
+    /// Link Manually" already parses: same SPKI pin, same one-time code, same expiry.
+    /// Showing it changes convenience, not trust.
+    @ViewBuilder
+    private func inviteLinkBlock(_ inviteLink: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Pairing link")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(inviteLink)
+                .font(.system(.caption, design: .monospaced))
+                .textSelection(.enabled)
+                .lineLimit(3)
+                .truncationMode(.middle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(6)
+                .background(Color(.textBackgroundColor))
+                .clipShape(RoundedRectangle(cornerRadius: 4))
+                .accessibilityLabel("Pairing link, selectable text")
+            Text("On the device: Enter Link Manually → paste this.")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+
+        HStack {
+            Button(copiedInvite ? "Pairing Link Copied" : "Copy Pairing Link", action: onCopyInvite)
+            if let shareURL = URL(string: inviteLink) {
+                ShareLink(item: shareURL) {
+                    Label("Share Link", systemImage: "square.and.arrow.up")
+                }
+            }
+        }
+        .buttonStyle(.bordered)
+
+        Text("This link lets a device connect to your library — share only with people you trust.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+
+        // Saves the next person an hour (#3774): the Simulator runs on the Mac's own
+        // network stack, so the Mac's loopback engine is reachable from it directly.
+        // A real iPhone is a different machine — 127.0.0.1 there means the phone
+        // itself, so it must pair to this Mac's address instead.
+        Text("iOS Simulator: it shares this Mac's network, so it can reach a local "
+             + "engine directly at https://127.0.0.1:8765. A real iPhone or iPad "
+             + "cannot — it needs this Mac's address above.")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+    }
+
+    @ViewBuilder
+    private func blockedCard(_ blocker: PairingBlocker) -> some View {
+        // Each cause states ITSELF and offers its cure. The old code printed
+        // "Secure sharing needs HTTPS" over every blocker — so a stopped engine was
+        // reported as an HTTPS problem, which is simply false.
+        VStack(alignment: .leading, spacing: 6) {
+            Text(blocker.headline)
+                .font(.headline)
+            Text(blocker.detail)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            if let actionTitle = blocker.actionTitle {
+                Button(isResolving ? "Working…" : actionTitle) {
+                    onResolve(blocker)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isResolving)
+            }
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+    }
 }
-private struct PairedDevicesSectionView: View {
+
+/// Connected devices, with a named empty state — a device list that simply isn't
+/// there when empty teaches the user nothing (#3769 blank-space rule).
+struct PairedDevicesSectionView: View {
     let devices: [PairedDeviceRecord]
     let isLoading: Bool
     let canHostRemoteAccess: Bool
@@ -594,7 +282,7 @@ private struct PairedDevicesSectionView: View {
             if devices.isEmpty {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("No devices have joined yet.")
-                    Text("Devices that scan this QR will appear here.")
+                    Text("Devices that scan the QR code will appear here.")
                 }
                 .font(.caption)
                 .foregroundStyle(.secondary)
@@ -619,48 +307,4 @@ private struct PairedDevicesSectionView: View {
         }
     }
 }
-
-private struct AdvancedRemoteAccessSection: View {
-    @Binding var hostingEnabled: Bool
-    @Binding var bonjourEnabled: Bool
-    @Binding var publicBaseURL: String
-    let canHostRemoteAccess: Bool
-    let isRestartingHost: Bool
-    let isRefreshingInvite: Bool
-    let canResetInvite: Bool
-    let onResetInvite: () -> Void
-    let onApply: () -> Void
-
-    var body: some View {
-        DisclosureGroup("Advanced / Debug") {
-            Toggle("Enable pairing and remote clients", isOn: $hostingEnabled)
-            Toggle("Advertise this Mac on the local network", isOn: $bonjourEnabled)
-                .disabled(!hostingEnabled)
-
-            TextField("Reachable URL", text: $publicBaseURL)
-                .textFieldStyle(.roundedBorder)
-                .autocorrectionDisabled()
-                .disabled(!hostingEnabled)
-
-            Text(hostedRemoteAccessHelpText)
-            .font(.caption)
-            .foregroundStyle(.secondary)
-
-            if hostingEnabled && !canHostRemoteAccess {
-                Text("Use the embedded engine on this Mac to host remotely.")
-                    .font(.caption)
-                    .foregroundStyle(.red)
-            }
-
-            if hostingEnabled, canHostRemoteAccess {
-                Button(isRefreshingInvite ? "Resetting Invite…" : "Reset Invite", action: onResetInvite)
-                    .disabled(isRestartingHost || isRefreshingInvite || !canResetInvite)
-            }
-
-            Button(isRestartingHost ? "Applying..." : "Apply and Restart Engine", action: onApply)
-                .disabled(isRestartingHost)
-        }
-    }
-}
 #endif
-// swiftlint:enable file_length

--- a/fichero/fichero/Views/Settings/BackendSettingsView.swift
+++ b/fichero/fichero/Views/Settings/BackendSettingsView.swift
@@ -34,16 +34,15 @@ struct BackendSettingsView: View {
                 }
             }
 
+            // Joining ANOTHER Mac's library — the client side of pairing, which is a
+            // different question from sharing this one, and stays here.
+            //
+            // Sharing THIS Mac used to be duplicated here too ("Share This Mac"), in
+            // parallel with Settings → Library Access → Devices: two surfaces, two
+            // toggles over the same keys, two device lists, two sets of reasons the
+            // QR could vanish. There is now one (#3777) — ShareSettingsView.
             #if canImport(AppKit)
             MacRemoteClientPairingSection(
-                appState: appState,
-                backendService: backendService,
-                libraryManager: libraryManager
-            )
-            #endif
-
-            #if canImport(AppKit)
-            BackendSettingsRemoteAccessSection(
                 appState: appState,
                 backendService: backendService,
                 libraryManager: libraryManager

--- a/fichero/fichero/Views/Settings/ShareSettingsView.swift
+++ b/fichero/fichero/Views/Settings/ShareSettingsView.swift
@@ -4,6 +4,21 @@ import CoreImage.CIFilterBuiltins
 import FicheroAPIClient
 import SwiftUI
 
+// The ONE host-side sharing and pairing surface (#3777).
+//
+// Turning sharing on is a SINGLE ACTION that does all of its own setup: it derives
+// this Mac's address, advertises it on the local network, restarts the engine with
+// TLS, mints the certificate pin and the invite. The user never types a URL, never
+// sees an SPKI pin, never presses "Apply and Restart Engine". The old second copy
+// of this pane (Engine → Backend → "Share This Mac") is gone; its only genuinely
+// useful escape hatches — a manual address override and "Reset Invite" — live in
+// the single Advanced disclosure at the bottom of this pane.
+//
+// What the toggle is and isn't: it is a CONVENIENCE ("don't listen"), never a
+// safety story. The secret protects the user, not the switch — the engine denies
+// any bearer token with no matching device row whatever this flag says. So sharing
+// being on is not a risk to explain away; it is a door with a lock on it.
+
 // swiftlint:disable file_length
 // swiftlint:disable:next type_body_length
 struct ShareSettingsView: View {
@@ -29,6 +44,9 @@ struct ShareSettingsView: View {
     @State private var isGeneratingCode = false
     @State private var isLoadingDevices = false
     @State private var didBootstrap = false
+    @State private var copiedInvite = false
+    @State private var addressDraft = ""
+    @State private var confirmRemoveAllDevices = false
 
     private let qrContext = CIContext()
 
@@ -60,35 +78,45 @@ struct ShareSettingsView: View {
                 .disabled(isApplyingChange || !EngineConfig.engineIsLocal)
                 .padding(.vertical, 4)
 
-                if hostingEnabled {
-                    qrOrStatusContent
+                // The card renders whenever there is something to say: sharing is on
+                // (QR, progress, or the one thing blocking it), or the toggle is dead
+                // because this Mac doesn't host the library — a disabled switch with
+                // no explanation is exactly the dead control we do not ship.
+                if hostingEnabled || pairingBlocker == .engineIsRemote {
+                    PairingCardView(
+                        pairingCode: pairingCode,
+                        qrCodeImage: qrCodeImage,
+                        publicURL: validatedPublicURL?.absoluteString,
+                        inviteLink: inviteLinkString,
+                        isGeneratingPairingCode: isGeneratingCode,
+                        blocker: pairingBlocker,
+                        errorMessage: shareError,
+                        isResolving: isApplyingChange,
+                        onResolve: { blocker in Task { await resolve(blocker) } },
+                        copiedInvite: copiedInvite,
+                        onCopyInvite: copyInvite
+                    )
                 }
             }
 
-            if !activePairedDevices(from: pairedDevices).isEmpty {
-                Section("Connected Devices") {
-                    ForEach(activePairedDevices(from: pairedDevices)) { device in
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text(device.name)
-                                Text(device.lastSeen, style: .relative)
-                                    .font(.caption)
-                                    .foregroundStyle(.secondary)
-                            }
-                            Spacer()
-                            Button("Remove") {
-                                Task { await revoke(deviceID: device.id) }
-                            }
-                            .buttonStyle(.borderless)
-                        }
-                    }
+            if hostingEnabled {
+                Section {
+                    PairedDevicesSectionView(
+                        devices: activePairedDevices(from: pairedDevices),
+                        isLoading: isLoadingDevices,
+                        canHostRemoteAccess: EngineConfig.engineIsLocal,
+                        onRefresh: { Task { await refreshDevices() } },
+                        onRevoke: { deviceID in Task { await revoke(deviceID: deviceID) } }
+                    )
                 }
             }
 
+            advancedSection
         }
         .formStyle(.grouped)
         .task {
             loadSPKIPin()
+            addressDraft = publicBaseURL
             // Refresh the backend's real multi-user state so this tab's status
             // matches Users + Engine (#3331).
             await appState.identityStore.load()
@@ -109,92 +137,73 @@ struct ShareSettingsView: View {
             guard didBootstrap else { return }
             await refreshPairingCode()
         }
-        .onChange(of: publicBaseURL) { _, _ in loadSPKIPin() }
+        .onChange(of: publicBaseURL) { _, newValue in
+            loadSPKIPin()
+            addressDraft = newValue
+        }
     }
 
-    // MARK: - QR / Status
+    // MARK: - Blocker
 
-    @ViewBuilder
-    private var qrOrStatusContent: some View {
-        if let pairingCode, let qrImage = makeQRImage(for: pairingCode) {
-            HStack {
-                Spacer(minLength: 0)
-                VStack(alignment: .center, spacing: 12) {
-                    Image(platformImage: qrImage)
-                        .interpolation(.none)
-                        .resizable()
-                        .frame(width: 220, height: 220)
-                        .accessibilityLabel("Pairing QR code")
+    /// Why the pairing card cannot show a QR right now — each precondition named
+    /// honestly, in the order it must hold (#3776/#3769).
+    private var pairingBlocker: PairingBlocker? {
+        guard EngineConfig.engineIsLocal else { return .engineIsRemote }
+        guard appState.isBackendRunning else { return .engineNotRunning }
+        guard hostingEnabled else { return .sharingNotStarted }
 
-                    Text("Scan this QR Code with Fichero on another device to connect.")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.center)
-
-                    DisclosureGroup("Show Details") {
-                        LabeledContent("Address") {
-                            Text(displayAddress)
-                                .textSelection(.enabled)
-                                .font(.caption.monospaced())
-                        }
-                        LabeledContent("Route") {
-                            Text(displayRoute)
-                        }
-                        LabeledContent("Code") {
-                            Text(formatCode(pairingCode.code))
-                                .textSelection(.enabled)
-                                .font(.caption.monospaced())
-                        }
-                    }
-                    .font(.caption)
-                }
-                Spacer(minLength: 0)
+        do {
+            _ = try validatedHostedRemoteURL(from: publicBaseURL)
+        } catch let error as RemoteURLValidationError {
+            switch error {
+            case .blank: return .addressMissing
+            case .insecureRemoteTransport: return .addressInsecure
+            default: return .addressInvalid(error.localizedDescription)
             }
-            .padding(.vertical, 4)
-        } else if isGeneratingCode {
-            ProgressView("Preparing QR code…")
-        } else {
-            Text(statusMessage)
-                .font(.caption)
-                .foregroundStyle(.secondary)
+        } catch {
+            return .addressInvalid(error.localizedDescription)
         }
 
-        if let shareError {
-            Text(shareError)
-                .font(.caption)
-                .foregroundStyle(.red)
+        // The pin is derived, not typed — and the derivation is optional. If it comes
+        // back nil the card used to go blank, which is the very disease #3769 is
+        // about. The app CAN fix this itself: restarting the engine mints the TLS
+        // material and re-derives the pin.
+        guard hasValidSPKIPin else { return .pinNotDerived }
+        return nil
+    }
+
+    /// Perform the blocker's own cure. Only offered where the app can genuinely do
+    /// the setup itself — the whole point of the design is that it does, rather than
+    /// telling the user to go and do it.
+    private func resolve(_ blocker: PairingBlocker) async {
+        switch blocker {
+        case .engineNotRunning:
+            isApplyingChange = true
+            shareError = nil
+            defer { isApplyingChange = false }
+            do {
+                try await backendService.start()
+            } catch {
+                shareError = error.localizedDescription
+            }
+            loadSPKIPin()
+        case .sharingNotStarted:
+            hostingEnabled = true
+            bonjourEnabled = true
+            if publicBaseURL.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                publicBaseURL = Self.autoLocalBaseURL
+            }
+            await applySharing()
+        case .pinNotDerived:
+            // Restart mints TLS material and re-derives the pin.
+            await applySharing()
+            await refreshPairingCode()
+        case .engineIsRemote, .addressMissing, .addressInsecure, .addressInvalid:
+            break  // no button offered — see PairingBlocker.actionTitle
         }
     }
 
-    private var statusMessage: String {
-        guard EngineConfig.engineIsLocal else {
-            return "Sharing works when Fichero is running on this Mac."
-        }
-        guard appState.isBackendRunning else {
-            return "Fichero is not connected on this Mac right now."
-        }
-        let url = publicBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !url.isEmpty else {
-            return "Setting up secure sharing…"
-        }
-        guard (try? RemoteCertificatePinning.validatedSPKIPin(spkiPin)) != nil else {
-            return "Applying certificate. Toggle sharing off and on if this persists."
-        }
-        return "Preparing…"
-    }
-
-    private var displayAddress: String {
-        let url = publicBaseURL.trimmingCharacters(in: .whitespacesAndNewlines)
-        return url.isEmpty ? EngineConfig.apiBaseURL.absoluteString : url
-    }
-
-    private var displayRoute: String {
-        let addr = displayAddress.lowercased()
-        if addr.contains(".local") || addr.contains("localhost") || addr.contains("127.0.0.1") {
-            return "Same Network"
-        }
-        return "Custom"
-    }
+    // MARK: - Security summary
 
     @ViewBuilder
     private var securitySection: some View {
@@ -244,6 +253,74 @@ struct ShareSettingsView: View {
         }
     }
 
+    // MARK: - Advanced (the ONE escape hatch)
+
+    @ViewBuilder
+    private var advancedSection: some View {
+        Section {
+            DisclosureGroup("Advanced") {
+                // Sharing works this out by itself. The override exists for the one
+                // case it cannot know about — a Tailscale hostname, a fixed IP behind
+                // a router — and nowhere else.
+                LabeledContent("Automatic address") {
+                    Text(Self.autoLocalBaseURL)
+                        .font(.caption.monospaced())
+                        .textSelection(.enabled)
+                        .foregroundStyle(.secondary)
+                }
+
+                TextField("Address other devices use", text: $addressDraft)
+                    .textFieldStyle(.roundedBorder)
+                    .autocorrectionDisabled()
+
+                Text("A literal IP address, a .local hostname, or a Tailscale .ts.net hostname. "
+                     + "It must be https:// so the connection can be pinned.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                HStack {
+                    Button("Use This Address") {
+                        publicBaseURL = addressDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+                        Task { await applySharing() }
+                    }
+                    .disabled(isApplyingChange || addressDraft == publicBaseURL)
+
+                    Button("Restore Automatic") {
+                        publicBaseURL = Self.autoLocalBaseURL
+                        Task { await applySharing() }
+                    }
+                    .disabled(isApplyingChange || publicBaseURL == Self.autoLocalBaseURL)
+                }
+
+                Divider()
+
+                // The only invite-rotation affordance in the app: mints a fresh
+                // one-time code and invalidates the one already on screen.
+                Button(isGeneratingCode ? "Resetting Invite…" : "Reset Invite") {
+                    Task { await refreshPairingCode() }
+                }
+                .disabled(isApplyingChange || isGeneratingCode || pairingBlocker != nil)
+
+                Button("Remove All Devices", role: .destructive) {
+                    confirmRemoveAllDevices = true
+                }
+                .disabled(!EngineConfig.engineIsLocal || activePairedDevices(from: pairedDevices).isEmpty)
+            }
+        }
+        .confirmationDialog(
+            "Remove all connected devices?",
+            isPresented: $confirmRemoveAllDevices,
+            titleVisibility: .visible
+        ) {
+            Button("Remove All Devices", role: .destructive) {
+                Task { await revokeAllDevices() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Every device that has joined this library will have to scan a new QR code to get back in.")
+        }
+    }
+
     /// The engine's real multi-user state — the single source of truth (#3331),
     /// shared with the Users + Engine tabs so all three agree. Reads
     /// `GET /api/auth/identity` via IdentityStore, never the local desired flag.
@@ -265,27 +342,41 @@ struct ShareSettingsView: View {
         ].joined(separator: "|")
     }
 
-    private func formatCode(_ code: String) -> String {
-        let chars = code.filter { $0.isNumber || $0.isLetter }
-        guard chars.count >= 4 else { return code }
-        let mid = chars.index(chars.startIndex, offsetBy: chars.count / 2)
-        return "\(chars[..<mid]) \(chars[mid...])"
+    // MARK: - Pairing payload
+
+    private var hasValidSPKIPin: Bool {
+        (try? RemoteCertificatePinning.validatedSPKIPin(spkiPin)) != nil
     }
 
-    // MARK: - QR generation
+    private var validatedPublicURL: URL? {
+        try? validatedHostedRemoteURL(from: publicBaseURL)
+    }
 
-    private func makeQRImage(for record: PairingCodeRecord) -> PlatformImage? {
-        guard let publicURL = try? validatedHostedRemoteURL(from: publicBaseURL) else { return nil }
+    private var advertisedPairingService: PairingService? {
+        guard let publicURL = validatedPublicURL else { return nil }
+        return PairingService(apiRoot: publicURL)
+    }
+
+    private var pairingQRPayload: PairingQRCodePayload? {
+        guard let pairingCode, let advertisedPairingService else { return nil }
         guard let normalizedPin = try? RemoteCertificatePinning.validatedSPKIPin(spkiPin) else { return nil }
-        let service = PairingService(apiRoot: publicURL)
-        let payload = service.buildQRCodePayload(
-            from: record,
+        return advertisedPairingService.buildQRCodePayload(
+            from: pairingCode,
             spki: normalizedPin,
             libraryPath: sharedLibraryPath
         )
+    }
+
+    private var inviteLinkString: String? {
+        guard let pairingQRPayload else { return nil }
+        return try? RemoteClientPairing.inviteLinkString(from: pairingQRPayload)
+    }
+
+    private var qrCodeImage: PlatformImage? {
+        guard let pairingQRPayload else { return nil }
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
-        guard let data = try? encoder.encode(payload) else { return nil }
+        guard let data = try? encoder.encode(pairingQRPayload) else { return nil }
         let filter = CIFilter.qrCodeGenerator()
         filter.message = data
         filter.correctionLevel = "M"
@@ -293,6 +384,18 @@ struct ShareSettingsView: View {
               let cgImage = qrContext.createCGImage(output, from: output.extent) else { return nil }
         return PlatformImage(cgImage: cgImage, size: .zero)
     }
+
+    private func copyInvite() {
+        guard let inviteLinkString else { return }
+        PlatformPasteboard.writeString(inviteLinkString)
+        copiedInvite = true
+        Task {
+            try? await Task.sleep(for: .seconds(2))
+            copiedInvite = false
+        }
+    }
+
+    // MARK: - Authz
 
     @MainActor
     private func loadAuthzSnapshot() async {
@@ -329,6 +432,8 @@ struct ShareSettingsView: View {
             .joined(separator: "|")
     }
 
+    /// ONE ACTION. Flipping this on derives the address, advertises the Mac, restarts
+    /// the engine with TLS and mints the invite — the user does not do our setup.
     private var sharingBinding: Binding<Bool> {
         Binding(
             get: { hostingEnabled },
@@ -381,12 +486,7 @@ struct ShareSettingsView: View {
     private func refreshPairingCode() async {
         pairingCode = nil
         shareError = nil
-        guard EngineConfig.engineIsLocal,
-              appState.isBackendRunning,
-              hostingEnabled,
-              (try? validatedHostedRemoteURL(from: publicBaseURL)) != nil,
-              (try? RemoteCertificatePinning.validatedSPKIPin(spkiPin)) != nil
-        else { return }
+        guard pairingBlocker == nil else { return }
         isGeneratingCode = true
         defer { isGeneratingCode = false }
         do {
@@ -420,6 +520,20 @@ struct ShareSettingsView: View {
         }
     }
 
+    private func revokeAllDevices() async {
+        shareError = nil
+        guard EngineConfig.engineIsLocal else { return }
+        let service = PairingService(apiRoot: EngineConfig.host)
+        do {
+            for device in activePairedDevices(from: pairedDevices) {
+                try await service.revokeDevice(id: device.id)
+            }
+        } catch {
+            shareError = error.localizedDescription
+        }
+        await refreshDevices()
+    }
+
     private func loadSPKIPin() {
         spkiPin = RemoteAccessConfig.hostedBackendSPKIPin(hostString: publicBaseURL) ?? ""
     }
@@ -433,3 +547,4 @@ struct ShareSettingsView: View {
     }
 }
 #endif
+// swiftlint:enable file_length

--- a/fichero/fichero/Views/Settings/UsersSettingsView.swift
+++ b/fichero/fichero/Views/Settings/UsersSettingsView.swift
@@ -164,10 +164,28 @@ extension UsersContent {
                 addAccountSection
             }
 
-            // Invite links (#3157) are only meaningful in multi-user mode, and
-            // only owners can mint them.
-            if identityStore.isOwnerAccess, authzSnapshot?.multiuserEnabled == true {
-                InviteAccountSection(store: store)
+            // Invite links (#3157) are only meaningful in multi-user mode, and only
+            // owners can mint them. When multi-user is off the section used to simply
+            // not exist, so a single-user owner never learned invites were a thing,
+            // let alone what turned them on. Name it, and name the place.
+            //
+            // ponytail: it names Engine settings rather than duplicating the
+            // multi-user switch here — a second switch over the same state is the
+            // exact duplicate-surface disease #3777 just removed.
+            if identityStore.isOwnerAccess {
+                if authzSnapshot?.multiuserEnabled == true {
+                    InviteAccountSection(store: store)
+                } else {
+                    Section {
+                        Text("Multi-user mode is off, so this library has one account and "
+                             + "nobody to invite. Turn it on in Settings → Engine, and Fichero "
+                             + "will restart its engine to apply it.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } header: {
+                        Text("Invite a Person")
+                    }
+                }
             }
 
             sharingSection
@@ -288,49 +306,78 @@ extension UsersContent {
     @ViewBuilder
     fileprivate func roleRow(_ role: Components.Schemas.LibraryRole) -> some View {
         let user = user(for: role.userId)
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 2) {
-                HStack(spacing: 6) {
-                    Text(user.map { displayName(for: $0) } ?? role.userId)
-                    if user?.id == store.currentUser?.id {
-                        Text("You")
-                            .font(.caption2)
-                            .fontWeight(.semibold)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 2)
-                            .background(.tint.opacity(0.15), in: Capsule())
-                            .foregroundStyle(.tint)
+        let isSelf = role.userId == store.currentUser?.id
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    HStack(spacing: 6) {
+                        Text(user.map { displayName(for: $0) } ?? role.userId)
+                        if isSelf {
+                            Text("You")
+                                .font(.caption2)
+                                .fontWeight(.semibold)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 2)
+                                .background(.tint.opacity(0.15), in: Capsule())
+                                .foregroundStyle(.tint)
+                        }
+                    }
+                    Text(user.map { "@\($0.username)" } ?? role.userId)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
+
+                Picker("Role", selection: roleBinding(for: role)) {
+                    ForEach(authzRoles, id: \.self) { roleName in
+                        Text(roleName.capitalized).tag(roleName)
                     }
                 }
-                Text(user.map { "@\($0.username)" } ?? role.userId)
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .frame(width: 120)
+                .disabled(isApplyingRoleChange || !isRoleEditable() || isSoleOwner(role))
+
+                // The engine refuses a self-revoke so a library always keeps an
+                // owner (authz.remove_role). We SURFACE that rule rather than
+                // reimplement it — and rather than silently hiding the button,
+                // which teaches the user nothing about why they can't do this.
+                if isRoleEditable(), !isSelf {
+                    Button("Remove") {
+                        Task { await revokeRole(userId: role.userId) }
+                    }
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.red)
+                    .disabled(isApplyingRoleChange)
+                }
+            }
+
+            if isRoleEditable(), isSelf {
+                Text(lastOwnerExplanation(isSoleOwner: isSoleOwner(role)))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
-
-            Spacer()
-
-            Picker("Role", selection: roleBinding(for: role)) {
-                ForEach(authzRoles, id: \.self) { roleName in
-                    Text(roleName.capitalized).tag(roleName)
-                }
-            }
-            .labelsHidden()
-            .pickerStyle(.menu)
-            .frame(width: 120)
-            .disabled(isApplyingRoleChange || !isRoleEditable())
-
-            // Revoke, hidden for your own row — the engine also refuses a
-            // self-revoke so the sole owner can't lock themselves out.
-            if isRoleEditable(), role.userId != store.currentUser?.id {
-                Button("Remove") {
-                    Task { await revokeRole(userId: role.userId) }
-                }
-                .buttonStyle(.borderless)
-                .foregroundStyle(.red)
-                .disabled(isApplyingRoleChange)
-            }
         }
         .padding(.vertical, 2)
+    }
+
+    /// Every library keeps at least one owner. Say WHY the control is unavailable —
+    /// a disabled button with no explanation is a dead control.
+    fileprivate func lastOwnerExplanation(isSoleOwner: Bool) -> String {
+        if isSoleOwner {
+            return "You're the only owner, so you can't remove or downgrade your own access — "
+                + "the library would be left with nobody who can administer it. "
+                + "Give someone else the Owner role first, then they can change yours."
+        }
+        return "You can't remove your own access. Another owner can do it for you."
+    }
+
+    /// True when this row is the library's last remaining owner. Read from the
+    /// engine's own ACL snapshot — the engine stays the enforcer.
+    fileprivate func isSoleOwner(_ role: Components.Schemas.LibraryRole) -> Bool {
+        guard role.role.lowercased() == "owner" else { return false }
+        return (authzSnapshot?.roles ?? []).filter { $0.role.lowercased() == "owner" }.count == 1
     }
 
     fileprivate func roleBinding(for role: Components.Schemas.LibraryRole) -> Binding<String> {


### PR DESCRIPTION
Two commits on the sharing UX milestone (#263).

## #3777 — kill the duplicate pairing surface (net −242 lines)
There were **two parallel host-side pairing UIs** — 'Share This Mac' under Engine→Backend and Library Access→Devices — with different gating, URLs, messages and QR sizes. The UX critique called consolidating them the single highest-leverage change. Now **one** surface.

**Preserved** (verified): the `PairingBlocker` enum (each failure names itself, offers a fix button only where the app can perform the cure) and the copyable pairing link (#3774). The consolidation folds them in, not away.

## #3787 — add/edit/delete users, with the last-owner rule SURFACED
The engine already guarantees a library keeps ≥1 owner (`authz.py:128-142`). The pane **surfaces** that rather than reimplementing it — and when you can't remove yourself it says **why**:

> "You're the only owner, so you can't remove or downgrade your own access…"

Not a greyed-out button with no explanation. That is the 'never a dead control' rule.

## Verification
Guardrails: accessibility, tooltips, observer_pattern, shell_chrome, native_controls, view_endpoint_access, dead_files, canonical_renderers → all exit 0. **Not built by me** — f_manager owns the lock; Swift compile verdict is theirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)