### PR TITLE
fix(#3773): await sandbox grant before engine reads a runtime-added library

### DIFF
--- a/fichero/fichero-tests/RuntimeLibraryGrantOrderingTests.swift
+++ b/fichero/fichero-tests/RuntimeLibraryGrantOrderingTests.swift
@@ -1,0 +1,106 @@
+#if os(macOS)
+@testable import Fichero
+import XCTest
+
+/// After-start attach ordering (#3773).
+///
+/// A library added while the sandboxed engine is already running must have its
+/// security-scoped grant IN PLACE before the engine is asked to read it. Both
+/// paths — folder import (ingest) and opening a `.fichero` package (load +
+/// registry) — route through `FolderAccessManager.grantThenEngineWork`, which
+/// must run the grant to completion FIRST. If the engine read raced ahead, the
+/// library would be unreadable until the app relaunched (the exact #3773 bug).
+///
+/// FICHERO_APP_STORE is off in the test target, so the REAL grant is a no-op
+/// here; these tests pin the ordering contract of the shared seam, which is what
+/// both call paths rely on.
+final class RuntimeLibraryGrantOrderingTests: XCTestCase {
+
+    /// The grant runs, then the engine work — never the reverse.
+    @MainActor
+    func testGrantCompletesBeforeEngineWork() async {
+        var order: [String] = []
+        await FolderAccessManager.grantThenEngineWork(
+            grant: { order.append("grant") },
+            engineWork: { order.append("engineWork") }
+        )
+        XCTAssertEqual(
+            order, ["grant", "engineWork"],
+            "the sandbox grant must finish before the engine reads the path"
+        )
+    }
+
+    /// The grant is fully AWAITED: an async grant with a real suspension point
+    /// still completes before engine work begins. This is the direct regression
+    /// guard against the fire-and-forget bug — a grant only kicked off (not
+    /// awaited) would let engine work interleave ahead of the suspension.
+    @MainActor
+    func testAsyncGrantIsAwaitedNotFireAndForget() async {
+        var order: [String] = []
+        await FolderAccessManager.grantThenEngineWork(
+            grant: {
+                await Task.yield()  // force a suspension mid-grant
+                order.append("grant")
+            },
+            engineWork: { order.append("engineWork") }
+        )
+        XCTAssertEqual(order, ["grant", "engineWork"])
+    }
+
+    /// The engine-work result is propagated back to the caller — the ingest
+    /// response / document ids both paths consume.
+    @MainActor
+    func testEngineWorkResultIsReturned() async {
+        let result = await FolderAccessManager.grantThenEngineWork(
+            grant: {},
+            engineWork: { "ingested" }
+        )
+        XCTAssertEqual(result, "ingested")
+    }
+
+    /// A DENIED grant stops the engine work entirely and propagates the error —
+    /// the engine is never asked to read a path it can't open (the core #3773
+    /// invariant: no silent proceed after a failed grant).
+    @MainActor
+    func testDeniedGrantPreventsEngineWork() async {
+        struct GrantDenied: Error {}
+        var order: [String] = []
+        do {
+            try await FolderAccessManager.grantThenEngineWork(
+                grant: {
+                    order.append("grant")
+                    throw GrantDenied()
+                },
+                engineWork: { order.append("engineWork") }
+            )
+            XCTFail("expected the denied grant to propagate")
+        } catch is GrantDenied {
+            XCTAssertEqual(order, ["grant"], "engine work must NOT run after a denied grant")
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+
+    /// A throwing engine-work still grants FIRST, then propagates the error —
+    /// import surfaces ingest failures to the user without skipping the grant.
+    @MainActor
+    func testThrowingEngineWorkStillGrantsFirstThenThrows() async {
+        struct IngestFailure: Error {}
+        var order: [String] = []
+        do {
+            try await FolderAccessManager.grantThenEngineWork(
+                grant: { order.append("grant") },
+                engineWork: {
+                    order.append("engineWork")
+                    throw IngestFailure()
+                }
+            )
+            XCTFail("expected the engine work to throw")
+        } catch is IngestFailure {
+            XCTAssertEqual(order, ["grant", "engineWork"])
+        } catch {
+            XCTFail("unexpected error: \(error)")
+        }
+    }
+}
+#endif

--- a/fichero/fichero/Models/LibraryManager+Operations.swift
+++ b/fichero/fichero/Models/LibraryManager+Operations.swift
@@ -68,15 +68,43 @@ extension LibraryManager {
         // Save open libraries for restoration on next launch
         saveOpenLibraryPaths()
 
-        scheduleLoadWhenBackendReady(for: library)
-        Task {
-            await KnownLibraryRegistryStore.shared.noteOpenedLibrary(
-                url: url,
-                displayName: displayName
-            )
-        }
+        loadAndRegister(library, at: url, displayName: displayName, needsSecurityAccess: needsSecurityAccess)
 
         return library
+    }
+
+    /// Kick off the engine load + registry-add for a freshly opened library.
+    ///
+    /// For a user-picked package (needsSecurityAccess), grant the sandboxed engine
+    /// access to it and AWAIT that grant BEFORE the load/registry requests, which
+    /// are the engine's first reads of the package — otherwise they race the grant
+    /// and the library stays unreadable until the app relaunches (#3773). Temporary
+    /// libraries live in the app's own container and need no grant.
+    private func loadAndRegister(
+        _ library: LibraryReference,
+        at url: URL,
+        displayName: String,
+        needsSecurityAccess: Bool
+    ) {
+        guard needsSecurityAccess else {
+            scheduleLoadWhenBackendReady(for: library)
+            Task {
+                await KnownLibraryRegistryStore.shared.noteOpenedLibrary(url: url, displayName: displayName)
+            }
+            return
+        }
+        Task { @MainActor in
+            // try?: a denied grant is already surfaced via engineAccessFailure and
+            // must stop the load/registry (grantThenEngineWork skips engineWork on a
+            // grant throw) without crashing the open.
+            try? await FolderAccessManager.grantThenEngineWork(
+                grant: { try await FolderAccessManager.shared.saveBookmarkIfDirectory(url) },
+                engineWork: {
+                    scheduleLoadWhenBackendReady(for: library)
+                    await KnownLibraryRegistryStore.shared.noteOpenedLibrary(url: url, displayName: displayName)
+                }
+            )
+        }
     }
 
     /// Switch the whole app to a known-registry library by its (possibly remote)

--- a/fichero/fichero/Services/ImportServiceGenerated.swift
+++ b/fichero/fichero/Services/ImportServiceGenerated.swift
@@ -67,18 +67,21 @@ class ImportServiceGenerated {
                 let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
 
                 if exists && isDirectory.boolValue {
-                    // Persist sandbox permission when folder is added.
-                    FolderAccessManager.shared.saveBookmarkIfDirectory(url)
-
-                    // Import folder using async task pattern
+                    // After-start attach (#3773): grant the sandboxed engine access
+                    // to the folder and AWAIT it before the ingest request reads it.
                     logger.info("Detected folder: \(url.lastPathComponent), using async folder import")
-                    let documentIds = try await importFolderAndWait(
-                        url,
-                        mode: mode,
-                        parentId: parentId,
-                        recursive: true,
-                        extractText: extractText,
-                        autoEmbed: autoEmbed
+                    let documentIds = try await FolderAccessManager.grantThenEngineWork(
+                        grant: { try await FolderAccessManager.shared.saveBookmarkIfDirectory(url) },
+                        engineWork: {
+                            try await importFolderAndWait(
+                                url,
+                                mode: mode,
+                                parentId: parentId,
+                                recursive: true,
+                                extractText: extractText,
+                                autoEmbed: autoEmbed
+                            )
+                        }
                     )
                     logger.info("Successfully imported folder with \(documentIds.count) documents: \(url.lastPathComponent)")
                     // Note: We only have document IDs, not full documents
@@ -194,25 +197,29 @@ class ImportServiceGenerated {
     ) async throws -> IngestTask {
         logger.info("Starting async folder import: \(url.lastPathComponent)")
 
-        // Persist sandbox permission when folder import starts directly.
-        FolderAccessManager.shared.saveBookmarkIfDirectory(url)
-
-        // Enable security-scoped access in sandboxed builds; non-sandboxed builds
-        // return false but the URL remains accessible via normal file I/O.
+        // Enable app-side security-scoped access in sandboxed builds; non-sandboxed
+        // builds return false but the URL remains accessible via normal file I/O.
         let didStartAccess = url.startAccessingSecurityScopedResource()
         defer {
             if didStartAccess { url.stopAccessingSecurityScopedResource() }
         }
 
-        let response = try await client.api.ingestFolderApiIngestFolderPost(
-            body: .json(.init(
-                path: url.path,
-                parentId: parentId,
-                copyMode: mode == .copy,
-                recursive: recursive,
-                extractText: extractText,
-                autoEmbed: autoEmbed
-            ))
+        // After-start attach (#3773): grant the sandboxed ENGINE access to the
+        // folder and AWAIT it before the ingest request reads it.
+        let response = try await FolderAccessManager.grantThenEngineWork(
+            grant: { try await FolderAccessManager.shared.saveBookmarkIfDirectory(url) },
+            engineWork: {
+                try await client.api.ingestFolderApiIngestFolderPost(
+                    body: .json(.init(
+                        path: url.path,
+                        parentId: parentId,
+                        copyMode: mode == .copy,
+                        recursive: recursive,
+                        extractText: extractText,
+                        autoEmbed: autoEmbed
+                    ))
+                )
+            }
         )
 
         switch response {

--- a/fichero/fichero/Views/Library/FolderAccessManager.swift
+++ b/fichero/fichero/Views/Library/FolderAccessManager.swift
@@ -126,15 +126,19 @@ class FolderAccessManager {
         return String(data: data, encoding: .utf8)
     }
 
-    /// Save a security-scoped bookmark
-    func saveBookmark(for url: URL) {
+    /// Mint + persist a security-scoped bookmark for `url` and register it in
+    /// `accessedFolders`. Returns the bookmark data (to hand to the engine), or nil
+    /// when the path is transient or minting failed. Does NOT contact the engine —
+    /// callers choose sync fire-and-forget (`saveBookmark`) or awaited
+    /// (`saveBookmarkIfDirectory`) handoff.
+    private func mintAndStoreBookmark(for url: URL) -> Data? {
         // Never bookmark transient temp paths — they're cleaned up after ingest
         // and will always fail to resolve on next launch, producing noisy errors.
         guard !url.path.contains("/fichero-drop-"),
               !url.path.hasPrefix("/var/folders/"),
               !url.path.hasPrefix("/tmp/") else {
             logger.debug("Skipping bookmark for transient path: \(url.path)")
-            return
+            return nil
         }
         do {
             // Start accessing to create bookmark
@@ -157,59 +161,92 @@ class FolderAccessManager {
             }
 
             logger.info("Saved bookmark for: \(url.path)")
-
-            // Hand it to the RUNNING engine (#3773). Storing it is not enough: the
-            // spawn-time payload is an environment variable, and an environment
-            // cannot change after the process starts — so a library picked now would
-            // be invisible to the live engine and unreadable until the app relaunched.
-            handOffToEngine(path: url.path, bookmark: bookmarkData)
-
             // Don't stop accessing - we need it throughout the app session
+            return bookmarkData
         } catch {
             logger.error("Failed to save bookmark: \(error.localizedDescription)")
+            return nil
         }
     }
 
-    /// Post a freshly-minted bookmark to the live engine. App Store build only.
+    /// Save a security-scoped bookmark, handing it to the RUNNING engine
+    /// fire-and-forget (#3773). Fine for callers that don't immediately read the
+    /// folder through the engine (the open panel, restore-refresh). Storing it is
+    /// not enough on its own: the spawn-time payload is an environment variable,
+    /// and an environment cannot change after the process starts — so a library
+    /// picked now would be invisible to the live engine until the app relaunched.
     ///
-    /// Fire-and-forget by necessity — saveBookmark() is synchronous and called from
-    /// several non-async paths (the open panel, the import flows). That is sound
-    /// because the grant is IDEMPOTENT on the engine and re-sent at every spawn via
-    /// the env var, so the worst case is ordering: if the engine is asked to open the
-    /// library before this lands, the open fails with a permission error the app
-    /// already surfaces, and the retry succeeds because the grant is there by then.
-    /// It does not silently half-open a library, which is the outcome that matters.
+    /// Callers that DO read the path through the engine right after (folder import,
+    /// opening a package) must use `saveBookmarkIfDirectory`, which AWAITS the grant.
+    func saveBookmark(for url: URL) {
+        guard let bookmarkData = mintAndStoreBookmark(for: url) else { return }
+        handOffToEngine(path: url.path, bookmark: bookmarkData)
+    }
+
+    /// Hand a freshly-minted bookmark to the live engine, fire-and-forget. App
+    /// Store build only. See `grantEngineAccess` for the ORDERED variant a caller
+    /// can await before it reads the folder through the engine (#3773).
+    ///
+    /// Sound for sync callers because the grant is IDEMPOTENT on the engine and
+    /// re-sent at every spawn via the env var, so the worst case is ordering: the
+    /// open fails with a permission error the app surfaces, and the retry succeeds.
     private func handOffToEngine(path: String, bookmark: Data) {
         #if FICHERO_APP_STORE
-        guard let service = engineAccessService else {
-            // Before the client exists there is no engine to tell. Not an error: the
-            // spawn-time env var covers everything minted this early.
-            logger.debug("No engine access service yet; \(path) will be granted at next spawn")
-            return
-        }
         Task { @MainActor in
-            do {
-                try await service.grantAccess(toPath: path, bookmark: bookmark)
-                engineAccessFailure = nil
-            } catch {
-                // Loud, not silent: the engine cannot read this folder, and the user
-                // needs to know that now rather than meet a DuckDB permission error.
-                logger.error("Engine refused folder access for \(path): \(error.localizedDescription)")
-                engineAccessFailure = error.localizedDescription
-            }
+            // Fire-and-forget: this caller does not immediately read the path, so a
+            // denial is swallowed here — it is still surfaced via engineAccessFailure
+            // (set before the throw) and re-sent at the next spawn.
+            try? await grantEngineAccess(path: path, bookmark: bookmark)
         }
         #endif
     }
 
-    /// Persist access for a directory selected via file importer.
-    /// This captures permission at add-time so later reads do not re-prompt.
-    func saveBookmarkIfDirectory(_ url: URL) {
+    /// Await the engine's grant for a freshly-minted bookmark (#3773). The ordered
+    /// counterpart to `handOffToEngine`: a caller about to open/ingest the path
+    /// through the engine awaits this so the grant is in place BEFORE the engine
+    /// reads it — otherwise the read races the grant and the library stays
+    /// unreadable until the app relaunches.
+    ///
+    /// THROWS when a live engine grant is denied, so the caller stops rather than
+    /// reading a folder the engine can't open. Returns normally (no throw) for the
+    /// two legitimate no-grant-needed cases: before the engine client exists (the
+    /// spawn-time env var covers anything minted that early) and on the
+    /// non-App-Store build (no sandbox — nothing to grant).
+    private func grantEngineAccess(path: String, bookmark: Data) async throws {
+        #if FICHERO_APP_STORE
+        guard let service = engineAccessService else {
+            logger.debug("No engine access service yet; \(path) will be granted at next spawn")
+            return
+        }
+        do {
+            try await service.grantAccess(toPath: path, bookmark: bookmark)
+            engineAccessFailure = nil
+        } catch {
+            // Loud AND fatal to the caller's engine work: the engine cannot read
+            // this folder, so ingesting/opening it would fail later with an
+            // inscrutable DuckDB permission error. Surface it and stop the read.
+            logger.error("Engine refused folder access for \(path): \(error.localizedDescription)")
+            engineAccessFailure = error.localizedDescription
+            throw error
+        }
+        #endif
+    }
+
+    /// Persist access for a directory (a picked folder, or a `.fichero` package)
+    /// and AWAIT the engine grant before returning, so a caller about to read that
+    /// path through the engine can't race the grant (#3773). Captures permission
+    /// at add-time so later reads do not re-prompt.
+    ///
+    /// THROWS if a live engine grant is denied — the caller must not proceed to
+    /// read a path the engine can't open.
+    func saveBookmarkIfDirectory(_ url: URL) async throws {
         var isDirectory: ObjCBool = false
         let exists = FileManager.default.fileExists(atPath: url.path, isDirectory: &isDirectory)
         guard exists, isDirectory.boolValue else {
             return
         }
-        saveBookmark(for: url)
+        guard let bookmarkData = mintAndStoreBookmark(for: url) else { return }
+        try await grantEngineAccess(path: url.path, bookmark: bookmarkData)
     }
 
     /// Restore bookmarks on app launch
@@ -300,7 +337,7 @@ class FolderAccessManager {
         logger.debug("Bookmark persistence is macOS-only; ignoring on iOS for: \(url.path)")
     }
 
-    func saveBookmarkIfDirectory(_ url: URL) {
+    func saveBookmarkIfDirectory(_ url: URL) async throws {
         // iOS: importing through document picker already grants access.
     }
 
@@ -311,3 +348,26 @@ class FolderAccessManager {
 }
 
 #endif
+
+// The grant-before-engine-read ordering seam (#3773), shared across platforms.
+extension FolderAccessManager {
+    /// Sequence the sandbox grant before engine work that reads the granted path.
+    /// Both after-start attach paths — folder import and opening a package — route
+    /// through here so the grant runs to completion FIRST; if the engine read
+    /// raced ahead, a library added after the engine started would be unreadable
+    /// until the app relaunched.
+    ///
+    /// A DENIED grant throws BEFORE `engineWork` runs, so the engine is never asked
+    /// to read a path it can't open (the error propagates to the caller). One
+    /// awaited seam so the ordering is unit-testable without a live sandbox
+    /// (FICHERO_APP_STORE is off in the test target, so the real grant is a no-op
+    /// there — this pins the contract both paths rely on).
+    @MainActor
+    static func grantThenEngineWork<T>(
+        grant: () async throws -> Void,
+        engineWork: () async throws -> T
+    ) async rethrows -> T {
+        try await grant()
+        return try await engineWork()
+    }
+}


### PR DESCRIPTION
## #3773 (Mac App Store — Sandbox) — Swift-only

A sandboxed engine cannot open a library **added after it starts**: the security-scoped grant to the engine was fire-and-forget, so the engine's first read of the path raced ahead of the grant and the library stayed unreadable until the app relaunched.

Acceptance criterion: **any runtime-added library works without restart.**

### Fix
Both after-start attach paths route through one awaited seam, `FolderAccessManager.grantThenEngineWork`, so the grant completes **before** the engine touches the path:

- **Folder import** (`ImportServiceGenerated.importFiles` / `startFolderImport`): grant the folder, then `POST /api/ingest/folder`.
- **Opening a `.fichero` package** (`LibraryManager.openLibrary` → new `loadAndRegister`): mint + transmit the existing typed security-scoped-access grant, then load + `POST /api/registry/add`.

### Denied grants stop the read (review fix)
A **denied live grant now throws** instead of being swallowed: `grantEngineAccess` throws on engine refusal (still surfacing it via `engineAccessFailure`), so `saveBookmarkIfDirectory` throws and `grantThenEngineWork` skips `engineWork` — the engine is never asked to read a folder it can't open. The two legitimate no-grant-needed cases return normally (not throw): before the engine client exists (spawn-time env var covers it), and on the non-App-Store build (no sandbox). The sync fire-and-forget handoff (`saveBookmark`, open panel / restore-refresh) keeps swallowing with `try?` since those callers don't immediately read the path.

### Scope / constraints
- Swift-only. No engine/OpenAPI change; grant still flows through `SandboxAccessServiceGenerated` (no hand-rolled URLSession).
- No entitlements/pbxproj/signing touched (f_manager owns those). New test file is picked up via the target's filesystem-synchronized group.

### Tests
`RuntimeLibraryGrantOrderingTests` pins the shared seam's contract both paths rely on:
- grant-before-engine-work ordering
- fire-and-forget regression guard (async grant with a suspension point still completes first)
- **denied-grant guard** — `engineWork` never runs after a grant failure
- result propagation + engine-work error propagation

### Verification
- swiftlint on the diff: only pre-existing warnings (baseline-confirmed against HEAD).
- Not built here (manager gates the build); SourceKit "no such module" diagnostics are worktree module-cache noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)