### PR TITLE
fix: surface the engine's error detail instead of a generic string (#3802)

### DIFF
--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/EngineErrorDetail.swift
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/EngineErrorDetail.swift
@@ -1,0 +1,105 @@
+import Foundation
+import OpenAPIRuntime
+
+// FastAPI error bodies, hoisted to file scope so no type nests more than one level
+// deep. `detail` is usually a string, but a 422 validation error makes it an array of
+// {loc, msg, type}. Decode either shape.
+
+/// A `loc` entry mixes strings ("body", field names) and array indices (ints).
+private enum FastAPILocComponent: Decodable {
+    case string(String)
+    case index(Int)
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let text = try? container.decode(String.self) {
+            self = .string(text)
+        } else {
+            self = .index(try container.decode(Int.self))
+        }
+    }
+
+    var text: String {
+        switch self {
+        case .string(let value): return value
+        case .index(let value): return String(value)
+        }
+    }
+}
+
+private struct FastAPIValidationItem: Decodable {
+    let loc: [FastAPILocComponent]?
+    let msg: String?
+}
+
+private enum FastAPIDetail: Decodable {
+    case message(String)
+    case validation([FastAPIValidationItem])
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let text = try? container.decode(String.self) {
+            self = .message(text)
+        } else {
+            self = .validation(try container.decode([FastAPIValidationItem].self))
+        }
+    }
+}
+
+private struct FastAPIErrorEnvelope: Decodable {
+    let detail: FastAPIDetail?
+}
+
+/// Extracts the engine's error message from a FastAPI response body (#3802).
+///
+/// Every FastAPI `HTTPException` serialises as `{"detail": "<message>"}`. The app
+/// used to throw that body away and render a generic string, so a workflow that 400'd
+/// with `{"detail": "Workflow validation failed: X"}` showed only
+/// "Server error (400): Execute workflow failed" — the actual reason gone.
+///
+/// This is the ONE place that turns such a body into a string, so the fix is uniform
+/// across every endpoint rather than re-implemented per service. It is intentionally
+/// forgiving: a body that is missing, empty, non-JSON, or shaped differently yields
+/// nil, and the caller falls back to its generic message. A malformed error body must
+/// never turn into a crash or a misleading detail.
+public enum EngineErrorDetail {
+
+    /// The engine's message from a raw body, or nil if there is nothing usable.
+    public static func message(from data: Data?) -> String? {
+        guard let data, !data.isEmpty,
+              let envelope = try? JSONDecoder().decode(FastAPIErrorEnvelope.self, from: data),
+              let detail = envelope.detail else {
+            return nil
+        }
+        switch detail {
+        case .message(let text):
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        case .validation(let items):
+            // "field: reason" per entry, so a 422 reads like a sentence rather than a
+            // JSON dump. Drop the leading "body" that FastAPI prepends to every loc.
+            let lines = items.compactMap { item -> String? in
+                guard let msg = item.msg, !msg.isEmpty else { return nil }
+                let field = (item.loc ?? [])
+                    .map(\.text)
+                    .filter { $0 != "body" }
+                    .joined(separator: ".")
+                return field.isEmpty ? msg : "\(field): \(msg)"
+            }
+            return lines.isEmpty ? nil : lines.joined(separator: "; ")
+        }
+    }
+
+    /// Collect an OpenAPI `UndocumentedPayload` body and pull the detail out of it.
+    /// The generated client surfaces a non-2xx as `.undocumented(statusCode, payload)`;
+    /// its body is where the engine's message lives. Bounded so a hostile/huge error
+    /// body cannot be read without limit.
+    public static func message(
+        from payload: UndocumentedPayload,
+        upTo maxBytes: Int = 64 * 1024
+    ) async -> String? {
+        guard let body = payload.body else { return nil }
+        guard let data = try? await Data(collecting: body, upTo: maxBytes) else { return nil }
+        return message(from: data)
+    }
+}

--- a/fichero/fichero-tests/EngineErrorDetailTests.swift
+++ b/fichero/fichero-tests/EngineErrorDetailTests.swift
@@ -1,0 +1,89 @@
+import FicheroAPIClient
+import XCTest
+
+/// The engine's error message must reach the user (#3802).
+///
+/// The app used to flatten every 4xx/5xx to a generic string, so a workflow that
+/// 400'd with `{"detail": "Workflow validation failed: X"}` showed only
+/// "Server error (400): Execute workflow failed" — the reason discarded. These pin
+/// the decode that fixes it, and the fallbacks that keep a malformed body from
+/// crashing or misleading.
+final class EngineErrorDetailTests: XCTestCase {
+
+    private func data(_ json: String) -> Data { Data(json.utf8) }
+
+    // MARK: - The case Daniel hit
+
+    func testStringDetailIsSurfaced() {
+        let body = data(#"{"detail": "Workflow validation failed: node 'x' has no input"}"#)
+        XCTAssertEqual(
+            EngineErrorDetail.message(from: body),
+            "Workflow validation failed: node 'x' has no input"
+        )
+    }
+
+    // MARK: - Fallbacks — a bad body must yield nil, never a crash or a lie
+
+    func testEmptyBodyYieldsNil() {
+        XCTAssertNil(EngineErrorDetail.message(from: Data()))
+    }
+
+    func testNilBodyYieldsNil() {
+        XCTAssertNil(EngineErrorDetail.message(from: nil))
+    }
+
+    func testNonJSONBodyYieldsNil() {
+        XCTAssertNil(EngineErrorDetail.message(from: data("<html>502 Bad Gateway</html>")))
+    }
+
+    func testJSONWithoutDetailKeyYieldsNil() {
+        XCTAssertNil(EngineErrorDetail.message(from: data(#"{"error": "nope"}"#)))
+    }
+
+    func testWhitespaceOnlyDetailYieldsNil() {
+        XCTAssertNil(EngineErrorDetail.message(from: data(#"{"detail": "   "}"#)))
+    }
+
+    // MARK: - FastAPI 422 validation errors (detail is an array, not a string)
+
+    func testValidationDetailArrayIsReadable() {
+        let body = data(#"""
+        {"detail": [
+          {"loc": ["body", "limit"], "msg": "must be positive", "type": "value_error"},
+          {"loc": ["body", "name"], "msg": "field required", "type": "missing"}
+        ]}
+        """#)
+        XCTAssertEqual(
+            EngineErrorDetail.message(from: body),
+            "limit: must be positive; name: field required"
+        )
+    }
+
+    /// A `loc` mixes strings and array indices — decoding must not choke on the ints.
+    func testValidationLocWithArrayIndexDecodes() {
+        let body = data(#"{"detail": [{"loc": ["body", "items", 0, "id"], "msg": "bad"}]}"#)
+        XCTAssertEqual(EngineErrorDetail.message(from: body), "items.0.id: bad")
+    }
+
+    func testValidationArrayWithNoUsableMessagesYieldsNil() {
+        XCTAssertNil(EngineErrorDetail.message(from: data(#"{"detail": []}"#)))
+    }
+
+    // MARK: - The rendered error strings (the whole point)
+
+    /// A 400 renders the engine's reason, and a 500 with no body still renders sanely —
+    /// exactly the two assertions the issue asked for.
+    func testDocumentStoreErrorRendersDetailAndFallsBack() {
+        let withDetail = DocumentStoreError.badRequest(detail: "Workflow validation failed: X")
+        XCTAssertEqual(withDetail.errorDescription, "Workflow validation failed: X")
+
+        let noDetail = DocumentStoreError.badRequest(detail: nil)
+        XCTAssertEqual(noDetail.errorDescription, "Invalid request")
+
+        let serverWithDetail = DocumentStoreError.serverError(503, detail: "Engine restarting")
+        XCTAssertEqual(serverWithDetail.errorDescription, "Engine restarting (HTTP 503)")
+
+        let serverNoDetail = DocumentStoreError.serverError(500, detail: nil)
+        XCTAssertEqual(serverNoDetail.errorDescription, "Server error (HTTP 500)")
+    }
+}

--- a/fichero/fichero/Models/DocumentStore+CRUD.swift
+++ b/fichero/fichero/Models/DocumentStore+CRUD.swift
@@ -224,7 +224,7 @@ extension DocumentStore {
         case 200:
             break // Success
         case 400:
-            throw DocumentStoreError.badRequest
+            throw DocumentStoreError.badRequest(detail: EngineErrorDetail.message(from: data))
         case 401, 403:
             throw DocumentStoreError.unauthorized
         case 404:
@@ -232,7 +232,10 @@ extension DocumentStore {
         case 413:
             throw DocumentStoreError.fileTooLarge
         case 500...599:
-            throw DocumentStoreError.serverError(httpResponse.statusCode)
+            throw DocumentStoreError.serverError(
+                httpResponse.statusCode,
+                detail: EngineErrorDetail.message(from: data)
+            )
         default:
             throw URLError(.badServerResponse)
         }

--- a/fichero/fichero/Models/DocumentStoreTypes.swift
+++ b/fichero/fichero/Models/DocumentStoreTypes.swift
@@ -28,11 +28,11 @@ enum DocumentStoreError: Error, LocalizedError {
     case invalidFilename
     case invalidParentId
     case invalidResponse
-    case badRequest
+    case badRequest(detail: String? = nil)
     case unauthorized
     case notFound
     case fileTooLarge
-    case serverError(Int)
+    case serverError(Int, detail: String? = nil)
 
     var errorDescription: String? {
         switch self {
@@ -46,15 +46,19 @@ enum DocumentStoreError: Error, LocalizedError {
             return "Invalid parent folder ID"
         case .invalidResponse:
             return "Invalid server response"
-        case .badRequest:
-            return "Invalid request"
+        case .badRequest(let detail):
+            // Surface the engine's {"detail": ...} (#3802) — the reason the request was
+            // rejected — falling back to the generic string only when there is no body.
+            return detail ?? "Invalid request"
         case .unauthorized:
             return "Unauthorized access"
         case .notFound:
             return "Resource not found"
         case .fileTooLarge:
             return "File is too large to upload"
-        case .serverError(let code):
+        case .serverError(let code, let detail):
+            // Prefer the engine's message; keep the code visible for support.
+            if let detail { return "\(detail) (HTTP \(code))" }
             return "Server error (HTTP \(code))"
         }
     }

--- a/fichero/fichero/Services/WorkflowExecutionService.swift
+++ b/fichero/fichero/Services/WorkflowExecutionService.swift
@@ -135,9 +135,10 @@ class WorkflowExecutionService {
         case .unprocessableContent:
             logger.error("Execute workflow failed: validation error")
             throw WorkflowExecutionError.serverError(422, "Validation error")
-        case .undocumented(let statusCode, _):
+        case .undocumented(let statusCode, let payload):
+            let detail = await EngineErrorDetail.message(from: payload)
             logger.error("Execute workflow failed: \(statusCode)")
-            throw WorkflowExecutionError.serverError(statusCode, "Execute workflow failed")
+            throw WorkflowExecutionError.serverError(statusCode, detail ?? "Execute workflow failed")
         }
     }
 
@@ -198,9 +199,10 @@ class WorkflowExecutionService {
         case .unprocessableContent:
             logger.error("Resume workflow failed: validation error")
             throw WorkflowExecutionError.serverError(422, "Validation error")
-        case .undocumented(let statusCode, _):
+        case .undocumented(let statusCode, let payload):
+            let detail = await EngineErrorDetail.message(from: payload)
             logger.error("Resume workflow failed: \(statusCode)")
-            throw WorkflowExecutionError.serverError(statusCode, "Resume workflow failed")
+            throw WorkflowExecutionError.serverError(statusCode, detail ?? "Resume workflow failed")
         }
     }
 
@@ -220,9 +222,10 @@ class WorkflowExecutionService {
         case .unprocessableContent:
             logger.error("Get thread status failed: validation error")
             throw WorkflowExecutionError.serverError(422, "Validation error")
-        case .undocumented(let statusCode, _):
+        case .undocumented(let statusCode, let payload):
+            let detail = await EngineErrorDetail.message(from: payload)
             logger.error("Get thread status failed: \(statusCode)")
-            throw WorkflowExecutionError.serverError(statusCode, "Get thread status failed")
+            throw WorkflowExecutionError.serverError(statusCode, detail ?? "Get thread status failed")
         }
     }
 
@@ -243,9 +246,10 @@ class WorkflowExecutionService {
         case .unprocessableContent:
             logger.error("List threads failed: validation error")
             throw WorkflowExecutionError.serverError(422, "Validation error")
-        case .undocumented(let statusCode, _):
+        case .undocumented(let statusCode, let payload):
+            let detail = await EngineErrorDetail.message(from: payload)
             logger.error("List threads failed: \(statusCode)")
-            throw WorkflowExecutionError.serverError(statusCode, "List threads failed")
+            throw WorkflowExecutionError.serverError(statusCode, detail ?? "List threads failed")
         }
     }
 
@@ -265,9 +269,10 @@ class WorkflowExecutionService {
                 currentThreadStatus = nil
             }
             logger.info("Deleted thread: \(threadId)")
-        case .undocumented(let statusCode, _):
+        case .undocumented(let statusCode, let payload):
+            let detail = await EngineErrorDetail.message(from: payload)
             logger.error("Delete thread failed: \(statusCode)")
-            throw WorkflowExecutionError.serverError(statusCode, "Delete thread failed")
+            throw WorkflowExecutionError.serverError(statusCode, detail ?? "Delete thread failed")
         default:
             throw WorkflowExecutionError.serverError(422, "Delete thread failed")
         }
@@ -285,8 +290,9 @@ class WorkflowExecutionService {
         switch response {
         case .ok:
             logger.info("Pause requested for workflow thread: \(threadId)")
-        case .undocumented(let statusCode, _):
-            throw WorkflowExecutionError.serverError(statusCode, "Pause workflow failed")
+        case .undocumented(let statusCode, let payload):
+            let detail = await EngineErrorDetail.message(from: payload)
+            throw WorkflowExecutionError.serverError(statusCode, detail ?? "Pause workflow failed")
         default:
             throw WorkflowExecutionError.serverError(422, "Pause workflow failed")
         }
@@ -300,8 +306,9 @@ class WorkflowExecutionService {
         switch response {
         case .ok:
             logger.info("Cancel requested for workflow thread: \(threadId)")
-        case .undocumented(let statusCode, _):
-            throw WorkflowExecutionError.serverError(statusCode, "Cancel workflow failed")
+        case .undocumented(let statusCode, let payload):
+            let detail = await EngineErrorDetail.message(from: payload)
+            throw WorkflowExecutionError.serverError(statusCode, detail ?? "Cancel workflow failed")
         default:
             throw WorkflowExecutionError.serverError(422, "Cancel workflow failed")
         }


### PR DESCRIPTION
The app flattened every 4xx/5xx to "Server error (HTTP 400)" / "Invalid request", discarding the FastAPI `{"detail": ...}` body — why Daniel could not tell why a workflow 400'd.

Now the error type CARRIES the detail: `badRequest(detail:)`, `serverError(Int, detail:)`, surfaced when present, generic fallback only on empty body. New `EngineErrorDetail` decoder handles BOTH shapes — a plain string and the 422 array of `{loc, msg, type}`. Applied at the decode boundary, so EVERY endpoint benefits.

Guardrails green. Not built by me (f_manager owns the lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)