### PR TITLE
feat(library): wire library-item column metadata through DocumentStore (#3758)

### DIFF
--- a/fichero/fichero-tests/DocumentStoreAndSidebarTypesTests.swift
+++ b/fichero/fichero-tests/DocumentStoreAndSidebarTypesTests.swift
@@ -1,4 +1,5 @@
 @testable import Fichero
+import FicheroAPIClient
 import Foundation
 import XCTest
 
@@ -68,6 +69,61 @@ final class DocumentStoreAndSidebarTypesTests: XCTestCase {
         XCTAssertTrue(source.contains("documentService.getRoots()"))
         XCTAssertFalse(source.contains("api.get(\"/documents\""))
         XCTAssertFalse(source.contains("api.post(\"/documents\""))
+    }
+
+    // MARK: - Batch library-item column metadata (#3758)
+
+    /// Test seam: a DocumentStore whose generated client is bound to a stubbed
+    /// URLProtocol session, so `libraryItemColumns` exercises the real
+    /// request/response mapping without a live engine.
+    private static func makeStubbedStore() -> DocumentStore {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ColumnsStubURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let client = FicheroClient(
+            baseURL: URL(string: "https://test.fichero")!,
+            libraryPath: "/tmp/test.fichero",
+            session: session
+        )
+        return DocumentStore(apiClient: APIClient(client: client))
+    }
+
+    func testLibraryItemColumnsReturnsRowsFromBackendThroughTheStore() async throws {
+        // The store is the only endpoint accessor: it POSTs the item ids and
+        // returns the parsed per-item rows.
+        ColumnsStubURLProtocol.handler = { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.path, "/api/library-items/columns")
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            return (response, Data(#"{"items":[{"item_id":"a"},{"item_id":"b"}]}"#.utf8))
+        }
+        defer { ColumnsStubURLProtocol.handler = nil }
+
+        let store = Self.makeStubbedStore()
+        let rows = try await store.libraryItemColumns(itemIds: ["a", "b"])
+
+        XCTAssertEqual(rows.map(\.itemId), ["a", "b"])
+    }
+
+    func testLibraryItemColumnsShortCircuitsOnEmptyInputWithoutHittingTheNetwork() async throws {
+        // Empty input must not reach the backend (it would just echo an empty
+        // set anyway) — the store returns [] directly.
+        ColumnsStubURLProtocol.handler = { request in
+            XCTFail("empty item ids must not hit the network")
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, Data(#"{"items":[]}"#.utf8))
+        }
+        defer { ColumnsStubURLProtocol.handler = nil }
+
+        let store = Self.makeStubbedStore()
+        let rows = try await store.libraryItemColumns(itemIds: [])
+
+        XCTAssertTrue(rows.isEmpty)
     }
 
     // MARK: - AppViewMode.category
@@ -512,5 +568,32 @@ final class DocumentStoreAndSidebarTypesTests: XCTestCase {
             createdAt: Date(), updatedAt: Date()
         )
     }
+}
+
+/// File-local URLProtocol stub for the batch-column-metadata store tests
+/// (#3758). A dedicated class — not the shared `MockURLProtocol` — so its
+/// static handler can never collide with another suite running in parallel.
+private final class ColumnsStubURLProtocol: URLProtocol {
+    nonisolated(unsafe) static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override static func canInit(with request: URLRequest) -> Bool { true }
+    override static func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        guard let handler = Self.handler else {
+            client?.urlProtocol(self, didFailWithError: URLError(.notConnectedToInternet))
+            return
+        }
+        do {
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
 }
 // swiftlint:enable file_length

--- a/fichero/fichero/Models/DocumentStore.swift
+++ b/fichero/fichero/Models/DocumentStore.swift
@@ -1,4 +1,5 @@
 import Combine
+import FicheroAPIClient
 import Foundation
 import Observation
 import OSLog
@@ -348,6 +349,23 @@ final class DocumentStore {
             )
             return []
         }
+    }
+
+    /// Batch per-item column metadata (#3758): entity / annotation / note /
+    /// bbox counts for the given library items, feeding the library list and
+    /// column-browser columns. Read-only. The store is the only endpoint
+    /// accessor — views call this, never the service. Empty input
+    /// short-circuits (the backend returns an empty set anyway); the backend
+    /// caps a batch at 200 ids.
+    func libraryItemColumns(
+        itemIds: [String],
+        includeDescendants: Bool = false
+    ) async throws -> [Components.Schemas.LibraryItemColumnsRow] {
+        guard !itemIds.isEmpty else { return [] }
+        return try await documentService.libraryItemColumns(
+            itemIds: itemIds,
+            includeDescendants: includeDescendants
+        )
     }
 }
 

--- a/fichero/fichero/Services/DocumentServiceGenerated.swift
+++ b/fichero/fichero/Services/DocumentServiceGenerated.swift
@@ -867,3 +867,36 @@ enum DocumentServiceError: Error, LocalizedError {
         }
     }
 }
+
+// MARK: - Batch library-item column metadata (#3758)
+
+extension DocumentServiceGenerated {
+    /// Batch per-item column metadata (#3758) — for each of `itemIds`, the
+    /// entity / annotation / note / bbox counts aggregated across that item's
+    /// document scope. Read-only, set-based: it powers the library list and
+    /// column-browser columns, never mutates. Typed OpenAPI op — no hand-rolled
+    /// URL. The backend caps the batch at 200 ids (422 beyond that). Lives on an
+    /// extension so the primary service type stays within its body-length limit.
+    func libraryItemColumns(
+        itemIds: [String],
+        includeDescendants: Bool = false
+    ) async throws -> [Components.Schemas.LibraryItemColumnsRow] {
+        let request = Components.Schemas.LibraryItemColumnsRequest(
+            itemIds: itemIds,
+            includeDescendants: includeDescendants
+        )
+        let response = try await client.api.libraryItemColumnsApiLibraryItemsColumnsPost(
+            body: .json(request)
+        )
+
+        switch response {
+        case .ok(let ok):
+            return try ok.body.json.items
+        case .unprocessableContent(let error):
+            let detail = try? error.body.json
+            throw DocumentServiceError.serverError(detail?.detail?.description ?? "Validation error")
+        default:
+            throw DocumentServiceError.unexpectedResponse
+        }
+    }
+}

--- a/scripts/check_endpoint_usage.py
+++ b/scripts/check_endpoint_usage.py
@@ -59,7 +59,6 @@ KNOWN_GAPS: dict[str, str] = {
     'POST /api/canvas/folders/{folder_id}/arrange': "#1920 baseline - cli-only",
     'POST /api/folders/{entity_type}/folders': "#1920 baseline - cli-only",
     'POST /api/library/links': "#1920 baseline - cli-only",
-    'POST /api/library-items/columns': "engine-side column browser; Swift wiring tracked in #3758",
     'POST /api/registry/unicode-collisions/merge': "#1920 baseline - cli-only",
     'PUT /api/folders/{entity_type}/folders': "#1920 baseline - cli-only",
     'PUT /api/folders/{entity_type}/move': "#1920 baseline - cli-only",


### PR DESCRIPTION
POST /api/library-items/columns existed in the engine but the app couldn't reach it. Now wired through DocumentStore (observable-data-layer: store is the only endpoint accessor). Store + service methods added; tests cover the through-store fetch and the empty-input short-circuit (no network). Worker removed the now-wired KNOWN_GAPS entry — check_endpoint_usage green. Not built by me (f_manager owns the lock).