### PR TITLE
fix(settings): restore the sharing/QR + Engine panes for beta testers (#3811/#3776)

### DIFF
--- a/fichero/fichero-tests/FeatureManagerTests.swift
+++ b/fichero/fichero-tests/FeatureManagerTests.swift
@@ -76,17 +76,18 @@ final class FeatureManagerTests: XCTestCase {
         }
     }
 
-    // The Library Access pane (People / Devices+QR / Capture) holds real, keepable
-    // capabilities, so its EXISTENCE must not hang off the `.alpha`-tier
-    // `settings_share_tab` flag — that hid the QR from beta testers ("nowhere to
-    // turn on the qrcode", #3811). It is reachable in internal + tester builds and
-    // still hidden in release until the fail-closed engine-refusal P0 lands (#3776).
-    func testLibraryAccessSettingsReachableForTestersHiddenInRelease() {
-        XCTAssertTrue(SettingsView.showsLibraryAccessSettings(tier: .dev))
-        XCTAssertTrue(SettingsView.showsLibraryAccessSettings(tier: .alpha))
-        // The regression case: beta testers must see the sharing/QR pane.
-        XCTAssertTrue(SettingsView.showsLibraryAccessSettings(tier: .beta))
+    // The Engine & Access panes (Engine/Backend + Library Access: People /
+    // Devices+QR / Capture) hold real, keepable capabilities, so their EXISTENCE
+    // must not hang off the `.alpha`-tier `settings_*_tab` flags — those hid the QR
+    // and the multi-user toggle from beta testers ("nowhere to turn on the qrcode",
+    // #3811). Reachable in internal + tester builds; still hidden in release until
+    // the fail-closed engine-refusal P0 lands (#3776).
+    func testTesterSettingsPanesReachableForTestersHiddenInRelease() {
+        XCTAssertTrue(SettingsView.showsTesterSettingsPane(tier: .dev))
+        XCTAssertTrue(SettingsView.showsTesterSettingsPane(tier: .alpha))
+        // The regression case: beta testers must see the sharing/QR + Engine panes.
+        XCTAssertTrue(SettingsView.showsTesterSettingsPane(tier: .beta))
         // Release stays gated until #3776's P0 verification.
-        XCTAssertFalse(SettingsView.showsLibraryAccessSettings(tier: .release))
+        XCTAssertFalse(SettingsView.showsTesterSettingsPane(tier: .release))
     }
 }

--- a/fichero/fichero-tests/FeatureManagerTests.swift
+++ b/fichero/fichero-tests/FeatureManagerTests.swift
@@ -75,4 +75,18 @@ final class FeatureManagerTests: XCTestCase {
             XCTAssertFalse(featureManager.isIntegrationsEnabled)
         }
     }
+
+    // The Library Access pane (People / Devices+QR / Capture) holds real, keepable
+    // capabilities, so its EXISTENCE must not hang off the `.alpha`-tier
+    // `settings_share_tab` flag — that hid the QR from beta testers ("nowhere to
+    // turn on the qrcode", #3811). It is reachable in internal + tester builds and
+    // still hidden in release until the fail-closed engine-refusal P0 lands (#3776).
+    func testLibraryAccessSettingsReachableForTestersHiddenInRelease() {
+        XCTAssertTrue(SettingsView.showsLibraryAccessSettings(tier: .dev))
+        XCTAssertTrue(SettingsView.showsLibraryAccessSettings(tier: .alpha))
+        // The regression case: beta testers must see the sharing/QR pane.
+        XCTAssertTrue(SettingsView.showsLibraryAccessSettings(tier: .beta))
+        // Release stays gated until #3776's P0 verification.
+        XCTAssertFalse(SettingsView.showsLibraryAccessSettings(tier: .release))
+    }
 }

--- a/fichero/fichero/Views/Settings/SettingsView.swift
+++ b/fichero/fichero/Views/Settings/SettingsView.swift
@@ -49,17 +49,16 @@ struct SettingsView: View {
                 }
 
                 Section("Engine & Access") {
-                    // Engine group (#3396): Backend folded in as a sub-section.
-                    if featureManager.isSettingsEngineTabEnabled || featureManager.isSettingsBackendTabEnabled {
+                    // Engine (multi-user toggle, restart, stats) + Library Access
+                    // (People / Devices+QR / Capture) hold real, keepable capabilities.
+                    // Their EXISTENCE must not hang off per-feature migration flags —
+                    // those are `.alpha`-tier, so both vanished for beta testers, which
+                    // is why Daniel had "nowhere to turn on the qrcode" and no way to
+                    // enable multi-user to share with people (#3811/#3776). Reachable
+                    // for internal + tester builds; still hidden in release until the
+                    // fail-closed engine-refusal P0 lands (#3776).
+                    if Self.showsTesterSettingsPane(tier: featureManager.activeBuildTier) {
                         row(.engine, "Engine", "square.grid.3x1.below.line.grid.1x2")
-                    }
-                    // Library Access group (#3396): People + Devices (pairing/QR) +
-                    // Capture. Its EXISTENCE must not hang off per-feature migration
-                    // flags — the sharing/QR pane is `.alpha`-tier, so it vanished for
-                    // beta testers and Daniel had "nowhere to turn on the qrcode"
-                    // (#3811/#3776). Show it to internal + tester builds; still hidden
-                    // in release until the fail-closed engine-refusal P0 lands (#3776).
-                    if Self.showsLibraryAccessSettings(tier: featureManager.activeBuildTier) {
                         row(.connect, "Library Access", "lock.shield")
                     }
                 }
@@ -89,14 +88,17 @@ struct SettingsView: View {
         Label(title, systemImage: symbol).tag(tab)
     }
 
-    /// Whether the Library Access pane (People / Devices+QR / Capture) is reachable
-    /// in this build. It holds real, keepable capabilities, so its existence must
-    /// NOT depend on a per-feature migration flag — the `.alpha`-tier
-    /// `settings_share_tab` flag hid the QR from beta testers, which is the whole of
-    /// #3811 ("nowhere to turn on the qrcode"). Visible to internal + tester builds;
+    /// Whether the Engine & Access panes (Engine/Backend and Library Access —
+    /// People / Devices+QR / Capture) are reachable in this build. They hold real,
+    /// keepable capabilities (the multi-user toggle, device pairing + QR, users),
+    /// so their existence must NOT depend on a per-feature migration flag — those
+    /// flags are `.alpha`-tier, so in a beta build the sharing/QR pane vanished and
+    /// Daniel had "nowhere to turn on the qrcode" (and no way to enable multi-user
+    /// to share with people) — #3811/#3776. Reachable in internal + tester builds;
     /// still hidden in release until the fail-closed engine-refusal P0 is verified
-    /// (#3776). When that lands, this gate goes too and the pane is simply always on.
-    static func showsLibraryAccessSettings(tier: FeatureTier) -> Bool {
+    /// (#3776). When that lands, this gate goes too and the panes are simply always
+    /// on — turning a capability on is one action, never "enable the subsystem first".
+    static func showsTesterSettingsPane(tier: FeatureTier) -> Bool {
         tier != .release
     }
 
@@ -309,19 +311,17 @@ private enum EngineGroupSection: String, CaseIterable, SettingsGroupSection {
 /// Engine tab (#3396): folds the former Backend tab in as a sub-section. Reuses
 /// EngineSettingsView + BackendSettingsView unchanged.
 private struct EngineGroupSettingsView: View {
-    /// Injected by the Settings scene (#3033/#3034) — the panes must not reach
-    /// for the singleton themselves. @EnvironmentObject, not @Environment:
-    /// FeatureManager is @AppStorage-backed and so must stay an
-    /// ObservableObject until #3743 re-backs its flags on UserDefaults.
-    @EnvironmentObject private var featureManager: FeatureManager
     @State private var selection: EngineGroupSection = .engine
 
     private var availableSections: [EngineGroupSection] {
+        // Engine + Backend are real capabilities; their existence no longer hangs
+        // off per-feature migration flags (#3811/#3776). The sidebar row gate
+        // (`SettingsView.showsTesterSettingsPane`) decides reachability per build.
         var sections: [EngineGroupSection] = []
         #if canImport(AppKit)
-        if featureManager.isSettingsEngineTabEnabled { sections.append(.engine) }
+        sections.append(.engine)
         #endif
-        if featureManager.isSettingsBackendTabEnabled { sections.append(.backend) }
+        sections.append(.backend)
         return sections
     }
 

--- a/fichero/fichero/Views/Settings/SettingsView.swift
+++ b/fichero/fichero/Views/Settings/SettingsView.swift
@@ -53,10 +53,13 @@ struct SettingsView: View {
                     if featureManager.isSettingsEngineTabEnabled || featureManager.isSettingsBackendTabEnabled {
                         row(.engine, "Engine", "square.grid.3x1.below.line.grid.1x2")
                     }
-                    // Library Access group (#3396): Connect + Users + Capture consolidated.
-                    if featureManager.isSettingsShareTabEnabled
-                        || featureManager.isSettingsUsersTabEnabled
-                        || featureManager.isSettingsCaptureTabEnabled {
+                    // Library Access group (#3396): People + Devices (pairing/QR) +
+                    // Capture. Its EXISTENCE must not hang off per-feature migration
+                    // flags — the sharing/QR pane is `.alpha`-tier, so it vanished for
+                    // beta testers and Daniel had "nowhere to turn on the qrcode"
+                    // (#3811/#3776). Show it to internal + tester builds; still hidden
+                    // in release until the fail-closed engine-refusal P0 lands (#3776).
+                    if Self.showsLibraryAccessSettings(tier: featureManager.activeBuildTier) {
                         row(.connect, "Library Access", "lock.shield")
                     }
                 }
@@ -84,6 +87,17 @@ struct SettingsView: View {
     /// `List(selection:)` drives `appState.selectedSettingsTab`.
     private func row(_ tab: SettingsTab, _ title: LocalizedStringKey, _ symbol: String) -> some View {
         Label(title, systemImage: symbol).tag(tab)
+    }
+
+    /// Whether the Library Access pane (People / Devices+QR / Capture) is reachable
+    /// in this build. It holds real, keepable capabilities, so its existence must
+    /// NOT depend on a per-feature migration flag — the `.alpha`-tier
+    /// `settings_share_tab` flag hid the QR from beta testers, which is the whole of
+    /// #3811 ("nowhere to turn on the qrcode"). Visible to internal + tester builds;
+    /// still hidden in release until the fail-closed engine-refusal P0 is verified
+    /// (#3776). When that lands, this gate goes too and the pane is simply always on.
+    static func showsLibraryAccessSettings(tier: FeatureTier) -> Bool {
+        tier != .release
     }
 
     // A flat tab → pane dispatch; its cyclomatic complexity is inherent to the
@@ -337,20 +351,20 @@ private enum LibraryAccessSection: String, CaseIterable, SettingsGroupSection {
 /// (device pairing / QR), Users (people/roles), and Capture (capture permissions)
 /// tabs, consolidated. Reuses each pane unchanged.
 private struct LibraryAccessSettingsView: View {
-    /// Injected by the Settings scene (#3033/#3034) — the panes must not reach
-    /// for the singleton themselves. @EnvironmentObject, not @Environment:
-    /// FeatureManager is @AppStorage-backed and so must stay an
-    /// ObservableObject until #3743 re-backs its flags on UserDefaults.
-    @EnvironmentObject private var featureManager: FeatureManager
     @State private var selection: LibraryAccessSection = .people
 
     private var availableSections: [LibraryAccessSection] {
-        var sections: [LibraryAccessSection] = []
-        if featureManager.isSettingsUsersTabEnabled { sections.append(.people) }
+        // People / Devices (pairing + QR) / Capture are all real, keepable
+        // capabilities (#3776) — the user's control is the sharing toggle inside
+        // Devices, not whether the pane is compiled in. Their existence no longer
+        // hangs off per-feature migration flags, which is what made the QR vanish
+        // for beta testers (#3811). The sidebar row gate
+        // (`SettingsView.showsLibraryAccessSettings`) decides reachability per build.
+        var sections: [LibraryAccessSection] = [.people]
         #if canImport(AppKit)
-        if featureManager.isSettingsShareTabEnabled { sections.append(.devices) }
+        sections.append(.devices)
         #endif
-        if featureManager.isSettingsCaptureTabEnabled { sections.append(.capture) }
+        sections.append(.capture)
         return sections
     }
 


### PR DESCRIPTION
**Why Daniel had 'nowhere to turn on the qrcode':** the sharing/QR pane was gated `.alpha`-tier, so it **vanished for beta testers**. And its existence hung off a per-feature migration flag (`settings_share_tab`) — the exact anti-pattern the UX critique flagged (a Settings pane must not exist-or-not based on a migration counter).

Now the sharing/QR pane (and the Engine settings pane) are **visible to internal + tester builds** — still tier-hidden in the public Release channel — and no longer depend on a per-feature migration flag. Beta testers can find where to share / show the QR.

This is the shareable-build slice of #3811; the deeper 'turn on sharing = ONE action (no Prepare-Certificate step)' refinement stays tracked in #3811/#3776.

## Verification
6 Swift guardrails green. FeatureManagerTests added. **Not built by me** — f_manager owns the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)