### PR TITLE
settings: Share-sheet roles Viewer/Editor only (#3787) + Reader transcript-layout setting (#3805)

### DIFF
--- a/fichero/fichero-tests/UsersManagementTests.swift
+++ b/fichero/fichero-tests/UsersManagementTests.swift
@@ -1,0 +1,78 @@
+@testable import Fichero
+import XCTest
+
+/// #3787 — Settings user management. Locks the roles the Share sheet may grant and
+/// the Users pane's state resolution. Owner is a whole-library administrator granted
+/// deliberately in Settings → People, never handed out casually while sharing.
+final class UsersManagementTests: XCTestCase {
+
+    // MARK: - Share sheet roles (#3787)
+
+    func testShareSheetOffersViewerAndEditorOnlyNotOwner() {
+        XCTAssertEqual(ShareLibrarySheet.shareRoles, ["editor", "viewer"])
+        XCTAssertFalse(
+            ShareLibrarySheet.shareRoles.contains("owner"),
+            "Owner is granted deliberately in Settings → People, not from the share sheet"
+        )
+    }
+
+    func testShareSheetDefaultRoleIsOneItOffers() {
+        // The default assignment must be a role the sheet actually offers, or the
+        // Picker selection would bind to a tag with no matching row.
+        XCTAssertTrue(ShareLibrarySheet.shareRoles.contains("viewer"))
+    }
+
+    // MARK: - Users pane presentation (#3787)
+
+    private func input(
+        isLoading: Bool = false,
+        loadError: String? = nil,
+        usersEmpty: Bool = true,
+        hasCurrentUser: Bool = false,
+        hasAuthzSnapshot: Bool = false,
+        listAccessDenied: Bool = false,
+        isOwnerAccess: Bool = false
+    ) -> UsersSettingsPresentation.Input {
+        .init(
+            isLoading: isLoading,
+            loadError: loadError,
+            usersEmpty: usersEmpty,
+            hasCurrentUser: hasCurrentUser,
+            hasAuthzSnapshot: hasAuthzSnapshot,
+            listAccessDenied: listAccessDenied,
+            isOwnerAccess: isOwnerAccess
+        )
+    }
+
+    func testPresentationLoadingWhenNothingLoadedYet() {
+        XCTAssertEqual(UsersSettingsPresentation.resolve(input(isLoading: true)), .loading)
+    }
+
+    /// A load failure with nothing loaded must surface honestly, never a blank pane.
+    func testPresentationLoadErrorSurfaces() {
+        XCTAssertEqual(
+            UsersSettingsPresentation.resolve(input(loadError: "boom")),
+            .loadError("boom")
+        )
+    }
+
+    func testPresentationEmptyWhenNothingAndNoError() {
+        XCTAssertEqual(UsersSettingsPresentation.resolve(input()), .empty)
+    }
+
+    func testPresentationAccountDetailsOnceSomethingLoaded() {
+        XCTAssertEqual(
+            UsersSettingsPresentation.resolve(input(usersEmpty: false, hasCurrentUser: true)),
+            .accountDetails
+        )
+    }
+
+    /// Still loading, but the signed-in user is already known → show details, not a
+    /// spinner that would hide the pane the owner is trying to use.
+    func testPresentationYieldsToDataWhileStillLoading() {
+        XCTAssertEqual(
+            UsersSettingsPresentation.resolve(input(isLoading: true, hasCurrentUser: true)),
+            .accountDetails
+        )
+    }
+}

--- a/fichero/fichero-tests/ViewSettingsEnumsTests.swift
+++ b/fichero/fichero-tests/ViewSettingsEnumsTests.swift
@@ -59,4 +59,25 @@ final class ViewSettingsEnumsTests: XCTestCase {
         // would break the bridge.
         XCTAssertEqual(PreviewMode.allCases.count, PreviewLayout.allCases.count)
     }
+
+    // MARK: - TranscriptLayout (#3805)
+
+    /// Diplomatic must be the default: the manuscript's line structure is real data
+    /// and must never be lost silently (Daniel). Reading reflow is opt-in.
+    func testTranscriptLayoutDefaultsToDiplomatic() {
+        XCTAssertEqual(TranscriptLayout.defaultValue, .diplomatic)
+    }
+
+    /// Raw values are the persisted @AppStorage identity — a rename would silently
+    /// reset every user's choice, so pin them along with the stable storage key.
+    func testTranscriptLayoutRawValuesAndStorageKeyAreStable() {
+        XCTAssertEqual(TranscriptLayout.diplomatic.rawValue, "diplomatic")
+        XCTAssertEqual(TranscriptLayout.reading.rawValue, "reading")
+        XCTAssertEqual(TranscriptLayout.storageKey, "fichero.reader.transcriptLayout")
+        XCTAssertEqual(TranscriptLayout.allCases.count, 2)
+        for layout in TranscriptLayout.allCases {
+            XCTAssertFalse(layout.label.isEmpty, "\(layout) label")
+            XCTAssertEqual(layout.id, layout.rawValue)
+        }
+    }
 }

--- a/fichero/fichero/Views/Settings/SettingsView.swift
+++ b/fichero/fichero/Views/Settings/SettingsView.swift
@@ -201,6 +201,32 @@ private struct PreviewViewSettingsPane: View {
     }
 }
 
+/// How the Reader lays out a transcript (#3805). DIPLOMATIC is the default because
+/// the manuscript's line structure is real data and must never be lost silently
+/// (Daniel); READING reflow is opt-in. This is the persisted CHOICE only — the
+/// engine reflow rendering and the raw/cleaned text wiring land in separate slices,
+/// which read this same `storageKey`. Kept module-accessible (not private) so those
+/// slices can reference it; RawRepresentable String so `@AppStorage` stores it.
+enum TranscriptLayout: String, CaseIterable, Identifiable {
+    /// Preserve the manuscript's original line breaks exactly.
+    case diplomatic
+    /// Reflow the text to fit the window width — the manuscript lines are not kept.
+    case reading
+
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .diplomatic: "Diplomatic (preserve manuscript lines)"
+        case .reading: "Reading (reflow to fit)"
+        }
+    }
+
+    static let storageKey = "fichero.reader.transcriptLayout"
+    /// Diplomatic by default — never lose the manuscript line structure silently.
+    static let defaultValue = TranscriptLayout.diplomatic
+}
+
 /// Reader View settings — the Reader text font-size override (#3681). A stepper
 /// over the semantic base size, clamped `0.8…2.0` (Daniel). The consumer wiring
 /// (WebKit CSS injection + native reader text) lands with #3681; this is the
@@ -211,9 +237,25 @@ private struct ReaderViewSettingsPane: View {
     private var readerScale = ViewSettings.FontScale.defaultValue
     @AppStorage(ReaderTextWrap.storageKey)
     private var textWrap = ReaderTextWrap.tidy
+    @AppStorage(TranscriptLayout.storageKey)
+    private var transcriptLayout = TranscriptLayout.defaultValue
 
     var body: some View {
         Form {
+            Section("Transcript") {
+                Picker("Layout", selection: $transcriptLayout) {
+                    ForEach(TranscriptLayout.allCases) { layout in
+                        Text(layout.label).tag(layout)
+                    }
+                }
+                Text("Diplomatic keeps the manuscript's original line breaks — that "
+                     + "line structure is real data. Reading reflows the text to fit "
+                     + "the window: easier to read, but the manuscript lines are lost. "
+                     + "Diplomatic is the default; Reading is opt-in.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
             Section("Text") {
                 Stepper(
                     value: $readerScale,

--- a/fichero/fichero/Views/Sidebar/ShareLibrarySheet.swift
+++ b/fichero/fichero/Views/Sidebar/ShareLibrarySheet.swift
@@ -63,7 +63,12 @@ struct ShareLibrarySheet: View {
     @State var isApplying = false
     @State var manageError: String?
 
-    let shareRoles = ["owner", "editor", "viewer"]
+    /// The share sheet grants Viewer/Editor only — Owner is deliberately NOT here
+    /// (#3787). Owner is a whole-library administrator, granted on purpose in
+    /// Settings → People, not handed out casually while sharing with someone. The
+    /// engine still enforces >=1 owner, so downgrading the last owner from here is
+    /// refused with an honest error, never silently.
+    static let shareRoles = ["editor", "viewer"]
     static let newPersonTag = "__new_person__"
 
     var body: some View {
@@ -104,7 +109,7 @@ extension ShareLibrarySheet {
             }
 
             Picker("Role", selection: $role) {
-                ForEach(shareRoles, id: \.self) { roleName in
+                ForEach(Self.shareRoles, id: \.self) { roleName in
                     Text(roleName.capitalized).tag(roleName)
                 }
             }
@@ -128,8 +133,9 @@ extension ShareLibrarySheet {
         } header: {
             Text("Share With")
         } footer: {
-            Text("The person gets the chosen role for this library. Owners manage members; "
-                + "editors change content; viewers are read-only.")
+            Text("The person gets the chosen role for this library. Editors change content; "
+                + "viewers are read-only. To make someone an Owner (full admin), use "
+                + "Settings → People.")
                 .foregroundStyle(.secondary)
         }
 
@@ -254,7 +260,7 @@ extension ShareLibrarySheet {
             }
             Spacer(minLength: 12)
             Menu(member.role.capitalized) {
-                ForEach(shareRoles, id: \.self) { roleName in
+                ForEach(Self.shareRoles, id: \.self) { roleName in
                     Button(roleName.capitalized) {
                         Task { await changeRole(userId: member.userId, role: roleName) }
                     }


### PR DESCRIPTION
**#3787:** the Share sheet grants Viewer/Editor only — Owner (whole-library administrator) is granted deliberately in the People pane, not one click from read access. Locks role resolution + users-pane state.

**#3805 (Settings half):** adds a Reader View 'Transcript layout' setting — Diplomatic (preserve manuscript lines) vs Reading (reflow) — defaulting Diplomatic (manuscript line structure is real data, never lost silently). The setting persists + exposes the choice; the engine reflow rendering is a separate slice.

Guardrails green. Not built by me (f_manager owns the lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)