### PR TITLE
feat(kg): wire external-authority settings into the Inspector via the store (#3757)

### DIFF
--- a/fichero/fichero-tests/EntityStoreTests.swift
+++ b/fichero/fichero-tests/EntityStoreTests.swift
@@ -375,6 +375,63 @@ final class EntityStoreTests: XCTestCase {
         XCTAssertEqual(store.entities.map(\.canonicalName), ["Beta"])
     }
 
+    func testAuthoritySettingsLoadAndToggleFlowThroughTheStore() async throws {
+        // #3757 — the store is the only endpoint accessor: GET reflects the
+        // persisted setting into the observable flag, PUT advances it to
+        // exactly what the backend returns.
+        MockFicheroURLProtocol.configure(
+            responses: [
+                .init(
+                    method: "GET", path: "/api/kg/entity-curation/authority/settings",
+                    statusCode: 200,
+                    body: Data(#"{"external_authority_enabled": true}"#.utf8)
+                ),
+                .init(
+                    method: "PUT", path: "/api/kg/entity-curation/authority/settings",
+                    statusCode: 200,
+                    body: Data(#"{"external_authority_enabled": false}"#.utf8)
+                )
+            ]
+        )
+
+        let store = makeStore()
+        XCTAssertFalse(store.externalAuthorityEnabled)
+
+        await store.loadAuthoritySettings()
+        XCTAssertTrue(store.externalAuthorityEnabled)
+        XCTAssertNil(store.authoritySettingsError)
+
+        try await store.setExternalAuthorityEnabled(false)
+        XCTAssertFalse(store.externalAuthorityEnabled)
+
+        let requests = MockFicheroURLProtocol.recordedRequests()
+        XCTAssertTrue(requests.contains {
+            $0.httpMethod == "GET" && $0.url?.path == "/api/kg/entity-curation/authority/settings"
+        })
+        XCTAssertTrue(requests.contains {
+            $0.httpMethod == "PUT" && $0.url?.path == "/api/kg/entity-curation/authority/settings"
+        })
+    }
+
+    func testAuthoritySettingsLoadFailurePublishesErrorAndLeavesFlagUnchanged() async throws {
+        // A failed probe must fail soft: keep the last-known flag and surface
+        // the error, never flip the setting on a transport failure (#3757).
+        MockFicheroURLProtocol.configure(
+            responses: [
+                .init(
+                    method: "GET", path: "/api/kg/entity-curation/authority/settings",
+                    statusCode: 500, body: Data()
+                )
+            ]
+        )
+
+        let store = makeStore()
+        await store.loadAuthoritySettings()
+
+        XCTAssertFalse(store.externalAuthorityEnabled)
+        XCTAssertNotNil(store.authoritySettingsError)
+    }
+
     private func makeStore() -> EntityStore {
         let client = FicheroClient(baseURL: URL(string: "https://127.0.0.1:8765")!, libraryPath: "/tmp/test.fichero")
         let entityService = EntityServiceGenerated(ficheroClient: client)

--- a/fichero/fichero/Models/EntityStore.swift
+++ b/fichero/fichero/Models/EntityStore.swift
@@ -393,6 +393,37 @@ final class EntityStore: ObservableDomainStore {
         }
     }
 
+    // MARK: - External authority curation (#3757)
+
+    /// Whether external authority linking (Wikidata / VIAF / LoC) is enabled for
+    /// this library. Views observe this; the store is the only endpoint accessor
+    /// (observable-data-layer, #1863) — a view never calls the curation service
+    /// directly.
+    private(set) var externalAuthorityEnabled = false
+    private(set) var isLoadingAuthoritySettings = false
+    private(set) var authoritySettingsError: String?
+
+    /// Load the external-authority setting from the backend. Fails soft: on
+    /// error the flag stays at its last value and the error is published for
+    /// the view to surface.
+    func loadAuthoritySettings() async {
+        isLoadingAuthoritySettings = true
+        authoritySettingsError = nil
+        defer { isLoadingAuthoritySettings = false }
+        do {
+            externalAuthorityEnabled = try await kgCurationService.externalAuthorityEnabled()
+        } catch {
+            authoritySettingsError = "Couldn't load authority settings: \(error.localizedDescription)"
+        }
+    }
+
+    /// Enable/disable external authority linking, then reflect the persisted
+    /// value the backend returns. Throws so the calling view can surface a
+    /// precise message; the observable flag is only advanced on success.
+    func setExternalAuthorityEnabled(_ enabled: Bool) async throws {
+        externalAuthorityEnabled = try await kgCurationService.setExternalAuthorityEnabled(enabled)
+    }
+
     // MARK: - ChangeEventConsumer (called by LibraryChangeStream, NOT by views)
 
     nonisolated var changeDomain: String { "entity" }

--- a/fichero/fichero/Services/ArtifactServiceGenerated.swift
+++ b/fichero/fichero/Services/ArtifactServiceGenerated.swift
@@ -2412,6 +2412,45 @@ final class KGCurationServiceGenerated {
         }
     }
 
+    // MARK: - External authority curation (#3757)
+
+    /// GET /api/kg/entity-curation/authority/settings — whether external
+    /// authority linking (Wikidata / VIAF / LoC) is enabled for this library.
+    /// The setting defaults off, so an absent flag reads as `false`.
+    func externalAuthorityEnabled() async throws -> Bool {
+        let response = try await client.api
+            .getExternalAuthoritySettingsApiKgEntityCurationAuthoritySettingsGet()
+
+        switch response {
+        case .ok(let okResponse):
+            return try okResponse.body.json.externalAuthorityEnabled ?? false
+        case .undocumented(let code, _):
+            kgCurationServiceLogger.error("externalAuthorityEnabled unexpected response: \(code)")
+            throw ServiceError.unexpectedResponse(code)
+        }
+    }
+
+    /// PUT /api/kg/entity-curation/authority/settings — enable/disable external
+    /// authority linking. Returns the persisted value so the store reflects
+    /// exactly what the backend stored.
+    @discardableResult
+    func setExternalAuthorityEnabled(_ enabled: Bool) async throws -> Bool {
+        let body = Components.Schemas.ExternalAuthoritySettings(externalAuthorityEnabled: enabled)
+        let response = try await client.api
+            .putExternalAuthoritySettingsApiKgEntityCurationAuthoritySettingsPut(body: .json(body))
+
+        switch response {
+        case .ok(let okResponse):
+            return try okResponse.body.json.externalAuthorityEnabled ?? false
+        case .unprocessableContent(let error):
+            let detail = try? error.body.json
+            throw ServiceError.validationError(detail?.detail?.description ?? "Validation error")
+        case .undocumented(let code, _):
+            kgCurationServiceLogger.error("setExternalAuthorityEnabled unexpected response: \(code)")
+            throw ServiceError.unexpectedResponse(code)
+        }
+    }
+
     func listClaimRules() async throws -> [Components.Schemas.ClaimRuleReadResponse] {
         let response = try await client.api.listClaimRulesApiKgCurationRulesClaimRulesGet()
 

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/OntologyBrowser+Toolbar.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/OntologyBrowser+Toolbar.swift
@@ -112,6 +112,22 @@ extension OntologyBrowser {
             } label: {
                 Label("Generate suggested links (heuristic)", systemImage: "wand.and.stars")
             }
+            Divider()
+            // #3757 — enable/disable external authority linking (Wikidata /
+            // VIAF / LoC). Library-wide setting, so it lives in the KG tools
+            // menu; the store owns the endpoint call (observable-data-layer).
+            Toggle("Link entities to external authorities", isOn: Binding(
+                get: { entityStore.externalAuthorityEnabled },
+                set: { newValue in
+                    Task {
+                        do {
+                            try await entityStore.setExternalAuthorityEnabled(newValue)
+                        } catch {
+                            toolStatus = "Failed: \(error.localizedDescription)"
+                        }
+                    }
+                }
+            ))
         } label: {
             Image(systemName: "wrench.and.screwdriver")
         }
@@ -119,6 +135,9 @@ extension OntologyBrowser {
         .menuIndicator(.hidden)
         .fixedSize()
         .help("Knowledge graph tools")
+        // Load the current authority setting when the browser appears (the
+        // toolbar is always mounted, so `.task` here fires on browser open).
+        .task { await entityStore.loadAuthoritySettings() }
     }
 
     /// Filter menu — Tinderbox-style 'displayed attributes' picker,

--- a/scripts/check_endpoint_usage.py
+++ b/scripts/check_endpoint_usage.py
@@ -35,6 +35,7 @@ HTTP_METHODS = {"get", "put", "post", "delete", "patch", "head", "options", "tra
 # Current baseline. The script exits 0 while every unused/asymmetric endpoint is
 # listed here and exits 1 when a new gap appears.
 KNOWN_GAPS: dict[str, str] = {
+    'GET /api/entities/digest': "CLI/engine-only: the app renders the entity digest via the WebKit document view, not this endpoint; the dead Swift entityDigest() wrapper was removed in #3765.",
     'DELETE /api/chains/executions/{execution_id}': "#1920 baseline - cli-only",
     'DELETE /api/folders/{entity_type}/folders': "#1920 baseline - cli-only",
     'DELETE /api/library/links/{link_id}': "#1920 baseline - cli-only",
@@ -62,7 +63,6 @@ KNOWN_GAPS: dict[str, str] = {
     'POST /api/registry/unicode-collisions/merge': "#1920 baseline - cli-only",
     'PUT /api/folders/{entity_type}/folders': "#1920 baseline - cli-only",
     'PUT /api/folders/{entity_type}/move': "#1920 baseline - cli-only",
-    'PUT /api/kg/entity-curation/authority/settings': "engine-side authority curation; Inspector wiring tracked in #3757",
     'PUT /api/schedules/{schedule_id}': "#1920 baseline - cli-only",
     'PUT /api/triggers/{trigger_id}': "#1920 baseline - cli-only",
     'POST /api/agent-memory': "#2152 agent memory - cli-only (SwiftUI deferred)",
@@ -161,7 +161,6 @@ KNOWN_GAPS: dict[str, str] = {
     'POST /api/kg/interpretations/patterns/{pattern_id}/claims/{claim_id}': "#3299 hermeneutics engine/CLI surface; SwiftUI deferred",
     'POST /api/kg/interpretations/suggestions': "#3299 hermeneutics engine/CLI surface; SwiftUI deferred",
     'GET /api/kg/review/summary': "#1920 baseline - cli-only",
-    'GET /api/kg/entity-curation/authority/settings': "engine-side authority curation; Inspector wiring tracked in #3757",
     'POST /api/kg/entity-curation/authority/link': "engine-side authority curation; Inspector wiring tracked in #3757",
     'POST /api/kg/entity-curation/authority/refresh': "engine-side authority curation; Inspector wiring tracked in #3757",
     'POST /api/local-inference/profiles/validate': "#1814 backend local-MLX control surface; Mac/SwiftUI wiring deferred",


### PR DESCRIPTION
The engine's entity **authority-curation settings** endpoints (GET/PUT /api/kg/entity-curation/authority/settings) existed but the app couldn't reach them. Now wired into the Knowledge inspector through **EntityStore** (observable-data-layer: the store is the only endpoint accessor — the view observes it, never calls the client directly). A toolbar entry in OntologyBrowser surfaces it; a store test covers load + toggle.

Baseline reconciled: the two now-wired authority/settings entries removed from endpoint-usage KNOWN_GAPS; GET /api/entities/digest added as CLI/engine-only (app renders the digest via the WebKit view; the dead entityDigest() wrapper was removed in #3765).

The authority **link/refresh** endpoints remain the worker's next slice.

## Verification
9 guardrails green incl. check_endpoint_usage. Store test added (auto-synced target). **Not built by me** — f_manager owns the lock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)