### PR TITLE
perf: cache date regexes + single-pass entity partition (#3869)

### DIFF
--- a/fichero/fichero-tests/OntologyBrowserDateTests.swift
+++ b/fichero/fichero-tests/OntologyBrowserDateTests.swift
@@ -1,0 +1,30 @@
+@testable import Fichero
+import FicheroAPIClient
+import Testing
+
+/// #3869 — the date-entity classifier moved to cached `NSRegularExpression`s. Lock
+/// its behaviour so the perf refactor can't quietly change which entities count as
+/// dates (they're split out of the named-entity scan).
+struct OntologyBrowserDateTests {
+
+    private func entity(_ name: String) -> Components.Schemas.KnowledgeEntity {
+        .init(canonicalName: name)
+    }
+
+    @Test("Year / numeric-date / month-name prefixes classify as dates")
+    func matchesDates() {
+        #expect(OntologyBrowser.isDateEntity(entity("1990")))
+        #expect(OntologyBrowser.isDateEntity(entity("2020-01-15")))
+        #expect(OntologyBrowser.isDateEntity(entity("January 1900")))
+        #expect(OntologyBrowser.isDateEntity(entity("Sept 1901")))
+        #expect(OntologyBrowser.isDateEntity(entity("dec")))
+    }
+
+    @Test("Names, places, and short numbers are not dates")
+    func rejectsNonDates() {
+        #expect(!OntologyBrowser.isDateEntity(entity("John Smith")))
+        #expect(!OntologyBrowser.isDateEntity(entity("Paris")))
+        #expect(!OntologyBrowser.isDateEntity(entity("12")))          // fewer than 3 digits
+        #expect(!OntologyBrowser.isDateEntity(entity("Marcus")))      // not "mar" boundary
+    }
+}

--- a/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/OntologyBrowser.swift
+++ b/fichero/fichero/Views/KnowledgeGraph/OntologyBrowser/OntologyBrowser.swift
@@ -166,6 +166,23 @@ struct OntologyBrowser: View {
         }
     }
 
+    // Compiled ONCE and reused (#3869). `range(of:options:.regularExpression)`
+    // recompiles the pattern on every call; over a library-wide entity list that was
+    // up to three recompiles per entity, twice per entity (date + non-date filter).
+    // Patterns are compile-time constants so the `try?` never actually yields nil;
+    // optional-chained matching below just avoids a banned force-try.
+    private static let dateNumericRegex = try? NSRegularExpression(
+        pattern: #"^\d{3,4}([-/]\d{1,2}){0,2}(\b|$)"#
+    )
+    private static let dateMonthEarlyRegex = try? NSRegularExpression(
+        pattern: #"^(jan(uary)?|feb(ruary)?|mar(ch)?|apr(il)?|may|jun(e)?|jul(y)?|aug(ust)?)\b"#,
+        options: [.caseInsensitive]
+    )
+    private static let dateMonthLateRegex = try? NSRegularExpression(
+        pattern: #"^(sep(t)?(ember)?|oct(ober)?|nov(ember)?|dec(ember)?)\b"#,
+        options: [.caseInsensitive]
+    )
+
     /// Date rows are still returned by older KG data as ordinary entities.
     /// Keep them available without mixing them into the named-entity scan.
     static func isDateEntity(_ entity: Components.Schemas.KnowledgeEntity) -> Bool {
@@ -173,18 +190,10 @@ struct OntologyBrowser: View {
             return true
         }
         let name = entity.canonicalName.trimmingCharacters(in: .whitespacesAndNewlines)
-        return name.range(
-            of: #"^\d{3,4}([-/]\d{1,2}){0,2}(\b|$)"#,
-            options: .regularExpression
-        ) != nil
-        || name.range(
-            of: #"^(jan(uary)?|feb(ruary)?|mar(ch)?|apr(il)?|may|jun(e)?|jul(y)?|aug(ust)?)\b"#,
-            options: [.regularExpression, .caseInsensitive]
-        ) != nil
-        || name.range(
-            of: #"^(sep(t)?(ember)?|oct(ober)?|nov(ember)?|dec(ember)?)\b"#,
-            options: [.regularExpression, .caseInsensitive]
-        ) != nil
+        let range = NSRange(name.startIndex..., in: name)
+        return dateNumericRegex?.firstMatch(in: name, range: range) != nil
+            || dateMonthEarlyRegex?.firstMatch(in: name, range: range) != nil
+            || dateMonthLateRegex?.firstMatch(in: name, range: range) != nil
     }
 
     // ponytail: recompute inputs — entityStore.libraryEntities, hiddenKindsCSV, suppressOcrGarbage
@@ -198,8 +207,19 @@ struct OntologyBrowser: View {
             result = result.filter { !Self.isOcrGarbage($0.canonicalName) }
         }
         filteredEntities = result
-        nonDateEntities = result.filter { !Self.isDateEntity($0) }
-        dateEntities = result.filter(Self.isDateEntity)
+        // One pass, one isDateEntity call per entity — not two filters that each
+        // re-scan the whole list and re-run the (now cached) date regexes (#3869).
+        var nonDate: [Components.Schemas.KnowledgeEntity] = []
+        var dates: [Components.Schemas.KnowledgeEntity] = []
+        for entity in result {
+            if Self.isDateEntity(entity) {
+                dates.append(entity)
+            } else {
+                nonDate.append(entity)
+            }
+        }
+        nonDateEntities = nonDate
+        dateEntities = dates
     }
 
     // MARK: - Load-state accessors


### PR DESCRIPTION
Closes #3869. OntologyBrowser isDateEntity uses cached static NSRegularExpression instead of recompiling per call; single-pass partition instead of two full filters over the entity list. Test added; guardrails green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)