### PR TITLE
perf: count PDF page-children once, sort-free, in the reading pane (#3866)

### DIFF
--- a/fichero/fichero-tests/PDFDocPageCountTests.swift
+++ b/fichero/fichero-tests/PDFDocPageCountTests.swift
@@ -1,0 +1,26 @@
+@testable import Fichero
+import XCTest
+
+/// Covers the sort-free page-child count `ContentView.pdfDocPageCount(in:)`
+/// introduced by #3866. The reading pane only needs the count, so this replaced
+/// the old `pdfDocPages` accessor whose filter+sort ran twice per render.
+final class PDFDocPageCountTests: XCTestCase {
+    func testCountsOnlyPageChildren() {
+        let docs = [
+            Document(name: "folder", docType: .folder),
+            Document(name: "p1", docType: .page),
+            Document(name: "file", docType: .file),
+            Document(name: "p2", docType: .page),
+            Document(name: "p3", docType: .page)
+        ]
+        XCTAssertEqual(ContentView.pdfDocPageCount(in: docs), 3)
+    }
+
+    func testEmptyAndNoPagesAreZero() {
+        XCTAssertEqual(ContentView.pdfDocPageCount(in: []), 0)
+        XCTAssertEqual(
+            ContentView.pdfDocPageCount(in: [Document(name: "x", docType: .file)]),
+            0
+        )
+    }
+}

--- a/fichero/fichero/Views/ContentView+ReadingLayout.swift
+++ b/fichero/fichero/Views/ContentView+ReadingLayout.swift
@@ -64,11 +64,18 @@ extension ContentView {
         Self.pdfPageIndex(for: pageFocusDocument ?? detailDocument)
     }
 
-    /// Page-child documents for the previewed PDF, sorted by sequence.
-    var pdfDocPages: [Document] {
-        documentStore.currentDocuments
-            .filter { $0.docType == .page }
-            .sorted { ($0.sequence ?? 0) < ($1.sequence ?? 0) }
+    /// Number of page-child documents for the previewed PDF (#3866). The reading
+    /// pane needs only the COUNT, so this skips the O(n log n) filter+sort +
+    /// array allocation that the old `pdfDocPages` accessor cost — read twice per
+    /// render for `isEmpty ? nil : count`.
+    var pdfDocPageCount: Int {
+        Self.pdfDocPageCount(in: documentStore.currentDocuments)
+    }
+
+    /// Pure page-child count over a document set — no sort, no allocation
+    /// (`lazy`). Static so it's unit-testable without a ContentView. (#3866)
+    static func pdfDocPageCount(in documents: [Document]) -> Int {
+        documents.lazy.filter { $0.docType == .page }.count
     }
 
 }

--- a/fichero/fichero/Views/ContentView+ViewBuilders.swift
+++ b/fichero/fichero/Views/ContentView+ViewBuilders.swift
@@ -488,13 +488,17 @@ extension ContentView {
     /// Extracted so it can be conditionally shown/hidden per-window (#1448).
     @ViewBuilder
     var widescreenReadingPane: some View {
+        // Compute the page count ONCE (#3866): reading `pdfDocPages` twice here
+        // (isEmpty + count) recomputed a filter+sort per read — 2x O(n log n) per
+        // render. The pane needs only the count, so use the sort-free accessor.
+        let pageCount = pdfDocPageCount
         // Each SplittablePane instance renders ReadingPaneView independently,
         // giving left and right split panes their own @State (including pin).
         adaptiveSplittablePane(storageKey: "reading") {
             ReadingPaneView(
                 liveDocument: detailDocument,
                 liveActivePageNumber: detailPDFDocumentId == nil ? nil : selectedPageIndex + 1,
-                livePageCount: pdfDocPages.isEmpty ? nil : pdfDocPages.count,
+                livePageCount: pageCount == 0 ? nil : pageCount,
                 scrollSync: documentScrollSync,
                 onPageSelected: { index in syncGridSelectionToPDFPage(index: index) },
                 onClose: { setPaneVisible(.reading, false) }


### PR DESCRIPTION
Closes #3866. pdfDocPages no longer filter+sorts twice per ContentView render; count computed once without sorting. Test added; guardrails green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)