### PR TITLE
feat: zero-touch enrollment + owner edit/delete users (#3789 #3858 #3859)

### DIFF
--- a/docs/contributor/api-reference/index.md
+++ b/docs/contributor/api-reference/index.md
@@ -145,6 +145,16 @@ These routes are in the committed OpenAPI contract. They are documented here
 until their corresponding Swift service wrappers land; the engine CLI already
 exposes them.
 
+### Device enrollment
+
+`POST /api/pair/enroll`
+
+- Purpose: exchange an owner's synced enrollment secret for a new, distinct
+  per-device token.
+- Request body: `EnrollmentRequest` with the required `enrollment_secret`.
+- Response: `200` with `PairResponse`. The enrollment secret is not itself a
+  device credential, so the returned token remains independently revocable.
+
 ### Agent workspace membership
 
 `PATCH /api/chat/workspaces/{workspace_id}/members`

--- a/docs/contributor/api-reference/openapi.json
+++ b/docs/contributor/api-reference/openapi.json
@@ -1865,6 +1865,48 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "users",
+          "users"
+        ],
+        "summary": "Delete User",
+        "description": "Remove a user and their active credentials and library grants.",
+        "operationId": "delete_user_api_users__user_id__delete",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/pair/code": {
@@ -1904,6 +1946,49 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/PairRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/pair/enroll": {
+      "post": {
+        "tags": [
+          "pairing",
+          "pairing"
+        ],
+        "summary": "Enroll Device",
+        "description": "Exchange one owner's synced enrollment secret for a new device token.",
+        "operationId": "enroll_device_api_pair_enroll_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnrollmentRequest"
               }
             }
           },
@@ -43052,6 +43137,26 @@
         "type": "object",
         "title": "EnhanceOperationRequest"
       },
+      "EnrollmentRequest": {
+        "properties": {
+          "enrollment_secret": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Enrollment Secret"
+          },
+          "device_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Device Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "enrollment_secret",
+          "device_name"
+        ],
+        "title": "EnrollmentRequest"
+      },
       "EntitiesPageResponse": {
         "properties": {
           "entities": {
@@ -46649,6 +46754,16 @@
             "minLength": 1,
             "nullable": true,
             "title": "Display Name"
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "qr",
+              "messages",
+              "email"
+            ],
+            "title": "Channel",
+            "default": "qr"
           }
         },
         "type": "object",
@@ -46680,6 +46795,15 @@
             "type": "string",
             "format": "date-time",
             "title": "Expires At"
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "qr",
+              "messages",
+              "email"
+            ],
+            "title": "Channel"
           }
         },
         "type": "object",
@@ -46688,7 +46812,8 @@
           "username",
           "display_name",
           "created_at",
-          "expires_at"
+          "expires_at",
+          "channel"
         ],
         "title": "InviteResponse"
       },
@@ -61335,6 +61460,17 @@
             "type": "boolean",
             "nullable": true,
             "title": "Active"
+          },
+          "display_name": {
+            "type": "string",
+            "minLength": 1,
+            "nullable": true,
+            "title": "Display Name"
+          },
+          "is_owner": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Is Owner"
           }
         },
         "type": "object",

--- a/docs/contributor/api-reference/path_allowlist.json
+++ b/docs/contributor/api-reference/path_allowlist.json
@@ -394,6 +394,7 @@
   "/api/pair/devices": "Current API reference index documents route families and the committed schema render, not per-path markdown callouts yet.",
   "/api/pair/devices/renew": "Current API reference index documents route families and the committed schema render, not per-path markdown callouts yet.",
   "/api/pair/devices/{device_id}/revoke": "Current API reference index documents route families and the committed schema render, not per-path markdown callouts yet.",
+  "/api/pair/enroll": "Zero-touch device enrollment endpoint (#3789); the API reference index documents route families + the committed schema render, per-path markdown callout is a follow-up.",
   "/api/policies/orchestration": "Current API reference index documents route families and the committed schema render, not per-path markdown callouts yet.",
   "/api/policies/orchestration/evaluate": "Current API reference index documents route families and the committed schema render, not per-path markdown callouts yet.",
   "/api/policies/orchestration/{rule_id}": "Current API reference index documents route families and the committed schema render, not per-path markdown callouts yet.",

--- a/fichero-engine/src/fichero/api/routes/auth_accounts.py
+++ b/fichero-engine/src/fichero/api/routes/auth_accounts.py
@@ -738,3 +738,25 @@ def update_user(
     if updated is None:
         raise HTTPException(status_code=404, detail="user not found")
     return _to_public_user(updated)
+
+
+@users_router.delete("/{user_id}", response_model=StatusResponse)
+def delete_user(
+    request: Request,
+    user_id: str,
+    app_db: AppDatabase = Depends(get_app_database),
+) -> StatusResponse:
+    """Remove a user and their active credentials and library grants."""
+    _multiuser_disabled()
+    _require_owner_or_bootstrap(request)
+
+    user = app_db.get_user(user_id)
+    if user is None:
+        raise HTTPException(status_code=404, detail="user not found")
+    session_user = _current_session_user(request)
+    if session_user is not None and session_user.id == user_id:
+        raise HTTPException(status_code=409, detail="cannot delete your own account")
+    if user.is_owner and len([candidate for candidate in app_db.list_users() if candidate.is_owner]) == 1:
+        raise HTTPException(status_code=409, detail="cannot delete the last owner")
+    app_db.delete_user(user_id)
+    return StatusResponse(status="ok")

--- a/fichero-engine/src/fichero/api/routes/auth_accounts.py
+++ b/fichero-engine/src/fichero/api/routes/auth_accounts.py
@@ -144,6 +144,8 @@ class CreateUserRequest(BaseModel):
 class UpdateUserRequest(BaseModel):
     password: str | None = Field(default=None, min_length=1)
     active: bool | None = None
+    display_name: str | None = Field(default=None, min_length=1)
+    is_owner: bool | None = None
 
 
 def _multiuser_disabled() -> None:
@@ -720,6 +722,17 @@ def update_user(
             app_db.revoke_all_for_user(user_id)
             app_db.revoke_all_devices_for_user(user_id)
         app_db.set_active(user_id, body.active)
+
+    if body.display_name is not None:
+        display_name = body.display_name.strip()
+        if not display_name:
+            raise HTTPException(status_code=422, detail="display_name is required")
+        app_db.set_display_name(user_id, display_name)
+
+    if body.is_owner is not None and body.is_owner != user.is_owner:
+        if not body.is_owner and len([candidate for candidate in app_db.list_users() if candidate.is_owner]) == 1:
+            raise HTTPException(status_code=409, detail="cannot demote the last owner")
+        app_db.set_is_owner(user_id, body.is_owner)
 
     updated = app_db.get_user(user_id)
     if updated is None:

--- a/fichero-engine/src/fichero/api/routes/pairing.py
+++ b/fichero-engine/src/fichero/api/routes/pairing.py
@@ -91,6 +91,11 @@ class PairRequest(BaseModel):
     device_name: str = Field(min_length=1)
 
 
+class EnrollmentRequest(BaseModel):
+    enrollment_secret: str = Field(min_length=1)
+    device_name: str = Field(min_length=1)
+
+
 class PairResponse(BaseModel):
     device_id: str
     device_token: str
@@ -444,6 +449,50 @@ def pair_device(
         )
         record.used = True
         _PAIRING_CODES.pop(code, None)
+        return _to_pair_response(device, raw_token)
+    except HTTPException:
+        _record_pair_attempt(request, now)
+        raise
+
+
+@router.post("/enroll", response_model=PairResponse)
+def enroll_device(
+    request: Request,
+    body: EnrollmentRequest,
+    app_db: AppDatabase = Depends(get_app_database),
+) -> PairResponse:
+    """Exchange one owner's synced enrollment secret for a new device token."""
+    _require_secure_pairing_transport(request)
+    now = datetime.now()
+    _check_pair_rate_limit(request, now, record_attempt=False)
+
+    try:
+        secret = app_db.get_enrollment_secret_by_token_hash(
+            accounts.hash_token(body.enrollment_secret.strip())
+        )
+        if secret is None or secret.revoked:
+            raise HTTPException(status_code=401, detail="invalid enrollment secret")
+        user = app_db.get_user(secret.user_id)
+        if user is None or not user.active:
+            raise HTTPException(status_code=401, detail="invalid enrollment secret")
+
+        name = body.device_name.strip()
+        if not name:
+            raise HTTPException(status_code=422, detail="device_name is required")
+        raw_token = accounts.new_session_token()
+        device = app_db.create_device(
+            name=name,
+            user_id=user.id,
+            token_hash=accounts.hash_token(raw_token),
+        )
+        _record_device_audit(
+            action_name="device.enroll",
+            actor=f"enrollment:{secret.id}",
+            params={"device_name": name},
+            device_id=device.id,
+            after=_to_public_device(device).model_dump(mode="json"),
+        )
+        logger.warning("Device enrolled for %s: %s", user.username, name)
         return _to_pair_response(device, raw_token)
     except HTTPException:
         _record_pair_attempt(request, now)

--- a/fichero-engine/src/fichero/app_db.py
+++ b/fichero-engine/src/fichero/app_db.py
@@ -1077,6 +1077,24 @@ class AppDatabase:
         self._update_user_fk_safe("is_owner = ?", [is_owner], user_id)
         return self.get_user(user_id)
 
+    def delete_user(self, user_id: str) -> bool:
+        """Delete a user and the credentials and grants that depend on it."""
+        with self._lock:
+            exists = self.conn.execute("SELECT 1 FROM users WHERE id = ?", [user_id]).fetchone()
+            if exists is None:
+                return False
+            for table in (
+                "library_acl_overrides",
+                "library_roles",
+                "sessions",
+                "devices",
+                "enrollment_secrets",
+            ):
+                self.conn.execute(f"DELETE FROM {table} WHERE user_id = ?", [user_id])
+            self.conn.execute("DELETE FROM users WHERE id = ?", [user_id])
+            self.conn.commit()
+        return True
+
     def _update_user_fk_safe(
         self,
         set_clause: str,

--- a/fichero-engine/src/fichero/app_db.py
+++ b/fichero-engine/src/fichero/app_db.py
@@ -1067,6 +1067,16 @@ class AppDatabase:
         )
         return self.get_user(user_id)
 
+    def set_display_name(self, user_id: str, display_name: str) -> AccountUser | None:
+        """Update one user's display name."""
+        self._update_user_fk_safe("display_name = ?", [display_name.strip()], user_id)
+        return self.get_user(user_id)
+
+    def set_is_owner(self, user_id: str, is_owner: bool) -> AccountUser | None:
+        """Update one user's app-wide owner status."""
+        self._update_user_fk_safe("is_owner = ?", [is_owner], user_id)
+        return self.get_user(user_id)
+
     def _update_user_fk_safe(
         self,
         set_clause: str,

--- a/fichero-engine/src/fichero/app_db.py
+++ b/fichero-engine/src/fichero/app_db.py
@@ -28,6 +28,7 @@ from fichero.models import (
     AccountSession,
     AccountUser,
     Device,
+    EnrollmentSecret,
     LibraryAclOverride,
     LibraryRole,
     Model,
@@ -250,6 +251,17 @@ class AppDatabase:
                 channel VARCHAR NOT NULL DEFAULT 'qr',
                 consumed_at TIMESTAMP,
                 revoked BOOLEAN DEFAULT FALSE
+            )
+        """)
+
+        self.conn.execute("""
+            CREATE TABLE IF NOT EXISTS enrollment_secrets (
+                id VARCHAR PRIMARY KEY,
+                user_id VARCHAR NOT NULL,
+                token_hash VARCHAR NOT NULL UNIQUE,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                revoked BOOLEAN DEFAULT FALSE,
+                FOREIGN KEY (user_id) REFERENCES users(id)
             )
         """)
 
@@ -1622,6 +1634,41 @@ class AppDatabase:
             )
             self.conn.commit()
         return self.get_invite(invite_id)
+
+    # =========================================================================
+    # Enrollment secrets
+    # =========================================================================
+
+    def create_enrollment_secret(self, *, user_id: str, token_hash: str) -> EnrollmentSecret:
+        """Persist a hashed grant that can mint independent device credentials."""
+        secret = EnrollmentSecret(user_id=user_id, token_hash=token_hash)
+        with self._lock:
+            self.conn.execute(
+                """
+                INSERT INTO enrollment_secrets (id, user_id, token_hash, created_at, revoked)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                [secret.id, secret.user_id, secret.token_hash, secret.created_at, secret.revoked],
+            )
+            self.conn.commit()
+        return secret
+
+    def get_enrollment_secret_by_token_hash(self, token_hash: str) -> EnrollmentSecret | None:
+        """Return a persistent enrollment grant by its stored hash."""
+        with self._lock:
+            row = self.conn.execute(
+                """
+                SELECT id, user_id, token_hash, created_at, revoked
+                FROM enrollment_secrets
+                WHERE token_hash = ?
+                """,
+                [token_hash],
+            ).fetchone()
+        if row is None:
+            return None
+        return EnrollmentSecret(
+            id=row[0], user_id=row[1], token_hash=row[2], created_at=row[3], revoked=row[4]
+        )
 
     # =========================================================================
     # Devices

--- a/fichero-engine/src/fichero/cli/openapi_surface_generated.py
+++ b/fichero-engine/src/fichero/cli/openapi_surface_generated.py
@@ -1405,6 +1405,7 @@ def register_generated_openapi_commands(
     @target_app.command("create-invite")
     def auth_create_invite_post(
         ctx: typer.Context,
+        channel: Optional[str] = typer.Option(None, "--channel", help="Request field: channel."),
         display_name: Optional[str] = typer.Option(None, "--display-name", help="Request field: display_name."),
         username: str = typer.Option(..., "--username", help="Request field: username."),
     ) -> None:
@@ -1413,9 +1414,11 @@ def register_generated_openapi_commands(
             endpoint_path = "/api/auth/invites"
             params = None
             payload = _build_json_payload({
+                "channel": channel,
                 "display_name": display_name,
                 "username": username,
             }, {
+                "channel": {'type': 'string', 'enum': ['qr', 'messages', 'email'], 'title': 'Channel', 'default': 'qr', 'x-cli-required': False},
                 "display_name": {'type': 'string', 'minLength': 1, 'nullable': True, 'title': 'Display Name', 'x-cli-required': False},
                 "username": {'type': 'string', 'minLength': 1, 'title': 'Username', 'x-cli-required': True},
             }, required=True)
@@ -10033,6 +10036,26 @@ def register_generated_openapi_commands(
             return client.request("POST", endpoint_path, params=params)
         invoke(ctx, op_call)
 
+    @target_app.command("enroll-device")
+    def pair_enroll_device_post(
+        ctx: typer.Context,
+        device_name: str = typer.Option(..., "--device-name", help="Request field: device_name."),
+        enrollment_secret: str = typer.Option(..., "--enrollment-secret", help="Request field: enrollment_secret."),
+    ) -> None:
+        """Enroll Device (POST /api/pair/enroll)."""
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = "/api/pair/enroll"
+            params = None
+            payload = _build_json_payload({
+                "device_name": device_name,
+                "enrollment_secret": enrollment_secret,
+            }, {
+                "device_name": {'type': 'string', 'minLength': 1, 'title': 'Device Name', 'x-cli-required': True},
+                "enrollment_secret": {'type': 'string', 'minLength': 1, 'title': 'Enrollment Secret', 'x-cli-required': True},
+            }, required=True)
+            return client.request("POST", endpoint_path, params=params, json=payload)
+        invoke(ctx, op_call)
+
     target_app = existing_apps.get('policies')
     if target_app is None:
         target_app = typer.Typer(help='Generated OpenAPI commands for policies endpoints.', no_args_is_help=True)
@@ -13337,11 +13360,28 @@ def register_generated_openapi_commands(
             return client.request("POST", endpoint_path, params=params, json=payload)
         invoke(ctx, op_call)
 
+    @target_app.command("delete")
+    def users_delete_delete(
+        ctx: typer.Context,
+        user_id: str = typer.Argument(..., help="Path parameter: user_id."),
+        yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation prompt."),
+    ) -> None:
+        """Delete User (DELETE /api/users/{user_id})."""
+        if not yes:
+            typer.confirm("Delete users?", abort=True)
+        def op_call(client: FicheroClient) -> Any:
+            endpoint_path = f"/api/users/{user_id}"
+            params = None
+            return client.request("DELETE", endpoint_path, params=params)
+        invoke(ctx, op_call)
+
     @target_app.command("update")
     def users_update_patch(
         ctx: typer.Context,
         user_id: str = typer.Argument(..., help="Path parameter: user_id."),
         active: Optional[bool] = typer.Option(None, "--active/--no-active", help="Request field: active."),
+        display_name: Optional[str] = typer.Option(None, "--display-name", help="Request field: display_name."),
+        is_owner: Optional[bool] = typer.Option(None, "--is-owner/--no-is-owner", help="Request field: is_owner."),
         password: Optional[str] = typer.Option(None, "--password", help="Request field: password."),
     ) -> None:
         """Update User (PATCH /api/users/{user_id})."""
@@ -13350,9 +13390,13 @@ def register_generated_openapi_commands(
             params = None
             payload = _build_json_payload({
                 "active": active,
+                "display_name": display_name,
+                "is_owner": is_owner,
                 "password": password,
             }, {
                 "active": {'type': 'boolean', 'nullable': True, 'title': 'Active', 'x-cli-required': False},
+                "display_name": {'type': 'string', 'minLength': 1, 'nullable': True, 'title': 'Display Name', 'x-cli-required': False},
+                "is_owner": {'type': 'boolean', 'nullable': True, 'title': 'Is Owner', 'x-cli-required': False},
                 "password": {'type': 'string', 'minLength': 1, 'nullable': True, 'title': 'Password', 'x-cli-required': False},
             }, required=True)
             return client.request("PATCH", endpoint_path, params=params, json=payload)

--- a/fichero-engine/src/fichero/models.py
+++ b/fichero-engine/src/fichero/models.py
@@ -1101,6 +1101,18 @@ class AccountInvite(BaseModel):
     revoked: bool = False
 
 
+class EnrollmentSecret(BaseModel):
+    """Hashed, revocable grant for enrolling one owner's own devices."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str = Field(default_factory=_new_id)
+    user_id: str
+    token_hash: str
+    created_at: datetime = Field(default_factory=datetime.now)
+    revoked: bool = False
+
+
 class Device(BaseModel):
     """App-wide paired device credential stored in the global app database."""
 

--- a/fichero-engine/tests/contracts/coverage_matrix.json
+++ b/fichero-engine/tests/contracts/coverage_matrix.json
@@ -543,12 +543,12 @@
     },
     {
       "domain": "pair",
-      "total": 5,
+      "total": 6,
       "swiftui_wired": 5,
-      "swiftui_unwired": 0,
-      "swiftui_allowlisted": 0,
-      "swiftui_coverage": 1.0,
-      "cli_wired": 5,
+      "swiftui_unwired": 1,
+      "swiftui_allowlisted": 1,
+      "swiftui_coverage": 0.8333,
+      "cli_wired": 6,
       "cli_untested": 0,
       "cli_allowlisted": 0,
       "cli_coverage": 1.0

--- a/fichero-engine/tests/contracts/endpoints.json
+++ b/fichero-engine/tests/contracts/endpoints.json
@@ -6983,6 +6983,16 @@
         "query_params": [],
         "request_model": null,
         "response_model": "StatusResponse"
+      },
+      {
+        "method": "POST",
+        "path": "/pair/enroll",
+        "operation_id": "enroll_device_api_pair_enroll_post",
+        "summary": "Enroll Device",
+        "path_params": [],
+        "query_params": [],
+        "request_model": "EnrollmentRequest",
+        "response_model": "PairResponse"
       }
     ],
     "policies": [
@@ -9174,6 +9184,18 @@
         "query_params": [],
         "request_model": "CreateUserRequest",
         "response_model": "UserResponse"
+      },
+      {
+        "method": "DELETE",
+        "path": "/users/{user_id}",
+        "operation_id": "delete_user_api_users__user_id__delete",
+        "summary": "Delete User",
+        "path_params": [
+          "user_id"
+        ],
+        "query_params": [],
+        "request_model": null,
+        "response_model": "StatusResponse"
       },
       {
         "method": "PATCH",

--- a/fichero-engine/tests/contracts/openapi.json
+++ b/fichero-engine/tests/contracts/openapi.json
@@ -1865,6 +1865,48 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "users",
+          "users"
+        ],
+        "summary": "Delete User",
+        "description": "Remove a user and their active credentials and library grants.",
+        "operationId": "delete_user_api_users__user_id__delete",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/pair/code": {
@@ -1904,6 +1946,49 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/PairRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/pair/enroll": {
+      "post": {
+        "tags": [
+          "pairing",
+          "pairing"
+        ],
+        "summary": "Enroll Device",
+        "description": "Exchange one owner's synced enrollment secret for a new device token.",
+        "operationId": "enroll_device_api_pair_enroll_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnrollmentRequest"
               }
             }
           },
@@ -43052,6 +43137,26 @@
         "type": "object",
         "title": "EnhanceOperationRequest"
       },
+      "EnrollmentRequest": {
+        "properties": {
+          "enrollment_secret": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Enrollment Secret"
+          },
+          "device_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Device Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "enrollment_secret",
+          "device_name"
+        ],
+        "title": "EnrollmentRequest"
+      },
       "EntitiesPageResponse": {
         "properties": {
           "entities": {
@@ -46649,6 +46754,16 @@
             "minLength": 1,
             "nullable": true,
             "title": "Display Name"
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "qr",
+              "messages",
+              "email"
+            ],
+            "title": "Channel",
+            "default": "qr"
           }
         },
         "type": "object",
@@ -46680,6 +46795,15 @@
             "type": "string",
             "format": "date-time",
             "title": "Expires At"
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "qr",
+              "messages",
+              "email"
+            ],
+            "title": "Channel"
           }
         },
         "type": "object",
@@ -46688,7 +46812,8 @@
           "username",
           "display_name",
           "created_at",
-          "expires_at"
+          "expires_at",
+          "channel"
         ],
         "title": "InviteResponse"
       },
@@ -61335,6 +61460,17 @@
             "type": "boolean",
             "nullable": true,
             "title": "Active"
+          },
+          "display_name": {
+            "type": "string",
+            "minLength": 1,
+            "nullable": true,
+            "title": "Display Name"
+          },
+          "is_owner": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Is Owner"
           }
         },
         "type": "object",

--- a/fichero-engine/tests/contracts/ui_wiring_allowlist_swiftui.json
+++ b/fichero-engine/tests/contracts/ui_wiring_allowlist_swiftui.json
@@ -109,6 +109,7 @@
   "/api/model-comparison/recommend-models": "#2204 backend model recommendation API; Settings/model-picker UI wiring tracked by #2116",
   "/api/notes/{note_id}/links": "baseline: not yet wired",
   "/api/notes/{note_id}/links/{link_id}": "baseline: not yet wired",
+  "/api/pair/enroll": "#3789 zero-touch enrollment is engine-only until the Swift keychain-sync pairing flow lands",
   "/api/policies/orchestration": "baseline: not yet wired",
   "/api/policies/orchestration/evaluate": "baseline: not yet wired",
   "/api/policies/orchestration/{rule_id}": "baseline: not yet wired",

--- a/fichero-engine/tests/unit/test_auth_accounts.py
+++ b/fichero-engine/tests/unit/test_auth_accounts.py
@@ -709,6 +709,53 @@ def test_owner_can_change_password_for_role_holder_without_losing_acl_rows(
     assert new_login.status_code == 200
 
 
+def test_owner_can_rename_user_and_change_owner_status(client, app_db, monkeypatch):
+    _enable_multiuser(monkeypatch)
+    owner = app_db.create_user(
+        username="owner",
+        display_name="Owner",
+        password_hash=accounts.hash_password("password"),
+        is_owner=True,
+    )
+    member = app_db.create_user(
+        username="member",
+        display_name="Member",
+        password_hash=accounts.hash_password("password"),
+        is_owner=False,
+    )
+    owner_token = _login(client, owner.username, "password")
+
+    response = client.patch(
+        f"/api/users/{member.id}",
+        headers=_bearer(owner_token),
+        json={"display_name": "Renamed Member", "is_owner": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["display_name"] == "Renamed Member"
+    assert response.json()["is_owner"] is True
+
+
+def test_update_user_refuses_to_demote_last_owner(client, app_db, monkeypatch):
+    _enable_multiuser(monkeypatch)
+    owner = app_db.create_user(
+        username="owner",
+        display_name="Owner",
+        password_hash=accounts.hash_password("password"),
+        is_owner=True,
+    )
+    owner_token = _login(client, owner.username, "password")
+
+    response = client.patch(
+        f"/api/users/{owner.id}",
+        headers=_bearer(owner_token),
+        json={"is_owner": False},
+    )
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "cannot demote the last owner"
+
+
 def test_set_active_preserves_acl_rows_for_role_holder(app_db):
     user = app_db.create_user(
         username="ann",

--- a/fichero-engine/tests/unit/test_auth_accounts.py
+++ b/fichero-engine/tests/unit/test_auth_accounts.py
@@ -17,6 +17,12 @@ def _bearer(token: str) -> dict[str, str]:
     return {"Authorization": f"Bearer {token}"}
 
 
+def _login(client: TestClient, username: str, password: str) -> str:
+    response = client.post("/api/auth/login", json={"username": username, "password": password})
+    assert response.status_code == 200
+    return response.json()["session_token"]
+
+
 def _enable_multiuser(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("FICHERO_MULTIUSER", "1")
 

--- a/fichero-engine/tests/unit/test_auth_accounts.py
+++ b/fichero-engine/tests/unit/test_auth_accounts.py
@@ -756,6 +756,73 @@ def test_update_user_refuses_to_demote_last_owner(client, app_db, monkeypatch):
     assert response.json()["detail"] == "cannot demote the last owner"
 
 
+def test_owner_can_delete_user_and_their_credentials_and_grants(client, app_db, monkeypatch):
+    _enable_multiuser(monkeypatch)
+    owner = app_db.create_user(
+        username="owner",
+        display_name="Owner",
+        password_hash=accounts.hash_password("password"),
+        is_owner=True,
+    )
+    member = app_db.create_user(
+        username="member",
+        display_name="Member",
+        password_hash=accounts.hash_password("password"),
+        is_owner=False,
+    )
+    app_db.create_session(
+        user_id=member.id,
+        token_hash=accounts.hash_token("member-session"),
+        device_label="Member Mac",
+        ttl=timedelta(days=1),
+    )
+    app_db.create_device(
+        user_id=member.id,
+        name="Member iPad",
+        token_hash=accounts.hash_token("member-device"),
+    )
+    app_db.set_library_role(user_id=member.id, library_path="/tmp/library.fichero", role="editor")
+    owner_token = _login(client, owner.username, "password")
+
+    response = client.delete(f"/api/users/{member.id}", headers=_bearer(owner_token))
+
+    assert response.status_code == 200
+    assert app_db.get_user(member.id) is None
+    assert app_db.list_library_roles_for_user(member.id) == []
+    assert app_db.get_session_by_token_hash(accounts.hash_token("member-session")) is None
+    assert app_db.get_device_by_token_hash(accounts.hash_token("member-device")) is None
+
+
+def test_delete_user_refuses_self_and_last_owner(client, app_db, monkeypatch):
+    _enable_multiuser(monkeypatch)
+    owner = app_db.create_user(
+        username="owner",
+        display_name="Owner",
+        password_hash=accounts.hash_password("password"),
+        is_owner=True,
+    )
+    other_owner = app_db.create_user(
+        username="other-owner",
+        display_name="Other Owner",
+        password_hash=accounts.hash_password("password"),
+        is_owner=True,
+    )
+    owner_token = _login(client, owner.username, "password")
+
+    self_delete = client.delete(f"/api/users/{owner.id}", headers=_bearer(owner_token))
+    last_owner = client.delete(
+        f"/api/users/{other_owner.id}",
+        headers=_bearer(owner_token),
+    )
+
+    assert self_delete.status_code == 409
+    assert self_delete.json()["detail"] == "cannot delete your own account"
+    assert last_owner.status_code == 200
+    final_owner_delete = client.delete(f"/api/users/{owner.id}", headers=_bearer(initialize_token()))
+    assert final_owner_delete.status_code == 409
+    assert final_owner_delete.json()["detail"] == "cannot delete the last owner"
+
+
 def test_set_active_preserves_acl_rows_for_role_holder(app_db):
     user = app_db.create_user(
         username="ann",

--- a/fichero-engine/tests/unit/test_pairing_auth_fork_adversarial.py
+++ b/fichero-engine/tests/unit/test_pairing_auth_fork_adversarial.py
@@ -103,6 +103,41 @@ def test_pairing_rejects_replay_after_code_is_used(pairing_client, app_db):
     assert code not in pairing._PAIRING_CODES
 
 
+def test_enrollment_secret_mints_distinct_per_device_tokens(pairing_client, app_db):
+    owner = _create_owner(app_db)
+    enrollment_secret = accounts.new_session_token()
+    app_db.create_enrollment_secret(
+        user_id=owner.id,
+        token_hash=accounts.hash_token(enrollment_secret),
+    )
+
+    iphone = pairing_client.post(
+        "/api/pair/enroll",
+        json={"enrollment_secret": enrollment_secret, "device_name": "Owner iPhone"},
+    )
+    ipad = pairing_client.post(
+        "/api/pair/enroll",
+        json={"enrollment_secret": enrollment_secret, "device_name": "Owner iPad"},
+    )
+
+    assert iphone.status_code == 200
+    assert ipad.status_code == 200
+    assert iphone.json()["device_id"] != ipad.json()["device_id"]
+    assert iphone.json()["device_token"] != ipad.json()["device_token"]
+    assert app_db.get_device(iphone.json()["device_id"]).user_id == owner.id
+    assert app_db.get_device(ipad.json()["device_id"]).user_id == owner.id
+
+
+def test_enrollment_rejects_invalid_secret(pairing_client):
+    response = pairing_client.post(
+        "/api/pair/enroll",
+        json={"enrollment_secret": "not-a-real-secret", "device_name": "Attacker iPad"},
+    )
+
+    assert response.status_code == 401
+    assert response.json()["detail"] == "invalid enrollment secret"
+
+
 def test_pairing_rejects_code_at_exact_expiry_boundary(app_db, monkeypatch):
     monkeypatch.setenv("FICHERO_MULTIUSER", "1")
     monkeypatch.setenv("FICHERO_TLS_SPKI_HASH", "c3BraS1waW4=")

--- a/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
+++ b/fichero/fichero-api-client/Sources/FicheroAPIClient/openapi.json
@@ -1865,6 +1865,48 @@
             }
           }
         }
+      },
+      "delete": {
+        "tags": [
+          "users",
+          "users"
+        ],
+        "summary": "Delete User",
+        "description": "Remove a user and their active credentials and library grants.",
+        "operationId": "delete_user_api_users__user_id__delete",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatusResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
       }
     },
     "/api/pair/code": {
@@ -1904,6 +1946,49 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/PairRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PairResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/pair/enroll": {
+      "post": {
+        "tags": [
+          "pairing",
+          "pairing"
+        ],
+        "summary": "Enroll Device",
+        "description": "Exchange one owner's synced enrollment secret for a new device token.",
+        "operationId": "enroll_device_api_pair_enroll_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EnrollmentRequest"
               }
             }
           },
@@ -43052,6 +43137,26 @@
         "type": "object",
         "title": "EnhanceOperationRequest"
       },
+      "EnrollmentRequest": {
+        "properties": {
+          "enrollment_secret": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Enrollment Secret"
+          },
+          "device_name": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Device Name"
+          }
+        },
+        "type": "object",
+        "required": [
+          "enrollment_secret",
+          "device_name"
+        ],
+        "title": "EnrollmentRequest"
+      },
       "EntitiesPageResponse": {
         "properties": {
           "entities": {
@@ -46649,6 +46754,16 @@
             "minLength": 1,
             "nullable": true,
             "title": "Display Name"
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "qr",
+              "messages",
+              "email"
+            ],
+            "title": "Channel",
+            "default": "qr"
           }
         },
         "type": "object",
@@ -46680,6 +46795,15 @@
             "type": "string",
             "format": "date-time",
             "title": "Expires At"
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "qr",
+              "messages",
+              "email"
+            ],
+            "title": "Channel"
           }
         },
         "type": "object",
@@ -46688,7 +46812,8 @@
           "username",
           "display_name",
           "created_at",
-          "expires_at"
+          "expires_at",
+          "channel"
         ],
         "title": "InviteResponse"
       },
@@ -61335,6 +61460,17 @@
             "type": "boolean",
             "nullable": true,
             "title": "Active"
+          },
+          "display_name": {
+            "type": "string",
+            "minLength": 1,
+            "nullable": true,
+            "title": "Display Name"
+          },
+          "is_owner": {
+            "type": "boolean",
+            "nullable": true,
+            "title": "Is Owner"
           }
         },
         "type": "object",


### PR DESCRIPTION
Closes #3789, #3858, #3859. Cohesive user/device-management batch — Sharing & Pairing milestone.

**Manager security review (guardrails-only, no heavy suite per Daniel):**
- **#3789 enroll** — `POST /pairing/enroll` fail-closed: secure-transport, rate-limited, rejects missing/revoked secret + inactive user (401), mints fresh per-device token (secret never exchanged for itself), audited. New `enrollment_secrets` table via idempotent CREATE-IF-NOT-EXISTS, token hashed + `revoked` flag.
- **#3858 edit user** — `PATCH /users/{id}` adds display_name + is_owner. Owner-gated (`_require_owner_or_bootstrap`), so the new `is_owner` field is NOT a privilege-escalation surface. Last-owner demotion blocked (409).
- **#3859 delete user** — `DELETE /users/{id}` owner-gated; blocks self-delete (409) and last-owner delete (409); removes credentials + library grants.
- `check_endpoint_usage` green on the batch.

**⚠️ f_manager: run the FULL backend suite before merge** (DB-adding + 3 new auth endpoints): OpenAPI regen + contract (per-domain coverage / docs-coverage) + auth/pairing/accounts suites (test_auth_accounts, test_pairing_auth_fork_adversarial, test_device_auth_boundary). Merge only if 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)