### PR TITLE
fix: decode RTF ansicpg codepage escapes (#3810)

### DIFF
--- a/fichero-engine/src/fichero/loaders/document_loader.py
+++ b/fichero-engine/src/fichero/loaders/document_loader.py
@@ -52,6 +52,7 @@ _RTF_SKIP_GROUP_WORDS = frozenset(
 
 # Matches RTF hex-escape sequences: \'XX where XX are two hex digits.
 _RTF_HEX_FULL_RE = re.compile(r"\\'([0-9a-fA-F]{2})")
+_RTF_HEX_RUN_RE = re.compile(r"(?:\\'[0-9a-fA-F]{2})+")
 _RTF_UNICODE_RE = re.compile(r"\\u(-?\d+)\?")
 
 
@@ -85,7 +86,19 @@ def _strip_rtf(text: str) -> str:
         return chr(value if value >= 0 else value + 65536)
 
     stripped = _RTF_UNICODE_RE.sub(_decode_unicode, stripped)
-    stripped = _RTF_HEX_FULL_RE.sub(_decode_rtf_hex_byte, stripped)
+    codepage = re.search(r"\\ansicpg(\d+)", stripped)
+    encoding = f"cp{codepage.group(1)}" if codepage else "cp1252"
+
+    def _decode_hex_run(match: "re.Match[str]") -> str:
+        raw = bytes(int(value, 16) for value in _RTF_HEX_FULL_RE.findall(match.group()))
+        try:
+            return raw.decode(encoding)
+        except LookupError:
+            return raw.decode("cp1252", errors="replace")
+        except UnicodeDecodeError:
+            return raw.decode(encoding, errors="replace")
+
+    stripped = _RTF_HEX_RUN_RE.sub(_decode_hex_run, stripped)
 
     output: list[str] = []
     # skip_until_depth > 0: skip content until depth drops below this value.

--- a/fichero-engine/tests/unit/test_rtf_accent_decode.py
+++ b/fichero-engine/tests/unit/test_rtf_accent_decode.py
@@ -54,6 +54,10 @@ def test_unicode_escapes(body, expected):
     assert expected in _strip_rtf(make_rtf(body))
 
 
+def test_ansicpg_multibyte_escapes():
+    assert "中文" in _strip_rtf(r"{\rtf1\ansi\ansicpg936 \'d6\'d0\'ce\'c4}")
+
+
 def test_word_with_multiple_accents():
     # "actu\'f3 como notario" → "actuó como notario"
     rtf = make_rtf(r"actu\'f3 como notario")


### PR DESCRIPTION
RTF `\'XX` hex escapes now decode via the document's **declared `\ansicpg` codepage** (e.g. cp936 for Chinese) instead of always cp1252 — non-Latin scribal/OCR text decodes correctly. Falls back to cp1252 when no codepage is declared. 47 loader/RTF tests pass.

**#3810 stays OPEN** for the last piece: a Reader-side defensive strip so no rendering path can show raw RTF. Engine-only; not built by me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)