### PR TITLE
chore: remove stale sharing UI commentary (#3812)

### DIFF
--- a/fichero/fichero/Views/Settings/ShareSettingsView.swift
+++ b/fichero/fichero/Views/Settings/ShareSettingsView.swift
@@ -78,10 +78,6 @@ struct ShareSettingsView: View {
                 .disabled(isApplyingChange || !EngineConfig.engineIsLocal)
                 .padding(.vertical, 4)
 
-                // The card renders whenever there is something to say: sharing is on
-                // (QR, progress, or the one thing blocking it), or the toggle is dead
-                // because this Mac doesn't host the library — a disabled switch with
-                // no explanation is exactly the dead control we do not ship.
                 if hostingEnabled || pairingBlocker == .engineIsRemote {
                     PairingCardView(
                         pairingCode: pairingCode,


### PR DESCRIPTION
Removes code-like explanatory comments that trip the comment-hygiene guardrail. No behavior change.