### PR TITLE
fix(engine): log workflow validation detail (#3820) + per-loop embedding semaphore (#3806)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/workflow_execution/core.py
+++ b/fichero-engine/src/fichero/api/routes/workflow_execution/core.py
@@ -117,9 +117,16 @@ def _validate_workflow_for_execution(workflow: Workflow) -> None:
             errors.append(str(exc))
 
     if errors:
+        detail = f"Workflow validation failed: {'; '.join(errors)}"
+        logger.warning(
+            "Workflow validation failed for id=%s name=%r: %s",
+            workflow.id,
+            workflow.name,
+            detail,
+        )
         raise HTTPException(
             status_code=400,
-            detail=f"Workflow validation failed: {'; '.join(errors)}",
+            detail=detail,
         )
 
 

--- a/fichero-engine/src/fichero/db_embeddings.py
+++ b/fichero-engine/src/fichero/db_embeddings.py
@@ -1229,14 +1229,17 @@ class DatabaseEmbeddingMixin:
             return
 
         # Lazily initialise a task-tracking set (prevents GC of in-flight tasks)
-        # and a semaphore to bound concurrent background DB connections.
+        # and semaphores to bound concurrent background DB connections per loop.
         if not hasattr(self, "_bg_embedding_tasks"):
             self._bg_embedding_tasks: set = set()
-        if not hasattr(self, "_bg_embedding_semaphore"):
-            self._bg_embedding_semaphore = asyncio.Semaphore(2)
+        if not hasattr(self, "_bg_embedding_semaphores"):
+            self._bg_embedding_semaphores: dict[asyncio.AbstractEventLoop, asyncio.Semaphore] = {}
 
         bg_tasks: set = self._bg_embedding_tasks
-        sem: asyncio.Semaphore = self._bg_embedding_semaphore
+        sem = self._bg_embedding_semaphores.get(loop)
+        if sem is None:
+            sem = asyncio.Semaphore(2)
+            self._bg_embedding_semaphores[loop] = sem
 
         async def _runner() -> None:
             async with sem:

--- a/fichero-engine/tests/unit/test_embed_batch_and_bg_tasks.py
+++ b/fichero-engine/tests/unit/test_embed_batch_and_bg_tasks.py
@@ -190,7 +190,7 @@ async def test_schedule_embedding_task_semaphore_limits_concurrency() -> None:
         for _ in range(6):
             mixin._schedule_embedding_task(["rec"], label="entity")
 
-        assert hasattr(mixin, "_bg_embedding_semaphore")
+        assert len(mixin._bg_embedding_semaphores) == 1
 
         tasks = list(mixin._bg_embedding_tasks)
         await asyncio.gather(*tasks, return_exceptions=True)
@@ -198,3 +198,21 @@ async def test_schedule_embedding_task_semaphore_limits_concurrency() -> None:
     assert peak_active <= 2, (
         f"Semaphore should cap concurrency at 2; peak was {peak_active}"
     )
+
+
+def test_schedule_embedding_task_uses_a_semaphore_per_event_loop() -> None:
+    mixin = _FakeMixin()
+
+    async def schedule_three() -> list[object]:
+        for _ in range(3):
+            mixin._schedule_embedding_task(["rec"], label="entity")
+        return await asyncio.gather(*list(mixin._bg_embedding_tasks), return_exceptions=True)
+
+    with patch("fichero.db.Database") as MockDB:
+        MockDB.return_value.embed_entities.return_value = None
+        MockDB.return_value.close.return_value = None
+
+        assert not any(isinstance(result, RuntimeError) for result in asyncio.run(schedule_three()))
+        assert not any(isinstance(result, RuntimeError) for result in asyncio.run(schedule_three()))
+
+    assert len(mixin._bg_embedding_semaphores) == 2

--- a/fichero-engine/tests/unit/test_routes_workflow_execution.py
+++ b/fichero-engine/tests/unit/test_routes_workflow_execution.py
@@ -6,6 +6,7 @@ mocking for LangGraph-dependent paths.
 """
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -420,11 +421,14 @@ class TestGlobalCacheStats:
 
 
 class TestExecuteWorkflow:
-    def test_execute_returns_accepted_with_thread_and_stream_url(self, client, db):
+    @pytest.mark.parametrize("selected_doc_id", ["folder-id", "image-id"])
+    def test_execute_returns_accepted_with_thread_and_stream_url(
+        self, client, db, selected_doc_id
+    ):
         wf = _make_workflow(db, "Gate Workflow")
         payload = {
             "workflow_id": wf.id,
-            "inputs": {"selected_doc_ids": ["doc-1"]},
+            "inputs": {"selected_doc_ids": [selected_doc_id]},
         }
 
         # Keep the route hermetic WITHOUT breaking the event loop. The earlier
@@ -475,7 +479,7 @@ class TestExecuteWorkflow:
         assert run.workflow_id == wf.id
         assert run.workflow_name == "Gate Workflow"
         assert run.status == "accepted"
-        assert run.workflow_snapshot["inputs"]["selected_doc_ids"] == ["doc-1"]
+        assert run.workflow_snapshot["inputs"]["selected_doc_ids"] == [selected_doc_id]
         # The route must have spawned a dedicated workflow worker thread (#1000).
         assert any(
             t.name.startswith("workflow-") for t in created_threads
@@ -516,7 +520,7 @@ class TestExecuteWorkflow:
             r = client.post("/api/workflow-execution/execute", json=payload)
         assert r.status_code == 404
 
-    def test_execute_rejects_empty_workflow(self, client, db):
+    def test_execute_rejects_empty_workflow(self, client, db, caplog):
         wf = Workflow(
             name="Empty Workflow",
             description="No nodes",
@@ -528,11 +532,15 @@ class TestExecuteWorkflow:
         db.save(wf)
         payload = {"workflow_id": wf.id, "inputs": {}}
 
-        r = client.post("/api/workflow-execution/execute", json=payload)
+        with caplog.at_level(
+            logging.WARNING, logger="fichero.api.routes.workflow_execution.core"
+        ):
+            r = client.post("/api/workflow-execution/execute", json=payload)
 
         assert r.status_code == 400
         assert "Workflow validation failed" in r.json()["detail"]
         assert "Workflow has no nodes" in r.json()["detail"]
+        assert "Workflow validation failed" in caplog.text
 
     def test_execute_rejects_unknown_tool(self, client, db):
         wf = _make_workflow(db, "Bad Tool Workflow")


### PR DESCRIPTION
Two safe engine fixes (zero auth/validation loosening).

**#3806 (FULL FIX):** the embedding scheduler crashed with 'Semaphore bound to a different event loop' — new entities never embedded. Now keyed **per running loop**. The multi-loop DB scheduling is intentional (the workflow runner owns its own loop/thread — confirmed). Two-loop regression + 7 existing concurrency tests pass.

**#3820 (INSTRUMENTATION, not yet the root-cause fix):** the workflow-execution endpoint now `logger.warning`s the validation detail + workflow id/name, so the single-item-vs-folder 400 is visible server-side (the app already surfaces it via #3802). Regression covers the same workflow with folder vs item `selected_doc_ids`. **#3820 stays OPEN** — this makes the failure observable; the remaining work is finding why the library-view invocation resolves a different/missing workflow_id.

## Verification
`test_routes_workflow_execution` + `tests/contracts` → 60 passed; embedding concurrency → 12 passed. Not built by me (f_manager owns the lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)