### PR TITLE
fix: clarify missing workflow library context (#3820)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/workflow_execution/core.py
+++ b/fichero-engine/src/fichero/api/routes/workflow_execution/core.py
@@ -249,7 +249,8 @@ async def execute_workflow(
         workflow = store.get(request.workflow_id)
         if not workflow:
             raise HTTPException(
-                status_code=404, detail=f"Workflow not found: {request.workflow_id}"
+                status_code=404,
+                detail=f"Workflow not found in this library: {request.workflow_id}",
             )
 
         _validate_workflow_for_execution(workflow)

--- a/fichero-engine/tests/unit/test_routes_workflow_execution.py
+++ b/fichero-engine/tests/unit/test_routes_workflow_execution.py
@@ -519,6 +519,7 @@ class TestExecuteWorkflow:
         ):
             r = client.post("/api/workflow-execution/execute", json=payload)
         assert r.status_code == 404
+        assert r.json() == {"detail": "Workflow not found in this library: no-such-workflow"}
 
     def test_execute_rejects_empty_workflow(self, client, db, caplog):
         wf = Workflow(


### PR DESCRIPTION
Returns an explicit library-context 404 for a workflow ID unavailable in the selected library.\n\nValidation: `PYTHONPATH=fichero-engine/src pytest fichero-engine/tests/unit/ -q` (7635 passed, 22 skipped, 4 xfailed).\n\nCloses #3820.