### PR TITLE
fix(workflow): run single library items in the menu's own library context (#3820)

### DIFF
--- a/fichero/fichero-tests/LibraryBottomActionBarSurfaceTests.swift
+++ b/fichero/fichero-tests/LibraryBottomActionBarSurfaceTests.swift
@@ -1,3 +1,4 @@
+@testable import Fichero
 import XCTest
 
 /// Source-surface tests for the Library bottom action bar's mini-toolbar
@@ -42,6 +43,35 @@ final class LibraryBottomActionBarSurfaceTests: XCTestCase {
         XCTAssertTrue(pickerSource.contains("@Environment(LibraryManager.self) private var libraryManager"))
         XCTAssertTrue(pickerSource.contains("@Environment(WindowState.self) private var windowState"))
         XCTAssertTrue(pickerSource.contains("libraryManager.getLibrary(id: windowState.libraryId)"))
+    }
+
+    // MARK: - Run-Workflow library-context coherence (#3820)
+
+    func testWorkflowIsRunnableOnlyWhenPresentInExecutionLibrary() {
+        // A single library item's Run-Workflow menu must offer only workflows
+        // resolvable in the library it executes against — otherwise the engine
+        // 400s on an unknown workflow_id (the #3820 root cause).
+        let workflows = [
+            WorkflowSidebarItem(id: "wf-a", name: "Alpha"),
+            WorkflowSidebarItem(id: "wf-b", name: "Beta")
+        ]
+        XCTAssertTrue(LibraryView.workflowIsRunnable(workflowId: "wf-a", in: workflows))
+        XCTAssertTrue(LibraryView.workflowIsRunnable(workflowId: "wf-b", in: workflows))
+        // An id from a different library (or a stale menu) is refused, not sent.
+        XCTAssertFalse(LibraryView.workflowIsRunnable(workflowId: "wf-from-other-library", in: workflows))
+        XCTAssertFalse(LibraryView.workflowIsRunnable(workflowId: "wf-a", in: []))
+    }
+
+    func testRunBatchWorkflowExecutesThroughTheMenuSourceLibrary() throws {
+        // Locks the fix: both the menu list and the execution derive from the
+        // SAME reference (`activeLibraryReference` / its workflowStreamService),
+        // never the environment's shared service, so they can't diverge.
+        let source = try Self.appSource("Views/Library/LibraryView+FilterAndBatch.swift")
+        XCTAssertTrue(source.contains("activeLibraryReference?.workflowStore.workflows"))
+        XCTAssertTrue(source.contains("guard let library = activeLibraryReference"))
+        XCTAssertTrue(source.contains("let stream = library.workflowStreamService"))
+        XCTAssertTrue(source.contains("try await stream.execute("))
+        XCTAssertTrue(source.contains("Self.workflowIsRunnable(workflowId: workflowId, in: workflows)"))
     }
 
     func testBatchWorkflowRefreshesDocumentsAsWorkflowStepsComplete() throws {

--- a/fichero/fichero/Views/Library/LibraryView+FilterAndBatch.swift
+++ b/fichero/fichero/Views/Library/LibraryView+FilterAndBatch.swift
@@ -25,8 +25,16 @@ extension LibraryView {
     }
 
     var libraryWorkflows: [WorkflowSidebarItem] {
-        let lib = libraryManager.getLibrary(id: windowState.libraryId) ?? libraryManager.globalLibrary
-        return lib?.workflowStore.workflows ?? []
+        // #3820 — source from the SAME reference the execution uses
+        // (`activeLibraryReference`), so the menu can never list a workflow the
+        // run would execute against a different library and 400 on.
+        activeLibraryReference?.workflowStore.workflows ?? []
+    }
+
+    /// A workflow id can only be run in the library it will execute against.
+    /// Pure so the guard in `runBatchWorkflow` is unit-testable (#3820).
+    static func workflowIsRunnable(workflowId: String, in workflows: [WorkflowSidebarItem]) -> Bool {
+        workflows.contains { $0.id == workflowId }
     }
 
     // MARK: - Filtered Documents
@@ -712,11 +720,27 @@ extension LibraryView {
         guard !selectedDocumentIdsForBatch.isEmpty else { return }
 
         let docIds = selectedDocumentIdsForBatch
-        let library = libraryManager.getLibrary(id: windowState.libraryId)
-        let activeWorkflows = library?.workflowStore.workflows
-        let workflowName = activeWorkflows?.first(where: { $0.id == workflowId })?.name
-            ?? libraryManager.globalLibrary?.workflowStore.workflows.first(where: { $0.id == workflowId })?.name
-            ?? workflowId
+        // #3820 — run through the SAME library reference that sourced the
+        // Run-Workflow menu (`libraryWorkflows` → `activeLibraryReference`), NOT
+        // the environment's shared WorkflowStreamService. When those diverged
+        // (the window's library vs. the global fallback), the menu offered a
+        // workflow_id unresolvable in the execution's library → engine 400 on
+        // single items. The sidebar path already binds list + execution to one
+        // library (which is why folders worked); mirror that here.
+        guard let library = activeLibraryReference else {
+            logger.error("runBatchWorkflow: no library reference — cannot run \(workflowId)")
+            return
+        }
+        let workflows = library.workflowStore.workflows
+        // Defensive: only send an id the execution library can resolve. With the
+        // coherent context above this holds by construction; the guard stops a
+        // stale menu from ever firing a doomed 400 request.
+        guard Self.workflowIsRunnable(workflowId: workflowId, in: workflows) else {
+            logger.error("runBatchWorkflow: \(workflowId) not in execution library — refusing to send")
+            return
+        }
+        let stream = library.workflowStreamService
+        let workflowName = workflows.first(where: { $0.id == workflowId })?.name ?? workflowId
 
         logger.info("Starting SSE workflow \(workflowId) on \(docIds.count) documents via context menu")
 
@@ -728,7 +752,7 @@ extension LibraryView {
         )
         var streamCompleted = false
         do {
-                let response = try await workflowStreamService.execute(
+                let response = try await stream.execute(
                     workflowId: workflowId,
                     inputs: ["selected_doc_ids": docIds],
                     providerOverride: providerOverride,
@@ -738,15 +762,15 @@ extension LibraryView {
                         executionObserver.promoteExecution(
                             from: executionThreadId,
                             to: threadId,
-                            onCancel: { [weak workflowStreamService] in
+                            onCancel: { [weak stream] in
                                 Task { @MainActor in
-                                    try? await workflowStreamService?.stopWorkflow(threadId: threadId)
+                                    try? await stream?.stopWorkflow(threadId: threadId)
                                 }
                             }
                         )
                         executionThreadId = threadId
                     },
-                    onEvent: { [weak documentStore = library?.documentStore] event in
+                    onEvent: { [weak documentStore = library.documentStore] event in
                     if handleBatchWorkflowEvent(
                         event,
                         threadId: executionThreadId,


### PR DESCRIPTION
**The root-cause cure for #3820.** The library-view single-item Run-Workflow menu was sourcing workflows from a different library context than the execution request, so it sent a workflow_id unresolvable in the execution library → 400 (the sidebar-folder path was always coherent). Now the single-item menu offers **only workflows resolvable in the library it executes against**, matching the sidebar path. `workflowIsRunnable(workflowId:in:)` + test. Together with the engine's honest 404 (#3846), running a workflow on a single library item works. Guardrails green. Not built by me — f_manager owns the lock; needs their app build to confirm at runtime.