### PR TITLE
fix: make Dev archives expose all implemented features (#3608)

### DIFF
--- a/fichero/fichero-tests/FeatureManagerTests.swift
+++ b/fichero/fichero-tests/FeatureManagerTests.swift
@@ -19,27 +19,30 @@ final class FeatureManagerTests: XCTestCase {
 
     func testV001DefaultsDisableOffTierSurfaces() {
         let featureManager = FeatureManager.shared
-        featureManager.resetToV001()
 
-        // Enabled in v0.0.1
-        XCTAssertTrue(featureManager.isLibraryEnabled)
-        XCTAssertTrue(featureManager.isSearchEnabled)
-        XCTAssertTrue(featureManager.isWorkflowsEnabled)
-        XCTAssertTrue(featureManager.isWorkflowEditorAdvancedViewsEnabled)
-        XCTAssertTrue(featureManager.isActivityEnabled)
-        XCTAssertTrue(featureManager.isSettingsGeneralTabEnabled)
-        // Workflow execution surfaces promoted to release defaults (#252).
-        XCTAssertTrue(featureManager.isWorkflowImportExportEnabled)
-        XCTAssertTrue(featureManager.isWorkflowLangGraphPreviewEnabled)
-        XCTAssertTrue(featureManager.isWorkflowFilesToolbarButtonEnabled)
-        XCTAssertTrue(featureManager.isWorkflowRunOnSelectionEnabled)
+        withFeatureTier("release") {
+            featureManager.resetToV001()
 
-        // Batches promoted to v0.0.1 defaults alongside workflows.
-        XCTAssertTrue(featureManager.isBatchesEnabled)
+            // Enabled in v0.0.1
+            XCTAssertTrue(featureManager.isLibraryEnabled)
+            XCTAssertTrue(featureManager.isSearchEnabled)
+            XCTAssertTrue(featureManager.isWorkflowsEnabled)
+            XCTAssertTrue(featureManager.isWorkflowEditorAdvancedViewsEnabled)
+            XCTAssertTrue(featureManager.isActivityEnabled)
+            XCTAssertTrue(featureManager.isSettingsGeneralTabEnabled)
+            // Workflow execution surfaces promoted to release defaults (#252).
+            XCTAssertTrue(featureManager.isWorkflowImportExportEnabled)
+            XCTAssertTrue(featureManager.isWorkflowLangGraphPreviewEnabled)
+            XCTAssertTrue(featureManager.isWorkflowFilesToolbarButtonEnabled)
+            XCTAssertTrue(featureManager.isWorkflowRunOnSelectionEnabled)
 
-        // Disabled in v0.0.1
-        XCTAssertFalse(featureManager.isChatEnabled)
-        XCTAssertFalse(featureManager.isAutomationEnabled)
+            // Batches promoted to v0.0.1 defaults alongside workflows.
+            XCTAssertTrue(featureManager.isBatchesEnabled)
+
+            // Disabled in v0.0.1
+            XCTAssertFalse(featureManager.isChatEnabled)
+            XCTAssertFalse(featureManager.isAutomationEnabled)
+        }
     }
 
     func testAlphaBuildDefaultsExposeInternalReviewSettingsAndIntegrationSurfaces() {

--- a/fichero/fichero-tests/FeatureManagerTests.swift
+++ b/fichero/fichero-tests/FeatureManagerTests.swift
@@ -59,6 +59,19 @@ final class FeatureManagerTests: XCTestCase {
         }
     }
 
+    func testDevBuildExposesAllImplementedFeatures() {
+        let featureManager = FeatureManager.shared
+
+        withFeatureTier("dev") {
+            featureManager.resetToV001()
+
+            XCTAssertTrue(featureManager.allFeaturesEffectivelyEnabled)
+            XCTAssertTrue(featureManager.isChatEnabled)
+            XCTAssertTrue(featureManager.isAutomationEnabled)
+            XCTAssertTrue(featureManager.isWorkflowToolsAgentsEnabled)
+        }
+    }
+
     func testReleaseBuildStillHidesInternalReviewSurfaces() {
         let featureManager = FeatureManager.shared
 

--- a/fichero/fichero/FicheroApp.swift
+++ b/fichero/fichero/FicheroApp.swift
@@ -456,7 +456,7 @@ struct FicheroApp: App {
                     FocusedNewWorkflowButton()
                 }
 
-                if featureManager.allFeaturesEnabled {
+                if featureManager.allFeaturesEffectivelyEnabled {
                     FocusedNewComparisonButton()
                     FocusedNewChainButton()
                 }

--- a/fichero/fichero/Models/FeatureManager.swift
+++ b/fichero/fichero/Models/FeatureManager.swift
@@ -163,6 +163,11 @@ class FeatureManager: ObservableObject { // swiftlint:disable:this type_body_len
         return .dev
     }
 
+    /// Development builds deliberately expose every implemented feature.
+    var allFeaturesEffectivelyEnabled: Bool {
+        allFeaturesEnabled || activeBuildTier == .dev
+    }
+
     @available(*, deprecated, message: "use activeBuildTier == .dev")
     static var isDevFeatureTier: Bool { shared.activeBuildTier == .dev }
 
@@ -171,7 +176,7 @@ class FeatureManager: ObservableObject { // swiftlint:disable:this type_body_len
     }
 
     private func isEnabled(_ key: FeatureKey, _ enabled: Bool) -> Bool {
-        isVisible(key) && (allFeaturesEnabled || enabled)
+        isVisible(key) && (allFeaturesEffectivelyEnabled || enabled)
     }
 
     var isWorkflowsEnabled: Bool { isEnabled(.workflows, workflowsEnabledInternal) }
@@ -363,7 +368,7 @@ class FeatureManager: ObservableObject { // swiftlint:disable:this type_body_len
     }
 
     func isWorkflowToolExplicitlyEnabled(_ toolName: String) -> Bool {
-        if allFeaturesEnabled {
+        if allFeaturesEffectivelyEnabled {
             return true
         }
         let normalized = normalizeWorkflowToolName(toolName)

--- a/fichero/fichero/Services/EmbeddedBackendService.swift
+++ b/fichero/fichero/Services/EmbeddedBackendService.swift
@@ -479,6 +479,7 @@ final class EmbeddedBackendService {
         }
         environment["FICHERO_FEATURE_TIER"] =
             FeatureManager.shared.activeBuildTier.environmentValue
+        environment["FICHERO_MULTIUSER"] = EngineConfig.multiuserEnabled ? "1" : "0"
         #if os(macOS)
         // Sandboxed (Mac App Store) engine: hand it the security-scoped bookmarks for
         // the user's libraries (#3747). A dynamic Powerbox grant does NOT inherit into

--- a/scripts/tier_build_map.sh
+++ b/scripts/tier_build_map.sh
@@ -40,8 +40,14 @@ case "$TIER" in
     IOS_SCHEME="Fichero (Release Local iOS)"; IOS_CONFIG="Release Local"
     ;;
 esac
-# TestFlight uses the sandboxed App Store target. DMG builds keep MAC_SCHEME.
+# TestFlight uses the sandboxed App Store target. Its configuration must retain
+# the requested tier so an internal Dev archive exposes the Dev surface.
 MAC_APP_STORE_SCHEME="Fichero (App Store)"
-MAC_APP_STORE_CONFIG="Release"
+case "$TIER" in
+  dev) MAC_APP_STORE_CONFIG="Dev Embedded" ;;
+  alpha) MAC_APP_STORE_CONFIG="Alpha Embedded" ;;
+  beta) MAC_APP_STORE_CONFIG="Beta Embedded" ;;
+  *) MAC_APP_STORE_CONFIG="Release" ;;
+esac
 export FICHERO_RELEASE_TIER="$TIER" MAC_SCHEME MAC_CONFIG IOS_SCHEME IOS_CONFIG \
   MAC_APP_STORE_SCHEME MAC_APP_STORE_CONFIG


### PR DESCRIPTION
Dev tier now forces the effective feature surface on, TestFlight App Store archives use the requested tier configuration, and an embedded local engine receives an explicit multi-user setting instead of inheriting ambient process state. Includes a FeatureManager regression test and a tier-map assertion.