### PR TITLE
perf: low-batch library/search cleanups — closes Performance milestone (#3870)

### DIFF
--- a/fichero/fichero-tests/SearchResultsDisplayTests.swift
+++ b/fichero/fichero-tests/SearchResultsDisplayTests.swift
@@ -68,6 +68,41 @@ final class SearchResultsDisplayTests: XCTestCase {
         )
     }
 
+    // MARK: - KeywordCloudSizing (the hoisted, compute-once path — #3870)
+
+    func testKeywordCloudSizingMatchesPerCallFontSize() {
+        // The cloud-scanned range is computed ONCE; the result must match the old
+        // per-pill `fontSize(for:cloud:)` for every entry, so hoisting changed only
+        // cost, not behaviour.
+        let cloud: [KeywordCloudEntryDTO] = [
+            KeywordCloudEntryDTO(name: "a", count: 1),
+            KeywordCloudEntryDTO(name: "b", count: 5),
+            KeywordCloudEntryDTO(name: "c", count: 20)
+        ]
+        let sizing = KeywordCloudSizing(cloud: cloud)
+        for entry in cloud {
+            XCTAssertEqual(
+                sizing.fontSize(for: entry),
+                SearchResultsDisplay.fontSize(for: entry, cloud: cloud),
+                accuracy: 0.001
+            )
+        }
+        // And the endpoints clamp as documented.
+        XCTAssertEqual(sizing.fontSize(for: cloud[0]), 11)
+        XCTAssertEqual(sizing.fontSize(for: cloud[2]), 17)
+    }
+
+    func testKeywordCloudSizingDegenerateInputsFallBackTo12() {
+        // No spread → default 12; empty cloud → default 12.
+        let flat = [KeywordCloudEntryDTO(name: "x", count: 7), KeywordCloudEntryDTO(name: "y", count: 7)]
+        XCTAssertEqual(KeywordCloudSizing(cloud: flat).fontSize(for: flat[0]), 12)
+        let empty: [KeywordCloudEntryDTO] = []
+        XCTAssertEqual(
+            KeywordCloudSizing(cloud: empty).fontSize(for: KeywordCloudEntryDTO(name: "z", count: 1)),
+            12
+        )
+    }
+
     func testSavedSearchReplayRestoresSortAndSearchType() throws {
         let viewSource = try Self.appSource("Views/Search/SearchView.swift")
         let helperSource = try Self.appSource("Views/Search/SearchView+Helpers.swift")

--- a/fichero/fichero/Services/StorageServiceGenerated.swift
+++ b/fichero/fichero/Services/StorageServiceGenerated.swift
@@ -98,7 +98,8 @@ class StorageServiceGenerated {
         if let cached = thumbnailCache[docId] {
             return cached
         }
-        logger.info("Loading thumbnail for document: \(docId)")
+        // .debug, not .info: fires per uncached thumbnail during hot scroll (#3870).
+        logger.debug("Loading thumbnail for document: \(docId)")
         let data = try await thumbnailData(for: docId)
         let image = try await Self.decodeImage(from: data)
         cacheThumbnail(image, for: docId)

--- a/fichero/fichero/Views/Components/LibraryImageView.swift
+++ b/fichero/fichero/Views/Components/LibraryImageView.swift
@@ -55,23 +55,35 @@ struct LibraryImageView: View {
     private func loadImage(for key: LibraryImageLoadKey) async {
         guard loadedKey != key || image == nil else { return }
 
+        // Seed a cache hit synchronously so the first render shows the thumbnail with
+        // no image=nil placeholder flash before the async fetch (#3870).
+        if key.imageType == .thumbnail,
+           let cached = storageService.cachedThumbnail(for: key.documentId) {
+            image = cached
+            loadedKey = key
+            isLoading = false
+            loadError = nil
+            return
+        }
+
         image = nil
         loadedKey = nil
         isLoading = true
         loadError = nil
 
         let imageTypeLabel = key.imageType == .thumbnail ? "thumbnail" : "display"
-        Self.logger.info("Loading \(imageTypeLabel) for document: \(key.documentId)")
+        // .debug, not .info: this fires per thumbnail during hot scroll (#3870).
+        Self.logger.debug("Loading \(imageTypeLabel) for document: \(key.documentId)")
 
         do {
             let loadedImage: Image
             switch key.imageType {
             case .thumbnail:
                 loadedImage = try await storageService.getThumbnail(key.documentId)
-                Self.logger.info("Successfully loaded thumbnail for: \(key.documentId)")
+                Self.logger.debug("Successfully loaded thumbnail for: \(key.documentId)")
             case .display:
                 loadedImage = try await storageService.getDisplayImage(key.documentId)
-                Self.logger.info("Successfully loaded display image for: \(key.documentId)")
+                Self.logger.debug("Successfully loaded display image for: \(key.documentId)")
             }
             guard loadKey == key else {
                 isLoading = false

--- a/fichero/fichero/Views/Library/LibraryView+DisplayModes.swift
+++ b/fichero/fichero/Views/Library/LibraryView+DisplayModes.swift
@@ -226,7 +226,7 @@ extension LibraryView {
 
     private func scheduleThumbnailPrefetch(around documentId: String) {
         guard !isShowingEntitiesCollection,
-              let index = filteredDocuments.firstIndex(where: { $0.id == documentId }) else { return }
+              let index = documentIndexById[documentId] else { return }
 
         let behind = max(gridColumnCount * 2, 8)
         let ahead = max(gridColumnCount * 8, 24)

--- a/fichero/fichero/Views/Library/LibraryView+FilterAndBatch.swift
+++ b/fichero/fichero/Views/Library/LibraryView+FilterAndBatch.swift
@@ -61,7 +61,17 @@ extension LibraryView {
             }
         }
         filteredDocuments = docs.sorted(using: sortOrder)
-        thumbnailPrefetchKey = filteredDocuments.map(\.id).joined()
+        // Hash the ids (Int) instead of joining every id into one giant String
+        // (#3870) — it only needs to CHANGE when the visible set changes.
+        var hasher = Hasher()
+        for doc in filteredDocuments { hasher.combine(doc.id) }
+        thumbnailPrefetchKey = hasher.finalize()
+        // id → index for O(1) prefetch scheduling (#3870); ids are unique, keep the
+        // first on the off chance of a dup rather than trapping.
+        documentIndexById = Dictionary(
+            filteredDocuments.enumerated().map { ($1.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
 
         // Entities — strip OCR/extraction garbage names, then decorate each with
         // its lowercased sort key ONCE (#3865). The old comparator re-computed

--- a/fichero/fichero/Views/Library/LibraryView.swift
+++ b/fichero/fichero/Views/Library/LibraryView.swift
@@ -184,9 +184,13 @@ struct LibraryView: View {
     // extension (a different file), so these must be at least internal to be visible there.
     @State var filteredDocuments: [Document] = []
     @State var filteredEntities: [Components.Schemas.KnowledgeEntity] = []
-    /// Stable key for .task(id:) in iconsView — updated inside recomputeFiltered()
-    /// to reset thumbnail prefetch state when the visible document set changes.
-    @State var thumbnailPrefetchKey: String = ""
+    /// Stable key for .onChange in iconsView — updated inside recomputeFiltered()
+    /// to reset thumbnail prefetch state when the visible document set changes. A
+    /// hash of the ids (Int), not a joined String of every id (#3870).
+    @State var thumbnailPrefetchKey: Int = 0
+    /// id → index in `filteredDocuments`, rebuilt in recomputeFiltered() so
+    /// prefetch scheduling is an O(1) lookup, not an O(n) firstIndex per cell (#3870).
+    @State var documentIndexById: [String: Int] = [:]
     @State var prefetchedThumbnailIds: Set<String> = []
     @State var thumbnailPrefetchTask: Task<Void, Never>?
 

--- a/fichero/fichero/Views/Search/SearchResultsDisplay.swift
+++ b/fichero/fichero/Views/Search/SearchResultsDisplay.swift
@@ -1,5 +1,27 @@
 import SwiftUI
 
+/// Keyword-cloud pill sizing with the count range computed ONCE (#3870). Callers
+/// build this per cloud and call `fontSize(for:)` per pill — O(1) each, instead of
+/// re-scanning the cloud for min/max on every pill.
+struct KeywordCloudSizing {
+    private let lowerBound: Int
+    private let upperBound: Int
+
+    init(cloud: [KeywordCloudEntryDTO]) {
+        let counts = cloud.map(\.count)
+        lowerBound = counts.min() ?? 0
+        upperBound = counts.max() ?? 0
+    }
+
+    /// Linear interpolation between 11pt (rarest) and 17pt (most common); 12pt when
+    /// there is no spread (empty cloud or all-equal counts).
+    func fontSize(for entry: KeywordCloudEntryDTO) -> CGFloat {
+        guard upperBound > lowerBound else { return 12 }
+        let interpolation = CGFloat(entry.count - lowerBound) / CGFloat(upperBound - lowerBound)
+        return 11 + interpolation * 6
+    }
+}
+
 /// Search results display supporting four view modes
 struct SearchResultsDisplay: View {
     let searchResults: [SearchResult]
@@ -39,15 +61,13 @@ struct SearchResultsDisplay: View {
     /// most-used tag in the cloud renders biggest; rare tags stay small.
     /// Linear interpolation between 11pt and 17pt over the count range
     /// for any given cloud snapshot.
+    /// Convenience for a single entry. Callers rendering the WHOLE cloud should
+    /// build one `KeywordCloudSizing` and reuse it (#3870) rather than call this per
+    /// pill — each call re-scans the cloud for min/max.
     static func fontSize(
         for entry: KeywordCloudEntryDTO, cloud: [KeywordCloudEntryDTO]
     ) -> CGFloat {
-        let counts = cloud.map(\.count)
-        guard let lowerBound = counts.min(),
-              let upperBound = counts.max(),
-              upperBound > lowerBound else { return 12 }
-        let interpolation = CGFloat(entry.count - lowerBound) / CGFloat(upperBound - lowerBound)
-        return 11 + interpolation * 6
+        KeywordCloudSizing(cloud: cloud).fontSize(for: entry)
     }
     var body: some View {
         if searchResults.isEmpty {

--- a/fichero/fichero/Views/Search/SearchResultsEmptyState.swift
+++ b/fichero/fichero/Views/Search/SearchResultsEmptyState.swift
@@ -71,6 +71,9 @@ struct SearchResultsEmptyState: View {
                             Text("Browse by keyword")
                                 .font(.caption)
                                 .foregroundStyle(.tertiary)
+                            // Count range computed ONCE for the whole cloud, not
+                            // re-scanned per pill (#3870).
+                            let cloudSizing = KeywordCloudSizing(cloud: keywordCloud)
                             FlowLayout(spacing: 4) {
                                 ForEach(keywordCloud) { entry in
                                     Button {
@@ -78,7 +81,7 @@ struct SearchResultsEmptyState: View {
                                     } label: {
                                         Text(entry.name)
                                             .font(.system(
-                                                size: SearchResultsDisplay.fontSize(for: entry, cloud: keywordCloud)
+                                                size: cloudSizing.fontSize(for: entry)
                                             ))
                                             .padding(.horizontal, 10)
                                             .padding(.vertical, 4)

--- a/fichero/fichero/Views/Sheets/DocumentPickerSheet.swift
+++ b/fichero/fichero/Views/Sheets/DocumentPickerSheet.swift
@@ -16,23 +16,27 @@ struct DocumentPickerSheet: View {
     @State private var selection: Set<String> = []
     @State private var processingOrder: BatchProcessingOrder = .alphabeticalAsc
 
+    @State private var filteredDocuments: [Document] = []
+    @State private var selectedDocumentsOrdered: [Document] = []
+
     private var allDocuments: [Document] {
         documentStore.currentDocuments.filter { $0.docType != .folder }
     }
 
-    private var filteredDocuments: [Document] {
+    /// One recompute into @State when an input changes (search / selection / order /
+    /// the store's documents) instead of re-filtering + re-sorting on every body
+    /// access through chained computed vars (#3870).
+    private func recompute() {
+        let all = allDocuments
         if searchText.isEmpty {
-            return allDocuments
+            filteredDocuments = all
+        } else {
+            filteredDocuments = all.filter { document in
+                document.name.localizedCaseInsensitiveContains(searchText) ||
+                    (document.pageContent?.localizedCaseInsensitiveContains(searchText) ?? false)
+            }
         }
-        return allDocuments.filter { document in
-            document.name.localizedCaseInsensitiveContains(searchText) ||
-                (document.pageContent?.localizedCaseInsensitiveContains(searchText) ?? false)
-        }
-    }
-
-    private var selectedDocumentsOrdered: [Document] {
-        let selected = allDocuments.filter { selection.contains($0.id) }
-        return processingOrder.sort(selected)
+        selectedDocumentsOrdered = processingOrder.sort(all.filter { selection.contains($0.id) })
     }
 
     var body: some View {
@@ -134,6 +138,11 @@ struct DocumentPickerSheet: View {
         #if os(macOS)
         .frame(width: 500, height: 600)
         #endif
+        .onAppear { recompute() }
+        .onChange(of: searchText) { _, _ in recompute() }
+        .onChange(of: selection) { _, _ in recompute() }
+        .onChange(of: processingOrder) { _, _ in recompute() }
+        .onChange(of: documentStore.currentDocuments) { _, _ in recompute() }
     }
 
     private func runBatch() {


### PR DESCRIPTION
Closes #3870. Hashed prefetch key (not a joined id string); [id:index] dict for prefetch instead of O(n) firstIndex; thumbnail logging dropped to .debug + seed from cache; DocumentPickerSheet recompute-into-@State; SearchResults fontSize min/max computed once. Test added; guardrails green. Final issue in Performance - SwiftUI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)