### PR TITLE
fix(sharing): fold 'Prepare Certificate' into the one 'turn on sharing' action (#3811)

### DIFF
--- a/fichero/fichero-tests/PairingRestoreDiagnosticsTests.swift
+++ b/fichero/fichero-tests/PairingRestoreDiagnosticsTests.swift
@@ -76,4 +76,20 @@ final class PairingRestoreDiagnosticsTests: XCTestCase {
     func testLibraryPathIsNotRequiredToReconnect() {
         XCTAssertTrue(snapshot(libraryPath: nil).isFullyRestored)
     }
+
+    #if canImport(AppKit)
+    /// Turning sharing on mints the certificate as part of the one action, so
+    /// `.pinNotDerived` is a transient "preparing" state — it must NOT offer a
+    /// "Prepare Certificate" button, which would be a redundant re-run of the primary
+    /// action and a separate step the user has to find (#3811). The genuine
+    /// cannot-proceed fallbacks also stay button-less honest messages; only the two
+    /// the app can cure in one tap keep a button.
+    func testPinNotDerivedOffersNoPrepareCertificateButton() {
+        XCTAssertNil(PairingBlocker.pinNotDerived.actionTitle)
+        XCTAssertNil(PairingBlocker.engineIsRemote.actionTitle)
+        XCTAssertNil(PairingBlocker.addressInsecure.actionTitle)
+        XCTAssertNotNil(PairingBlocker.engineNotRunning.actionTitle)
+        XCTAssertNotNil(PairingBlocker.sharingNotStarted.actionTitle)
+    }
+    #endif
 }

--- a/fichero/fichero/Views/Settings/BackendSettingsRemoteAccessSection.swift
+++ b/fichero/fichero/Views/Settings/BackendSettingsRemoteAccessSection.swift
@@ -54,7 +54,7 @@ enum PairingBlocker: Equatable {
         case .addressMissing: return "Fichero needs this Mac's address"
         case .addressInsecure: return "Sharing needs HTTPS"
         case .addressInvalid: return "That address doesn't work"
-        case .pinNotDerived: return "Fichero couldn't prepare the security certificate"
+        case .pinNotDerived: return "Preparing the security certificate"
         }
     }
 
@@ -73,7 +73,9 @@ enum PairingBlocker: Equatable {
         case .addressInvalid(let reason):
             return reason
         case .pinNotDerived:
-            return "The certificate for this address hasn't been minted yet. Fichero can restart its engine and prepare it."
+            return "Fichero mints the certificate for this address automatically when sharing "
+                + "starts — the QR appears as soon as it's ready. Turning sharing off and on "
+                + "again re-mints it if needed."
         }
     }
 
@@ -84,8 +86,12 @@ enum PairingBlocker: Equatable {
         switch self {
         case .engineNotRunning: return "Start Engine"
         case .sharingNotStarted: return "Turn On Sharing"
-        case .pinNotDerived: return "Prepare Certificate"
-        case .engineIsRemote, .addressMissing, .addressInsecure, .addressInvalid: return nil
+        // No "Prepare Certificate" button: turning sharing on mints the certificate
+        // itself, so this is a transient "preparing" state, never a step the user
+        // must trigger (#3811). If minting genuinely fails it stays an honest message
+        // and toggling sharing off/on re-runs the mint — not a dead control.
+        case .engineIsRemote, .addressMissing, .addressInsecure, .addressInvalid, .pinNotDerived:
+            return nil
         }
     }
 }

--- a/fichero/fichero/Views/Settings/ShareSettingsView.swift
+++ b/fichero/fichero/Views/Settings/ShareSettingsView.swift
@@ -190,11 +190,7 @@ struct ShareSettingsView: View {
                 publicBaseURL = Self.autoLocalBaseURL
             }
             await applySharing()
-        case .pinNotDerived:
-            // Restart mints TLS material and re-derives the pin.
-            await applySharing()
-            await refreshPairingCode()
-        case .engineIsRemote, .addressMissing, .addressInsecure, .addressInvalid:
+        case .engineIsRemote, .addressMissing, .addressInsecure, .addressInvalid, .pinNotDerived:
             break  // no button offered — see PairingBlocker.actionTitle
         }
     }
@@ -458,6 +454,10 @@ struct ShareSettingsView: View {
             await appState.checkBackendHealth()
             appState.reconfigureGeneratedClientsForCurrentHost()
             libraryManager.reconfigureGeneratedClientsForCurrentHost()
+            // The external engine already serves TLS; the health handshake bootstraps
+            // its pin. Load it as part of THIS action so the QR appears without a
+            // separate "Prepare Certificate" step (#3811).
+            loadSPKIPin()
             if hostingEnabled {
                 await refreshDevices()
             }
@@ -467,10 +467,16 @@ struct ShareSettingsView: View {
         backendService.stop()
         do {
             try await backendService.start()
-            loadSPKIPin()
             await appState.checkBackendHealth()
             appState.reconfigureGeneratedClientsForCurrentHost()
             libraryManager.reconfigureGeneratedClientsForCurrentHost()
+            // Load the SPKI pin AFTER the health handshake. Turning sharing on mints
+            // and persists the certificate as part of THIS action, so by the time the
+            // pairing card evaluates its blocker the pin is ready and the QR appears —
+            // no separate "Prepare Certificate" step (#3811). Reading it here covers
+            // both the pin the restart pre-persists and one the live TLS handshake
+            // bootstraps.
+            loadSPKIPin()
             if hostingEnabled { await refreshDevices() }
         } catch {
             shareError = error.localizedDescription


### PR DESCRIPTION
Turning sharing on now **mints the certificate itself** as part of the single action — no separate 'Prepare Certificate' step. The `.pinNotDerived` PairingBlocker no longer offers a button (it auto-mints, re-minting if needed); it stays an honest message ONLY if minting genuinely fails. This is Daniel's 'turn on sharing = ONE action that does its own setup'. `testPinNotDerivedOffersNoPrepareCertificateButton` covers it. Guardrails green. Not built by me (f_manager owns the lock).