### PR TITLE
fix: make Dev Embedded spawn the bundled engine

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -6470,7 +6470,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = "Dev Embedded";


### PR DESCRIPTION
Closes #3369

Dev Embedded set `FICHERO_EMBED_ENGINE=YES` but inherited the Swift `DEBUG` compilation condition, forcing the debug-external provisioning branch. Remove only that condition from the Dev Embedded project configuration.

Verified with `xcodebuild -showBuildSettings`: Dev Embedded resolves `FICHERO_EMBED_ENGINE=YES` with no `SWIFT_ACTIVE_COMPILATION_CONDITIONS=DEBUG`.