### PR TITLE
perf: diff list-row selection tint by value, not the whole Set (#3868)

### DIFF
--- a/fichero/fichero-tests/LibrarySelectableRowTests.swift
+++ b/fichero/fichero-tests/LibrarySelectableRowTests.swift
@@ -1,0 +1,56 @@
+@testable import Fichero
+import SwiftUI
+import Testing
+
+/// #3868 — the list-row selection tint is diffed by VALUE so one selection click
+/// only re-renders the rows whose selection actually changed. These lock the
+/// `Equatable` contract SwiftUI's `.equatable()` relies on: equal (skippable) when
+/// identity + isSelected + tint match, regardless of content; unequal when any of
+/// those change.
+@MainActor
+struct LibrarySelectableRowTests {
+
+    @Test("Same identity/isSelected/tint are equal even with different content (row is skipped)")
+    func equalIgnoresContent() {
+        let base = LibrarySelectableRow(identity: "doc1", isSelected: false, tint: Color.accentColor) {
+            Text("A")
+        }
+        let differentContent = LibrarySelectableRow(identity: "doc1", isSelected: false, tint: Color.accentColor) {
+            Text("B")
+        }
+        #expect(base == differentContent)
+    }
+
+    @Test("A flipped selection is not equal — the row must re-render")
+    func selectionFlipBreaksEquality() {
+        let unselected = LibrarySelectableRow(identity: "doc1", isSelected: false, tint: Color.accentColor) {
+            Text("A")
+        }
+        let selected = LibrarySelectableRow(identity: "doc1", isSelected: true, tint: Color.accentColor) {
+            Text("A")
+        }
+        #expect(unselected != selected)
+    }
+
+    @Test("A different data identity is not equal")
+    func identityBreaksEquality() {
+        let first = LibrarySelectableRow(identity: "doc1", isSelected: false, tint: Color.accentColor) {
+            Text("A")
+        }
+        let second = LibrarySelectableRow(identity: "doc2", isSelected: false, tint: Color.accentColor) {
+            Text("A")
+        }
+        #expect(first != second)
+    }
+
+    @Test("A different tint (e.g. pane focus changed) is not equal")
+    func tintBreaksEquality() {
+        let accent = LibrarySelectableRow(identity: "doc1", isSelected: true, tint: Color.accentColor) {
+            Text("A")
+        }
+        let secondary = LibrarySelectableRow(identity: "doc1", isSelected: true, tint: Color.secondary) {
+            Text("A")
+        }
+        #expect(accent != secondary)
+    }
+}

--- a/fichero/fichero/Views/Library/LibraryView+DisplayModes.swift
+++ b/fichero/fichero/Views/Library/LibraryView+DisplayModes.swift
@@ -256,16 +256,19 @@ extension LibraryView {
                     if isShowingEntitiesCollection {
                         ForEach(filteredEntities, id: \.stableInspectorId) { entity in
                             let entityId = entitySelectionId(for: entity)
-                            EntityRow(
-                                entity: entity,
-                                claimCount: entity.corroborationCount ?? 0,
-                                style: .browser
-                            )
+                            LibrarySelectableRow(
+                                identity: entity,
+                                isSelected: selection.contains(entityId),
+                                tint: selectionFill
+                            ) {
+                                EntityRow(
+                                    entity: entity,
+                                    claimCount: entity.corroborationCount ?? 0,
+                                    style: .browser
+                                )
+                            }
+                            .equatable()
                             .id(entityId)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(selection.contains(entityId) ? selectionFill : Color.clear)
-                            .contentShape(Rectangle())
                             .onTapGesture(count: 2) {
                                 handleEntityDoubleClick(entity)
                             }
@@ -278,20 +281,27 @@ extension LibraryView {
                         }
                     } else {
                         ForEach(filteredDocuments) { doc in
-                            MailStyleRow(
-                                document: doc,
+                            LibrarySelectableRow(
+                                // Identity must capture EVERYTHING the row content
+                                // renders from — the document AND which entity-type
+                                // tags are shown — so a filter change still re-renders
+                                // the row (isSelected/tint cover selection + focus).
+                                identity: DocRowIdentity(document: doc, visibleEntityTypes: listVisibleEntityTypes),
                                 isSelected: selection.contains(doc.id),
-                                visibleEntityTypes: listVisibleEntityTypes
-                            ) { tag in
-                                searchText = tag
-                                showFilterBar = true
+                                tint: selectionFill
+                            ) {
+                                MailStyleRow(
+                                    document: doc,
+                                    isSelected: selection.contains(doc.id),
+                                    visibleEntityTypes: listVisibleEntityTypes
+                                ) { tag in
+                                    searchText = tag
+                                    showFilterBar = true
+                                }
                             }
+                            .equatable()
                             .id(doc.id)
                             .draggable(libraryItemDrag(for: doc))
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 8)
-                            .background(selection.contains(doc.id) ? selectionFill : Color.clear)
-                            .contentShape(Rectangle())
                             .onTapGesture(count: 2) {
                                 handleDoubleClick(doc)
                             }
@@ -447,5 +457,40 @@ extension LibraryView {
         .help("Filter entity types shown")
     }
 
+}
+
+/// A list row whose selection tint is diffed by VALUE — the row's data `identity`,
+/// `isSelected`, and `tint` — not the whole selection `Set` (#3868). Marked
+/// `Equatable` and applied with `.equatable()` so one selection click only
+/// re-renders the rows whose selection actually changed; unchanged rows are skipped
+/// even though their content holds closures (which would otherwise defeat SwiftUI's
+/// field diffing). The tap / context-menu actions are applied OUTSIDE this wrapper,
+/// so they're excluded from `==` — safe because they act on the same `identity`.
+/// Everything a document list row renders from besides its selection state, so the
+/// `.equatable()` skip stays correct when the visible-tag filter changes (#3868).
+struct DocRowIdentity: Equatable {
+    let document: Document
+    let visibleEntityTypes: Set<String>
+}
+
+struct LibrarySelectableRow<Identity: Equatable, Content: View>: View, Equatable {
+    let identity: Identity
+    let isSelected: Bool
+    let tint: Color
+    @ViewBuilder let content: Content
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.identity == rhs.identity
+            && lhs.isSelected == rhs.isSelected
+            && lhs.tint == rhs.tint
+    }
+
+    var body: some View {
+        content
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(isSelected ? tint : Color.clear)
+            .contentShape(Rectangle())
+    }
 }
 // swiftlint:enable file_length

--- a/scripts/check_native_controls.py
+++ b/scripts/check_native_controls.py
@@ -30,7 +30,7 @@ KNOWN_VIOLATIONS: dict[str, str] = {
     "KnowledgeGraph/OntologyBrowser/HeuristicReviewSheet.swift#aa939bcbf4": "#1912 baseline",
     "KnowledgeGraph/OntologyBrowser/SpeakerComparisonView.swift#ffffcf8a29": "#1912 baseline",
     "Library/ImageEditor/ImageEditChainPanel.swift#83a0175036": "#1912 baseline",
-    "Library/LibraryView+DisplayModes.swift#1905c7aded": "#1912 baseline (rehashed: #3705 added .draggable; #3875 changed the selection-fill background; the collection itself is unchanged)",
+    "Library/LibraryView+DisplayModes.swift#19c3b271df": "#1912 baseline (rehashed: #3705 .draggable; #3875 selection-fill; #3868 extracted a value-typed selectable row wrapper; the collection itself is unchanged)",
     "Library/Workspace/WorkspaceItemPicker.swift#2e87b93a6b": "#1912 baseline",
     "Research/ResearchTasksPane.swift#1d731da4e7": "#1912 baseline (shifted by store migration)",
     "Research/ResearchTasksPane.swift#f50acbd404": "#1912 baseline (shifted by store migration)",


### PR DESCRIPTION
Closes #3868. Extracted a value-typed selectable row wrapper (isSelected: Bool, tint: Color) so one selection click no longer re-evaluates every visible row body; SwiftUI per-view diffing skips unchanged rows. Re-pinned native-controls baseline (sanctioned collection restructured). Test added; guardrails green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)