### PR TITLE
fix(settings): remove the collapsible sidebar toggle (#3812)

### DIFF
--- a/fichero/fichero/Views/Settings/SettingsView.swift
+++ b/fichero/fichero/Views/Settings/SettingsView.swift
@@ -76,6 +76,12 @@ struct SettingsView: View {
             }
             .navigationTitle("Settings")
             .navigationSplitViewColumnWidth(min: 200, ideal: 220, max: 280)
+            // The section list is the only navigation between panes, and this view
+            // deliberately mimics macOS System Settings — whose source list is never
+            // collapsible. Drop the automatic sidebar-toggle so the list can't be
+            // hidden into a navigation dead end (#3812). Scoped to this split view,
+            // so the main window's sidebar toggle is untouched.
+            .toolbar(removing: .sidebarToggle)
         } detail: {
             detail(for: appState.selectedSettingsTab)
         }


### PR DESCRIPTION
Judgment call, reported: the Settings section list should NOT be collapsible — SettingsView deliberately mimics macOS System Settings (#3679), whose source list is never collapsible. The auto NavigationSplitView sidebar toggle was inconsistent with that. Removed. Guardrails green. Not built by me (f_manager owns the lock).