### PR TITLE
feat(kg): wire authority link/refresh through EntityStore (#3757 remainder)

### DIFF
--- a/fichero/fichero-tests/EntityStoreTests.swift
+++ b/fichero/fichero-tests/EntityStoreTests.swift
@@ -432,6 +432,80 @@ final class EntityStoreTests: XCTestCase {
         XCTAssertNotNil(store.authoritySettingsError)
     }
 
+    func testParseAuthorityCandidatesKeepsCompleteItemsAndDropsIncomplete() {
+        // #3757 — the `items` envelope is freeform; parse defensively. An item
+        // missing the required authority / id / label is dropped, not crashed.
+        let data = Data(#"""
+        {"items":[
+          {"authority":"wikidata","authority_id":"Q42","label":"Douglas Adams","description":"author","source_url":"https://wd/Q42"},
+          {"authority":"viaf","authority_id":"113230702","label":"Adams, Douglas"},
+          {"authority":"loc"}
+        ],"count":3}
+        """#.utf8)
+
+        let candidates = EntityStore.parseAuthorityCandidates(data)
+        XCTAssertEqual(candidates.map(\.id), ["wikidata|Q42", "viaf|113230702"])
+        XCTAssertEqual(candidates.first?.label, "Douglas Adams")
+        XCTAssertEqual(candidates.first?.description, "author")
+        XCTAssertEqual(candidates.first?.sourceURL, "https://wd/Q42")
+        XCTAssertNil(candidates.last?.description)
+    }
+
+    func testAuthorityRefreshAndLinkFlowThroughTheStore() async throws {
+        // #3757 — the store is the only endpoint accessor: refresh returns
+        // parsed candidates; link posts and succeeds on a 2xx.
+        MockFicheroURLProtocol.configure(
+            responses: [
+                .init(
+                    method: "POST", path: "/api/kg/entity-curation/authority/refresh",
+                    statusCode: 200,
+                    body: Data(#"{"items":[{"authority":"wikidata","authority_id":"Q42","label":"Douglas Adams"}],"count":1}"#.utf8)
+                ),
+                .init(
+                    method: "POST", path: "/api/kg/entity-curation/authority/link",
+                    statusCode: 200,
+                    body: Data("{}".utf8)
+                )
+            ]
+        )
+
+        let store = makeStore()
+
+        let candidates = try await store.refreshAuthorityCandidates(query: "Douglas Adams")
+        XCTAssertEqual(candidates.map(\.id), ["wikidata|Q42"])
+
+        try await store.linkAuthority(entityId: "entity-1", authority: "wikidata", authorityId: "Q42")
+
+        let requests = MockFicheroURLProtocol.recordedRequests()
+        XCTAssertTrue(requests.contains {
+            $0.httpMethod == "POST" && $0.url?.path == "/api/kg/entity-curation/authority/refresh"
+        })
+        XCTAssertTrue(requests.contains {
+            $0.httpMethod == "POST" && $0.url?.path == "/api/kg/entity-curation/authority/link"
+        })
+    }
+
+    func testAuthorityLinkPropagatesBackendFailure() async throws {
+        // A non-2xx link must throw so the sheet surfaces it — never a silent
+        // success (#3757).
+        MockFicheroURLProtocol.configure(
+            responses: [
+                .init(
+                    method: "POST", path: "/api/kg/entity-curation/authority/link",
+                    statusCode: 404, body: Data()
+                )
+            ]
+        )
+
+        let store = makeStore()
+        do {
+            try await store.linkAuthority(entityId: "missing", authority: "wikidata", authorityId: "Q42")
+            XCTFail("Expected linkAuthority to throw on a 404")
+        } catch {
+            // expected
+        }
+    }
+
     private func makeStore() -> EntityStore {
         let client = FicheroClient(baseURL: URL(string: "https://127.0.0.1:8765")!, libraryPath: "/tmp/test.fichero")
         let entityService = EntityServiceGenerated(ficheroClient: client)

--- a/fichero/fichero/Models/EntityStore.swift
+++ b/fichero/fichero/Models/EntityStore.swift
@@ -19,6 +19,20 @@ struct EntityReconciliationCandidate: Identifiable, Hashable {
     var id: String { "\(entityAId)|\(entityBId)" }
 }
 
+/// One external-authority match (#3757) from
+/// `/api/kg/entity-curation/authority/refresh` — a *locally cached* snapshot
+/// (Wikidata / VIAF / LoC) the user can link to an entity. Never a live lookup
+/// at render time; the refresh call is the only outbound step.
+struct AuthorityCandidate: Identifiable, Hashable {
+    let authority: String
+    let authorityId: String
+    let label: String
+    let description: String?
+    let sourceURL: String?
+
+    var id: String { "\(authority)|\(authorityId)" }
+}
+
 /// Observable domain store for knowledge entities (#1885, keystone template).
 ///
 /// The single endpoint accessor for the entity list a view renders. A view
@@ -422,6 +436,46 @@ final class EntityStore: ObservableDomainStore {
     /// precise message; the observable flag is only advanced on success.
     func setExternalAuthorityEnabled(_ enabled: Bool) async throws {
         externalAuthorityEnabled = try await kgCurationService.setExternalAuthorityEnabled(enabled)
+    }
+
+    /// Refresh (fetch + cache) external-authority candidates matching `query`
+    /// (#3757). The store is the only endpoint accessor; the link sheet reads
+    /// the returned candidates. Throws so the view can surface the failure —
+    /// notably a 403 when external authority linking is disabled.
+    func refreshAuthorityCandidates(query: String, limit: Int = 10) async throws -> [AuthorityCandidate] {
+        let data = try await entityService.refreshAuthoritySnapshots(query: query, limit: limit)
+        return Self.parseAuthorityCandidates(data)
+    }
+
+    /// Parse the `{ items: [...], count }` authority envelope. The OpenAPI
+    /// `items` schema is freeform, so parse defensively — an item missing the
+    /// required authority / id / label is dropped. Pure + exposed for tests.
+    static func parseAuthorityCandidates(_ data: Data) -> [AuthorityCandidate] {
+        guard let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let items = obj["items"] as? [[String: Any]] else { return [] }
+        return items.compactMap { item -> AuthorityCandidate? in
+            guard let authority = item["authority"] as? String,
+                  let authorityId = item["authority_id"] as? String,
+                  let label = item["label"] as? String else { return nil }
+            return AuthorityCandidate(
+                authority: authority,
+                authorityId: authorityId,
+                label: label,
+                description: item["description"] as? String,
+                sourceURL: item["source_url"] as? String
+            )
+        }
+    }
+
+    /// Link `entityId` to a previously refreshed authority snapshot (#3757).
+    /// Throws so the sheet can surface a precise message; a non-throwing call is
+    /// success.
+    func linkAuthority(entityId: String, authority: String, authorityId: String) async throws {
+        _ = try await entityService.linkAuthority(
+            entityId: entityId,
+            authority: authority,
+            authorityId: authorityId
+        )
     }
 
     // MARK: - ChangeEventConsumer (called by LibraryChangeStream, NOT by views)

--- a/fichero/fichero/Services/ArtifactServiceGenerated.swift
+++ b/fichero/fichero/Services/ArtifactServiceGenerated.swift
@@ -594,6 +594,30 @@ final class EntityServiceGenerated {
         )
     }
 
+    /// POST /api/kg/entity-curation/authority/refresh (#3757) — fetch and cache
+    /// external-authority snapshots (Wikidata / VIAF / LoC) matching `query`.
+    /// Returns the raw `{ items, count }` envelope; the store parses it. This is
+    /// the only opt-in outbound-network call — refresh is always explicit.
+    func refreshAuthoritySnapshots(query: String, limit: Int = 10) async throws -> Data {
+        try await endpointData(
+            path: "/api/kg/entity-curation/authority/refresh",
+            method: "POST",
+            jsonBody: ["query": query, "limit": limit]
+        )
+    }
+
+    /// POST /api/kg/entity-curation/authority/link (#3757) — persist an
+    /// entity→authority link from a previously refreshed snapshot. Returns the
+    /// raw audit envelope; the store treats a non-throwing call as success.
+    @discardableResult
+    func linkAuthority(entityId: String, authority: String, authorityId: String) async throws -> Data {
+        try await endpointData(
+            path: "/api/kg/entity-curation/authority/link",
+            method: "POST",
+            jsonBody: ["entity_id": entityId, "authority": authority, "authority_id": authorityId]
+        )
+    }
+
     /// Merge multiple entities into a single absorbing entity with audit.
     /// Backed by `/api/kg/entity-curation/merge`.
     func mergeEntities(

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView+Metadata.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView+Metadata.swift
@@ -1,5 +1,6 @@
 import FicheroAPIClient
 import Foundation
+import SwiftUI
 
 // MARK: - Raw metadata JSON editing
 
@@ -71,6 +72,148 @@ extension EntityDetailView {
             return nil as String?
         default:
             return nil
+        }
+    }
+
+    /// #3757 — header affordance that opens the external-authority link sheet.
+    /// Lives on the extension (not the main struct body) so the entity detail
+    /// view stays under its type-body budget; authority links are metadata,
+    /// which is why this sits with the metadata editor.
+    var authorityLinkButton: some View {
+        Button {
+            showAuthorityLinkSheet = true
+        } label: {
+            Label("Link authority", systemImage: "link.badge.plus")
+                .font(.caption)
+        }
+        .buttonStyle(.bordered)
+        .disabled(entity.id == nil)
+        .help("Link this entity to an external authority (Wikidata, VIAF, Library of Congress)")
+    }
+}
+
+// MARK: - External authority link (#3757)
+
+/// Search external authorities (Wikidata / VIAF / LoC) and link one to this
+/// entity. All endpoint access goes through `EntityStore` (observable-data-
+/// layer): this sheet only reads the returned candidates and dispatches the
+/// refresh/link actions — it never calls a service directly. Authority links
+/// live in the entity's metadata (`authority_links`), which is why this sits
+/// alongside the metadata editor.
+struct EntityAuthorityLinkSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let entity: Components.Schemas.KnowledgeEntity
+    let entityStore: EntityStore
+
+    @State private var query: String
+    @State private var candidates: [AuthorityCandidate] = []
+    @State private var isSearching = false
+    @State private var statusMessage: String?
+    @State private var linkedIds: Set<String> = []
+
+    init(entity: Components.Schemas.KnowledgeEntity, entityStore: EntityStore) {
+        self.entity = entity
+        self.entityStore = entityStore
+        _query = State(initialValue: entity.canonicalName)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Link to external authority")
+                .font(.headline)
+            Text("Search Wikidata, VIAF, and the Library of Congress, then link a record to “\(entity.canonicalName)”.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack {
+                TextField("Search term", text: $query)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit { Task { await search() } }
+                Button("Search") { Task { await search() } }
+                    .disabled(query.trimmingCharacters(in: .whitespaces).isEmpty || isSearching)
+            }
+
+            if isSearching {
+                ProgressView().frame(maxWidth: .infinity)
+            } else if let statusMessage {
+                Text(statusMessage)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            List(candidates) { candidate in
+                candidateRow(candidate)
+            }
+            .frame(minHeight: 200)
+
+            HStack {
+                Spacer()
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 520, height: 460)
+    }
+
+    @ViewBuilder
+    private func candidateRow(_ candidate: AuthorityCandidate) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(candidate.label).font(.body)
+                Text("\(candidate.authority.uppercased()) · \(candidate.authorityId)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let description = candidate.description, !description.isEmpty {
+                    Text(description)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+            Spacer()
+            if linkedIds.contains(candidate.id) {
+                Label("Linked", systemImage: "checkmark.circle.fill")
+                    .labelStyle(.iconOnly)
+                    .foregroundStyle(.green)
+            } else {
+                Button("Link") { Task { await link(candidate) } }
+            }
+        }
+    }
+
+    private func search() async {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        isSearching = true
+        statusMessage = nil
+        defer { isSearching = false }
+        do {
+            candidates = try await entityStore.refreshAuthorityCandidates(query: trimmed)
+            if candidates.isEmpty {
+                statusMessage = "No authority records found for “\(trimmed)”."
+            }
+        } catch {
+            candidates = []
+            statusMessage = "Search failed: \(error.localizedDescription)"
+        }
+    }
+
+    private func link(_ candidate: AuthorityCandidate) async {
+        guard let entityId = entity.id else {
+            statusMessage = "This entity has no id yet — save it before linking."
+            return
+        }
+        do {
+            try await entityStore.linkAuthority(
+                entityId: entityId,
+                authority: candidate.authority,
+                authorityId: candidate.authorityId
+            )
+            linkedIds.insert(candidate.id)
+        } catch {
+            statusMessage = "Link failed: \(error.localizedDescription)"
         }
     }
 }

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/EntityDetailView.swift
@@ -103,6 +103,10 @@ struct EntityDetailView: View {
     @State var metadataSaveMessage: String?
     @State var isSavingMetadata = false
     @State private var showDigestSheet = false
+    /// #3757 — external-authority (Wikidata / VIAF / LoC) search-and-link sheet.
+    /// Internal (not private) so the header button in the +Metadata extension
+    /// can drive it.
+    @State var showAuthorityLinkSheet = false
     @State var showContradictionTriageSheet = false
     @State var showClaimReviewQueueSheet = false
 
@@ -286,6 +290,8 @@ struct EntityDetailView: View {
                 }
                 .buttonStyle(.bordered)
                 .help("Every subject-verb-object statement we know about this entity")
+
+                authorityLinkButton
             }
 
             if let description = cleanedDisplayText(entity.description) {
@@ -316,6 +322,9 @@ struct EntityDetailView: View {
             EntityDigestContent(entity: entity, entityService: entityService)
                 .frame(minWidth: 780, minHeight: 560)
                 .padding(20)
+        }
+        .sheet(isPresented: $showAuthorityLinkSheet) {
+            EntityAuthorityLinkSheet(entity: entity, entityStore: entityStore)
         }
     }
 }

--- a/scripts/check_endpoint_usage.py
+++ b/scripts/check_endpoint_usage.py
@@ -161,8 +161,6 @@ KNOWN_GAPS: dict[str, str] = {
     'POST /api/kg/interpretations/patterns/{pattern_id}/claims/{claim_id}': "#3299 hermeneutics engine/CLI surface; SwiftUI deferred",
     'POST /api/kg/interpretations/suggestions': "#3299 hermeneutics engine/CLI surface; SwiftUI deferred",
     'GET /api/kg/review/summary': "#1920 baseline - cli-only",
-    'POST /api/kg/entity-curation/authority/link': "engine-side authority curation; Inspector wiring tracked in #3757",
-    'POST /api/kg/entity-curation/authority/refresh': "engine-side authority curation; Inspector wiring tracked in #3757",
     'POST /api/local-inference/profiles/validate': "#1814 backend local-MLX control surface; Mac/SwiftUI wiring deferred",
     'POST /api/local-inference/profiles/{profile_id}/health': "#1814 backend local-MLX control surface; Mac/SwiftUI wiring deferred",
     'GET /api/settings/model-profiles': "#2058 backend model-profile API; Settings UI/store wiring deferred",


### PR DESCRIPTION
Completes #3757: POST /api/kg/entity-curation/authority/link and /refresh now wired into the Inspector via EntityStore (store is the only endpoint accessor). Their KNOWN_GAPS baseline entries dropped by the worker — check_endpoint_usage green. All authority-curation endpoints now reachable from the app. Guardrails green. Not built by me.