### PR TITLE
feat(kg): pure non-destructive SVO cleanup module — step 1 (#3808)

### DIFF
--- a/fichero-engine/src/fichero/knowledge/svo_cleanup.py
+++ b/fichero-engine/src/fichero/knowledge/svo_cleanup.py
@@ -1,0 +1,64 @@
+"""Pure, non-destructive cleanup for displayed SVO clauses (#3808)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+import re
+from typing import Iterable, Protocol
+
+NEAR_DUPLICATE_THRESHOLD = 0.86
+_DEHYPHENATE = re.compile(r"(?<!\d)([^\W\d_])-\s+([^\W\d_])(?!\d)")
+_PERSPECTIVE_VERBS = re.compile(r"\b(?:otorgan|dan|gave|es dado|given)\b", re.I)
+
+
+class SVOClaim(Protocol):
+    id: str
+    subject_canonical: str | None
+    predicate_verb: str | None
+    object_phrase: str | None
+
+
+@dataclass(frozen=True)
+class CleanedClause:
+    predicate_verb: str
+    object_phrase: str
+    source_claim_ids: tuple[str, ...]
+    transforms: tuple[str, ...]
+
+
+def _dehyphenate(text: str) -> str:
+    return _DEHYPHENATE.sub(r"\1\2", text)
+
+
+def _without_repeated_subject(text: str, subject: str) -> str:
+    return re.sub(rf"^\s*{re.escape(subject)}\s*[,;:]?\s*", "", text, flags=re.I)
+
+
+def _comparison_key(verb: str, object_phrase: str) -> str:
+    text = _PERSPECTIVE_VERBS.sub("transfer", f"{verb} {object_phrase}").lower()
+    return " ".join(re.sub(r"[^\w\s]", " ", text).split())
+
+
+def clean_svo_claims(
+    claims: Iterable[SVOClaim], *, near_duplicate_threshold: float = NEAR_DUPLICATE_THRESHOLD
+) -> list[CleanedClause]:
+    """Return display clauses while preserving every absorbed raw claim id."""
+    cleaned: list[CleanedClause] = []
+    for claim in claims:
+        subject = claim.subject_canonical or ""
+        verb = _dehyphenate(claim.predicate_verb or "")
+        object_phrase = _without_repeated_subject(_dehyphenate(claim.object_phrase or ""), subject)
+        transforms = ["dehyphenate"] if verb != (claim.predicate_verb or "") or object_phrase != (claim.object_phrase or "") else []
+        key = _comparison_key(verb, object_phrase)
+        for index, existing in enumerate(cleaned):
+            existing_key = _comparison_key(existing.predicate_verb, existing.object_phrase)
+            if key == existing_key or (
+                SequenceMatcher(None, key, existing_key).ratio() >= near_duplicate_threshold
+                and set(key.split()) == set(existing_key.split())
+            ):
+                cleaned[index] = CleanedClause(existing.predicate_verb, existing.object_phrase, existing.source_claim_ids + (claim.id,), existing.transforms + ("dedup",))
+                break
+        else:
+            cleaned.append(CleanedClause(verb, object_phrase, (claim.id,), tuple(transforms)))
+    return cleaned

--- a/fichero-engine/tests/unit/test_svo_cleanup.py
+++ b/fichero-engine/tests/unit/test_svo_cleanup.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+
+from fichero.knowledge.svo_cleanup import clean_svo_claims
+
+
+def _claim(id, subject, verb, object_phrase):
+    return SimpleNamespace(id=id, subject_canonical=subject, predicate_verb=verb, object_phrase=object_phrase)
+
+
+def test_dehyphenates_words_but_not_digit_ranges():
+    clauses = clean_svo_claims([_claim("a", "Ana", "trans-\nferred", "land in 1830- 31")])
+    assert clauses[0].predicate_verb == "transferred"
+    assert clauses[0].object_phrase == "land in 1830- 31"
+
+
+def test_dedup_preserves_sources_but_keeps_distinct_facts():
+    clauses = clean_svo_claims([
+        _claim("a", "Ana", "gave", "the house to Pedro"),
+        _claim("b", "Ana", "given", "the house to Pedro"),
+        _claim("c", "Ana", "gave", "the farm to Pedro"),
+    ])
+    assert len(clauses) == 2
+    assert clauses[0].source_claim_ids == ("a", "b")
+    assert clauses[1].source_claim_ids == ("c",)
+
+
+def test_strips_only_leading_repeated_subject():
+    clause = clean_svo_claims([_claim("a", "Ana", "said", "Ana: Pedro met Ana")])[0]
+    assert clause.object_phrase == "Pedro met Ana"


### PR DESCRIPTION
Step 1 of the SVO/Knowledge-graph cleanup: a **pure stdlib** `knowledge/svo_cleanup.py` — no DB writes, no stored copy, computed at read time (non-destructive by construction, per Daniel's decision). Each cleaned clause carries `source_claim_ids` + a `transforms` audit → full provenance.

Safe deterministic transforms only: de-hyphenate, strip-repeated-subject (label once), dedup, perspective-verb neutralize. The de-hyphenation regex `(?<!\d)([^\W\d_])-\s+([^\W\d_])(?!\d)` correctly does NOT join digit ranges ('1830- 31') — the bug in Daniel's prototype.

Per Daniel's overrides on #3808: NO scribal-normalization/entity-merge here (separate deliberate entity-cleanup step), NO translation (separate additive feature). Tests assert the general approach on synthetic inputs (de-hyphenation joins words not digits; dedup collapses dupes but keeps distinct facts), not a frozen fixture.

Wiring it into the read view + the raw/cleaned toggle is a later step. 12 tests (module + contracts) pass. Not built by me (engine-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)