### PR TITLE
test: guardrail for ArtifactServiceGenerated scene-root injection (#3386)

### DIFF
--- a/fichero/fichero-tests/ArtifactServiceInjectionTests.swift
+++ b/fichero/fichero-tests/ArtifactServiceInjectionTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+/// Guardrail for #3386 ("No Observable object of type ArtifactServiceGenerated
+/// found"). SwiftUI's environment does NOT flow across separate `Scene`s, so
+/// every window/document scene root that can present a view reading
+/// `@Environment(ArtifactServiceGenerated.self)` must inject
+/// `library.artifactService` itself — exactly like the About window injects
+/// `appState` (see `testMacAboutWindowInjectsAppState`).
+///
+/// The artifact-service consumers (`ContentView`, `DocumentTabView`,
+/// `LibraryView`, `DocumentKGSurface`, `ArtifactEntitiesView`,
+/// `ArtifactsInspectorPane`, `DocumentInspector`) are reached only through two
+/// injecting roots:
+///   • `LibraryWorkspaceRoot` — main window, Duplicate Window (WindowSeed), and
+///     the iOS main window all funnel through it above `DocumentTabView`.
+///   • `DocumentDetailWindow` — the detachable `document-detail` scene
+///     (macOS + iOS), which self-injects per-library services.
+/// These source-reading assertions fail the moment either injection is deleted,
+/// catching the regression before it ships as a runtime fatalError.
+final class ArtifactServiceInjectionTests: XCTestCase {
+    func testWorkspaceRootInjectsArtifactService() throws {
+        let source = try Self.appSource("Views/Library/Workspace/LibraryWorkspaceRoot.swift")
+        // The main / Duplicate / iOS scene roots host DocumentTabView (and thus
+        // ContentView, LibraryView, the inspector…) here; the service must ride
+        // the same per-library environment chain.
+        XCTAssertTrue(
+            source.contains(".environment(library.artifactService)"),
+            "LibraryWorkspaceRoot must inject library.artifactService so ContentView and its consumers resolve it (#3386)."
+        )
+    }
+
+    func testDocumentDetailWindowInjectsArtifactService() throws {
+        let source = try Self.appSource("Views/Library/Inspector/FocusedDocument.swift")
+        // The detached document-detail scene (macOS FicheroApp + iOS
+        // FicheroApp_iOS) presents DocumentInspector, which reads the service.
+        XCTAssertTrue(
+            source.contains(".environment(library.artifactService)"),
+            "DocumentDetailWindow must inject library.artifactService for the detached DocumentInspector (#3386)."
+        )
+    }
+
+    private static func appSource(_ relativePath: String) throws -> String {
+        let baseURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .appendingPathComponent("../fichero")
+        return try String(contentsOf: baseURL.appendingPathComponent(relativePath), encoding: .utf8)
+    }
+}


### PR DESCRIPTION
Closes #3386.

Audit found the `ArtifactServiceGenerated` injection already correct at both scene roots on HEAD (no live missing-injection site — likely fixed since the issue was filed). Rather than fabricate a change, delivered the guardrail the issue explicitly asks for: `ArtifactServiceInjectionTests.swift`, mirroring `testMacAboutWindowInjectsAppState` — removing either injection now fails a test instead of shipping the runtime fatalError.

Test-only; fichero-tests is a synchronized group (no pbxproj edit). Guardrails green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)