### PR TITLE
test: cover fresh local owner bootstrap (#3819)

### DIFF
--- a/fichero-engine/tests/unit/test_auth_accounts.py
+++ b/fichero-engine/tests/unit/test_auth_accounts.py
@@ -91,6 +91,24 @@ def test_bootstrap_first_user_creates_owner(client, app_db, monkeypatch):
     assert app_db.get_user_by_username("owner").is_owner is True
 
 
+def test_fresh_local_bootstrap_identity_creates_owner_without_onboarding(
+    client, app_db, monkeypatch
+):
+    monkeypatch.delenv("FICHERO_MULTIUSER", raising=False)
+
+    response = client.get("/api/auth/identity", headers=_bearer(initialize_token()))
+
+    assert response.status_code == 200
+    assert response.json()["auth_kind"] == "bootstrap"
+    assert response.json()["user"] == {
+        "id": app_db.get_user_by_username("owner").id,
+        "username": "owner",
+        "display_name": "Owner",
+        "is_owner": True,
+    }
+    assert response.json()["is_owner_access"] is True
+
+
 def test_login_success_returns_session_and_me(client, app_db, monkeypatch):
     _enable_multiuser(monkeypatch)
     app_db.create_user(


### PR DESCRIPTION
Confirms the engine side of #3819 is already correct: `GET /api/auth/identity` (auth_accounts.py:449) bootstraps the single-user owner via `_resolve_single_user_owner` — a fresh local install returns `auth_kind=bootstrap` + the `owner` user with **no onboarding required**. Regression test added; no auth loosened. 34 passed. Not built by me (f_manager owns the lock).

The remaining #3819 work is APP-side: the app must call `/api/auth/identity` on first run and treat `auth_kind=bootstrap` as 'already the owner' rather than gating on a users row / routing to create-user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)