### PR TITLE
perf: shared document-keyed store kills artifact-entity N+1 fetch storm (#3861)

### DIFF
--- a/fichero/fichero-tests/ArtifactEntityStoreTests.swift
+++ b/fichero/fichero-tests/ArtifactEntityStoreTests.swift
@@ -1,0 +1,56 @@
+@testable import Fichero
+import XCTest
+
+/// Covers the parsing logic moved out of `ArtifactEntitiesView` /
+/// `ArtifactEntityCell` into the shared `ArtifactEntityStore` (#3861). The N+1
+/// fix hinges on `parse` producing the SAME per-type name lists the views used
+/// to build inline, so a document visible as a row + up to six type cells reads
+/// one shared bundle instead of firing seven `getArtifacts()` calls.
+@MainActor
+final class ArtifactEntityStoreTests: XCTestCase {
+    private func artifact(_ type: String, data: [String: AnyCodable]) -> Artifact {
+        Artifact(documentId: "d1", artifactType: type, data: data)
+    }
+
+    func testParseMapsEachEntityTypeToItsField() {
+        let artifacts = [
+            artifact("people", data: ["items": AnyCodable([["name": "Alice"], ["name": "Bob"]])]),
+            artifact("places", data: ["items": AnyCodable([["name": "Quibdó"]])]),
+            artifact("organizations", data: ["items": AnyCodable([["name": "ACME"]])]),
+            artifact("events", data: ["items": AnyCodable([["event": "Flood"]])]),
+            artifact("keywords", data: ["keywords": AnyCodable(["war", "peace"])]),
+            artifact("dates", data: ["items": AnyCodable([["date_normalized": "1990-01-02"], ["date": "raw"]])])
+        ]
+
+        let bundle = ArtifactEntityStore.parse(artifacts)
+
+        XCTAssertEqual(bundle.people, ["Alice", "Bob"])
+        XCTAssertEqual(bundle.places, ["Quibdó"])
+        XCTAssertEqual(bundle.organizations, ["ACME"])
+        XCTAssertEqual(bundle.events, ["Flood"])
+        XCTAssertEqual(bundle.keywords, ["war", "peace"])
+        // Dates prefer date_normalized, fall back to date.
+        XCTAssertEqual(bundle.dates, ["1990-01-02", "raw"])
+        XCTAssertFalse(bundle.isEmpty)
+    }
+
+    func testParseOfNoEntityArtifactsIsEmpty() {
+        // A non-entity artifact type (e.g. transcription) contributes nothing.
+        let bundle = ArtifactEntityStore.parse([artifact("transcription", data: [:])])
+        XCTAssertTrue(bundle.isEmpty)
+        XCTAssertEqual(bundle.people, [])
+    }
+
+    func testNamesForEntityTypeMatchesTheParsedField() {
+        let bundle = ArtifactEntityStore.parse([
+            artifact("people", data: ["items": AnyCodable([["name": "Alice"]])]),
+            artifact("keywords", data: ["keywords": AnyCodable(["war"])])
+        ])
+        // The per-column table cell reads through names(for:) — it must agree
+        // with the multiLine row's per-field reads.
+        XCTAssertEqual(bundle.names(for: "people"), ["Alice"])
+        XCTAssertEqual(bundle.names(for: "keywords"), ["war"])
+        XCTAssertEqual(bundle.names(for: "places"), [])
+        XCTAssertEqual(bundle.names(for: "unknown"), [])
+    }
+}

--- a/fichero/fichero/Models/ArtifactEntityStore.swift
+++ b/fichero/fichero/Models/ArtifactEntityStore.swift
@@ -1,0 +1,229 @@
+import Foundation
+import Observation
+import OSLog
+
+/// Parsed entity-artifact names for one document (#3861).
+///
+/// The list-row / table-cell entity previews only need the extracted *names*
+/// per entity-type, not the raw `Artifact` payloads. Parsing once into this
+/// value (in `ArtifactEntityStore`) keeps every consuming view free of decode
+/// work and lets `nil` vs a present-but-empty bundle distinguish "still
+/// loading" from "loaded, nothing found".
+struct ArtifactEntityBundle: Equatable {
+    var people: [String] = []
+    var places: [String] = []
+    var organizations: [String] = []
+    var events: [String] = []
+    var dates: [String] = []
+    var keywords: [String] = []
+
+    var isEmpty: Bool {
+        people.isEmpty && places.isEmpty && organizations.isEmpty
+            && events.isEmpty && dates.isEmpty && keywords.isEmpty
+    }
+
+    /// Names for a single entity-type column (table cell).
+    func names(for entityType: String) -> [String] {
+        switch entityType {
+        case "people": return people
+        case "places": return places
+        case "organizations": return organizations
+        case "events": return events
+        case "dates": return dates
+        case "keywords": return keywords
+        default: return []
+        }
+    }
+}
+
+/// Shared, document-keyed cache for list/table entity previews (#3861).
+///
+/// Fixes the N+1 fetch storm: previously `ArtifactEntitiesView` and each
+/// `ArtifactEntityCell` fired `getArtifacts()` in `.onAppear` — so one document
+/// visible as a Mail-style row plus up to six per-type table cells fetched the
+/// SAME document up to seven times, and `.onChange(workflowCompletedCount)`
+/// force-refetched every visible row/cell at once on any workflow completion.
+///
+/// Now the store is the single endpoint accessor (observable-data-layer rule,
+/// #1863): rows/cells call `ensureLoaded(_:)` and OBSERVE `bundles`; concurrent
+/// requests for the same document collapse to one fetch (`inFlight`); a workflow
+/// completion invalidates ONLY the document ids that run actually touched.
+///
+/// Wraps the EXISTING `ArtifactServiceGenerated` transport unchanged (the
+/// iterate-never-replace rule): the store owns *when* to fetch and the per-doc
+/// dedupe; the service still owns *how* (and its own `artifactsByDocument` cache).
+@MainActor
+@Observable
+final class ArtifactEntityStore {
+    /// Parsed previews keyed by documentId. `nil` for an id means "not loaded
+    /// yet" (show the silent placeholder); a present-but-empty bundle means
+    /// "loaded, no entity artifacts" (show "—").
+    private(set) var bundles: [String: ArtifactEntityBundle] = [:]
+
+    /// Documents with a fetch in flight — a second consumer for the same id is a
+    /// no-op, so seven views for one document trigger exactly one request.
+    private var inFlight: Set<String> = []
+
+    /// Workflow executions whose completion we've already reconciled, so the N
+    /// views that each observe `workflowCompletedCount` don't re-invalidate the
+    /// same run N times.
+    private var seenCompletedThreadIds: Set<String> = []
+
+    private let artifactService: ArtifactServiceGenerated
+    private let log = Logger(subsystem: "app.fichero.fichero", category: "ArtifactEntityStore")
+
+    init(artifactService: ArtifactServiceGenerated) {
+        self.artifactService = artifactService
+    }
+
+    // MARK: - Per-service sharing
+
+    // ponytail: one store per ArtifactServiceGenerated (i.e. per library),
+    // resolved from the service the views already hold in their environment —
+    // avoids threading a new @Environment object through the window/scene roots
+    // (a separate lane). The map is never pruned; libraries are few, so the
+    // upgrade path (clear on library close) isn't worth its wiring yet.
+    private static var registry: [ObjectIdentifier: ArtifactEntityStore] = [:]
+
+    static func shared(for artifactService: ArtifactServiceGenerated) -> ArtifactEntityStore {
+        let key = ObjectIdentifier(artifactService)
+        if let existing = registry[key] { return existing }
+        let store = ArtifactEntityStore(artifactService: artifactService)
+        registry[key] = store
+        return store
+    }
+
+    // MARK: - Reads (views observe these)
+
+    func bundle(for documentId: String) -> ArtifactEntityBundle? {
+        bundles[documentId]
+    }
+
+    // MARK: - Loading (the store, not the view, owns fetching)
+
+    /// Load `documentId` once. No-op if already loaded or a fetch is in flight —
+    /// this is what collapses the per-row + per-cell N+1 into a single request.
+    func ensureLoaded(_ documentId: String) {
+        guard bundles[documentId] == nil, !inFlight.contains(documentId) else { return }
+        inFlight.insert(documentId)
+        Task { await fetch(documentId, forceRefresh: false) }
+    }
+
+    /// Batch-warm the visible set (each id still deduped). Handed the folder's
+    /// visible document ids by the caller; there is no server batch endpoint, so
+    /// this fans out one deduped request per not-yet-loaded document.
+    func prefetch(_ documentIds: [String]) {
+        for id in documentIds { ensureLoaded(id) }
+    }
+
+    /// Re-fetch the given ids from the server (workflow completion / manual
+    /// refresh). Keeps the existing bundle visible until the fresh value lands
+    /// (no empty flash), and blocks a re-entrant `ensureLoaded` via `inFlight`.
+    func invalidate(_ documentIds: Set<String>) {
+        let ids = documentIds.filter { !inFlight.contains($0) }
+        guard !ids.isEmpty else { return }
+        for id in ids { inFlight.insert(id) }
+        Task {
+            for id in ids { await fetch(id, forceRefresh: true) }
+        }
+    }
+
+    /// Invalidate only the documents that newly-completed workflow runs touched.
+    /// Idempotent across the many rows/cells that each observe
+    /// `workflowCompletedCount`: once a run's threadId is seen it's never
+    /// reprocessed, and only documents we currently hold are refetched.
+    func reconcileCompletions(_ observer: WorkflowExecutionObserver) {
+        let newThreadIds = observer.completedExecutions.keys.filter {
+            !seenCompletedThreadIds.contains($0)
+        }
+        guard !newThreadIds.isEmpty else { return }
+
+        var affected: Set<String> = []
+        for threadId in newThreadIds {
+            seenCompletedThreadIds.insert(threadId)
+            if let execution = observer.completedExecutions[threadId] {
+                affected.formUnion(execution.documentProgress.keys)
+            }
+        }
+
+        let held = affected.filter { bundles[$0] != nil }
+        guard !held.isEmpty else { return }
+        log.debug("Reconciling \(held.count, privacy: .public) affected docs after workflow completion")
+        invalidate(held)
+    }
+
+    // MARK: - Private
+
+    /// Caller MUST have inserted `documentId` into `inFlight` before spawning
+    /// this — both `ensureLoaded` and `invalidate` do, so a re-entrant read can't
+    /// start a duplicate fetch; this always clears the flag when done.
+    private func fetch(_ documentId: String, forceRefresh: Bool) async {
+        defer { inFlight.remove(documentId) }
+        // Strict per-document scope ("{id}|own") — per-row counts must NOT include
+        // page-child descendants, matching the prior view behaviour + V2 convention.
+        let cacheKey = "\(documentId)|own"
+        let artifacts: [Artifact]
+        if !forceRefresh, let cached = artifactService.artifactsByDocument[cacheKey] {
+            artifacts = cached
+        } else if let fetched = try? await artifactService.getArtifacts(
+            forDocumentId: documentId,
+            forceRefresh: forceRefresh,
+            includeDescendants: false
+        ) {
+            artifacts = fetched
+        } else {
+            // Mark loaded-but-empty so the view stops reserving space and shows "—".
+            bundles[documentId] = ArtifactEntityBundle()
+            return
+        }
+        bundles[documentId] = Self.parse(artifacts)
+    }
+
+    // MARK: - Parsing (moved out of the views)
+
+    static func parse(_ artifacts: [Artifact]) -> ArtifactEntityBundle {
+        var bundle = ArtifactEntityBundle()
+        for artifact in artifacts {
+            switch artifact.artifactType {
+            case "people":
+                bundle.people = extractNames(artifact, key: "name")
+            case "places":
+                bundle.places = extractNames(artifact, key: "name")
+            case "organizations":
+                bundle.organizations = extractNames(artifact, key: "name")
+            case "events":
+                bundle.events = extractNames(artifact, key: "event")
+            case "keywords":
+                bundle.keywords = extractKeywords(artifact)
+            case "dates":
+                bundle.dates = extractDates(artifact)
+            default:
+                break
+            }
+        }
+        return bundle
+    }
+
+    static func extractNames(_ artifact: Artifact, key: String) -> [String] {
+        guard let data = artifact.data,
+              let value = data["items"]?.value,
+              let items = value as? [[String: Any]] else { return [] }
+        return items.compactMap { $0[key] as? String }
+    }
+
+    static func extractKeywords(_ artifact: Artifact) -> [String] {
+        guard let data = artifact.data,
+              let value = data["keywords"]?.value,
+              let array = value as? [String] else { return [] }
+        return array
+    }
+
+    static func extractDates(_ artifact: Artifact) -> [String] {
+        guard let data = artifact.data,
+              let value = data["items"]?.value,
+              let items = value as? [[String: Any]] else { return [] }
+        return items.compactMap { item in
+            (item["date_normalized"] as? String) ?? (item["date"] as? String)
+        }
+    }
+}

--- a/fichero/fichero/Views/Library/Inspector/ArtifactEntityViews.swift
+++ b/fichero/fichero/Views/Library/Inspector/ArtifactEntityViews.swift
@@ -3,14 +3,15 @@ import SwiftUI
 // MARK: - Artifact Entities View (#519)
 
 /// Surfaces the entity-flavored artifacts (people/places/organizations/
-/// events/dates/keywords) for a document row. Two styles share one data
-/// path so the singleLine table-cell and multiLine list-row presentations
-/// fetch + parse identically.
+/// events/dates/keywords) for a document row. Both styles observe the shared
+/// `ArtifactEntityStore` so the singleLine table-cell and multiLine list-row
+/// presentations read ONE fetched+parsed bundle instead of fetching per view.
 ///
-/// Cache: reads ArtifactServiceGenerated.artifactsByDocument["{id}|own"]
-/// (matches the V2 strict-scope convention used by DocumentInspectorContentV2 —
-/// per-row counts shouldn't include descendants, otherwise a parent PDF
-/// shows the union of every page-child's artifacts).
+/// Data: `ArtifactEntityStore` keyed by documentId, strict per-document scope
+/// ("{id}|own") — matches the V2 convention used by DocumentInspectorContentV2;
+/// per-row counts must NOT include descendants, otherwise a parent PDF shows the
+/// union of every page-child's artifacts. The store is the single endpoint
+/// accessor (#3861 / #1863); views never call getArtifacts() themselves.
 struct ArtifactEntitiesView: View {
     enum Style { case singleLine, multiLine }
 
@@ -25,48 +26,48 @@ struct ArtifactEntitiesView: View {
     @Environment(ArtifactServiceGenerated.self) var artifactService
     @Environment(WorkflowExecutionObserver.self) var executionObserver
 
-    @State private var people: [String] = []
-    @State private var places: [String] = []
-    @State private var organizations: [String] = []
-    @State private var events: [String] = []
-    @State private var dates: [String] = []
-    @State private var keywords: [String] = []
-    @State private var loaded = false
+    /// Shared document-keyed store (#3861) — the single endpoint accessor. Every
+    /// row/cell for the same document observes ONE fetch instead of firing its
+    /// own `getArtifacts()` in `.onAppear`.
+    private var store: ArtifactEntityStore { .shared(for: artifactService) }
+    private var bundle: ArtifactEntityBundle? { store.bundle(for: documentId) }
 
     var body: some View {
         Group {
-            if !loaded {
-                // Reserve space silently while the first fetch is in flight.
-                Color.clear.frame(height: style == .singleLine ? 14 : 1)
-            } else if isEmpty {
-                if style == .singleLine {
-                    Text("—").font(.caption).foregroundStyle(.secondary)
+            if let bundle {
+                if bundle.isEmpty {
+                    if style == .singleLine {
+                        Text("—").font(.caption).foregroundStyle(.secondary)
+                    } else {
+                        EmptyView()
+                    }
                 } else {
-                    EmptyView()
+                    content(bundle)
                 }
             } else {
-                content
+                // Reserve space silently while the first fetch is in flight.
+                Color.clear.frame(height: style == .singleLine ? 14 : 1)
             }
         }
-        .onAppear { Task { await loadEntities() } }
-        .onChange(of: documentId) {
-            Task { await loadEntities(forceRefresh: true) }
-        }
+        .onAppear { store.ensureLoaded(documentId) }
+        .onChange(of: documentId) { store.ensureLoaded(documentId) }
+        // Workflow completion refetches ONLY the documents that run touched —
+        // idempotent across the many rows that each observe this counter.
         .onChange(of: executionObserver.workflowCompletedCount) {
-            Task { await loadEntities(forceRefresh: true) }
+            store.reconcileCompletions(executionObserver)
         }
     }
 
     @ViewBuilder
-    private var content: some View {
+    private func content(_ bundle: ArtifactEntityBundle) -> some View {
         switch style {
         case .singleLine:
             HStack(spacing: 8) {
-                chip(systemName: "person", names: people, max: 2)
-                chip(systemName: "mappin", names: places, max: 2)
-                chip(systemName: "building.2", names: organizations, max: 1)
-                chip(systemName: "calendar", names: dates, max: 1)
-                chip(systemName: "bolt", names: events, max: 1)
+                chip(systemName: "person", names: bundle.people, max: 2)
+                chip(systemName: "mappin", names: bundle.places, max: 2)
+                chip(systemName: "building.2", names: bundle.organizations, max: 1)
+                chip(systemName: "calendar", names: bundle.dates, max: 1)
+                chip(systemName: "bolt", names: bundle.events, max: 1)
             }
             .font(.caption)
             .lineLimit(1)
@@ -74,22 +75,22 @@ struct ArtifactEntitiesView: View {
         case .multiLine:
             VStack(alignment: .leading, spacing: 4) {
                 if visibleTypes.contains("people") {
-                    lozengeRow("People", names: people)
+                    lozengeRow("People", names: bundle.people)
                 }
                 if visibleTypes.contains("places") {
-                    lozengeRow("Places", names: places)
+                    lozengeRow("Places", names: bundle.places)
                 }
                 if visibleTypes.contains("organizations") {
-                    lozengeRow("Organizations", names: organizations)
+                    lozengeRow("Organizations", names: bundle.organizations)
                 }
                 if visibleTypes.contains("dates") {
-                    lozengeRow("Dates", names: dates)
+                    lozengeRow("Dates", names: bundle.dates)
                 }
                 if visibleTypes.contains("events") {
-                    lozengeRow("Events", names: events)
+                    lozengeRow("Events", names: bundle.events)
                 }
                 if visibleTypes.contains("keywords") {
-                    lozengeRow("Keywords", names: keywords)
+                    lozengeRow("Keywords", names: bundle.keywords)
                 }
             }
             .font(.caption2)
@@ -154,77 +155,6 @@ struct ArtifactEntitiesView: View {
         }
     }
 
-    private var isEmpty: Bool {
-        people.isEmpty && places.isEmpty && organizations.isEmpty
-            && events.isEmpty && dates.isEmpty && keywords.isEmpty
-    }
-
-    @MainActor
-    private func loadEntities(forceRefresh: Bool = false) async {
-        let cacheKey = "\(documentId)|own"
-        let artifacts: [Artifact]
-        people = []
-        places = []
-        organizations = []
-        events = []
-        dates = []
-        keywords = []
-
-        if !forceRefresh, let cached = artifactService.artifactsByDocument[cacheKey] {
-            artifacts = cached
-        } else if let fetched = try? await artifactService.getArtifacts(
-            forDocumentId: documentId,
-            forceRefresh: forceRefresh,
-            includeDescendants: false
-        ) {
-            artifacts = fetched
-        } else {
-            loaded = true
-            return
-        }
-        for artifact in artifacts {
-            switch artifact.artifactType {
-            case "people":
-                people = extractNames(artifact, key: "name")
-            case "places":
-                places = extractNames(artifact, key: "name")
-            case "organizations":
-                organizations = extractNames(artifact, key: "name")
-            case "events":
-                events = extractNames(artifact, key: "event")
-            case "keywords":
-                keywords = extractKeywords(artifact)
-            case "dates":
-                dates = extractDates(artifact)
-            default:
-                break
-            }
-        }
-        loaded = true
-    }
-
-    private func extractNames(_ artifact: Artifact, key: String) -> [String] {
-        guard let data = artifact.data,
-              let value = data["items"]?.value,
-              let items = value as? [[String: Any]] else { return [] }
-        return items.compactMap { $0[key] as? String }
-    }
-
-    private func extractKeywords(_ artifact: Artifact) -> [String] {
-        guard let data = artifact.data,
-              let value = data["keywords"]?.value,
-              let array = value as? [String] else { return [] }
-        return array
-    }
-
-    private func extractDates(_ artifact: Artifact) -> [String] {
-        guard let data = artifact.data,
-              let value = data["items"]?.value,
-              let items = value as? [[String: Any]] else { return [] }
-        return items.compactMap { item in
-            (item["date_normalized"] as? String) ?? (item["date"] as? String)
-        }
-    }
 }
 
 // MARK: - Artifact Entity Cell — per-type column (#519 table view)
@@ -243,23 +173,27 @@ struct ArtifactEntityCell: View {
     @Environment(ArtifactServiceGenerated.self) var artifactService
     @Environment(WorkflowExecutionObserver.self) var executionObserver
 
-    @State private var names: [String] = []
-    @State private var loaded = false
+    /// Shared document-keyed store (#3861): the six per-type cells of one row now
+    /// share ONE fetch with each other and with the row's `ArtifactEntitiesView`.
+    private var store: ArtifactEntityStore { .shared(for: artifactService) }
+    private var names: [String]? { store.bundle(for: documentId)?.names(for: entityType) }
 
     var body: some View {
         Group {
-            if !loaded {
-                Color.clear.frame(height: 14)
-            } else if names.isEmpty {
-                Text("—").font(.caption2).foregroundStyle(.secondary)
-            } else {
-                FlowLayout(spacing: 4) {
-                    // Same #1966 dedup as lozengeRow — unique IDs, no double render.
-                    ForEach(names.uniqued(), id: \.self) { name in
-                        EntityLozenge(name: name, entityType: entityType)
+            if let names {
+                if names.isEmpty {
+                    Text("—").font(.caption2).foregroundStyle(.secondary)
+                } else {
+                    FlowLayout(spacing: 4) {
+                        // Same #1966 dedup as lozengeRow — unique IDs, no double render.
+                        ForEach(names.uniqued(), id: \.self) { name in
+                            EntityLozenge(name: name, entityType: entityType)
+                        }
                     }
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
                 }
-                .frame(maxWidth: .infinity, alignment: .topLeading)
+            } else {
+                Color.clear.frame(height: 14)
             }
         }
         // Top-align so cells in the same row don't vertically center —
@@ -268,63 +202,10 @@ struct ArtifactEntityCell: View {
         // Finder's table-cell behaviour.
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(.vertical, 2)
-        .onAppear { Task { await load() } }
+        .onAppear { store.ensureLoaded(documentId) }
+        .onChange(of: documentId) { store.ensureLoaded(documentId) }
         .onChange(of: executionObserver.workflowCompletedCount) {
-            Task { await load(forceRefresh: true) }
-        }
-    }
-
-    @MainActor
-    private func load(forceRefresh: Bool = false) async {
-        let cacheKey = "\(documentId)|own"
-        let artifacts: [Artifact]
-        if !forceRefresh, let cached = artifactService.artifactsByDocument[cacheKey] {
-            artifacts = cached
-        } else if let fetched = try? await artifactService.getArtifacts(
-            forDocumentId: documentId, forceRefresh: forceRefresh, includeDescendants: false
-        ) {
-            artifacts = fetched
-        } else {
-            loaded = true
-            return
-        }
-        for artifact in artifacts where artifact.artifactType == entityType {
-            switch entityType {
-            case "people", "places", "organizations":
-                names = extractNames(artifact, key: "name")
-            case "events":
-                names = extractNames(artifact, key: "event")
-            case "keywords":
-                names = extractKeywords(artifact)
-            case "dates":
-                names = extractDates(artifact)
-            default:
-                break
-            }
-        }
-        loaded = true
-    }
-
-    private func extractNames(_ artifact: Artifact, key: String) -> [String] {
-        guard let data = artifact.data,
-              let value = data["items"]?.value,
-              let items = value as? [[String: Any]] else { return [] }
-        return items.compactMap { $0[key] as? String }
-    }
-
-    private func extractKeywords(_ artifact: Artifact) -> [String] {
-        guard let data = artifact.data,
-              let value = data["keywords"]?.value,
-              let array = value as? [String] else { return [] }
-        return array
-    }
-
-    private func extractDates(_ artifact: Artifact) -> [String] {
-        guard let data = artifact.data,
-              let value = data["items"]?.value,
-              let items = value as? [[String: Any]] else { return [] }
-        return items.compactMap { item in
-            (item["date_normalized"] as? String) ?? (item["date"] as? String)
+            store.reconcileCompletions(executionObserver)
         }
     }
 }


### PR DESCRIPTION
Closes #3861. New @Observable ArtifactEntityStore keyed by documentId; rows/cells observe it instead of each firing getArtifacts() in .onAppear. Workflow completion invalidates only affected doc ids (no more force-refetch of every visible row). Store is the only endpoint accessor. Test added; guardrails green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)