### PR TITLE
fix: channel-aware email invite TTL (#3790)

### DIFF
--- a/fichero-engine/src/fichero/api/routes/auth_accounts.py
+++ b/fichero-engine/src/fichero/api/routes/auth_accounts.py
@@ -12,6 +12,7 @@ import os
 from datetime import datetime, timedelta
 from functools import cache
 import sys
+from typing import Literal
 from urllib.parse import quote
 
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -21,7 +22,7 @@ from pydantic import BaseModel, Field
 from fichero import accounts
 from fichero.api.auth import _rate_limit_scope_from_request, _use_multiuser_auth, auth_kind_from_request
 from fichero.app_db import AppDatabase, get_app_db
-from fichero.models import AccountInvite, AccountUser, AuthIdentityResponse, AuthIdentityUser
+from fichero.models import AccountInvite, AccountUser, ActionAudit, AuthIdentityResponse, AuthIdentityUser
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ SESSION_TTL = timedelta(days=30)
 LOGIN_RATE_LIMIT = 5
 LOGIN_RATE_WINDOW = timedelta(minutes=1)
 INVITE_TTL = timedelta(minutes=15)
+EMAIL_INVITE_TTL = timedelta(days=1)
 INVITE_RATE_LIMIT = 5
 INVITE_RATE_WINDOW = timedelta(minutes=1)
 
@@ -104,6 +106,7 @@ class SessionListResponse(BaseModel):
 class InviteRequest(BaseModel):
     username: str = Field(min_length=1)
     display_name: str | None = Field(default=None, min_length=1)
+    channel: Literal["qr", "messages", "email"] = "qr"
 
 
 class InviteRedeemRequest(BaseModel):
@@ -117,6 +120,7 @@ class InviteResponse(BaseModel):
     display_name: str
     created_at: datetime
     expires_at: datetime
+    channel: Literal["qr", "messages", "email"]
 
 
 class InviteListResponse(BaseModel):
@@ -368,6 +372,7 @@ def _invite_response(invite: AccountInvite) -> InviteResponse:
         display_name=invite.display_name,
         created_at=invite.created_at,
         expires_at=invite.expires_at,
+        channel=invite.channel,
     )
 
 
@@ -499,7 +504,8 @@ def create_invite(
         username=username,
         display_name=display_name,
         token_hash=accounts.hash_token(raw_token),
-        ttl=INVITE_TTL,
+        channel=body.channel,
+        ttl=EMAIL_INVITE_TTL if body.channel == "email" else INVITE_TTL,
     )
     return InviteMintResponse(
         invite=_invite_response(invite),
@@ -554,6 +560,16 @@ def redeem_invite(
         ttl=SESSION_TTL,
     )
     app_db.consume_invite(invite.id, when=now)
+    app_db.save_action_audit(
+        ActionAudit(
+            action_name="invite.redeemed",
+            actor=f"invite:{invite.id}",
+            target_ids=[invite.id],
+            params={"username": invite.username, "channel": invite.channel},
+            created_at=now,
+        )
+    )
+    logger.warning("Invite redeemed for %s via %s", invite.username, invite.channel)
     return LoginResponse(session_token=raw_session_token, user=_to_public_user(user))
 
 

--- a/fichero-engine/src/fichero/app_db.py
+++ b/fichero-engine/src/fichero/app_db.py
@@ -247,6 +247,7 @@ class AppDatabase:
                 token_hash VARCHAR NOT NULL UNIQUE,
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                 expires_at TIMESTAMP NOT NULL,
+                channel VARCHAR NOT NULL DEFAULT 'qr',
                 consumed_at TIMESTAMP,
                 revoked BOOLEAN DEFAULT FALSE
             )
@@ -286,6 +287,14 @@ class AppDatabase:
             # process dies before the next checkpoint the WAL is poisoned and every
             # restart crashes natively. CHECKPOINT here keeps the migration durable
             # and out of the recovery WAL. See app-db migration incident 2026-06-12.
+            self.conn.execute("CHECKPOINT")
+
+        _invite_cols = {
+            row[1] for row in self.conn.execute("PRAGMA table_info(invites)").fetchall()
+        }
+        if "channel" not in _invite_cols:
+            self.conn.execute("ALTER TABLE invites ADD COLUMN channel VARCHAR DEFAULT 'qr'")
+            self.conn.execute("UPDATE invites SET channel = 'qr' WHERE channel IS NULL")
             self.conn.execute("CHECKPOINT")
 
         # Per-library ACL tables (global identity scope, not per-library DB).
@@ -1482,6 +1491,7 @@ class AppDatabase:
         username: str,
         display_name: str,
         token_hash: str,
+        channel: str,
         ttl: timedelta,
     ) -> AccountInvite:
         """Insert a new invite row and return the typed record."""
@@ -1492,15 +1502,16 @@ class AppDatabase:
             token_hash=token_hash,
             created_at=now,
             expires_at=now + ttl,
+            channel=channel,
         )
         with self._lock:
             self.conn.execute(
                 """
                 INSERT INTO invites (
                     id, username, display_name, token_hash,
-                    created_at, expires_at, consumed_at, revoked
+                    created_at, expires_at, channel, consumed_at, revoked
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 [
                     invite.id,
@@ -1509,6 +1520,7 @@ class AppDatabase:
                     invite.token_hash,
                     invite.created_at,
                     invite.expires_at,
+                    invite.channel,
                     invite.consumed_at,
                     invite.revoked,
                 ],
@@ -1524,8 +1536,9 @@ class AppDatabase:
             token_hash=row[3],
             created_at=row[4],
             expires_at=row[5],
-            consumed_at=row[6],
-            revoked=row[7],
+            channel=row[6],
+            consumed_at=row[7],
+            revoked=row[8],
         )
 
     def get_invite(self, invite_id: str) -> AccountInvite | None:
@@ -1534,7 +1547,7 @@ class AppDatabase:
             result = self.conn.execute(
                 """
                 SELECT id, username, display_name, token_hash,
-                       created_at, expires_at, consumed_at, revoked
+                       created_at, expires_at, channel, consumed_at, revoked
                 FROM invites
                 WHERE id = ?
                 """,
@@ -1548,7 +1561,7 @@ class AppDatabase:
             result = self.conn.execute(
                 """
                 SELECT id, username, display_name, token_hash,
-                       created_at, expires_at, consumed_at, revoked
+                       created_at, expires_at, channel, consumed_at, revoked
                 FROM invites
                 WHERE token_hash = ?
                 """,
@@ -1563,7 +1576,7 @@ class AppDatabase:
             rows = self.conn.execute(
                 """
                 SELECT id, username, display_name, token_hash,
-                       created_at, expires_at, consumed_at, revoked
+                       created_at, expires_at, channel, consumed_at, revoked
                 FROM invites
                 WHERE revoked = FALSE AND consumed_at IS NULL AND expires_at > ?
                 ORDER BY created_at DESC, username
@@ -1579,7 +1592,7 @@ class AppDatabase:
             result = self.conn.execute(
                 """
                 SELECT id, username, display_name, token_hash,
-                       created_at, expires_at, consumed_at, revoked
+                       created_at, expires_at, channel, consumed_at, revoked
                 FROM invites
                 WHERE username = ? AND revoked = FALSE AND consumed_at IS NULL AND expires_at > ?
                 ORDER BY created_at DESC

--- a/fichero-engine/src/fichero/models.py
+++ b/fichero-engine/src/fichero/models.py
@@ -31,7 +31,7 @@ Usage:
 from pydantic import BaseModel, Field, ConfigDict, computed_field, field_validator
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 import base64
 import logging
@@ -1096,6 +1096,7 @@ class AccountInvite(BaseModel):
     token_hash: str
     created_at: datetime = Field(default_factory=datetime.now)
     expires_at: datetime
+    channel: Literal["qr", "messages", "email"] = "qr"
     consumed_at: datetime | None = None
     revoked: bool = False
 

--- a/fichero-engine/tests/unit/test_invites.py
+++ b/fichero-engine/tests/unit/test_invites.py
@@ -156,6 +156,78 @@ def test_invite_is_one_time_only(app_db, monkeypatch):
     assert second.json()["code"] == "invite_consumed"
 
 
+def test_invites_keep_short_qr_ttl_but_email_lives_for_a_day(app_db, monkeypatch):
+    _enable_multiuser(monkeypatch)
+    base_now = datetime(2026, 7, 5, 12, 0, 0)
+
+    class FrozenDateTime(datetime):
+        current = base_now
+
+        @classmethod
+        def now(cls, tz=None):
+            return cls.current if tz is None else tz.fromutc(cls.current.replace(tzinfo=tz))
+
+    monkeypatch.setattr(auth_accounts, "datetime", FrozenDateTime)
+    monkeypatch.setattr("fichero.app_db.datetime", FrozenDateTime)
+
+    with _client(app_db, monkeypatch) as client:
+        qr = client.post(
+            "/api/auth/invites",
+            headers=_bearer(initialize_token()),
+            json={"username": "qr-user", "display_name": "QR User", "channel": "qr"},
+        )
+        messages = client.post(
+            "/api/auth/invites",
+            headers=_bearer(initialize_token()),
+            json={
+                "username": "messages-user",
+                "display_name": "Messages User",
+                "channel": "messages",
+            },
+        )
+        email = client.post(
+            "/api/auth/invites",
+            headers=_bearer(initialize_token()),
+            json={"username": "email-user", "display_name": "Email User", "channel": "email"},
+        )
+
+    assert qr.status_code == 200
+    assert messages.status_code == 200
+    assert email.status_code == 200
+    assert qr.json()["invite"]["expires_at"] == (base_now + timedelta(minutes=15)).isoformat()
+    assert messages.json()["invite"]["expires_at"] == (
+        base_now + timedelta(minutes=15)
+    ).isoformat()
+    assert email.json()["invite"]["expires_at"] == (base_now + timedelta(days=1)).isoformat()
+    assert qr.json()["invite"]["channel"] == "qr"
+    assert messages.json()["invite"]["channel"] == "messages"
+    assert email.json()["invite"]["channel"] == "email"
+
+
+def test_invite_redemption_records_a_durable_notice(app_db, monkeypatch):
+    _enable_multiuser(monkeypatch)
+
+    with _client(app_db, monkeypatch) as client:
+        invite = client.post(
+            "/api/auth/invites",
+            headers=_bearer(initialize_token()),
+            json={"username": "invitee", "display_name": "Invitee", "channel": "email"},
+        )
+        redeemed = client.post(
+            "/api/auth/invites/redeem",
+            json={
+                "invite_token": invite.json()["invite_token"],
+                "new_password": "password-1",
+            },
+        )
+
+    assert redeemed.status_code == 200
+    notices = [audit for audit in app_db.list_action_audits() if audit.action_name == "invite.redeemed"]
+    assert len(notices) == 1
+    assert notices[0].target_ids == [invite.json()["invite"]["id"]]
+    assert notices[0].params == {"username": "invitee", "channel": "email"}
+
+
 def test_expired_invite_fails(app_db, monkeypatch):
     _enable_multiuser(monkeypatch)
     base_now = datetime(2026, 7, 5, 12, 0, 0)


### PR DESCRIPTION
Closes #3790.

Email invites get a 24h TTL on the email path only (QR stays default), single-use + revocable, with a durable redemption audit notice.

- `invites.channel` column added via idempotent ALTER + backfill (migration policy compliant)
- 8 invite tests + 46 accounts/auth_accounts tests pass; endpoint guardrail clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)