### PR TITLE
fix: avoid beta startup routes in release builds

### DIFF
--- a/fichero/fichero-tests/FeatureManagerTests.swift
+++ b/fichero/fichero-tests/FeatureManagerTests.swift
@@ -92,6 +92,18 @@ final class FeatureManagerTests: XCTestCase {
         }
     }
 
+    func testReleaseTierHidesBetaStartupServices() {
+        let betaStartupServices: [FeatureKey] = [.providers, .workflows, .chat, .activity]
+
+        for feature in betaStartupServices {
+            XCTAssertLessThan(
+                FeatureTiers.map[feature]!.tier.rank,
+                FeatureTier.release.rank,
+                "\(feature.rawValue) must not start against a release-tier engine"
+            )
+        }
+    }
+
     // The Engine & Access panes (Engine/Backend + Library Access: People /
     // Devices+QR / Capture) hold real, keepable capabilities, so their EXISTENCE
     // must not hang off the `.alpha`-tier `settings_*_tab` flags — those hid the QR

--- a/fichero/fichero/App/AppState.swift
+++ b/fichero/fichero/App/AppState.swift
@@ -483,6 +483,11 @@ class AppState {
     }
 
     func loadProviders() async {
+        guard FeatureManager.shared.isVisible(.providers) else {
+            providers = []
+            hasCheckedProviders = true
+            return
+        }
         do {
             providers = try await providerService.listProviders()
 

--- a/fichero/fichero/Models/LibraryManager+Helpers.swift
+++ b/fichero/fichero/Models/LibraryManager+Helpers.swift
@@ -234,12 +234,16 @@ extension LibraryManager {
         libraryManagerLogger.info("⏱ loadLibraryData documents loaded (\(docCount) items)")
 
         guard !Task.isCancelled else { return }
-        await library.workflowStore.loadWorkflows()
-        libraryManagerLogger.info("⏱ loadLibraryData workflows loaded")
+        if FeatureManager.shared.isVisible(.workflows) {
+            await library.workflowStore.loadWorkflows()
+            libraryManagerLogger.info("⏱ loadLibraryData workflows loaded")
+        }
 
         guard !Task.isCancelled else { return }
-        try? await library.conversationServiceGenerated.loadConversations()
-        libraryManagerLogger.info("⏱ loadLibraryData conversations loaded")
+        if FeatureManager.shared.isVisible(.chat) {
+            try? await library.conversationServiceGenerated.loadConversations()
+            libraryManagerLogger.info("⏱ loadLibraryData conversations loaded")
+        }
 
         guard !Task.isCancelled else { return }
         try? await library.savedSearchServiceGenerated.loadSavedSearches()

--- a/fichero/fichero/Views/ContentViewModifiers.swift
+++ b/fichero/fichero/Views/ContentViewModifiers.swift
@@ -7,6 +7,7 @@ private let logger = Logger(subsystem: "app.fichero.fichero", category: "Content
 
 /// Data loading modifiers (initial task + cache rebuilding)
 struct DataLoadingModifiers: ViewModifier {
+    @Environment(FeatureManager.self) private var featureManager
     let documentStore: DocumentStore
     let workflowStore: WorkflowStore
     let conversationService: ConversationServiceGenerated
@@ -20,13 +21,17 @@ struct DataLoadingModifiers: ViewModifier {
                         guard !Task.isCancelled else { return }
                         await documentStore.loadCollections()
                     }
-                    group.addTask {
-                        guard !Task.isCancelled else { return }
-                        await workflowStore.loadWorkflows()
+                    if featureManager.isVisible(.workflows) {
+                        group.addTask {
+                            guard !Task.isCancelled else { return }
+                            await workflowStore.loadWorkflows()
+                        }
                     }
-                    group.addTask {
-                        guard !Task.isCancelled else { return }
-                        try? await conversationService.loadConversations()
+                    if featureManager.isVisible(.chat) {
+                        group.addTask {
+                            guard !Task.isCancelled else { return }
+                            try? await conversationService.loadConversations()
+                        }
                     }
                     group.addTask {
                         guard !Task.isCancelled else { return }

--- a/fichero/fichero/Views/Library/Workspace/LibraryWorkspaceRoot.swift
+++ b/fichero/fichero/Views/Library/Workspace/LibraryWorkspaceRoot.swift
@@ -36,6 +36,7 @@ enum LibraryWorkspaceSelection {
 /// iPad, and visionOS embed the same workspace directly.
 struct LibraryWorkspaceRoot: View {
     @Environment(AppState.self) private var appState
+    @Environment(FeatureManager.self) private var featureManager
     @Environment(LibraryManager.self) private var libraryManager
     #if canImport(UIKit) && !os(macOS)
     @Environment(MobileCaptureQueueStore.self) private var captureQueue
@@ -107,7 +108,9 @@ struct LibraryWorkspaceRoot: View {
                 // pill until the user taps Reconnect (#3351).
                 guard appState.isBackendRunning else { return }
                 library.changeStream.start()
-                library.activityStore.start()
+                if featureManager.isVisible(.activity) {
+                    library.activityStore.start()
+                }
             }
         }
         .environment(library.documentStore)


### PR DESCRIPTION
Fixes #3878

Release-tier startup now skips providers, workflows, chat, and activity requests because their API route groups are beta-only. Core document, search, and change-stream startup remains available.

The embedded bootstrap token path was separately verified inside the App Sandbox; #3852 fixed stale session-token precedence.

Verification: swiftlint clean; Xcode build intentionally left to Daniel's active session to avoid build contention.