### PR TITLE
fix: generate usable library-share pairing links (#3813)

### DIFF
--- a/fichero/fichero/Views/Sidebar/ShareLibrarySheet.swift
+++ b/fichero/fichero/Views/Sidebar/ShareLibrarySheet.swift
@@ -1,6 +1,8 @@
 import FicheroAPIClient
 import SwiftUI
 
+// swiftlint:disable file_length
+
 /// "Share this library…" surface (#3149, plan §5 F1).
 ///
 /// Pick an existing account — or create a new person inline — assign a role,
@@ -19,11 +21,22 @@ struct ShareLibrarySheet: View {
 
     @Environment(\.dismiss) private var dismiss
 
+    // The reachable-host + pin state that turns a role grant into a link someone
+    // can actually open. Same @AppStorage keys the one pairing surface owns
+    // (ShareSettingsView), so this reflects whether sharing is on and where.
+    @AppStorage(RemoteAccessConfig.publicBaseURLKey) private var publicBaseURL = ""
+    @AppStorage(RemoteAccessConfig.hostingEnabledKey) private var hostingEnabled = false
+
     // Share form
     @State var personChoice: String = ""
     @State var role = "viewer"
     @State var isSharing = false
-    @State var shareURL: String?
+    // Set once the role grant succeeds — the "Share Link" section appears then.
+    @State var didShare = false
+    // The short-lived, single-use pair code minted for the link — SAME code
+    // semantics as the QR. nil until minted; the link cannot exist without it.
+    @State var pairingCode: PairingCodeRecord?
+    @State var spkiPin = ""
     @State var shareError: String?
     @State var copied = false
 
@@ -111,23 +124,57 @@ extension ShareLibrarySheet {
                 .foregroundStyle(.secondary)
         }
 
-        if let shareURL {
-            Section("Share Link") {
+        if didShare {
+            shareLinkSection
+        }
+    }
+
+    /// The link the person you just shared with actually opens.
+    ///
+    /// It is the SAME `fichero://` payload as the pairing QR and the copyable
+    /// pairing link (#3774/#3813): reachable host + SPKI pin + short-lived
+    /// single-use pair code. It is NOT the engine's `share_url`, which is a
+    /// loopback API URL that 401s and is dead to anyone but this Mac.
+    ///
+    /// When no reachable address exists (sharing off, loopback only), there is no
+    /// working link to make — we say so honestly and point at the switch, rather
+    /// than hand out a link that looks valid and isn't. Never a dead control.
+    @ViewBuilder
+    var shareLinkSection: some View {
+        Section("Share Link") {
+            if let pairingLink {
                 LabeledContent("Link") {
-                    Text(shareURL)
+                    Text(pairingLink)
                         .textSelection(.enabled)
                         .font(.caption.monospaced())
                         .lineLimit(1)
                         .truncationMode(.middle)
                 }
                 HStack {
-                    Button(copied ? "Copied" : "Copy Link") { copyShareURL() }
-                    if let url = URL(string: shareURL) {
+                    Button(copied ? "Copied" : "Copy Link") { copyPairingLink() }
+                    if let url = URL(string: pairingLink) {
                         ShareLink(item: url) {
                             Label("Send…", systemImage: "square.and.arrow.up")
                         }
                     }
                 }
+                Text("This link lets \(sharedPersonName) connect to your library — "
+                    + "it carries a single-use code that expires. Share only with them.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else if let reason = shareLinkUnavailableReason {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(reason.headline)
+                        .font(.headline)
+                    Text(reason.detail)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("Turn on sharing in Settings → Library Access → Devices, then reopen this.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                ProgressView("Preparing link…")
             }
         }
     }
@@ -281,20 +328,90 @@ extension ShareLibrarySheet {
         guard canShare else { return }
         isSharing = true
         shareError = nil
-        shareURL = nil
+        didShare = false
+        pairingCode = nil
         defer { isSharing = false }
         do {
-            let response = try await library.actionsService.shareLibrary(user: personChoice, role: role)
-            shareURL = response.shareUrl
+            // Grant the role — the sheet's actual purpose. We deliberately IGNORE
+            // the returned share_url: it is a loopback API URL that 401s and is
+            // dead to anyone but this Mac (#3813). The link the recipient opens is
+            // the pairing payload built in `pairingLink`.
+            _ = try await library.actionsService.shareLibrary(user: personChoice, role: role)
+            didShare = true
+            loadSPKIPin()
+            await mintPairingCodeIfPossible()
             await loadMembers()
         } catch {
             shareError = error.localizedDescription
         }
     }
 
-    func copyShareURL() {
-        guard let shareURL else { return }
-        PlatformPasteboard.writeString(shareURL)
+    func loadSPKIPin() {
+        spkiPin = RemoteAccessConfig.hostedBackendSPKIPin(hostString: publicBaseURL) ?? ""
+    }
+
+    /// Mint the short-lived, single-use pair code — same code semantics as the QR.
+    /// Skipped when there is no reachable address to bind it to; the honest
+    /// unavailable state renders instead of a dead link.
+    @MainActor
+    func mintPairingCodeIfPossible() async {
+        guard shareLinkUnavailableReason == nil else { return }
+        do {
+            pairingCode = try await PairingService(apiRoot: EngineConfig.host).createPairingCode()
+        } catch {
+            shareError = error.localizedDescription
+        }
+    }
+
+    /// The one link format (#3774/#3813): reachable host + SPKI pin + pair code,
+    /// as the `fichero://` payload iOS's `PairingQRCodePayloadDecoder` already
+    /// parses. Identical to the QR and the copyable pairing link — not a second
+    /// format, and never the loopback share_url.
+    var pairingLink: String? {
+        guard let pairingCode,
+              let reachableURL = try? validatedHostedRemoteURL(from: publicBaseURL),
+              let normalizedPin = try? RemoteCertificatePinning.validatedSPKIPin(spkiPin) else { return nil }
+        let payload = PairingService(apiRoot: reachableURL).buildQRCodePayload(
+            from: pairingCode,
+            spki: normalizedPin,
+            libraryPath: library.url.path
+        )
+        return try? RemoteClientPairing.inviteLinkString(from: payload)
+    }
+
+    /// Why there is no working share link yet — honest, named, and pointing at the
+    /// fix. Mirrors the pairing surface's `PairingBlocker` vocabulary without
+    /// coupling this cross-platform sheet to that AppKit-only type.
+    var shareLinkUnavailableReason: (headline: String, detail: String)? {
+        guard EngineConfig.engineIsLocal else {
+            return ("This library is hosted on another machine",
+                    "Sharing happens on the Mac that hosts the library, not on this one.")
+        }
+        guard hostingEnabled else {
+            return ("Sharing is off",
+                    "Turn sharing on so Fichero can prepare a reachable address and a security code for the link.")
+        }
+        do {
+            _ = try validatedHostedRemoteURL(from: publicBaseURL)
+        } catch {
+            return ("No reachable address yet",
+                    "This Mac only has a loopback address that other devices can't open. "
+                    + "Turning sharing on derives a shareable address.")
+        }
+        guard (try? RemoteCertificatePinning.validatedSPKIPin(spkiPin)) != nil else {
+            return ("Preparing the security certificate",
+                    "Fichero is still minting the certificate for this address — try again in a moment.")
+        }
+        return nil
+    }
+
+    var sharedPersonName: String {
+        usersStore.users.first(where: { $0.id == personChoice }).map { displayName($0) } ?? "this person"
+    }
+
+    func copyPairingLink() {
+        guard let pairingLink else { return }
+        PlatformPasteboard.writeString(pairingLink)
         copied = true
         Task {
             try? await Task.sleep(for: .seconds(2))
@@ -340,3 +457,5 @@ extension ShareLibrarySheet {
         }
     }
 }
+
+// swiftlint:enable file_length


### PR DESCRIPTION
Uses the real pairing payload instead of a loopback-only link.