### PR TITLE
fix: preserve single-user pairing mode (#3286)

### DIFF
--- a/fichero-engine/src/fichero/api/auth.py
+++ b/fichero-engine/src/fichero/api/auth.py
@@ -547,6 +547,40 @@ def action_context(
     )
 
 
+CANONICAL_OWNER_USERNAME = "owner"
+
+
+def ensure_owner_account(app_db=None):
+    """Return the canonical owner, creating it only when none exists."""
+    if app_db is None:
+        from fichero.app_db import get_app_db
+
+        app_db = get_app_db()
+
+    canonical = app_db.get_user_by_username(CANONICAL_OWNER_USERNAME)
+    if canonical is not None and canonical.is_owner:
+        if not canonical.active:
+            return app_db.set_active(canonical.id, True) or canonical
+        return canonical
+
+    active_owners = [
+        user for user in app_db.list_users() if user.is_owner and user.active
+    ]
+    if active_owners:
+        # Preserve an existing real owner; the paired-device migration handles
+        # the only known duplicate identity when the canonical row also exists.
+        return active_owners[0]
+
+    bootstrap_token = initialize_token()
+    return app_db.create_user(
+        username=CANONICAL_OWNER_USERNAME,
+        display_name="Owner",
+        password_hash=accounts.hash_password(bootstrap_token),
+        is_owner=True,
+        active=True,
+    )
+
+
 def _resolve_single_user_owner():
     """Return the single-user owner account, creating it if needed.
 
@@ -555,24 +589,7 @@ def _resolve_single_user_owner():
     is populated — no login wall for the single-user local owner (#3331).
     """
     try:
-        from fichero.app_db import get_app_db
-        app_db = get_app_db()
-        owners = [u for u in app_db.list_users() if u.is_owner and u.active]
-        if len(owners) == 1:
-            return owners[0]
-        if len(owners) == 0:
-            # ponytail: deterministic owner account keyed to the bootstrap
-            # token so the owner CAN sign in if multi-user is later enabled.
-            bootstrap_token = initialize_token()
-            return app_db.create_user(
-                username="owner",
-                display_name="Owner",
-                password_hash=accounts.hash_password(bootstrap_token),
-                is_owner=True,
-                active=True,
-            )
-        # Multiple owners — return the first active one
-        return owners[0]
+        return ensure_owner_account()
     except Exception:
         # Degrade to bootstrap-only (user=None) — the same trust as before
         # #3331 — but never silently: a failure here means audit attribution

--- a/fichero-engine/src/fichero/api/routes/pairing.py
+++ b/fichero-engine/src/fichero/api/routes/pairing.py
@@ -17,7 +17,7 @@ from pydantic import BaseModel, Field
 
 from fichero import accounts
 from fichero.actions import ActionContext, ChangeSpec, action
-from fichero.api.auth import _has_proxy_origin_headers, _rate_limit_scope_from_request, _use_multiuser_auth, actor_from_request
+from fichero.api.auth import _has_proxy_origin_headers, _rate_limit_scope_from_request, _use_multiuser_auth, actor_from_request, ensure_owner_account
 from fichero.api.routes.auth_accounts import _current_session_user
 from fichero.app_db import AppDatabase, get_app_db
 from fichero.models import AccountUser, ActionAudit, Device
@@ -76,7 +76,6 @@ _PAIRING_CODES: dict[str, _PairingCode] = {}
 _PAIRING_ATTEMPTS: dict[str, list[datetime]] = {}
 _PAIRING_RENEW_ATTEMPTS: dict[str, list[datetime]] = {}
 _PAIRING_WORKER_WARNING_EMITTED = False
-_SINGLE_USER_PAIRING_OWNER = "__paired_device_owner__"
 _LOCAL_PAIRING_CLIENT_HOSTS = {"127.0.0.1", "::1", "localhost", "testclient", "testserver"}
 
 
@@ -191,24 +190,8 @@ def _can_manage_device(request: Request, device: Device) -> bool:
 
 
 def _single_user_pairing_owner(app_db: AppDatabase) -> AccountUser:
-    owner = app_db.get_user_by_username(_SINGLE_USER_PAIRING_OWNER)
-    if owner is not None:
-        if not owner.active:
-            owner = app_db.set_active(owner.id, True) or owner
-        return owner
-    # ponytail: deterministic password from the bootstrap token so the owner
-    # CAN actually sign in (the old random-password __paired_device_owner__
-    # was un-signin-able and its mere existence flipped multi-user on via
-    # _has_account_rows — #3331).
-    from fichero.api.auth import initialize_token
-    bootstrap_token = initialize_token()
-    return app_db.create_user(
-        username=_SINGLE_USER_PAIRING_OWNER,
-        display_name="Owner",
-        password_hash=accounts.hash_password(bootstrap_token),
-        is_owner=True,
-        active=True,
-    )
+    """Compatibility name for the shared canonical owner resolver."""
+    return ensure_owner_account(app_db)
 
 
 def _new_pairing_code() -> str:

--- a/fichero-engine/src/fichero/app_db.py
+++ b/fichero-engine/src/fichero/app_db.py
@@ -316,6 +316,12 @@ class AppDatabase:
             )
         """)
 
+        # App-wide identity migration.  This runs only when both historical
+        # owner rows exist, so a real pre-existing owner is never replaced.
+        from fichero.db_migrations import migrate_paired_device_owner
+
+        migrate_paired_device_owner(self.conn)
+
         # Create indexes
         self.conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_providers_type ON providers(provider_type)"

--- a/fichero-engine/src/fichero/db_migrations.py
+++ b/fichero-engine/src/fichero/db_migrations.py
@@ -12,6 +12,62 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def migrate_paired_device_owner(conn) -> None:
+    """Fold the retired pairing owner into the canonical owner account.
+
+    Early single-user pairing created ``__paired_device_owner__`` while the
+    auth middleware created ``owner``.  When both rows exist, resolve every
+    device and library-role reference to ``owner`` before disabling the
+    retired row.  A sole legacy row is deliberately left alone: it remains a
+    real account and this migration must not invent or discard user data.
+    """
+    canonical = conn.execute(
+        "SELECT id FROM users WHERE username = ?", ["owner"]
+    ).fetchone()
+    legacy = conn.execute(
+        "SELECT id FROM users WHERE username = ?", ["__paired_device_owner__"]
+    ).fetchone()
+    if canonical is None or legacy is None:
+        return
+
+    canonical_id, legacy_id = canonical[0], legacy[0]
+    if canonical_id == legacy_id:
+        return
+
+    conn.execute(
+        "UPDATE devices SET user_id = ? WHERE user_id = ?", [canonical_id, legacy_id]
+    )
+
+    # ``library_roles`` is unique per (user, library), so preserve the
+    # canonical row when both identities already have a role for one library.
+    legacy_roles = conn.execute(
+        "SELECT id, library_path, role FROM library_roles WHERE user_id = ?",
+        [legacy_id],
+    ).fetchall()
+    role_rank = {"viewer": 1, "editor": 2, "owner": 3}
+    for role_id, library_path, role in legacy_roles:
+        existing = conn.execute(
+            "SELECT id, role FROM library_roles WHERE user_id = ? AND library_path = ?",
+            [canonical_id, library_path],
+        ).fetchone()
+        if existing is None:
+            conn.execute(
+                "UPDATE library_roles SET user_id = ? WHERE id = ?",
+                [canonical_id, role_id],
+            )
+        else:
+            existing_id, existing_role = existing
+            if role_rank.get(role, 0) > role_rank.get(existing_role, 0):
+                conn.execute(
+                    "UPDATE library_roles SET role = ? WHERE id = ?",
+                    [role, existing_id],
+                )
+            conn.execute("DELETE FROM library_roles WHERE id = ?", [role_id])
+
+    conn.execute("UPDATE users SET active = FALSE WHERE id = ?", [legacy_id])
+    conn.commit()
+
+
 def migrate_workflow_table(conn) -> None:
     """Migrate workflows table to new schema if needed."""
     from fichero.errors import ErrorCategory, handle_error

--- a/fichero-engine/tests/unit/test_paired_device_owner_migration.py
+++ b/fichero-engine/tests/unit/test_paired_device_owner_migration.py
@@ -1,0 +1,46 @@
+"""Regression coverage for consolidating the former pairing owner identity."""
+
+from __future__ import annotations
+
+from fichero import accounts
+from fichero.app_db import AppDatabase
+
+
+def _owner(db: AppDatabase, username: str):
+    return db.create_user(
+        username=username,
+        display_name=username,
+        password_hash=accounts.hash_password("test-password"),
+        is_owner=True,
+    )
+
+
+def test_reopen_consolidates_paired_device_owner_references(tmp_path):
+    path = tmp_path / "app.duckdb"
+    db = AppDatabase(path)
+    canonical = _owner(db, "owner")
+    legacy = _owner(db, "__paired_device_owner__")
+    device = db.create_device(
+        name="Paired iPad",
+        user_id=legacy.id,
+        token_hash=accounts.hash_token("device-token"),
+    )
+    db.set_library_role(user_id=legacy.id, library_path="/library", role="editor")
+    db.close()
+
+    reopened = AppDatabase(path)
+    migrated_legacy = reopened.get_user(legacy.id)
+    migrated_device = next(
+        item for item in reopened.list_devices() if item.id == device.id
+    )
+    migrated_role = reopened.get_library_role(canonical.id, "/library")
+
+    assert migrated_legacy is not None and migrated_legacy.active is False
+    assert migrated_device.user_id == canonical.id
+    assert migrated_role is not None and migrated_role.role == "editor"
+
+    reopened.close()
+    again = AppDatabase(path)
+    assert again.get_user(legacy.id).active is False
+    assert again.get_library_role(canonical.id, "/library").role == "editor"
+    again.close()


### PR DESCRIPTION
Carries the paired-device owner migration and regression coverage. The historical commit footer references the wrong closed issue; this PR tracks the actual pairing-mode bug #3286.