### PR TITLE
test: assert CLI surface exposes #3860 pair/users groups

### DIFF
--- a/fichero-engine/tests/unit/test_cli_entrypoint.py
+++ b/fichero-engine/tests/unit/test_cli_entrypoint.py
@@ -27,6 +27,9 @@ def test_python_module_help_imports_cleanly():
 
     assert result.returncode == 0, result.stderr
     assert "Fichero CLI" in result.stdout
+    # CLI surface must include the #3860 device-enrollment + user-management groups.
+    assert "pair" in result.stdout
+    assert "users" in result.stdout
 
 
 def test_python_module_entity_help_imports_cleanly():


### PR DESCRIPTION
Positive assertion that the merged #3860 device-enrollment (`pair`) and user-management (`users`) endpoints are wired into the generated CLI surface. Complements the load-safe `--help` timeout already in main (#3895). Test-only; verified 2/2 isolated.

Handing to f_manager to gate/merge independently, per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)