### PR TITLE
fix: don't flash the live-updates pill before the first connect (#3874)

### DIFF
--- a/fichero/fichero-tests/LibraryChangeStreamTransportTests.swift
+++ b/fichero/fichero-tests/LibraryChangeStreamTransportTests.swift
@@ -225,4 +225,20 @@ struct LibraryChangeStreamTransportTests {
         // so a lone transient could hit the threshold; now only genuine errors do.
         #expect(LibraryChangeStream.shouldSurfaceUnavailable(failureCount: 1) == false)
     }
+
+    // MARK: - No launch flash before the first connect (#3874)
+
+    @Test("a drop during the initial connect window never surfaces the pill (#3874)")
+    func initialConnectWindowNeverSurfaces() {
+        // Never connected yet: even past the two-strike threshold the pill stays
+        // hidden — the app-level BackendConnectionView owns "not connected yet",
+        // so the per-surface pill must not flash on launch.
+        #expect(LibraryChangeStream.shouldSurfaceAfterDrop(failureCount: 2, hasConnectedBefore: false) == false)
+        #expect(LibraryChangeStream.shouldSurfaceAfterDrop(failureCount: 5, hasConnectedBefore: false) == false)
+
+        // After a successful connect, a genuine drop still surfaces on the second
+        // consecutive miss (the existing debounce is preserved).
+        #expect(LibraryChangeStream.shouldSurfaceAfterDrop(failureCount: 1, hasConnectedBefore: true) == false)
+        #expect(LibraryChangeStream.shouldSurfaceAfterDrop(failureCount: 2, hasConnectedBefore: true) == true)
+    }
 }

--- a/fichero/fichero/Services/ActivityStreamService.swift
+++ b/fichero/fichero/Services/ActivityStreamService.swift
@@ -36,6 +36,14 @@ final class ActivityStreamService {
         failureCount >= 2
     }
 
+    /// Whether a transient drop should surface the paused pill. Only AFTER a
+    /// successful connect — never during the initial connect window, where the
+    /// app-level BackendConnectionView owns "not connected yet". Stops the pill
+    /// flashing on launch (#3874). Once connected, the two-strike debounce applies.
+    static func shouldSurfaceAfterDrop(failureCount: Int, hasConnectedBefore: Bool) -> Bool {
+        hasConnectedBefore && shouldSurfaceUnavailable(failureCount: failureCount)
+    }
+
     init(activityService: ActivityServiceGenerated) {
         self.activityService = activityService
     }
@@ -63,9 +71,11 @@ final class ActivityStreamService {
     private func runLoop(onEvent: @escaping @MainActor (ActivityItem) -> Void) async {
         var backoffNanos: UInt64 = 1_000_000_000
         var consecutiveUnavailableCycles = 0
+        var hasConnectedBefore = false
         while !Task.isCancelled {
             do {
                 try await subscribeOnce(onEvent: onEvent)
+                hasConnectedBefore = true
                 consecutiveUnavailableCycles = 0
                 backoffNanos = 1_000_000_000
             } catch StreamError.accessDenied {
@@ -81,8 +91,13 @@ final class ActivityStreamService {
                 if !Task.isCancelled {
                     log.error("activity stream dropped: \(error.localizedDescription, privacy: .public)")
                     consecutiveUnavailableCycles += 1
-                    liveUpdatesUnavailable = Self.shouldSurfaceUnavailable(
-                        failureCount: consecutiveUnavailableCycles
+                    // Surface the pill only for a drop AFTER a successful connect;
+                    // during the initial connect window the app-level
+                    // BackendConnectionView owns "not connected yet", so the pill
+                    // stays hidden and doesn't flash on launch (#3874).
+                    liveUpdatesUnavailable = Self.shouldSurfaceAfterDrop(
+                        failureCount: consecutiveUnavailableCycles,
+                        hasConnectedBefore: hasConnectedBefore
                     )
                 }
             }

--- a/fichero/fichero/Services/LibraryChangeStream.swift
+++ b/fichero/fichero/Services/LibraryChangeStream.swift
@@ -250,6 +250,15 @@ final class LibraryChangeStream {
         failureCount >= 2
     }
 
+    /// Whether a transient drop should surface the per-surface paused pill.
+    /// Only AFTER a successful connect — never during the initial connect window
+    /// (never connected yet), where the app-level BackendConnectionView already
+    /// owns "not connected yet". This is what stops the pill flashing on launch
+    /// (#3874). Once connected, the usual two-strike debounce applies.
+    static func shouldSurfaceAfterDrop(failureCount: Int, hasConnectedBefore: Bool) -> Bool {
+        hasConnectedBefore && shouldSurfaceUnavailable(failureCount: failureCount)
+    }
+
     // MARK: - Internals
 
     /// Distinguishes an authorization failure (terminal — don't retry) from a
@@ -285,8 +294,13 @@ final class LibraryChangeStream {
                         "change-stream dropped: \(error.localizedDescription, privacy: .public)"
                     )
                     consecutiveUnavailableCycles += 1
-                    liveUpdatesUnavailable = Self.shouldSurfaceUnavailable(
-                        failureCount: consecutiveUnavailableCycles
+                    // Surface the paused pill only for a drop AFTER a successful
+                    // connect; during the initial connect window the app-level
+                    // BackendConnectionView owns "not connected yet", so the pill
+                    // stays hidden and doesn't flash on launch (#3874).
+                    liveUpdatesUnavailable = Self.shouldSurfaceAfterDrop(
+                        failureCount: consecutiveUnavailableCycles,
+                        hasConnectedBefore: hasConnectedBefore
                     )
                 }
             }


### PR DESCRIPTION
Closes #3874. New shouldSurfaceAfterDrop(hasConnectedBefore:) — liveUpdatesUnavailable only surfaces for a drop AFTER a successful connect, not during the initial-connect window (the app-level BackendConnectionView owns 'not connected yet'). Applied to both LibraryChangeStream + ActivityStreamService; 403 access-denied path unchanged. Test added; guardrails green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)