### PR TITLE
perf: stop whole-sidebar rebuild on status-poll churn + cache buckets (#3862)

### DIFF
--- a/fichero/fichero-tests/SidebarLibraryBucketsTests.swift
+++ b/fichero/fichero-tests/SidebarLibraryBucketsTests.swift
@@ -1,0 +1,38 @@
+@testable import Fichero
+import XCTest
+
+/// Covers the header-derived bucket filtering that #3862 moved out of the body's
+/// per-eval `unifiedLibraryBuckets` into the cached, pure
+/// `SidebarView.computeLibraryItemBuckets`. The cache is only correct if this
+/// pure function sorts a library header's children into the same document /
+/// search / workflow buckets the inline filter used to.
+@MainActor
+final class SidebarLibraryBucketsTests: XCTestCase {
+    func testComputeSortsChildrenIntoTypeBuckets() {
+        let lib = UUID()
+        let doc = SidebarItem.fromDocument(Document(name: "Report", docType: .folder), libraryId: lib)
+        let docFolder = SidebarItem.folder(name: "Docs", folderPath: "/docs", category: .folder, libraryId: lib)
+        let searchFolder = SidebarItem.folder(name: "Saved", folderPath: "/s", category: .search, libraryId: lib)
+        let workflowFolder = SidebarItem.folder(name: "Flows", folderPath: "/w", category: .workflow, libraryId: lib)
+
+        let header = SidebarItem.folder(
+            name: "root", folderPath: "/", category: .folder, libraryId: lib,
+            children: [doc, docFolder, searchFolder, workflowFolder]
+        )
+
+        let buckets = SidebarView.computeLibraryItemBuckets(from: header)
+
+        // Documents + category:.folder folders land in documentItems (order kept).
+        XCTAssertEqual(buckets.documentItems.map(\.id), [doc.id, docFolder.id])
+        XCTAssertEqual(buckets.searchItems.map(\.id), [searchFolder.id])
+        XCTAssertEqual(buckets.workflowItems.map(\.id), [workflowFolder.id])
+    }
+
+    func testHeaderWithoutChildrenYieldsEmptyBuckets() {
+        let header = SidebarItem.folder(name: "empty", folderPath: "/", category: .folder, libraryId: UUID())
+        let buckets = SidebarView.computeLibraryItemBuckets(from: header)
+        XCTAssertTrue(buckets.documentItems.isEmpty)
+        XCTAssertTrue(buckets.searchItems.isEmpty)
+        XCTAssertTrue(buckets.workflowItems.isEmpty)
+    }
+}

--- a/fichero/fichero/Views/Sidebar/Components/SidebarObservers.swift
+++ b/fichero/fichero/Views/Sidebar/Components/SidebarObservers.swift
@@ -101,7 +101,17 @@ extension SidebarView {
             _ = store.childrenCache
         } onChange: {
             Task { @MainActor in
-                rebuildCaches(for: libraryId)
+                // #3862: currentDocuments (and status overrides on collections)
+                // churn on every processing poll, but they don't shape the sidebar
+                // tree. Only rebuild when the tree-relevant signature actually
+                // changed — otherwise a status-poll storm rebuilt the whole tree
+                // and re-rendered the entire List for no visible change.
+                if let library = libraryManager.getLibrary(id: libraryId) {
+                    let signature = sidebarTreeSignature(for: library)
+                    if sidebarTreeSignatures[libraryId] != signature {
+                        rebuildCaches(for: libraryId)
+                    }
+                }
                 observeDocumentStore(store, libraryId: libraryId)
             }
         }

--- a/fichero/fichero/Views/Sidebar/SidebarView+Helpers.swift
+++ b/fichero/fichero/Views/Sidebar/SidebarView+Helpers.swift
@@ -52,14 +52,54 @@ extension SidebarView {
 
     /// Rebuild all sidebar item caches from ALL libraries
     func rebuildCaches() {
-        cachedLibraryHeaders = libraryManager.openLibraries.map { buildLibraryHeader(for: $0) }
+        cachedLibraryHeaders = libraryManager.openLibraries.map { library in
+            let header = buildLibraryHeader(for: library)
+            cacheLibraryDerivedState(header: header, library: library)
+            return header
+        }
     }
 
     /// Rebuild one library header in place, preserving every other library snapshot.
     func rebuildCaches(for libraryId: UUID) {
         guard let library = libraryManager.getLibrary(id: libraryId) else { return }
         let header = buildLibraryHeader(for: library)
+        cacheLibraryDerivedState(header: header, library: library)
         cachedLibraryHeaders = sidebarReplacingLibraryHeader(cachedLibraryHeaders, with: header)
+    }
+
+    /// Recompute and store the per-library derived state that used to be redone
+    /// on every body eval / poll (#3862): the filtered item buckets (so the body
+    /// stops re-filtering `header.children`) and the tree signature (so the
+    /// documentStore observer can skip a no-op rebuild).
+    private func cacheLibraryDerivedState(header: SidebarItem, library: LibraryManager.LibraryReference) {
+        cachedLibraryItemBuckets[library.id] = Self.computeLibraryItemBuckets(from: header)
+        sidebarTreeSignatures[library.id] = sidebarTreeSignature(for: library)
+    }
+
+    /// Hash of ONLY the fields that shape the sidebar document tree (#3862).
+    /// Deliberately excludes per-doc processing status/content, so a status poll
+    /// that mutates `currentDocuments` (or a status override on `collections`)
+    /// does NOT force a whole-tree rebuild — the sidebar never renders status
+    /// (`SidebarItem.fromDocument` sets `showProgress: false`).
+    ///
+    /// `sidebarDocuments` is `collections + childrenCache.values` and dictionary
+    /// iteration order is unstable, so sort by id for a deterministic signature.
+    func sidebarTreeSignature(for library: LibraryManager.LibraryReference) -> Int {
+        var hasher = Hasher()
+        for doc in library.documentStore.sidebarDocuments.sorted(by: { $0.id < $1.id }) {
+            hasher.combine(doc.id)
+            hasher.combine(doc.parentId)
+            hasher.combine(doc.name)
+            hasher.combine(doc.sortOrder)
+            hasher.combine(doc.sequence)
+            hasher.combine(doc.docType)
+            hasher.combine(doc.fileType)
+            // Structure drives PDF outline rows; ids catch a re-parse that keeps
+            // the same count.
+            hasher.combine(doc.structure.count)
+            for node in doc.structure { hasher.combine(node.id) }
+        }
+        return hasher.finalize()
     }
 
     /// Recursively find an item by ID

--- a/fichero/fichero/Views/Sidebar/SidebarView+UnifiedLibrarySections.swift
+++ b/fichero/fichero/Views/Sidebar/SidebarView+UnifiedLibrarySections.swift
@@ -13,6 +13,43 @@ extension SidebarView {
         let activityItems: [SidebarItem]
     }
 
+    /// The header-derived buckets that only change when the library header is
+    /// rebuilt (#3862). Cached in `rebuildCaches` so the body stops re-filtering
+    /// `header.children` on every sidebar state change. The chain/schedule/
+    /// trigger buckets are NOT cached here — they're small @State maps that
+    /// mutate outside `rebuildCaches`, so they stay computed live.
+    struct CachedLibraryItemBuckets {
+        let documentItems: [SidebarItem]
+        let searchItems: [SidebarItem]
+        let workflowItems: [SidebarItem]
+    }
+
+    /// Filter a library header's children into the document / search / workflow
+    /// buckets. Pure over the header, so it can be memoised per library.
+    static func computeLibraryItemBuckets(from libraryHeader: SidebarItem) -> CachedLibraryItemBuckets {
+        let allChildren = libraryHeader.children ?? []
+        let documentItems = allChildren.filter { item in
+            if case .document = item.itemType { return true }
+            if case .folder = item.itemType, item.category == .folder { return true }
+            return false
+        }
+        let searchItems = allChildren.filter { item in
+            if case .savedSearch = item.itemType { return true }
+            if case .folder = item.itemType, item.category == .search { return true }
+            return false
+        }
+        let workflowItems = allChildren.filter { item in
+            if case .workflow = item.itemType { return true }
+            if case .folder = item.itemType, item.category == .workflow { return true }
+            return false
+        }
+        return CachedLibraryItemBuckets(
+            documentItems: documentItems,
+            searchItems: searchItems,
+            workflowItems: workflowItems
+        )
+    }
+
     @ViewBuilder
     func unifiedLibrarySection(_ libraryHeader: SidebarItem) -> some View {
         if let libraryId = libraryHeader.libraryId,
@@ -58,22 +95,18 @@ extension SidebarView {
         library: LibraryManager.LibraryReference,
         libraryId: UUID
     ) -> UnifiedLibraryBuckets {
-        let allChildren = libraryHeader.children ?? []
-        let documentItems = allChildren.filter { item in
-            if case .document = item.itemType { return true }
-            if case .folder = item.itemType, item.category == .folder { return true }
-            return false
-        }
-        let searchItems = allChildren.filter { item in
-            if case .savedSearch = item.itemType { return true }
-            if case .folder = item.itemType, item.category == .search { return true }
-            return false
-        }
-        let workflowItems = allChildren.filter { item in
-            if case .workflow = item.itemType { return true }
-            if case .folder = item.itemType, item.category == .workflow { return true }
-            return false
-        }
+        // Reuse the header-derived filtering cached by `rebuildCaches` (#3862);
+        // fall back to computing it for a header not yet cached (first render).
+        // While a search filter is active the passed header has FILTERED
+        // children, so bypass the (unfiltered) cache and compute from it — a
+        // rare, user-driven path, unlike the poll/scroll churn the cache targets.
+        let query = sidebarFilterText.trimmingCharacters(in: .whitespacesAndNewlines)
+        let itemBuckets = query.isEmpty
+            ? (cachedLibraryItemBuckets[libraryId] ?? Self.computeLibraryItemBuckets(from: libraryHeader))
+            : Self.computeLibraryItemBuckets(from: libraryHeader)
+        let documentItems = itemBuckets.documentItems
+        let searchItems = itemBuckets.searchItems
+        let workflowItems = itemBuckets.workflowItems
         let isGlobalLibrary = libraryId == LibraryManager.globalLibraryId
         let chainItems = (isGlobalLibrary && FeatureManager.shared.isWorkflowChainsEnabled)
             ? chains.map { SidebarItem.fromChain($0, libraryId: libraryId) }

--- a/fichero/fichero/Views/Sidebar/SidebarView.swift
+++ b/fichero/fichero/Views/Sidebar/SidebarView.swift
@@ -43,6 +43,13 @@ struct SidebarView: View {
 
     // Cached sidebar items - rebuilt when service data changes (via Combine observers)
     @State var cachedLibraryHeaders: [SidebarItem] = []
+    // #3862: last hash of ONLY the tree-shaping doc fields per library. Lets the
+    // documentStore observer skip a whole-tree rebuild when a status poll mutated
+    // currentDocuments/status but the sidebar structure is unchanged.
+    @State var sidebarTreeSignatures: [UUID: Int] = [:]
+    // #3862: header-derived, filtered item buckets cached per library so the body
+    // stops re-filtering `header.children` on every sidebar state change.
+    @State var cachedLibraryItemBuckets: [UUID: CachedLibraryItemBuckets] = [:]
     @State var sidebarFilterText = ""
 
     // Chain service for workflows sidebar (global - not per-library yet)


### PR DESCRIPTION
Closes #3862. Diff-aware sidebar: skip full rebuild when only currentDocuments status of an already-rendered folder changed; cache unifiedLibraryBuckets in rebuildCaches. No more whole-tree recursive rebuild + full List re-render on every status flip. Test added; guardrails green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)