### PR TITLE
fix: inject app state into the About window — fixes the About Fichero crash (#3853)

### DIFF
--- a/fichero/fichero-tests/AboutSettingsSurfaceTests.swift
+++ b/fichero/fichero-tests/AboutSettingsSurfaceTests.swift
@@ -55,6 +55,14 @@ final class AboutSettingsSurfaceTests: XCTestCase {
         XCTAssertTrue(source.contains("fallbackCopyright"))
     }
 
+    func testMacAboutWindowInjectsAppState() throws {
+        let source = try Self.appSource("FicheroApp.swift")
+        let aboutWindow = try XCTUnwrap(
+            source.components(separatedBy: "Window(\"About Fichero\", id: \"about\") {").dropFirst().first
+        )
+        XCTAssertTrue(aboutWindow.contains("AboutView()\n                .environment(appState)"))
+    }
+
     private static func appSource(_ relativePath: String) throws -> String {
         let baseURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/fichero/fichero/FicheroApp.swift
+++ b/fichero/fichero/FicheroApp.swift
@@ -500,6 +500,7 @@ struct FicheroApp: App {
         // Single-instance `Window`, sized to its content.
         Window("About Fichero", id: "about") {
             AboutView()
+                .environment(appState)
         }
         .windowResizability(.contentSize)
         .defaultPosition(.center)


### PR DESCRIPTION
**Fixes the show-stopper: opening 'About Fichero' crashed.** The About window (`Window(id:'about')`, a separate Scene in FicheroApp.swift) was **missing `.environment(appState)`** that every other window injects — so `AboutView` crashed reading appState from an environment that didn't provide it. One-line fix: `AboutView().environment(appState)`. Test asserts the About window injects app state. Guardrails green. **Not built by me — needs f_manager's build to confirm the crash is gone** (f_manager was also looking at this; this is the minimal correct fix).