### PR TITLE
chore: record entity digest native wiring scope

### DIFF
--- a/fichero-engine/tests/contracts/ui_wiring_allowlist_swiftui.json
+++ b/fichero-engine/tests/contracts/ui_wiring_allowlist_swiftui.json
@@ -30,6 +30,7 @@
   "/api/documents/{doc_id}/page-ranges/at/{page}": "backend #1377 prototypes / #1378 page-ranges; SwiftUI surfacing tracked as doc-prototypes/page-range UI backlog",
   "/api/documents/{doc_id}/purge": "#2075 backend; UI tracked in #2077",
   "/api/documents/{doc_id}/related": "baseline: not yet wired",
+  "/api/entities/digest": "WebKit document view consumes the digest; no native Swift call site (#3765)",
   "/api/entities/{entity_id}/export": "engine half of #3703; Swift drag-export wiring pending in the same issue - remove this entry when the Swift side calls it",
   "/api/documents/{document_id}/outline": "#3398 retired document-inspector Outline tab; endpoint remains CLI/engine-only unless a new outline UX is designed",
   "/api/export/excel": "binary .xlsx download via a direct authenticated URL, not the typed generated client",

--- a/scripts/check_endpoint_coverage_matrix_known_gaps.json
+++ b/scripts/check_endpoint_coverage_matrix_known_gaps.json
@@ -108,6 +108,7 @@
   "GET /api/documents/{document_id}/outline": "store missing",
   "GET /api/entities/alias-map": "store missing",
   "GET /api/entities/claim-counts": "store missing",
+  "GET /api/entities/digest": "WebKit document view consumes the digest; no native Swift store surface (#3765)",
   "GET /api/entities/{entity_id}/export": "engine half of #3703; Swift drag-export wiring pending in the same issue",
   "GET /api/folders/{entity_type}/folders": "store missing",
   "GET /api/folders/{folder_id}/views": "store missing",


### PR DESCRIPTION
Documents the intentional WebKit-only entity digest surface in both endpoint wiring guardrails. No production behavior change.