### PR TITLE
fix: resolve 3 App Store build blockers on main (concurrency + env + pbxproj)

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -7,6 +7,586 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		001 /* FicheroApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101 /* FicheroApp.swift */; };
+		002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102 /* ContentView.swift */; };
+		003 /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103 /* Document.swift */; };
+		0030E825BA124AFEADB7A596 /* CheckerboardPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0690C2C95A7BBA1840E71AED /* CheckerboardPattern.swift */; };
+		008 /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108 /* EditorView.swift */; };
+		009 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 201 /* Assets.xcassets */; };
+		010 /* SidebarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109 /* SidebarItem.swift */; };
+		011 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110 /* SearchView.swift */; };
+		011D2B0F5D8064D8ABF7A999 /* ArtifactRichTextCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25A2C92607779F4D928B8E3 /* ArtifactRichTextCodec.swift */; };
+		018 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117 /* ChatView.swift */; };
+		019 /* DocumentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118 /* DocumentStore.swift */; };
+		019CE6D6AA066E977DCB6813 /* ContentView+KnowledgeSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A698478801C79143E8D71A65 /* ContentView+KnowledgeSurface.swift */; };
+		01FF0FCBACD44A622D068866 /* PDFPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D0A22B5A712240EAE78053 /* PDFPageView.swift */; };
+		020 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119 /* APIClient.swift */; };
+		023 /* ChatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 122 /* ChatService.swift */; };
+		025 /* SavedSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 124 /* SavedSearchService.swift */; };
+		028 /* ModelService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127 /* ModelService.swift */; };
+		02C3632FB97086976DD89BBE /* DocumentInterpretationsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFD7D8095D23EBDA3F42D9 /* DocumentInterpretationsTab.swift */; };
+		02DC70ACB03D52EDE04B84C3 /* SpatialLibraryProjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC62467E297F09DF404643C1 /* SpatialLibraryProjector.swift */; };
+		035 /* WorkflowTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134 /* WorkflowTypes.swift */; };
+		036 /* WorkflowStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135 /* WorkflowStore.swift */; };
+		037 /* WorkflowExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136 /* WorkflowExporter.swift */; };
+		038 /* WorkflowChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137 /* WorkflowChain.swift */; };
+		039 /* ChainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138 /* ChainService.swift */; };
+		040 /* WorkflowChainListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139 /* WorkflowChainListView.swift */; };
+		041 /* WorkflowStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140 /* WorkflowStreamService.swift */; };
+		042 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141 /* AppleScriptSupport.swift */; };
+		043 /* Fichero.sdef in Resources */ = {isa = PBXBuildFile; fileRef = 142 /* Fichero.sdef */; };
+		044 /* WorkflowServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143 /* WorkflowServiceGenerated.swift */; };
+		045 /* SavedSearchServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144 /* SavedSearchServiceGenerated.swift */; };
+		045C6648800D0B7D95D13B32 /* AnnotationHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4DEA1D7E10749DA258D26F /* AnnotationHighlight.swift */; };
+		046 /* ConversationServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145 /* ConversationServiceGenerated.swift */; };
+		047 /* ChatServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146 /* ChatServiceGenerated.swift */; };
+		048 /* WorkflowExecutionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149 /* WorkflowExecutionObserver.swift */; };
+		049 /* DocumentServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148 /* DocumentServiceGenerated.swift */; };
+		04EC79C508ADFCB840661C01 /* BookmarksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA02CD36EF110174B8E2206 /* BookmarksView.swift */; };
+		079E7B626FA4EE5877BB24B0 /* FicheroApp_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29941DE439073B7364322ECF /* FicheroApp_iOS.swift */; };
+		08A233915452687AD06DA9DE /* DocumentInspectorArtifactsTab+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BB27716102361159F020CD /* DocumentInspectorArtifactsTab+Previews.swift */; };
+		097E07610FB8E2B3AB4A6264 /* CitationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1424784E87E1971372F0109 /* CitationDetailView.swift */; };
+		09E406188BE97EB78EFD0429 /* PDFPageWithToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902DF4705DA9730D76AF2C06 /* PDFPageWithToolbar.swift */; };
+		09F7968790ECF62B772D3895 /* NoteListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89B5319A472F190E68188ECC /* NoteListView.swift */; };
+		0A33E891AB84D96B6F3C3C2F /* ResearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375F58443D6F498C1FEDD3E3 /* ResearchStore.swift */; };
+		0A667D33534B55BD383F4D55 /* KGMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F131D425C0276D277D805678 /* KGMapView.swift */; };
+		0A798A14E8BC54C9115FBAF7 /* FileMenuCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C768E2159A6D869E204FC478 /* FileMenuCommands.swift */; };
+		0C6B1EE6EDE444C4F95ED9FD /* NoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF58B21F339179A8162AD6C5 /* NoteService.swift */; };
+		0E0C4A9843C989F7A157F986 /* WorkspaceItemPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8C2AF12DD3E6EAB64C68B4 /* WorkspaceItemPicker.swift */; };
+		0F105FC52C12302CF5A2AC42 /* ClaimSummaryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F1ACEB8F688C8749B36E04B /* ClaimSummaryCardView.swift */; };
+		0F10EA9CD30A9CC13ED3E074 /* EntityDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F14337BE87CA15E70323ED4 /* EntityDetailView.swift */; };
+		0F17A8BE887BF69F2A84F67B /* OntologyBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F1C81E90821C016E2CE3A60 /* OntologyBrowser.swift */; };
+		0F1CA90D364622756AFC004A /* EntityRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F11A721FF01A4F5A66A4568 /* EntityRowView.swift */; };
+		0FEA39950E6F6135CC4E34DE /* IdentityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFD8D2157AA0C0F66955D78 /* IdentityStore.swift */; };
+		1008C273C68E049FC8909FE2 /* CanvasDropResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034BEE1157D9D2C95C1F885A /* CanvasDropResolver.swift */; };
+		1198B2465AC02D0DCAE85184 /* EngineReadinessProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5715F64F9F1AF567F5E43C42 /* EngineReadinessProbe.swift */; };
+		1198B2465AC02D0DCAE85185 /* EngineSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5715F64F9F1AF567F5E43C43 /* EngineSession.swift */; };
+		122B14F33BEDA95169037201 /* SpeakerComparisonView+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599CF5FBD9D2B619B9353BC7 /* SpeakerComparisonView+Preview.swift */; };
+		127F8AA713B90A0B24269C98 /* DocumentInspectorAnnotationsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB786740043A3DAB4CDBFD6F /* DocumentInspectorAnnotationsTab.swift */; };
+		129B66EC2432B98151597597 /* FocusedArtifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74949C6AC5364C768581B8CE /* FocusedArtifact.swift */; };
+		136B9D5C51C43F1243329476 /* CitationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866758A89BA93E91F5E4DCC5 /* CitationListView.swift */; };
+		150 /* ChainEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151 /* ChainEditorView.swift */; };
+		154 /* ScheduleCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152 /* ScheduleCreationSheet.swift */; };
+		155 /* TriggerCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153 /* TriggerCreationSheet.swift */; };
+		15785F4FC901A743D5DE7D09 /* DocumentInspectorInfoTab+Prototype.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715408B079BD7610A53FA99C /* DocumentInspectorInfoTab+Prototype.swift */; };
+		158C918190068A0805613D21 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D817ADFBBCAF433008A6380D /* AboutView.swift */; };
+		17ED8EB9711094AF388E4677 /* LibrarySharingBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAEF12C9BBE42A6FCA5004A /* LibrarySharingBadge.swift */; };
+		18569C1644053B267C3581C3 /* FocusedAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322ECCB87D28069C9539D009 /* FocusedAnnotation.swift */; };
+		186AB9CF6F951F8878BC81AF /* EntityKindChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986AE09BC3B5DC9ECD5820A5 /* EntityKindChartView.swift */; };
+		19F0E17B6ABA9BAF96D135C5 /* AnnotationsInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA6DF64867F557144B14A23 /* AnnotationsInspectorPane.swift */; };
+		1AA8D13CBE8E1D392BDDD4CF /* DocumentCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E4C1042F69F06267FA6CCD /* DocumentCanvas.swift */; };
+		1ACCE61BCF118B415F1E457E /* OntologyBrowser+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849CA4F172401769E6140F13 /* OntologyBrowser+Toolbar.swift */; };
+		1BA428828543A7D4091C0A98 /* ActivityOverviewView+Cards.swift in Sources */ = {isa = PBXBuildFile; fileRef = D661A54EFC8800F710E16A23 /* ActivityOverviewView+Cards.swift */; };
+		1BD8C58F169EE984D4CF90A4 /* EntitySplitSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3FE2F360EADE051A3D2D51 /* EntitySplitSheet.swift */; };
+		1D911B0CF5214057FC57F23A /* EntityDetailView+Biography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1016BD8B24F412A49A3BED88 /* EntityDetailView+Biography.swift */; };
+		1DB87289F50626AC3C840F28 /* DocumentInspectorInfoTab+Workflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9037096857E2AE5F3339A8DC /* DocumentInspectorInfoTab+Workflow.swift */; };
+		1E1F0FD4E828C80187F7C03A /* OntologyBrowser+Sheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9987CAE57F0DD5387F6DD2 /* OntologyBrowser+Sheets.swift */; };
+		200BCF2C2F3D501800D7851A /* ContentView+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BCF2B2F3D501800D7851A /* ContentView+State.swift */; };
+		200BCF362F3D547F00D7851A /* ContentView+ViewBuilders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BCF352F3D547F00D7851A /* ContentView+ViewBuilders.swift */; };
+		200BCF382F3D548000D7851A /* ContentView+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BCF372F3D548000D7851A /* ContentView+Persistence.swift */; };
+		200BCF3A2F3D548000D7851A /* ContentView+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BCF392F3D548000D7851A /* ContentView+Navigation.swift */; };
+		200BCF3C2F3D548000D7851A /* ContentView+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BCF3B2F3D548000D7851A /* ContentView+Actions.swift */; };
+		201090099DFFEC36A41DB652 /* ActivityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0EC9D283E4FFF816B0460 /* ActivityStore.swift */; };
+		2011E35A2F93ADF700606651 /* ComparisonTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2011E3592F93ADF700606651 /* ComparisonTypes.swift */; };
+		202674952F475B1D008EAB5D /* NodeConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674942F475B1D008EAB5D /* NodeConfigView.swift */; };
+		202674972F475B23008EAB5D /* CollectionNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674962F475B23008EAB5D /* CollectionNodeConfig.swift */; };
+		202674992F475B33008EAB5D /* SearchNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674982F475B33008EAB5D /* SearchNodeConfig.swift */; };
+		2026749B2F475B4A008EAB5D /* FilesNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026749A2F475B4A008EAB5D /* FilesNodeConfig.swift */; };
+		2026749D2F475B64008EAB5D /* TranscribeNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026749C2F475B64008EAB5D /* TranscribeNodeConfig.swift */; };
+		2026749F2F475B7A008EAB5D /* DescribeNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026749E2F475B7A008EAB5D /* DescribeNodeConfig.swift */; };
+		202674A42F47642A008EAB5D /* SummarizeFileNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674A32F47642A008EAB5D /* SummarizeFileNodeConfig.swift */; };
+		202674A62F476439008EAB5D /* SummarizeFolderNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674A52F476439008EAB5D /* SummarizeFolderNodeConfig.swift */; };
+		202674A82F476447008EAB5D /* SummarizeCollectionNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674A72F476447008EAB5D /* SummarizeCollectionNodeConfig.swift */; };
+		202674AA2F476453008EAB5D /* ExtractEntitiesNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674A92F476453008EAB5D /* ExtractEntitiesNodeConfig.swift */; };
+		202674AC2F4779AA008EAB5D /* NodeProviderModelSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674AB2F4779AA008EAB5D /* NodeProviderModelSelector.swift */; };
+		202674AE2F477AFE008EAB5D /* NodeInputMappings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674AD2F477AFE008EAB5D /* NodeInputMappings.swift */; };
+		202674B02F4781BA008EAB5D /* TrackingImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674AF2F4781BA008EAB5D /* TrackingImageView.swift */; };
+		202674B22F478206008EAB5D /* ImageWithCursorTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674B12F478206008EAB5D /* ImageWithCursorTracking.swift */; };
+		202674B42F4783A9008EAB5D /* WorkflowNodeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674B32F4783A9008EAB5D /* WorkflowNodeCard.swift */; };
+		202674B62F4783BC008EAB5D /* WorkflowNodeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674B52F4783BC008EAB5D /* WorkflowNodeRow.swift */; };
+		202674B82F4783D5008EAB5D /* WorkflowDiagramPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674B72F4783D5008EAB5D /* WorkflowDiagramPreview.swift */; };
+		202674BC2F478636008EAB5D /* SidebarCreationHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674BB2F478636008EAB5D /* SidebarCreationHandlers.swift */; };
+		202674BF2F478647008EAB5D /* SidebarActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674BE2F478647008EAB5D /* SidebarActions.swift */; };
+		202674C22F47865B008EAB5D /* SidebarObservers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674C12F47865B008EAB5D /* SidebarObservers.swift */; };
+		202674C52F4788CB008EAB5D /* WorkflowDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674C42F4788CB008EAB5D /* WorkflowDetailView.swift */; };
+		202674C72F4788E0008EAB5D /* WorkflowMiniPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674C62F4788E0008EAB5D /* WorkflowMiniPreview.swift */; };
+		202674C92F4788EB008EAB5D /* WorkflowThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674C82F4788EB008EAB5D /* WorkflowThumbnailView.swift */; };
+		202674CC2F4788F2008EAB5D /* WorkflowLibraryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674CB2F4788F2008EAB5D /* WorkflowLibraryRow.swift */; };
+		202674CE2F4788FF008EAB5D /* NewWorkflowSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674CD2F4788FF008EAB5D /* NewWorkflowSheet.swift */; };
+		202674D02F4789BF008EAB5D /* LibraryViewComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674CF2F4789BF008EAB5D /* LibraryViewComponents.swift */; };
+		202674D22F478A13008EAB5D /* LibraryView+DisplayModes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674D12F478A13008EAB5D /* LibraryView+DisplayModes.swift */; };
+		202674D42F489633008EAB5D /* SearchFiltersPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674D32F489633008EAB5D /* SearchFiltersPanel.swift */; };
+		202674D62F48963F008EAB5D /* SearchResultRowFromAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674D52F48963F008EAB5D /* SearchResultRowFromAPI.swift */; };
+		202674D82F48964E008EAB5D /* SearchMapComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674D72F48964E008EAB5D /* SearchMapComponents.swift */; };
+		202674DA2F489665008EAB5D /* SearchResultsDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674D92F489665008EAB5D /* SearchResultsDisplay.swift */; };
+		202674DC2F489677008EAB5D /* SearchView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674DB2F489677008EAB5D /* SearchView+Helpers.swift */; };
+		202674DE2F489678008EAB5D /* RecentSearchesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674DD2F489678008EAB5D /* RecentSearchesStore.swift */; };
+		202674DE2F48972A008EAB5D /* MessageCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674DD2F48972A008EAB5D /* MessageCard.swift */; };
+		202674E02F489737008EAB5D /* ChatStatusViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674DF2F489737008EAB5D /* ChatStatusViews.swift */; };
+		202674E22F48973E008EAB5D /* ChatInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674E12F48973E008EAB5D /* ChatInputView.swift */; };
+		202674E62F489757008EAB5D /* ChatMessagesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674E52F489757008EAB5D /* ChatMessagesList.swift */; };
+		202674E82F48976C008EAB5D /* ChatView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674E72F48976C008EAB5D /* ChatView+Extensions.swift */; };
+		202674E92F4897A4008EAB5D /* SearchResultsEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674EA2F4897A4008EAB5D /* SearchResultsEmptyState.swift */; };
+		20D8ED492F48E2B1006950A3 /* WorkflowInspector+AgentsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED482F48E2B1006950A3 /* WorkflowInspector+AgentsSection.swift */; };
+		20D8ED4B2F48E2B3006950A3 /* ActivityProgressModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED4A2F48E2B3006950A3 /* ActivityProgressModels.swift */; };
+		20D8ED4D2F48E2BE006950A3 /* WorkflowInspector+MCPTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED4C2F48E2BE006950A3 /* WorkflowInspector+MCPTools.swift */; };
+		20D8ED4F2F48E2C1006950A3 /* ActivityProgressView+LiveProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED4E2F48E2C1006950A3 /* ActivityProgressView+LiveProgress.swift */; };
+		20D8ED532F48E2CA006950A3 /* WorkflowInspector+DataLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED522F48E2CA006950A3 /* WorkflowInspector+DataLoading.swift */; };
+		20D8ED572F48E2D7006950A3 /* ActivityProgressView+HistoricalProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED562F48E2D7006950A3 /* ActivityProgressView+HistoricalProgress.swift */; };
+		20D8ED592F48E2DE006950A3 /* ActivityProgressView+DataLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED582F48E2DE006950A3 /* ActivityProgressView+DataLoading.swift */; };
+		20D8ED5B2F48E4CA006950A3 /* TriggerDetailView+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED5A2F48E4CA006950A3 /* TriggerDetailView+Configuration.swift */; };
+		20D8ED5D2F48E4D4006950A3 /* TriggerDetailView+ExecutionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED5C2F48E4D4006950A3 /* TriggerDetailView+ExecutionHistory.swift */; };
+		20D8ED5F2F48E4DA006950A3 /* TriggerDetailView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED5E2F48E4DA006950A3 /* TriggerDetailView+Helpers.swift */; };
+		20D8ED612F48E604006950A3 /* WorkflowSupportTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED602F48E604006950A3 /* WorkflowSupportTypes.swift */; };
+		20D8ED632F48E61C006950A3 /* SidebarItem+MoreFactories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED622F48E61B006950A3 /* SidebarItem+MoreFactories.swift */; };
+		20D8ED652F48E61C006950A3 /* WorkflowToolTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED642F48E61C006950A3 /* WorkflowToolTypes.swift */; };
+		20D8ED672F48E626006950A3 /* DocumentStore+CRUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED662F48E626006950A3 /* DocumentStore+CRUD.swift */; };
+		20D8ED692F48E626006950A3 /* SidebarChatTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED682F48E626006950A3 /* SidebarChatTypes.swift */; };
+		20D8ED6B2F48E62B006950A3 /* WorkflowResponseTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED6A2F48E62B006950A3 /* WorkflowResponseTypes.swift */; };
+		20D8ED6D2F48E62F006950A3 /* DocumentStore+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED6C2F48E62F006950A3 /* DocumentStore+Helpers.swift */; };
+		20D8ED6F2F48E633006950A3 /* SidebarSearchTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED6E2F48E633006950A3 /* SidebarSearchTypes.swift */; };
+		20D8ED712F48E63B006950A3 /* DocumentStoreTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED702F48E63B006950A3 /* DocumentStoreTypes.swift */; };
+		20D8ED732F48E644006950A3 /* SidebarViewTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED722F48E644006950A3 /* SidebarViewTypes.swift */; };
+		20D8EDCA2F48F49C006950A3 /* BatchTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDC92F48F49C006950A3 /* BatchTypes.swift */; };
+		20D8EDCC2F48F4A8006950A3 /* LibraryWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDCB2F48F4A8006950A3 /* LibraryWindow.swift */; };
+		20D8EDD02F48F4AE006950A3 /* CheckpointTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDCF2F48F4AE006950A3 /* CheckpointTypes.swift */; };
+		20D8EDD22F48F4B4006950A3 /* IntegrationsPlaceholderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDD12F48F4B4006950A3 /* IntegrationsPlaceholderSheet.swift */; };
+		20D8EDD42F48F4BE006950A3 /* WorkflowRunResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDD32F48F4BE006950A3 /* WorkflowRunResponse.swift */; };
+		20D8EDF82F4BBC04006950A3 /* WorkflowStreamTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDF72F4BBC04006950A3 /* WorkflowStreamTypes.swift */; };
+		20D8EDFA2F4BBC12006950A3 /* ModelComparisonTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDF92F4BBC12006950A3 /* ModelComparisonTypes.swift */; };
+		20D8EDFC2F4BBC1A006950A3 /* WorkflowStreamService+Parsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDFB2F4BBC1A006950A3 /* WorkflowStreamService+Parsing.swift */; };
+		20D8EE202F4BBFAF006950A3 /* AppleScriptCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE1F2F4BBFAF006950A3 /* AppleScriptCommands.swift */; };
+		20D8EE222F4BBFB8006950A3 /* AutomationServiceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE212F4BBFB8006950A3 /* AutomationServiceTypes.swift */; };
+		20D8EE242F4BBFBA006950A3 /* ProviderServiceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE232F4BBFBA006950A3 /* ProviderServiceTypes.swift */; };
+		20D8EE262F4BC0E2006950A3 /* IntegrationsServiceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE252F4BC0E2006950A3 /* IntegrationsServiceTypes.swift */; };
+		20D8EE282F4BC0ED006950A3 /* IntegrationsService+AppSpecific.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE272F4BC0ED006950A3 /* IntegrationsService+AppSpecific.swift */; };
+		20D8EE2A2F4BC0F3006950A3 /* WorkflowExecutionTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE292F4BC0F3006950A3 /* WorkflowExecutionTypes.swift */; };
+		20D8EE302F4BC10F006950A3 /* WorkflowExecutionObserver+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE2F2F4BC10F006950A3 /* WorkflowExecutionObserver+Events.swift */; };
+		20D8EE382F4BD559006950A3 /* LibraryView+KeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE372F4BD559006950A3 /* LibraryView+KeyboardShortcuts.swift */; };
+		20D8EE3A2F4BD9F6006950A3 /* LibraryView+InlineEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE392F4BD9F6006950A3 /* LibraryView+InlineEditing.swift */; };
+		20D8EE3C2F4BE0D8006950A3 /* ActionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE3B2F4BE0D8006950A3 /* ActionsService.swift */; };
+		20D8EE3E2F4BE1AB006950A3 /* ActionLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE3D2F4BE1AB006950A3 /* ActionLibraryService.swift */; };
+		20D8EE452F4BE260006950A3 /* ActionLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE442F4BE260006950A3 /* ActionLibraryView.swift */; };
+		20D8EE472F4BE285006950A3 /* ActionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE462F4BE285006950A3 /* ActionPickerView.swift */; };
+		20D8EE492F4BED4B006950A3 /* ActionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE482F4BED4B006950A3 /* ActionRowView.swift */; };
+		20D8EE4B2F4BED57006950A3 /* ActionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE4A2F4BED57006950A3 /* ActionDetailView.swift */; };
+		20ED240D4093078C1DD920D5 /* Spatial2DCanvasItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C09E634BBFD5CA7C83DBCC4 /* Spatial2DCanvasItems.swift */; };
+		230EB3E3E820CFEC092A3C49 /* ResearchTasksPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5287875D44BA51CD93CA12F8 /* ResearchTasksPane.swift */; };
+		235BB484E009F2DC1E3B149D /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA362DBBB6387D0FEB6A7626 /* MarkdownText.swift */; };
+		23BB0DDC9E8089CB1452632D /* ArtifactEntityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE70F7B7D331135FEFF34739 /* ArtifactEntityStore.swift */; };
+		24B8539890A424B7A35E21AD /* CanvasSpaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52AFBAB2B16555EF8A55BF3 /* CanvasSpaceView.swift */; };
+		24D8496D37D6F2973BD2E825 /* AnnotationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABB27CA283069DA160FB5AA /* AnnotationStore.swift */; };
+		25B9458F0E27EB2BCD55B439 /* ClaimSummaryCard+Details.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA39991F769A1DD42BB17F01 /* ClaimSummaryCard+Details.swift */; };
+		274511309DDD1821496D42C3 /* PDFPageControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDD973DE51567CB7FABA63C /* PDFPageControllers.swift */; };
+		283826C50E2AE354A7EB5611 /* SpatialNodeThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5FD0D414191E6FFC18E8BC /* SpatialNodeThumbnail.swift */; };
+		28510D794CAA15808E28CB6C /* BackendHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B2292335F30622AB8F0ABE /* BackendHost.swift */; };
+		286700373FC6B54B843E8DA5 /* NodePopover+Comparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F310DFF84C9557A77D4FDA /* NodePopover+Comparison.swift */; };
+		2A7F1839345B56CA811A4941 /* ViewDisplayMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956F66055D569E37A35E0377 /* ViewDisplayMode.swift */; };
+		2C2268FA2E4307AAA02C7EC4 /* APIClient+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300A8405FFC476E5124372AE /* APIClient+Types.swift */; };
+		2D2BD6F65172A039357FB3D2 /* CanvasOrtho2DRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6696D9961E42071EE854350 /* CanvasOrtho2DRenderer.swift */; };
+		2D4468D68538BE7767729108 /* ResearchProjectListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE29C018865C9A1538200D8E /* ResearchProjectListView.swift */; };
+		2D54DDB20954138D91EC7359 /* DocumentInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1424D757E2C82D4E5325413F /* DocumentInspector.swift */; };
+		2E9F1141ED5087B3424E7826 /* CanvasSceneRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F287F61A7D65912EF63D362C /* CanvasSceneRenderer.swift */; };
+		2ED84CCBA91252EA2D0C5D34 /* TriggerEditorPreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAA47F1959AD79AA6C2E3EF /* TriggerEditorPreviewPanel.swift */; };
+		2F08B4F9E864BB8619BD5138 /* NoteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA65406167827DCB144E3E2 /* NoteStore.swift */; };
+		2FA0C9F98B2B1A0A35107B07 /* ChainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41994E6C746A0B0171534212 /* ChainStore.swift */; };
+		300ED1FDA9255CD4182A3664 /* ForceDirectedGraphView+Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE62C7312D0E473288483C9 /* ForceDirectedGraphView+Render.swift */; };
+		342DA5972C51F45081E9FB80 /* EntityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B118FE1DE4F78C0EE238539 /* EntityStore.swift */; };
+		34F019EE1DA4E427EF3674EC /* OpenAffordances.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68A831B2F81707B5E082D6F /* OpenAffordances.swift */; };
+		3591D3E8CE619A9731DF2242 /* CanvasDetailTier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80920949B39DD526745B0BF2 /* CanvasDetailTier.swift */; };
+		35B42F6B063872E635AD5362 /* WindowSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE84D175FC1F5C5644EB914 /* WindowSeed.swift */; };
+		35CD189B6E6257ACC5F97863 /* SidebarItemRow+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47244E304896B65E6F12976C /* SidebarItemRow+Preview.swift */; };
+		36C67BBF07CCFEAF928943C9 /* ImageEditorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF014F0FAEFCA5233DCB114F /* ImageEditorModel.swift */; };
+		37125B13A36AF61C3B5868C3 /* NodeComparisonSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D455270E3396946CF4F1939 /* NodeComparisonSheet.swift */; };
+		37B827A97DAB87AADDC8642A /* CanvasScene3DRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A8D1A3FCF024827D89665 /* CanvasScene3DRenderer.swift */; };
+		3D3445F0B90D093149C9A7D6 /* DocumentInspectorContentTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36234E44A7E494963A441CDC /* DocumentInspectorContentTab.swift */; };
+		4016BD3CF245BCA932D3D1D5 /* InviteAccountSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6337F0388FCB9CD46ACFEE95 /* InviteAccountSection.swift */; };
+		40B4487F9C8C03F6518A8988 /* PageImageGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753C4D174F9A42A6593BECC6 /* PageImageGrid.swift */; };
+		417694AF6ACC5AEEF6E2E4B9 /* ClaimSummaryCard+Provenance.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CE0962968DEE7EAB60E454 /* ClaimSummaryCard+Provenance.swift */; };
+		44088B69B036974D72906372 /* ShareSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FF20EF84262D15A268246D /* ShareSettingsView.swift */; };
+		441627D26C9932352CE1FDF1 /* CanvasItemStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5921F26A97AF84B80B4DCD29 /* CanvasItemStore.swift */; };
+		4458475E8C2BF728591E504F /* AIDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C4E4291B8C33D501F176BF5 /* AIDefaults.swift */; };
+		44FA1DBF0A63CD22C7237172 /* SourceProvenancePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAC32EFF977CFA4E7D253F6A /* SourceProvenancePopover.swift */; };
+		451693E6DEA7C6AEEB8C8183 /* InspectorSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DACA616BBD1A6AA5E8518E /* InspectorSection.swift */; };
+		4521CFC5D73D8706FAE283CA /* InterpretationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42C41E0F485064FDA5EAEB9 /* InterpretationStore.swift */; };
+		48566E1CB89ED6382581A546 /* ObservableDomainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B628D9325A5B301E5827F0C1 /* ObservableDomainStore.swift */; };
+		48644281A751D62184D6C831 /* FicheroActionIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A05B7F3C09F6A27BE55971 /* FicheroActionIntents.swift */; };
+		495FCF3ED790C015FBF4BE70 /* NotesBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA77E9001736B77957513A4 /* NotesBrowserView.swift */; };
+		4A49D387AEF64378BFDC1E3E /* LiveUpdatesPausedPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53331A42DA98730B8F854E58 /* LiveUpdatesPausedPill.swift */; };
+		4AFAA394C8AB364CB2425517 /* ResearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB5E2213FF12794A689A7F /* ResearchService.swift */; };
+		4B6F0446E2EB820AD456A8EF /* PDFReadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75558D1F0B1D0F65CEFF577C /* PDFReadingView.swift */; };
+		4C823323E8BC468934CFD1C4 /* AppNavigationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C6A533EA3E96E1F5AE19ED /* AppNavigationHistory.swift */; };
+		4CB7B16CFB076724595D6EE4 /* DocumentInspectorArtifactsTab+Interpretations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E852347E800839A52286849 /* DocumentInspectorArtifactsTab+Interpretations.swift */; };
+		4D873A751876E0F56C149319 /* SidebarView+UnifiedLibrarySections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 052B352354B208CBDD7F8A1F /* SidebarView+UnifiedLibrarySections.swift */; };
+		4DD61218DD8818B2488E3AC1 /* DocumentKGSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C119BA4657FD54B0F01D6C /* DocumentKGSurface.swift */; };
+		4E6331788690437E1344F2C5 /* NavigatorMiniMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE8ADCDBC94EF23E0D0E1C4 /* NavigatorMiniMap.swift */; };
+		4EBA402FBE51F9F56366C3A5 /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3CD4902A47A5787D61C6D72 /* FlowLayout.swift */; };
+		4F070C9F83A1E68CBABB98DA /* PairedHostEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CF4FEC94C539A14626CD6B /* PairedHostEndpoints.swift */; };
+		4F0D8E596D331C45B6A8BC73 /* Canvas3DProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC0777B2A518265D4ACABB8 /* Canvas3DProjection.swift */; };
+		50667A0C0A15D67B79D303AC /* ShareLibrarySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47EED3CD156012F59D46F7B /* ShareLibrarySheet.swift */; };
+		517753E47832A6BD397EA6B3 /* EngineSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4F63C0FA3C779A6BA5B655 /* EngineSettingsView.swift */; };
+		527561D7A2B768C662B2D74E /* PaneVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47F88D458E8ED7BD95E5B47 /* PaneVisibility.swift */; };
+		538B4B2C658DECF4B98FA0CD /* PDFRegionGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66ADB5B1F77763C5F3295611 /* PDFRegionGeometry.swift */; };
+		5435A98021D72C073130730B /* AuditHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E28651A4F5835C8AD6A06B /* AuditHistoryView.swift */; };
+		544F0C27E64420694C462156 /* ResearchBrowserPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2290E008AD4F8ACF613B8C /* ResearchBrowserPane.swift */; };
+		54A07EFB77CACCF2E0ADDD84 /* ImageEditingServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA2442EE35411B543D0868B /* ImageEditingServiceGenerated.swift */; };
+		54D6AB78C2AD173F9E7C3E2C /* FocusedCitation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75255EDB2E723056D7BA67B /* FocusedCitation.swift */; };
+		560311302E8DCC126BD757E2 /* LibraryToolbarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99857D7C99E753A3405778FC /* LibraryToolbarState.swift */; };
+		560712308F658F0586314B6C /* LibraryAccessDeniedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C5267955AE57DD7BCEA674 /* LibraryAccessDeniedView.swift */; };
+		568F313267F4F71EE3FD6BEC /* iOSLibraryPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015D191B1A9A578C0A4BC6BA /* iOSLibraryPickerMenu.swift */; };
+		56B06FF519C1F4B9CD4E6214 /* ActionInvokeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6175F28D959ABB4DB0C2F4CD /* ActionInvokeService.swift */; };
+		56DCD53ACD6483561CF542B3 /* KGTemporalSpatial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43EAB861267206E7A929830F /* KGTemporalSpatial.swift */; };
+		57EFBE5436C18075ECE90EFC /* ClaimStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C527476477074D83F628468 /* ClaimStore.swift */; };
+		5A1F3C88D4E27B0196AB3301 /* ReadingPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F3C88D4E27B0196AB3302 /* ReadingPaneView.swift */; };
+		5C81FC2A7C0C2C47F3071EB5 /* DocumentInspectorContentV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8837F3B333F0ACFB9929CF /* DocumentInspectorContentV2.swift */; };
+		5D064ECAAD353BDB778B8580 /* AnnotationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D7DC57117008EBCFE607A9 /* AnnotationService.swift */; };
+		5D621E99ED66F859FD195491 /* AnnotatableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032AA7721B1C054A6CD89D4C /* AnnotatableTextView.swift */; };
+		5E8 /* SidebarItemBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9 /* SidebarItemBuilder.swift */; };
+		5F01DCF2F7EC8E307F172402 /* DisplayAttributesStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E5C6B2FBD2462E90B5F43D /* DisplayAttributesStrip.swift */; };
+		5FBCA4ACC1D0F229DA5E85AC /* EntityDetailView+Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9506E8C3C8030EE3075E9A0 /* EntityDetailView+Metadata.swift */; };
+		600993746CBF4F9F5E6AE35B /* ReaderToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE00C2DC909B57AA030519E /* ReaderToolbar.swift */; };
+		618EC62E8F7BA72F72B5A0A1 /* NewEntitySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675E69DE1A8C941ABBEBB0E0 /* NewEntitySheet.swift */; };
+		63C9659B6755FB880F50C6D5 /* ForceDirectedGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003E584BBE51001B1E3F6843 /* ForceDirectedGraphView.swift */; };
+		64000200016ACCF0AA1B529A /* UsersStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1EB898A19FAA64EF466CD2 /* UsersStore.swift */; };
+		64574A29B56CBA1F27542556 /* BackendSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371A4629B0A6A51DE6D6D872 /* BackendSettingsView.swift */; };
+		64712D1DA458621D00C216F0 /* SpaceSceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCA353DE8E2AFD149DADB3A /* SpaceSceneView.swift */; };
+		6577690F3500AFDA003B1E54 /* SpatialModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B320C62BB61F14256AECCF5 /* SpatialModels.swift */; };
+		669E5960825CCF224C5297A1 /* BackendWorkPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5ED84DA059F760ECDB09B4 /* BackendWorkPill.swift */; };
+		67FA5A93E29E64305C9D74CE /* ResearchModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B98F1F8C255A9F7C3386A59 /* ResearchModels.swift */; };
+		6858AFB3D476FE28DEDE81BA /* ClaimReviewQueueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F46B999D0208EA4C734535C /* ClaimReviewQueueSheet.swift */; };
+		6863442A96E849A029663A77 /* DocumentTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F707FEBE62834FFB3024991 /* DocumentTabView.swift */; };
+		6944EB9DA6305E692A58C4E8 /* AISettingsView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9195539F44B4ADCA2A3C9974 /* AISettingsView+Helpers.swift */; };
+		699D8A080D56300C542DEE87 /* ContradictionTriageSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53458DC3387BC4C694EE3452 /* ContradictionTriageSheet.swift */; };
+		69B6C56B15927E1F89E831D7 /* InspectorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC6B695132C68202062560A /* InspectorPresenter.swift */; };
+		6AFCCD468ED23422DA7132CF /* ImageViewerComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD8AD20E191046B70950B1E /* ImageViewerComponents.swift */; };
+		6B2E4D99C5F38A0297BC4401 /* ContentView+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2E4D99C5F38A0297BC4402 /* ContentView+Toolbar.swift */; };
+		6C79AC237DF842B5E8AE31E7 /* CitationsInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9C3B5A53041FFAA09E0221 /* CitationsInspectorPane.swift */; };
+		6CBF2E328348510A4B781B7C /* SidebarView+PinnedNavigationRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0DFC89B8C073DBEE0A743F /* SidebarView+PinnedNavigationRows.swift */; };
+		6EF56175D31C5732E5A0D119 /* OntologyBrowserGraphModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18ABABDD0527530DA73B5C7 /* OntologyBrowserGraphModel.swift */; };
+		6FC9AFB7D35EBFB12E9F8225 /* CitationExportButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79192DB989A34D1DBEEF3E34 /* CitationExportButton.swift */; };
+		6FE4896A20BB18BC70193BB7 /* BackupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C062A29951726302108FD2 /* BackupStore.swift */; };
+		718AAD56294BDA27EFF854ED /* BoundingBoxOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCDF89C1460FA69DB0A0630 /* BoundingBoxOverlay.swift */; };
+		71B9A55B210E4DE0AA4B4A2A /* ScheduleEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5ACEA3F5BC4462B7B18AA7 /* ScheduleEditorView.swift */; };
+		7233BDB6DCB842F75D52EA15 /* ReferenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBCBCC9A6B923D6A560F7277 /* ReferenceStore.swift */; };
+		73CFDAD2CD3E5A4A2EFF5FEC /* CanvasSceneDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = F355E37D6E92E270CCE27EF6 /* CanvasSceneDiff.swift */; };
+		75FF7AE84AC04F85A9A728AA /* AuditStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8F8D42618D304271F81962 /* AuditStore.swift */; };
+		76C7BC71C747DBF9E6BD678D /* SpatialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBBA30F68AE440FAF4DC1E4 /* SpatialView.swift */; };
+		76EEEC44E89E3A5F714F989C /* SidebarItemRow+Presentation+Body.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872F7ADB0C1953F67D681C24 /* SidebarItemRow+Presentation+Body.swift */; };
+		7800350961E1C38A10D02D54 /* ImageEditChainPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95706A3222B50B478F15D83D /* ImageEditChainPanel.swift */; };
+		78C35F469E90405F21DF19B0 /* DocumentInspectorArtifactsTab+EntitiesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F6D53AD0FD306FE58CF26D /* DocumentInspectorArtifactsTab+EntitiesTab.swift */; };
+		78F8389F0A4A57F5A2D6F260 /* BackendActivityEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07BE5ECB91F929ADBD8595A /* BackendActivityEvent.swift */; };
+		7BC4AED0E0043218B6104F4A /* ScrollWheelZoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3080C713216B7BBD39725487 /* ScrollWheelZoom.swift */; };
+		7C3A91E4B2D14F0A9E5C1A70 /* KGQueryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A91E4B2D14F0A9E5C1A71 /* KGQueryStore.swift */; };
+		7C874A46B0C0C85ACD9F23AA /* DocumentInspectorArtifactsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312845068CA928DA393E0468 /* DocumentInspectorArtifactsTab.swift */; };
+		7D8F36CB01DB7346C305CA3C /* ContentView+ReadingLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6650E28284D750D9076B0612 /* ContentView+ReadingLayout.swift */; };
+		7DBC189DE3A7BC27C2B3BEFF /* LibraryOutlineNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453CA6ACF420E59AED37F906 /* LibraryOutlineNode.swift */; };
+		7ECBD1BC6380EBF38150DBAF /* DocumentInspectorInfoTab+RelatedClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0164BBC35A375AA74214F42 /* DocumentInspectorInfoTab+RelatedClaims.swift */; };
+		7F7BE70A69F9550AE8D82690 /* AuthGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CF6ABBC8F558282E73502 /* AuthGateView.swift */; };
+		80C2B74EFACBD0E3CEA2B919 /* LibraryWorkspaceRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5517E790C3AF9853989225 /* LibraryWorkspaceRoot.swift */; };
+		81C171EFA30E237D92BC79C0 /* ShellLayoutPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BBD41061EB9112C9EB7D6F /* ShellLayoutPolicy.swift */; };
+		82E7E9935A5A324121ECB468 /* DocumentKGWebPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80DDED3870C2457BFD97D1E /* DocumentKGWebPane.swift */; };
+		832 /* Workflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462 /* Workflow.swift */; };
+		836 /* CacheModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4119 /* CacheModel.swift */; };
+		838 /* PerformanceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4121 /* PerformanceService.swift */; };
+		840 /* ErrorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4123 /* ErrorService.swift */; };
+		841 /* ErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4124 /* ErrorModel.swift */; };
+		841863C00C3C889B9C71C040 /* CanvasDropOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D8F04A6421AEC5B5370E92 /* CanvasDropOutcome.swift */; };
+		842 /* SidebarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4125 /* SidebarState.swift */; };
+		843 /* DragDropModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4126 /* DragDropModel.swift */; };
+		850BB2FC48139F2EF4E8CA30 /* PDFLoupeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EC13FF6B70F7EC2D9A950C /* PDFLoupeOverlay.swift */; };
+		852B1713BA5220E613865101 /* LibraryManager+Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFA9C3247C03BDCE9BE6092 /* LibraryManager+Operations.swift */; };
+		861B6FECAB63CDE10DBC5D7E /* EntityDigestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB488A4AF6BAB72C33902C4 /* EntityDigestView.swift */; };
+		8667DE091F46137A2B6AC20E /* SidebarItemRow+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE6CF3DE02E1F999AE8F1A9 /* SidebarItemRow+Presentation.swift */; };
+		87738FE508498598CE9DC2F6 /* CoalescingSaveRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74ECCAE0282E67AA4A150871 /* CoalescingSaveRunner.swift */; };
+		898AABCC531843909C0C6AA8 /* TriggerEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75371C597B1E4689B6E1803F /* TriggerEditorView.swift */; };
+		89A148373109E3D71999629D /* FocusedDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8609BBFA7EF7B54ED73C59A1 /* FocusedDocument.swift */; };
+		8B136BE0DDA41615174E4AF4 /* SessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4FE6FA42E3E4887451FB21 /* SessionStore.swift */; };
+		8C35E319E4B9A46AB0383C10 /* TriggerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C69898938F25CFEA64385A16 /* TriggerDetailView.swift */; };
+		8C55B492C37B1BBED91F2B9B /* NotesInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F1C6302A9E0863FB1E6775 /* NotesInspectorPane.swift */; };
+		8D462745B97D9C6E1A8EDEB0 /* ArtifactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA5F6DA59D0A499D28F3C75 /* ArtifactDetailView.swift */; };
+		8EC8D8B6E0595E51192F1C3C /* Representation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71ADE00621970AC5AE6E45A /* Representation.swift */; };
+		8F7C131CEB5C672DD1E4813A /* BackendRootGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43576573521F73AE202B2E9B /* BackendRootGate.swift */; };
+		8FE44C97EB98125395148B86 /* AnnotationToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AF6A1C596C845A9BABDAFC /* AnnotationToolbar.swift */; };
+		913F07667F8EF62FE204D1E7 /* SidebarView+ActivityRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E93BA60F99453057135B99 /* SidebarView+ActivityRows.swift */; };
+		9155478503635D556FECE3D4 /* EngineConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C31EBD6243D124565257708 /* EngineConfig.swift */; };
+		92F3AFC896A444D7D060547E /* CanvasLayoutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4887C223276D2F5E2C498065 /* CanvasLayoutStore.swift */; };
+		92F7E655373456AAB3EAFB8C /* ActivityMonitorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36839A1C65A10F63B92E4121 /* ActivityMonitorModel.swift */; };
+		9366577BEB84A06792568C3F /* DocumentInspectorArtifactsTab+EntityKindRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D62D87E6614928970950D52 /* DocumentInspectorArtifactsTab+EntityKindRow.swift */; };
+		93C8C41A0D48127945007810 /* SearchArrowKeyNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0888678B07B4D4F9B3111FE /* SearchArrowKeyNavigation.swift */; };
+		94E38983F9F94E779B431D3F /* AnnotationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CC17746FA5E4A08F1F31F2 /* AnnotationDetailView.swift */; };
+		94EAA15C7E791548A7BA4E2E /* CanvasSceneState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9414DAA022DF2D96230B86A7 /* CanvasSceneState.swift */; };
+		96DDD5373DEE2458D1D94450 /* BreadcrumbBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE9F6E549990F086C442F3B /* BreadcrumbBuilder.swift */; };
+		9702C23273B6222FF84B6288 /* CanvasSceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6D6698151FC8A29A2BE3BA /* CanvasSceneView.swift */; };
+		9905931F5511D084D56DEDD2 /* MagnifierPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14E6171BBCA610CF1B87D7F /* MagnifierPanel.swift */; };
+		9A321613F87806CF952668A1 /* PlatformAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BDC2DC273F8F91B9CA1B3C /* PlatformAliases.swift */; };
+		9A44B73B118219D1160AFFD3 /* ArtifactEntityViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5E81DFE56AC41F34CC4EAE /* ArtifactEntityViews.swift */; };
+		9A45089C636C56BF221BD7BC /* MiniToolbarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC02D722B13BC58D4D4B37B7 /* MiniToolbarComponents.swift */; };
+		9D71A811170D438B938FC1DA /* LibraryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377DA5DA45FB4CE09C7F76FF /* LibraryManager.swift */; };
+		9DD32C9E1B17D298CF3138F1 /* SourceSnippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EC894548A8DBFA37D41557 /* SourceSnippet.swift */; };
+		9F50071471DB4B1EA1618E6E /* ActivityMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C939F2EE06FF349761CA2F /* ActivityMonitorView.swift */; };
+		9F8F3883E8324E76A746FAF8 /* BoundingBoxGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D870DB81D42B1614D58CE3F /* BoundingBoxGeometry.swift */; };
+		9FB2B2B858EA25B4757ECFEC /* EntitySourceGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B0073490980740B06C80D7 /* EntitySourceGroupsView.swift */; };
+		A0DB690A7FF2BA11F0D05AE7 /* DocumentInspectorArtifactsTab+KGSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7EC6F2955D032D3FA13E30 /* DocumentInspectorArtifactsTab+KGSection.swift */; };
+		A13E7C1F2F27E01E00EC9EE1 /* ActivityRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C122F27E01E00EC9EE1 /* ActivityRun.swift */; };
+		A13E7C272F27E03300EC9EE1 /* SidebarModeIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C262F27E03300EC9EE1 /* SidebarModeIcon.swift */; };
+		A13E7C282F27E03300EC9EE1 /* SidebarModeBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C252F27E03300EC9EE1 /* SidebarModeBar.swift */; };
+		A13E7C2A2F27E04300EC9EE1 /* ActivityDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C292F27E04300EC9EE1 /* ActivityDetailView.swift */; };
+		A13E7C2E2F27E17F00EC9EE1 /* ProviderServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C2C2F27E17F00EC9EE1 /* ProviderServiceGenerated.swift */; };
+		A13E7C2F2F27E17F00EC9EE1 /* SearchServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C2D2F27E17F00EC9EE1 /* SearchServiceGenerated.swift */; };
+		A13E7C302F27E17F00EC9EE1 /* BatchServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C2B2F27E17F00EC9EE1 /* BatchServiceGenerated.swift */; };
+		A13E7C3A2F27F36000EC9EE1 /* ActivityServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */; };
+		A13E7C3C2F27F36000EC9EE1 /* ActivityTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C3B2F27F36000EC9EE1 /* ActivityTypes.swift */; };
+		A13E7C3D2F27F36000EC9EE1 /* ActivityStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C3E2F27F36000EC9EE1 /* ActivityStreamService.swift */; };
+		A13E7C462F280BE900EC9EE1 /* ActivityProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C432F280BE900EC9EE1 /* ActivityProgressView.swift */; };
+		A13E7C492F280BE900EC9EE1 /* ActivityConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C3C2F280BE900EC9EE1 /* ActivityConsoleView.swift */; };
+		A13E7C4B2F280BE900EC9EE1 /* ActivityOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C422F280BE900EC9EE1 /* ActivityOverviewView.swift */; };
+		A13E7C4C2F280BE900EC9EE1 /* ActivityLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C412F280BE900EC9EE1 /* ActivityLogView.swift */; };
+		A13E7C4E2F280BE900EC9EE1 /* ActivityViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C442F280BE900EC9EE1 /* ActivityViewHelpers.swift */; };
+		A13E7C642F27F36000EC9EE1 /* ArtifactServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C632F27F36000EC9EE1 /* ArtifactServiceGenerated.swift */; };
+		A13E7C652F27F36000EC9EE1 /* StorageServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C662F27F36000EC9EE1 /* StorageServiceGenerated.swift */; };
+		A13E80A22F2AD75100EC9EE1 /* ModelComparisonService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E80A12F2AD75100EC9EE1 /* ModelComparisonService.swift */; };
+		A13E80A52F2AD78100EC9EE1 /* ModelComparisonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E80A32F2AD78100EC9EE1 /* ModelComparisonView.swift */; };
+		A14AD1B92F2E2E07001CF205 /* EmbeddedBackendService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14AD1B82F2E2E07001CF205 /* EmbeddedBackendService.swift */; };
+		A18ED3AB2F13E313007C2C6E /* FicheroAPIClient in Frameworks */ = {isa = PBXBuildFile; productRef = A18ED3AA2F13E313007C2C6E /* FicheroAPIClient */; };
+		A18ED3F22F141DFE007C2C6E /* FicheroAPIClient in Frameworks */ = {isa = PBXBuildFile; productRef = A18ED3F12F141DFE007C2C6E /* FicheroAPIClient */; };
+		A1A3A9C02F1028480021909D /* MCPToolsCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9BE2F1028480021909D /* MCPToolsCatalogView.swift */; };
+		A1A3A9C12F1028480021909D /* AddMCPServerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9BA2F1028480021909D /* AddMCPServerSheet.swift */; };
+		A1A3A9C22F1028480021909D /* MCPServerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9BB2F1028480021909D /* MCPServerDetailView.swift */; };
+		A1A3A9C32F1028480021909D /* MCPServersSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9BC2F1028480021909D /* MCPServersSheet.swift */; };
+		A1A3A9C42F1028480021909D /* MCPServersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9BD2F1028480021909D /* MCPServersView.swift */; };
+		A1A3A9F42F1028E70021909D /* MCPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9F32F1028E70021909D /* MCPService.swift */; };
+		A1A3A9F72F110CFD0021909D /* WorkflowExecutionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9F62F110CFD0021909D /* WorkflowExecutionService.swift */; };
+		A1A3A9FA2F110D170021909D /* ContentViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9F92F110D170021909D /* ContentViewModifiers.swift */; };
+		A1A3AA112F110D520021909D /* WorkflowCanvasView+DropHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA052F110D520021909D /* WorkflowCanvasView+DropHandling.swift */; };
+		A1A3AA122F110D520021909D /* WorkflowCanvasView+Gestures.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA072F110D520021909D /* WorkflowCanvasView+Gestures.swift */; };
+		A1A3AA132F110D520021909D /* NodePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA022F110D520021909D /* NodePopover.swift */; };
+		A1A3AA142F110D520021909D /* WorkflowCanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA042F110D520021909D /* WorkflowCanvasView.swift */; };
+		A1A3AA152F110D520021909D /* WorkflowEdgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA082F110D520021909D /* WorkflowEdgeView.swift */; };
+		A1A3AA162F110D520021909D /* WorkflowEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA092F110D520021909D /* WorkflowEditor.swift */; };
+		A1A3AA172F110D520021909D /* WorkflowExecutionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA0A2F110D520021909D /* WorkflowExecutionView.swift */; };
+		A1A3AA182F110D520021909D /* WorkflowNodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA0D2F110D520021909D /* WorkflowNodeView.swift */; };
+		A1A3AA192F110D520021909D /* WorkflowLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA0C2F110D520021909D /* WorkflowLibraryView.swift */; };
+		A1A3AA1A2F110D520021909D /* AgentNodeBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA002F110D520021909D /* AgentNodeBlockView.swift */; };
+		A1A3AA1B2F110D520021909D /* SimpleWorkflowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA032F110D520021909D /* SimpleWorkflowView.swift */; };
+		A1A3AA1C2F110D520021909D /* WorkflowOutputLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA0E2F110D520021909D /* WorkflowOutputLog.swift */; };
+		A1A3AA1D2F110D520021909D /* WorkflowPortView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA0F2F110D520021909D /* WorkflowPortView.swift */; };
+		A1A3AA1E2F110D520021909D /* WorkflowInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA0B2F110D520021909D /* WorkflowInspector.swift */; };
+		A1A3AA1F2F110D520021909D /* WorkflowCanvasView+EdgeConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA062F110D520021909D /* WorkflowCanvasView+EdgeConnection.swift */; };
+		A1A3AA202F110D520021909D /* CanvasHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA012F110D520021909D /* CanvasHelpers.swift */; };
+		A1A3AA212F110D520021909D /* WorkflowToolBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA102F110D520021909D /* WorkflowToolBlocks.swift */; };
+		A1A3AA282F113E6F0021909D /* AutomationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA272F113E6F0021909D /* AutomationService.swift */; };
+		A1A3AA292F113E6F0021909D /* AutomationServiceMappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA2A2F113E6F0021909D /* AutomationServiceMappers.swift */; };
+		A1A3AA382F1166660021909D /* IntegrationsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA372F1166660021909D /* IntegrationsService.swift */; };
+		A1A3AB242F11CCC70021909D /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AB162F11CCC70021909D /* Artifact.swift */; };
+		A1A3AB252F11CCC70021909D /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AB172F11CCC70021909D /* Event.swift */; };
+		A1A3AB262F11CCC70021909D /* Trace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AB1E2F11CCC70021909D /* Trace.swift */; };
+		A1A3AB2B2F11CCC70021909D /* MCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AB192F11CCC70021909D /* MCPServer.swift */; };
+		A1A3AB2C2F11CCC70021909D /* Run.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AB1C2F11CCC70021909D /* Run.swift */; };
+		A1A3AB2F2F11CCC70021909D /* Note.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AB1A2F11CCC70021909D /* Note.swift */; };
+		A1BFB2C82F042C0500EAA55A /* ViewSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2C62F042C0500EAA55A /* ViewSettings.swift */; };
+		A1BFB2C92F042C0500EAA55A /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2C52F042C0500EAA55A /* AppState.swift */; };
+		A1BFB2CF2F042C4100EAA55A /* AIModelSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2CC2F042C4100EAA55A /* AIModelSelectionView.swift */; };
+		A1BFB2D02F042C4100EAA55A /* AIProviderAddModelsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2CD2F042C4100EAA55A /* AIProviderAddModelsSheet.swift */; };
+		A1BFB2D12F042C4100EAA55A /* ProvidersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2CE2F042C4100EAA55A /* ProvidersView.swift */; };
+		A1BFB2D32F042C4100EAA55A /* AddProviderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2CA2F042C4100EAA55A /* AddProviderSheet.swift */; };
+		A1BFB2D72F042C6D00EAA55A /* ProviderLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2D42F042C6D00EAA55A /* ProviderLogoView.swift */; };
+		A1BFB2D82F042C6D00EAA55A /* StatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2D52F042C6D00EAA55A /* StatusBadge.swift */; };
+		A1BFB2DC2F042E5100EAA55A /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2DA2F042E5100EAA55A /* SettingsView.swift */; };
+		A1BFB2DF2F04328300EAA55A /* ImagePreviewMenuCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2DE2F04328300EAA55A /* ImagePreviewMenuCommands.swift */; };
+		A1BFB2E02F04328300EAA55A /* FocusedCommandButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2DD2F04328300EAA55A /* FocusedCommandButtons.swift */; };
+		A1BFB2E42F0439FE00EAA55A /* ImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2E32F0439FE00EAA55A /* ImportService.swift */; };
+		A1BFB2E72F043D2300EAA55A /* StorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2E62F043D2300EAA55A /* StorageService.swift */; };
+		A1BFB2EB2F043F4500EAA55A /* ViewContexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2EA2F043F4500EAA55A /* ViewContexts.swift */; };
+		A1BFB2EC2F043F4500EAA55A /* FicheroDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2E92F043F4500EAA55A /* FicheroDocument.swift */; };
+		A1BFB2F02F043FA100EAA55A /* BackendConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2EF2F043FA100EAA55A /* BackendConnectionView.swift */; };
+		A1BFB2F32F045C8A00EAA55A /* LibraryImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2F22F045C8A00EAA55A /* LibraryImageView.swift */; };
+		A1BFB4032F057B9300EAA55A /* QuickLookComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB3FF2F057B9300EAA55A /* QuickLookComponents.swift */; };
+		A1BFB4052F057B9300EAA55A /* FolderAccessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB3FB2F057B9300EAA55A /* FolderAccessManager.swift */; };
+		A1BFB4092F057BAC00EAA55A /* ViewMenuCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4082F057BAC00EAA55A /* ViewMenuCommands.swift */; };
+		A1BFB4502F0AABA600EAA55A /* ItemTypeRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB44E2F0AABA600EAA55A /* ItemTypeRegistry.swift */; };
+		A1BFB4532F0AABBC00EAA55A /* AddItemMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4522F0AABBC00EAA55A /* AddItemMenu.swift */; };
+		A1BFB4572F0AAC1E00EAA55A /* MiniToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4562F0AAC1E00EAA55A /* MiniToolbar.swift */; };
+		A1BFB45C2F0AAC3700EAA55A /* WorkflowToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB45B2F0AAC3700EAA55A /* WorkflowToolbar.swift */; };
+		A1BFB45E2F0AAC3700EAA55A /* ChatViewToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4582F0AAC3700EAA55A /* ChatViewToolbar.swift */; };
+		A1BFB4612F0AADC000EAA55A /* LayoutMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4602F0AADC000EAA55A /* LayoutMode.swift */; };
+		A1BFB4F22F30000100EAA55A /* MacPlainTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4F12F30000100EAA55A /* MacPlainTextEditor.swift */; };
+		A1D8BCE82F2CD054006D91D7 /* WorkflowPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D8BCE62F2CD054006D91D7 /* WorkflowPickerSheet.swift */; };
+		A1D8BCE92F2CD054006D91D7 /* DocumentPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D8BCE52F2CD054006D91D7 /* DocumentPickerSheet.swift */; };
+		A1FB1D7B2F0420310023093C /* AIModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D792F0420310023093C /* AIModelCatalog.swift */; };
+		A1FB1D7D2F0420930023093C /* ChatInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D7C2F0420930023093C /* ChatInspector.swift */; };
+		A1FB1D812F0420A90023093C /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D7F2F0420A90023093C /* LibraryView.swift */; };
+		A1FB1D9B2F0420D50023093C /* SidebarItemContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D952F0420D50023093C /* SidebarItemContextMenu.swift */; };
+		A1FB1D9C2F0420D50023093C /* SidebarItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D962F0420D50023093C /* SidebarItemRow.swift */; };
+		A1FB1D9D2F0420D50023093C /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D992F0420D50023093C /* SidebarView.swift */; };
+		A1FB1D9F2F0420D50023093C /* SidebarStateManagers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D982F0420D50023093C /* SidebarStateManagers.swift */; };
+		A1FB1DA02F0420D50023093C /* SidebarViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D9A2F0420D50023093C /* SidebarViewExtensions.swift */; };
+		A1FB1DA12F0420D50023093C /* SidebarSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D972F0420D50023093C /* SidebarSectionHeader.swift */; };
+		A1FB1DA22F0420D50023093C /* SidebarConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D932F0420D50023093C /* SidebarConstants.swift */; };
+		A23260012F90000100000001 /* RemoteClientPairing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23260032F90000100000001 /* RemoteClientPairing.swift */; };
+		A23260022F90000100000001 /* MacRemoteClientPairingSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23260042F90000100000001 /* MacRemoteClientPairingSection.swift */; };
+		A23530010000000000000001 /* MobileCaptureQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23530030000000000000003 /* MobileCaptureQueue.swift */; };
+		A23530020000000000000002 /* MobileCaptureQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23530040000000000000004 /* MobileCaptureQueueView.swift */; };
+		A2B7F2520C79F1636F31681A /* PageContentPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32974474262617AAAE4A322 /* PageContentPane.swift */; };
+		A32C13985AC2C769740EF9B7 /* OntologyBrowser+Detail.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60E9A8C3AD1B87728A4E3FB /* OntologyBrowser+Detail.swift */; };
+		A35052BDBE9CC694D88D322A /* ResearchChatPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E23447A5C31CE397D337CC /* ResearchChatPane.swift */; };
+		A3C1803DF6559D5BFCC9935E /* ComparisonDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38753C6C4C3EECE670188B92 /* ComparisonDetailView.swift */; };
+		A48C3E366EB68F5DFBD38499 /* ThinkingModePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8C3EFBCE91C295309468AB /* ThinkingModePicker.swift */; };
+		A6400FE26A8158543B1FD124 /* SplittablePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D0B24DE95228CEA6B853324 /* SplittablePane.swift */; };
+		A6AD2F07985565F991995037 /* ArtifactEntityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE70F7B7D331135FEFF34739 /* ArtifactEntityStore.swift */; };
+		A78E883CED66AEE3DC11477B /* ClaimAttributionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16AE4AAB56FEB5190D97239 /* ClaimAttributionView.swift */; };
+		A98A6F971E62F9DA640BCA54 /* ResearchWorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B8B6B4FF52EDA955679CF0 /* ResearchWorkspaceView.swift */; };
+		AA10000000000000000031B0 /* LocalInferenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000000000000000031A0 /* LocalInferenceStore.swift */; };
+		AA10000000000000000031B1 /* AppleAvailabilityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000000000000000031A1 /* AppleAvailabilityStore.swift */; };
+		AA10000000000000000031B2 /* LocalInferenceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000000000000000031A2 /* LocalInferenceSettingsView.swift */; };
+		AA112233001122AA /* LibraryView+Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA112233001122BB /* LibraryView+Sorting.swift */; };
+		AA112233001122CC /* LibraryView+ColumnConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA112233001122DD /* LibraryView+ColumnConfig.swift */; };
+		AA112233001122EE /* LibraryView+FilterAndBatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA112233001122FF /* LibraryView+FilterAndBatch.swift */; };
+		AA1DB6B1BCD300BF5D523EF2 /* SpeakerComparisonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034677F6AF68D5DCA5CB3E8C /* SpeakerComparisonView.swift */; };
+		AA214031892F4668F16A3E75 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0104EC0811F842CAC3CC887 /* GeneralSettingsView.swift */; };
+		AC989D334C6B0156C021AA09 /* ActionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12109CF3A70EB2ACA74B24D /* ActionStore.swift */; };
+		AD284E03A3377968AE568677 /* DocumentInspectorMetadataTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B146AE8AC4CEEC3775CB94 /* DocumentInspectorMetadataTab.swift */; };
+		ADC61F9B335300BEA77F278C /* EntityDetailView+Audit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E8622F0305ED125BEDB904 /* EntityDetailView+Audit.swift */; };
+		ADEE74E7CF17264BA16507C7 /* FicheroWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA64CFDF3C633C03CCE24A6 /* FicheroWebView.swift */; };
+		AF3C46E684A7D133B1BAA5D2 /* TriggerEditorFormPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0264B7B8616BA5159B2CEF1 /* TriggerEditorFormPanel.swift */; };
+		AF3C8529001F34ACB80A8D50 /* EntityDetailView+Notes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD96D53320D07109835C90BF /* EntityDetailView+Notes.swift */; };
+		AF868ABDCF249BD2499197F3 /* ContentView+NavigationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43322F30A05232A97F8B3B87 /* ContentView+NavigationHistory.swift */; };
+		ANIM00012F045C8A00EAA55A /* FrameAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ANIM00022F045C8A00EAA55A /* FrameAnimation.swift */; };
+		AUT00022F27F36000EC9EE1 /* AutomationServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUT00012F27F36000EC9EE1 /* AutomationServiceGenerated.swift */; };
+		B26A164F6D09131C95152691 /* SidebarView+UnifiedRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 688ECE0FC82045A06149A5FA /* SidebarView+UnifiedRows.swift */; };
+		B2A0020100000000BATCH2S1 /* SidebarItemRow+Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010100000000BATCH2S1 /* SidebarItemRow+Label.swift */; };
+		B2A0020200000000BATCH2S2 /* SidebarItemRow+DropHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010200000000BATCH2S2 /* SidebarItemRow+DropHandlers.swift */; };
+		B2A0020300000000BATCH2S3 /* SidebarItemRow+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010300000000BATCH2S3 /* SidebarItemRow+Helpers.swift */; };
+		B2A0020400000000BATCH2S4 /* SidebarItemRow+Rename.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010400000000BATCH2S4 /* SidebarItemRow+Rename.swift */; };
+		B2A0020500000000BATCH2W1 /* WorkflowEditor+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010500000000BATCH2W1 /* WorkflowEditor+Actions.swift */; };
+		B2A0020600000000BATCH2W2 /* WorkflowEditor+NodeViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010600000000BATCH2W2 /* WorkflowEditor+NodeViews.swift */; };
+		B2A0020700000000BATCH2W3 /* WorkflowEditor+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010700000000BATCH2W3 /* WorkflowEditor+Preview.swift */; };
+		B2A0020800000000BATCH2C1 /* ChainListContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010800000000BATCH2C1 /* ChainListContent.swift */; };
+		B2A0020900000000BATCH2C2 /* ChainListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010900000000BATCH2C2 /* ChainListRow.swift */; };
+		B2A0020A00000000BATCH2C3 /* ChainStepRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010A00000000BATCH2C3 /* ChainStepRow.swift */; };
+		B2A0020B00000000BATCH2C4 /* ChainDetailContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010B00000000BATCH2C4 /* ChainDetailContent.swift */; };
+		B2A0020C00000000BATCH2C5 /* ChainDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010C00000000BATCH2C5 /* ChainDetailSheet.swift */; };
+		B2A0020D00000000BATCH2C6 /* NewChainSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010D00000000BATCH2C6 /* NewChainSheet.swift */; };
+		B30013000000000000000001 /* FirstRunWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30013000000000000000002 /* FirstRunWindow.swift */; };
+		B34DE9B78D69C7BC29AC56E9 /* ArtifactPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7785FFCD6AB43D36199856 /* ArtifactPanel.swift */; };
+		B3742CD0628CC8C97E4788E2 /* CanvasInteractionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E16D1FB324019CBF50B37D /* CanvasInteractionController.swift */; };
+		B384820C8A9FEDA2B98FA1B0 /* MiniToolbarOverflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F420C7687D317EE817591121 /* MiniToolbarOverflow.swift */; };
+		B3A002010000000000BATCH3 /* ProvidersView+ModelTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001010000000000BATCH3 /* ProvidersView+ModelTypes.swift */; };
+		B3A002020000000000BATCH3 /* ProvidersView+ProviderDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001020000000000BATCH3 /* ProvidersView+ProviderDetailView.swift */; };
+		B3A002030000000000BATCH3 /* ProvidersView+ProviderSettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001030000000000BATCH3 /* ProvidersView+ProviderSettingsRow.swift */; };
+		B3A002040000000000BATCH3 /* ChatInspector+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001040000000000BATCH3 /* ChatInspector+Actions.swift */; };
+		B3A002050000000000BATCH3 /* ChatInspector+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001050000000000BATCH3 /* ChatInspector+Header.swift */; };
+		B3A002060000000000BATCH3 /* ChatInspector+ScopedDocuments.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001060000000000BATCH3 /* ChatInspector+ScopedDocuments.swift */; };
+		B3A002070000000000BATCH3 /* ChatInspector+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001070000000000BATCH3 /* ChatInspector+Search.swift */; };
+		B3A002080000000000BATCH3 /* ActivityDataProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001080000000000BATCH3 /* ActivityDataProcessing.swift */; };
+		B47244FDC35E7D8B8EAA65AB /* FicheroShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68C8C5672F78A996924D42D1 /* FicheroShortcuts.swift */; };
+		B4A002010000000000BATCH4 /* ModelComparisonView+Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A001010000000000BATCH4 /* ModelComparisonView+Sidebar.swift */; };
+		B4A002020000000000BATCH4 /* ComparisonResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A001020000000000BATCH4 /* ComparisonResultView.swift */; };
+		B4A002030000000000BATCH4 /* ModelResultCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A001030000000000BATCH4 /* ModelResultCard.swift */; };
+		B4A002040000000000BATCH4 /* ModelPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A001040000000000BATCH4 /* ModelPickerSheet.swift */; };
+		B4A002050000000000BATCH4 /* PresetPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A001050000000000BATCH4 /* PresetPickerSheet.swift */; };
+		B4A0020B0000000000BATCH4 /* DynamicConfigView+FieldRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A0010B0000000000BATCH4 /* DynamicConfigView+FieldRendering.swift */; };
+		B4A0020C0000000000BATCH4 /* DynamicConfigView+SchemaHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A0010C0000000000BATCH4 /* DynamicConfigView+SchemaHelpers.swift */; };
+		B4A0020D0000000000BATCH4 /* DynamicConfigView+StateManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A0010D0000000000BATCH4 /* DynamicConfigView+StateManagement.swift */; };
+		B4F1A71E768A776F8AFB3E3A /* CanvasModifierTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1CAB23253BF2D09F02A66D /* CanvasModifierTracker.swift */; };
+		B5A0020400000000BATCH5W1 /* WorkflowOutputLog+Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A0010400000000BATCH5W1 /* WorkflowOutputLog+Models.swift */; };
+		B5A0020500000000BATCH5W2 /* WorkflowOutputLog+StatusViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A0010500000000BATCH5W2 /* WorkflowOutputLog+StatusViews.swift */; };
+		B5A0020600000000BATCH5W3 /* WorkflowOutputLog+ErrorCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A0010600000000BATCH5W3 /* WorkflowOutputLog+ErrorCell.swift */; };
+		B5A0020700000000BATCH5W4 /* WorkflowOutputLog+EmptyStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A0010700000000BATCH5W4 /* WorkflowOutputLog+EmptyStates.swift */; };
+		B5A0020800000000BATCH5S1 /* ScheduleEditorView+Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A0010800000000BATCH5S1 /* ScheduleEditorView+Category.swift */; };
+		B5B3CB0BD14A95E9D7172810 /* OntologyBrowser+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376E2EE5F22D7B7127D9CB2A /* OntologyBrowser+List.swift */; };
+		B6A0020100000000BATCH6C1 /* ComparisonDetailView+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010100000000BATCH6C1 /* ComparisonDetailView+Actions.swift */; };
+		B6A0020200000000BATCH6C2 /* ComparisonDetailView+Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010200000000BATCH6C2 /* ComparisonDetailView+Models.swift */; };
+		B6A0020300000000BATCH6C3 /* ComparisonDetailView+Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010300000000BATCH6C3 /* ComparisonDetailView+Sections.swift */; };
+		B6A0020500000000BATCH6S2 /* SidebarView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010500000000BATCH6S2 /* SidebarView+Helpers.swift */; };
+		B6A0020600000000BATCH6S3 /* SidebarView+SelectionHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010600000000BATCH6S3 /* SidebarView+SelectionHandling.swift */; };
+		B6A0020700000000BATCH6S4 /* SidebarView+ViewComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010700000000BATCH6S4 /* SidebarView+ViewComponents.swift */; };
+		B6A0020800000000BATCH6A1 /* AddProviderSheet+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010800000000BATCH6A1 /* AddProviderSheet+Helpers.swift */; };
+		B6A0020900000000BATCH6A2 /* AddProviderSheet+Step1.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010900000000BATCH6A2 /* AddProviderSheet+Step1.swift */; };
+		B6A0020A00000000BATCH6A3 /* AddProviderSheet+Step2.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010A00000000BATCH6A3 /* AddProviderSheet+Step2.swift */; };
+		B6A0020B00000000BATCH6A4 /* AddProviderSheet+Step3.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010B00000000BATCH6A4 /* AddProviderSheet+Step3.swift */; };
+		B7586390552367B89CFC2E9D /* DocumentInspectorArtifactsTab+EntityKindBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A697CECBDA1A7EF050BF765 /* DocumentInspectorArtifactsTab+EntityKindBlock.swift */; };
+		B82F169352D7D0876DE0FCF9 /* EntityDetailView+Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0044833E201FFB8B8A5B37 /* EntityDetailView+Sections.swift */; };
+		B8CED5AA645840B7AC1696DD /* WindowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E04EE1958EB4E23A7E1E328 /* WindowState.swift */; };
+		B9D568CD0AD338467B063C47 /* ArtifactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC331F7BFE50CEECD3B4414 /* ArtifactStore.swift */; };
+		B9D683849EE15602A86CC385 /* AccessError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE34A7C933EA9305CAAA50FA /* AccessError.swift */; };
+		BA24BF71010589D1597B9025 /* BackendSettingsRemoteAccessSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70599D1C032FF0B54C7C18A2 /* BackendSettingsRemoteAccessSection.swift */; };
+		BB3C5B993DECE6FA5931CEAD /* QuickLookPreviewViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAAFE05184A40A50ADFC54A9 /* QuickLookPreviewViews.swift */; };
+		BE7EB837BA99FD18B310B6A2 /* DocumentInspectorInfoTab+Bibliography.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01276A4ABA0F672CF1D8067 /* DocumentInspectorInfoTab+Bibliography.swift */; };
+		BFC56BC755C4B7C58EEAE341 /* LibraryManager+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF91C082286A2B7BB74E438D /* LibraryManager+Persistence.swift */; };
+		C0FFEE0000000000000000A2 /* PairingRestoreDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFEE0000000000000000A1 /* PairingRestoreDiagnostics.swift */; };
+		C0FFEE0000000000000000A3 /* PairingRestoreDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFEE0000000000000000A1 /* PairingRestoreDiagnostics.swift */; };
+		C10000010000000000000001 /* SparkleUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000110000000000000001 /* SparkleUpdater.swift */; };
+		C10000010000000000000002 /* AppInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000110000000000000002 /* AppInstaller.swift */; };
+		C10000020000000000000001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; platformFilters = (macos, ); productRef = C10000310000000000000001 /* Sparkle */; };
+		C1C484907B28189E223436BE /* LibraryManager+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE5EBB51D90DE16D32A82FC /* LibraryManager+Helpers.swift */; };
+		C340001000000000PROMPT01 /* PromptPreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C340001100000000PROMPT01 /* PromptPreviewPanel.swift */; };
+		C37B1043409A6ED500E30F29 /* BackupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91100495C9D776E200E2F9C0 /* BackupsView.swift */; };
+		C38F232612EE4EEB87E62A76 /* FicheroAppEntities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FFFFE4A294ADC2F1299E2D /* FicheroAppEntities.swift */; };
+		C559CD1D045F9710AD81C44E /* CollectionWorkspaceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C9BD4E928F0D32E6EABBA7 /* CollectionWorkspaceStub.swift */; };
+		C5B7DEB948261159D439C454 /* DocumentNotesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00A8552DEACF83751D617C6 /* DocumentNotesTab.swift */; };
+		C835851846598745D40790B6 /* EntityDetailView+FilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18BA434B3CB3A8C31139293 /* EntityDetailView+FilterChips.swift */; };
+		C866DE6CD23ED6AF11B48FF0 /* DocumentStore+ChangeStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D040114E6D969FD49C8317E /* DocumentStore+ChangeStream.swift */; };
+		C8B0CB90BD1E1AFBFFF80F5A /* ContentViewHelperViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D6A52184F57ACFC6926FBB /* ContentViewHelperViews.swift */; };
+		C8C6F3D22AFD4A309FA11A3C /* SpaceTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626E23DB6F8B778F70AF3B35 /* SpaceTheme.swift */; };
+		C96A47B8A003AF3A6FC98CF8 /* AISettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07B489C8F89204C43BD6E46 /* AISettingsView.swift */; };
+		CA00000000000000000000B1 /* CanvasLayoutStore+ChangeStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA00000000000000000000A1 /* CanvasLayoutStore+ChangeStream.swift */; };
+		CA00000000000000000000B2 /* CanvasItemStore+ChangeStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA00000000000000000000A2 /* CanvasItemStore+ChangeStream.swift */; };
+		CA2079FADD45BDDD971FB694 /* Canvas2DProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F68955CC563FF070D02897 /* Canvas2DProjection.swift */; };
+		CBBBE21102B26A79DF02811E /* ChangeStreamTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3A4A14186A5886AC932517 /* ChangeStreamTransport.swift */; };
+		CC357CD884EE29BAE8A64F4B /* PlatformPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772A6A57C4986C2765A174EE /* PlatformPasteboard.swift */; };
+		CC8B35B398A7393E4D687941 /* BookmarkServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3133E93619FB262825F4F55 /* BookmarkServiceGenerated.swift */; };
+		CC92A0172BBECF22F2332F4B /* DocumentTextReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C127C3CD9D352C283597AB /* DocumentTextReader.swift */; };
+		CFC9C70DBE40510A012E46EE /* WorkflowExecutionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669F81AC0106B415218C419D /* WorkflowExecutionStore.swift */; };
+		D0D540A3F924325236C1E440 /* DocumentInspectorArtifactsTab+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FDDBCA3101A6E468A3105D2 /* DocumentInspectorArtifactsTab+Shared.swift */; };
+		D2A64087B8C786EE95E842A5 /* LocalModelsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4F4939BDACA726554E086D /* LocalModelsSettingsView.swift */; };
+		D584DA0264AC18C07D78233A /* KGFocusState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82A9BAC0F995F9199F94B69 /* KGFocusState.swift */; };
+		D72388A90102AB0902C995E4 /* SidebarView+LibraryHeaderHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6931274044832BD7EFE8A4D3 /* SidebarView+LibraryHeaderHelpers.swift */; };
+		D80C598CBAB2817738ECF0CB /* ChatDocumentDropPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB24ED93772AA96CF319D4B /* ChatDocumentDropPayload.swift */; };
+		D9D582D305FA54570A7F6093 /* UITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397DBEE7CB99C18C680AB85E /* UITestSupport.swift */; };
+		DA49843739ACA26F5AD0759C /* AISettingsView+Tabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4189C51250E0B39E05CD87B /* AISettingsView+Tabs.swift */; };
+		DA731A1441637DFFBE146AD4 /* EntityDetailView+Claims.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99ACF7102EB736967DDAE57 /* EntityDetailView+Claims.swift */; };
+		DA736D4429C7945E0C30216E /* DocumentInspectorInfoTab+Sharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37003B253D97CBE012D3A811 /* DocumentInspectorInfoTab+Sharing.swift */; };
+		DA7BED2393CD7FD13C5521D1 /* ImmersiveReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E92E864B4AF4383634E221 /* ImmersiveReaderView.swift */; };
+		DAF7008910EF661F7ED718CC /* SearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE609F48196839FAA6981CFF /* SearchStore.swift */; };
+		DC1FCDEE6B31AEA018C6F0DA /* ArtifactsInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C36D41D71387394E6AEB453 /* ArtifactsInspectorPane.swift */; };
+		DCC4D9C15886A018CBA1AA2E /* FocusedNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20829DBAC5757AEA6096835 /* FocusedNote.swift */; };
+		DCFC0B2C370966F9B57072A2 /* EntityMergeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB5DE35F2956544D2771C85 /* EntityMergeSheet.swift */; };
+		DD1C07E557CD9392EF3C3BC5 /* PDFThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C59C2205AA2F446083A9C9 /* PDFThumbnailView.swift */; };
+		DDE8A1E95DE61B0723A40BC9 /* DynamicConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DA25B2C1FBB75B0B1CC643 /* DynamicConfigView.swift */; };
+		E03D3AB8185C98A43134F6EF /* DocumentInspectorInfoTab+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35793BBA8A74DAA0982CCFA4 /* DocumentInspectorInfoTab+Header.swift */; };
+		E16CECCFD4B4BCE53B2FEC36 /* KGTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF77122ADD78F941D7F1968D /* KGTimelineView.swift */; };
+		E2B03B964149B8CDE9958E69 /* ImportServiceGenerated+Upload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44352F043915E2760BB0DD30 /* ImportServiceGenerated+Upload.swift */; };
+		E38C6073276421EC63C789B7 /* SidebarItemRow+Workflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FF71320EAE8FE11653EB06 /* SidebarItemRow+Workflow.swift */; };
+		E6E64CE83B1FF1235DCFDF80 /* ScheduleDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BEAA9442D4996FBD92BC7F /* ScheduleDetailView.swift */; };
+		E75A45471E6698C1C2812BA6 /* DocumentInspectorInfoTab+Citations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C74251DECC247DF8B5A816 /* DocumentInspectorInfoTab+Citations.swift */; };
+		E8DB4DEABBD7388DB33D81DA /* DocumentInspectorInfoTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD03402A88F98251F388870F /* DocumentInspectorInfoTab.swift */; };
+		E9DCE0BB3E64AD1549E6F117 /* LibraryChangeStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B629229088E72B485569FC /* LibraryChangeStream.swift */; };
+		EA5A4BBFC0797C7403FB49B3 /* LibraryView+TableMapViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92773EAEE52587BBA8DEDC9F /* LibraryView+TableMapViews.swift */; };
+		EB1E1BBC3C6557291CA96D4B /* AdaptiveAppleShellHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AFDD1AF51EC0A0BA0C061E /* AdaptiveAppleShellHost.swift */; };
+		EBA0B270972261795158D09B /* CaptureSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF964748FC3450263DCB1D1 /* CaptureSettingsView.swift */; };
+		EBE6623631BD8E10280B09F8 /* DocumentInspectorArtifactsTab+KGModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F23C597BA2DF9A27BE94F609 /* DocumentInspectorArtifactsTab+KGModels.swift */; };
+		EC4998990D9C5947B11A1E57 /* AnnotationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C6E9911CCE3E7F0C92E672 /* AnnotationListView.swift */; };
+		ECC8E5CB193E9BC5CE2E8294 /* SidebarItemRow+Drop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588D0F19667B99B2AA69A1A3 /* SidebarItemRow+Drop.swift */; };
+		EEE878CB5349F5D321517F55 /* ContentView+WorkflowActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923BD592D3257176C51CAC1C /* ContentView+WorkflowActions.swift */; };
+		EF8A33F9696257468DB2325C /* ArtifactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63F3EB72383ED2E5BA85C0E /* ArtifactListView.swift */; };
+		EF9F8C04CD7D1BFE3514BF42 /* WorkflowSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D280D880BB4526630C8CB3 /* WorkflowSync.swift */; };
+		EFD8B28CC600C4E64EF3EA90 /* DeviceTokenRenewal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110C8D9D75D6823D7B1EF43D /* DeviceTokenRenewal.swift */; };
+		F005FD31F4EE988533A672D9 /* Spatial2DCanvasGestures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC44420C3D37275174DF38F /* Spatial2DCanvasGestures.swift */; };
+		F023AC196079761CD2CF8E7A /* ActivityMonitorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811A6E6F398CBE8A81AEB7CE /* ActivityMonitorWindow.swift */; };
+		F0B74209906E1D1F5A904335 /* NodeClassPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D11FC06A71EAC1E8C4F6897 /* NodeClassPicker.swift */; };
+		F23CD14AC5C36398DB6CCC74 /* ImageEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8EFF7D9BC634BAE18E0F47 /* ImageEditorView.swift */; };
+		F248EE1CA83C5FFF604EF4CE /* SpatialModels+Links.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C0909F7C7B21871D35EB5C /* SpatialModels+Links.swift */; };
+		F272CFE1FADD5F15F71CFC23 /* ImageMarqueeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D05E0BE3C8D1AEA1AA3A8D /* ImageMarqueeOverlay.swift */; };
+		F2A340AB9853DC0671499E68 /* DocumentInspectorArtifactsTab+CurationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F259EE92E81B78CBE35C9947 /* DocumentInspectorArtifactsTab+CurationHistory.swift */; };
+		F32122ACDAC4211F72C2658F /* InspectorTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = F447E424F3A26C138C9BB99D /* InspectorTab.swift */; };
+		F5924EAC2877F93A6178107C /* HeuristicReviewSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEAE79F9381616EC474F4ED /* HeuristicReviewSheet.swift */; };
+		FA00000000000000003677B0 /* KnownLibraryRegistryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA00000000000000003677A0 /* KnownLibraryRegistryStore.swift */; };
+		FB55B6D23D3573E8E04CCD50 /* UsersSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5D9E12155EC0A6E738B878 /* UsersSettingsView.swift */; };
+		FBC6479F61CDE8E911D6BDBB /* NoteDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD4DC8D0E00D06ECFFEA224 /* NoteDetailView.swift */; };
+		FC38FF82492B7D35C486CF71 /* EditClaimSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C61D10AF212650451E8C13B /* EditClaimSheet.swift */; };
+		FC3F95AC0E1F4A7DB6B9993E /* FeatureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B27E2AF4EC43E993C19836 /* FeatureManager.swift */; };
+		FC3F95AD0E1F4A7DB6B9993F /* FeatureTiers.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B27E2BF4EC43E993C19837 /* FeatureTiers.generated.swift */; };
+		FCBC65A5D3BC1141E6FD9695 /* WorkflowRunProviderCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C34038F8A349C075DFBAC /* WorkflowRunProviderCache.swift */; };
 		FEED00000000000000000001 /* ClaimSummaryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F1ACEB8F688C8749B36E04B /* ClaimSummaryCardView.swift */; };
 		FEED00000000000000000002 /* EntityDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F14337BE87CA15E70323ED4 /* EntityDetailView.swift */; };
 		FEED00000000000000000003 /* EntityRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F11A721FF01A4F5A66A4568 /* EntityRowView.swift */; };
@@ -111,7 +691,6 @@
 		FEED00000000000000000066 /* ChainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138 /* ChainService.swift */; };
 		FEED00000000000000000067 /* ContentView+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BCF372F3D548000D7851A /* ContentView+Persistence.swift */; };
 		FEED00000000000000000068 /* ActivityServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */; };
-		SBX00032F27F36000EC9EE1 /* SandboxAccessServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = SBX00022F27F36000EC9EE1 /* SandboxAccessServiceGenerated.swift */; };
 		FEED00000000000000000069 /* LocationServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */; };
 		FEED0000000000000000006A /* PDFDocumentCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = PDFC00022F27F36000EC9EE1 /* PDFDocumentCache.swift */; };
 		FEED0000000000000000006B /* PreviewDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = PRDL00022F27F36000EC9EE1 /* PreviewDownloadService.swift */; };
@@ -600,602 +1179,25 @@
 		FEED0000000000000000024F /* FicheroAPIClient in Frameworks */ = {isa = PBXBuildFile; productRef = A18ED3F12F141DFE007C2C6E /* FicheroAPIClient */; };
 		FEED00000000000000000251 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 201 /* Assets.xcassets */; };
 		FEED00000000000000000252 /* Fichero.sdef in Resources */ = {isa = PBXBuildFile; fileRef = 142 /* Fichero.sdef */; };
-		001 /* FicheroApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 101 /* FicheroApp.swift */; };
-		002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 102 /* ContentView.swift */; };
-		003 /* Document.swift in Sources */ = {isa = PBXBuildFile; fileRef = 103 /* Document.swift */; };
-		0030E825BA124AFEADB7A596 /* CheckerboardPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0690C2C95A7BBA1840E71AED /* CheckerboardPattern.swift */; };
-		008 /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108 /* EditorView.swift */; };
-		009 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 201 /* Assets.xcassets */; };
-		010 /* SidebarItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 109 /* SidebarItem.swift */; };
-		011 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110 /* SearchView.swift */; };
-		011D2B0F5D8064D8ABF7A999 /* ArtifactRichTextCodec.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25A2C92607779F4D928B8E3 /* ArtifactRichTextCodec.swift */; };
-		018 /* ChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 117 /* ChatView.swift */; };
-		019 /* DocumentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 118 /* DocumentStore.swift */; };
-		019CE6D6AA066E977DCB6813 /* ContentView+KnowledgeSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A698478801C79143E8D71A65 /* ContentView+KnowledgeSurface.swift */; };
-		01FF0FCBACD44A622D068866 /* PDFPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D0A22B5A712240EAE78053 /* PDFPageView.swift */; };
-		020 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119 /* APIClient.swift */; };
-		023 /* ChatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 122 /* ChatService.swift */; };
-		025 /* SavedSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 124 /* SavedSearchService.swift */; };
-		028 /* ModelService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 127 /* ModelService.swift */; };
-		02C3632FB97086976DD89BBE /* DocumentInterpretationsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDCFD7D8095D23EBDA3F42D9 /* DocumentInterpretationsTab.swift */; };
-		02DC70ACB03D52EDE04B84C3 /* SpatialLibraryProjector.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC62467E297F09DF404643C1 /* SpatialLibraryProjector.swift */; };
-		035 /* WorkflowTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 134 /* WorkflowTypes.swift */; };
-		036 /* WorkflowStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135 /* WorkflowStore.swift */; };
-		037 /* WorkflowExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136 /* WorkflowExporter.swift */; };
-		038 /* WorkflowChain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 137 /* WorkflowChain.swift */; };
-		039 /* ChainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 138 /* ChainService.swift */; };
-		040 /* WorkflowChainListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 139 /* WorkflowChainListView.swift */; };
-		041 /* WorkflowStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140 /* WorkflowStreamService.swift */; };
-		042 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 141 /* AppleScriptSupport.swift */; };
-		043 /* Fichero.sdef in Resources */ = {isa = PBXBuildFile; fileRef = 142 /* Fichero.sdef */; };
-		044 /* WorkflowServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 143 /* WorkflowServiceGenerated.swift */; };
-		045 /* SavedSearchServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 144 /* SavedSearchServiceGenerated.swift */; };
-		045C6648800D0B7D95D13B32 /* AnnotationHighlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D4DEA1D7E10749DA258D26F /* AnnotationHighlight.swift */; };
-		046 /* ConversationServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 145 /* ConversationServiceGenerated.swift */; };
-		047 /* ChatServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 146 /* ChatServiceGenerated.swift */; };
-		048 /* WorkflowExecutionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149 /* WorkflowExecutionObserver.swift */; };
-		049 /* DocumentServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148 /* DocumentServiceGenerated.swift */; };
-		04EC79C508ADFCB840661C01 /* BookmarksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA02CD36EF110174B8E2206 /* BookmarksView.swift */; };
-		079E7B626FA4EE5877BB24B0 /* FicheroApp_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29941DE439073B7364322ECF /* FicheroApp_iOS.swift */; };
-		08A233915452687AD06DA9DE /* DocumentInspectorArtifactsTab+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BB27716102361159F020CD /* DocumentInspectorArtifactsTab+Previews.swift */; };
-		097E07610FB8E2B3AB4A6264 /* CitationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1424784E87E1971372F0109 /* CitationDetailView.swift */; };
-		09E406188BE97EB78EFD0429 /* PDFPageWithToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 902DF4705DA9730D76AF2C06 /* PDFPageWithToolbar.swift */; };
-		09F7968790ECF62B772D3895 /* NoteListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89B5319A472F190E68188ECC /* NoteListView.swift */; };
-		0A33E891AB84D96B6F3C3C2F /* ResearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 375F58443D6F498C1FEDD3E3 /* ResearchStore.swift */; };
-		0A667D33534B55BD383F4D55 /* KGMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F131D425C0276D277D805678 /* KGMapView.swift */; };
-		0A798A14E8BC54C9115FBAF7 /* FileMenuCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C768E2159A6D869E204FC478 /* FileMenuCommands.swift */; };
-		0C6B1EE6EDE444C4F95ED9FD /* NoteService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF58B21F339179A8162AD6C5 /* NoteService.swift */; };
-		0E0C4A9843C989F7A157F986 /* WorkspaceItemPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF8C2AF12DD3E6EAB64C68B4 /* WorkspaceItemPicker.swift */; };
-		0F105FC52C12302CF5A2AC42 /* ClaimSummaryCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F1ACEB8F688C8749B36E04B /* ClaimSummaryCardView.swift */; };
-		0F10EA9CD30A9CC13ED3E074 /* EntityDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F14337BE87CA15E70323ED4 /* EntityDetailView.swift */; };
-		0F17A8BE887BF69F2A84F67B /* OntologyBrowser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F1C81E90821C016E2CE3A60 /* OntologyBrowser.swift */; };
-		0F1CA90D364622756AFC004A /* EntityRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F11A721FF01A4F5A66A4568 /* EntityRowView.swift */; };
-		0FEA39950E6F6135CC4E34DE /* IdentityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFD8D2157AA0C0F66955D78 /* IdentityStore.swift */; };
-		1008C273C68E049FC8909FE2 /* CanvasDropResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034BEE1157D9D2C95C1F885A /* CanvasDropResolver.swift */; };
-		1198B2465AC02D0DCAE85184 /* EngineReadinessProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5715F64F9F1AF567F5E43C42 /* EngineReadinessProbe.swift */; };
-		1198B2465AC02D0DCAE85185 /* EngineSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5715F64F9F1AF567F5E43C43 /* EngineSession.swift */; };
-		122B14F33BEDA95169037201 /* SpeakerComparisonView+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599CF5FBD9D2B619B9353BC7 /* SpeakerComparisonView+Preview.swift */; };
-		127F8AA713B90A0B24269C98 /* DocumentInspectorAnnotationsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB786740043A3DAB4CDBFD6F /* DocumentInspectorAnnotationsTab.swift */; };
-		129B66EC2432B98151597597 /* FocusedArtifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74949C6AC5364C768581B8CE /* FocusedArtifact.swift */; };
-		136B9D5C51C43F1243329476 /* CitationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866758A89BA93E91F5E4DCC5 /* CitationListView.swift */; };
-		150 /* ChainEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 151 /* ChainEditorView.swift */; };
-		154 /* ScheduleCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152 /* ScheduleCreationSheet.swift */; };
-		155 /* TriggerCreationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153 /* TriggerCreationSheet.swift */; };
-		15785F4FC901A743D5DE7D09 /* DocumentInspectorInfoTab+Prototype.swift in Sources */ = {isa = PBXBuildFile; fileRef = 715408B079BD7610A53FA99C /* DocumentInspectorInfoTab+Prototype.swift */; };
-		158C918190068A0805613D21 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D817ADFBBCAF433008A6380D /* AboutView.swift */; };
-		17ED8EB9711094AF388E4677 /* LibrarySharingBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DAEF12C9BBE42A6FCA5004A /* LibrarySharingBadge.swift */; };
-		18569C1644053B267C3581C3 /* FocusedAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 322ECCB87D28069C9539D009 /* FocusedAnnotation.swift */; };
-		186AB9CF6F951F8878BC81AF /* EntityKindChartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986AE09BC3B5DC9ECD5820A5 /* EntityKindChartView.swift */; };
-		19F0E17B6ABA9BAF96D135C5 /* AnnotationsInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFA6DF64867F557144B14A23 /* AnnotationsInspectorPane.swift */; };
-		1AA8D13CBE8E1D392BDDD4CF /* DocumentCanvas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80E4C1042F69F06267FA6CCD /* DocumentCanvas.swift */; };
-		MEDIA0012F69F06267FA6CCD /* MediaStreamPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = MEDIA0022F69F06267FA6CCD /* MediaStreamPreview.swift */; };
-		1ACCE61BCF118B415F1E457E /* OntologyBrowser+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 849CA4F172401769E6140F13 /* OntologyBrowser+Toolbar.swift */; };
-		1BA428828543A7D4091C0A98 /* ActivityOverviewView+Cards.swift in Sources */ = {isa = PBXBuildFile; fileRef = D661A54EFC8800F710E16A23 /* ActivityOverviewView+Cards.swift */; };
-		1BD8C58F169EE984D4CF90A4 /* EntitySplitSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3FE2F360EADE051A3D2D51 /* EntitySplitSheet.swift */; };
-		1D911B0CF5214057FC57F23A /* EntityDetailView+Biography.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1016BD8B24F412A49A3BED88 /* EntityDetailView+Biography.swift */; };
-		1DB87289F50626AC3C840F28 /* DocumentInspectorInfoTab+Workflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9037096857E2AE5F3339A8DC /* DocumentInspectorInfoTab+Workflow.swift */; };
-		1E1F0FD4E828C80187F7C03A /* OntologyBrowser+Sheets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B9987CAE57F0DD5387F6DD2 /* OntologyBrowser+Sheets.swift */; };
-		200BCF2C2F3D501800D7851A /* ContentView+State.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BCF2B2F3D501800D7851A /* ContentView+State.swift */; };
-		200BCF362F3D547F00D7851A /* ContentView+ViewBuilders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BCF352F3D547F00D7851A /* ContentView+ViewBuilders.swift */; };
-		6B2E4D99C5F38A0297BC4401 /* ContentView+Toolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B2E4D99C5F38A0297BC4402 /* ContentView+Toolbar.swift */; };
-		200BCF382F3D548000D7851A /* ContentView+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BCF372F3D548000D7851A /* ContentView+Persistence.swift */; };
-		200BCF3A2F3D548000D7851A /* ContentView+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BCF392F3D548000D7851A /* ContentView+Navigation.swift */; };
-		200BCF3C2F3D548000D7851A /* ContentView+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200BCF3B2F3D548000D7851A /* ContentView+Actions.swift */; };
-		201090099DFFEC36A41DB652 /* ActivityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C0EC9D283E4FFF816B0460 /* ActivityStore.swift */; };
-		2011E35A2F93ADF700606651 /* ComparisonTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2011E3592F93ADF700606651 /* ComparisonTypes.swift */; };
-		202674952F475B1D008EAB5D /* NodeConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674942F475B1D008EAB5D /* NodeConfigView.swift */; };
-		202674972F475B23008EAB5D /* CollectionNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674962F475B23008EAB5D /* CollectionNodeConfig.swift */; };
-		202674992F475B33008EAB5D /* SearchNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674982F475B33008EAB5D /* SearchNodeConfig.swift */; };
-		2026749B2F475B4A008EAB5D /* FilesNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026749A2F475B4A008EAB5D /* FilesNodeConfig.swift */; };
-		2026749D2F475B64008EAB5D /* TranscribeNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026749C2F475B64008EAB5D /* TranscribeNodeConfig.swift */; };
-		2026749F2F475B7A008EAB5D /* DescribeNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026749E2F475B7A008EAB5D /* DescribeNodeConfig.swift */; };
-		202674A42F47642A008EAB5D /* SummarizeFileNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674A32F47642A008EAB5D /* SummarizeFileNodeConfig.swift */; };
-		202674A62F476439008EAB5D /* SummarizeFolderNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674A52F476439008EAB5D /* SummarizeFolderNodeConfig.swift */; };
-		202674A82F476447008EAB5D /* SummarizeCollectionNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674A72F476447008EAB5D /* SummarizeCollectionNodeConfig.swift */; };
-		202674AA2F476453008EAB5D /* ExtractEntitiesNodeConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674A92F476453008EAB5D /* ExtractEntitiesNodeConfig.swift */; };
-		202674AC2F4779AA008EAB5D /* NodeProviderModelSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674AB2F4779AA008EAB5D /* NodeProviderModelSelector.swift */; };
-		202674AE2F477AFE008EAB5D /* NodeInputMappings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674AD2F477AFE008EAB5D /* NodeInputMappings.swift */; };
-		202674B02F4781BA008EAB5D /* TrackingImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674AF2F4781BA008EAB5D /* TrackingImageView.swift */; };
-		202674B22F478206008EAB5D /* ImageWithCursorTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674B12F478206008EAB5D /* ImageWithCursorTracking.swift */; };
-		202674B42F4783A9008EAB5D /* WorkflowNodeCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674B32F4783A9008EAB5D /* WorkflowNodeCard.swift */; };
-		202674B62F4783BC008EAB5D /* WorkflowNodeRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674B52F4783BC008EAB5D /* WorkflowNodeRow.swift */; };
-		202674B82F4783D5008EAB5D /* WorkflowDiagramPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674B72F4783D5008EAB5D /* WorkflowDiagramPreview.swift */; };
-		202674BC2F478636008EAB5D /* SidebarCreationHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674BB2F478636008EAB5D /* SidebarCreationHandlers.swift */; };
-		202674BF2F478647008EAB5D /* SidebarActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674BE2F478647008EAB5D /* SidebarActions.swift */; };
-		202674C22F47865B008EAB5D /* SidebarObservers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674C12F47865B008EAB5D /* SidebarObservers.swift */; };
-		202674C52F4788CB008EAB5D /* WorkflowDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674C42F4788CB008EAB5D /* WorkflowDetailView.swift */; };
-		202674C72F4788E0008EAB5D /* WorkflowMiniPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674C62F4788E0008EAB5D /* WorkflowMiniPreview.swift */; };
-		202674C92F4788EB008EAB5D /* WorkflowThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674C82F4788EB008EAB5D /* WorkflowThumbnailView.swift */; };
-		202674CC2F4788F2008EAB5D /* WorkflowLibraryRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674CB2F4788F2008EAB5D /* WorkflowLibraryRow.swift */; };
-		202674CE2F4788FF008EAB5D /* NewWorkflowSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674CD2F4788FF008EAB5D /* NewWorkflowSheet.swift */; };
-		202674D02F4789BF008EAB5D /* LibraryViewComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674CF2F4789BF008EAB5D /* LibraryViewComponents.swift */; };
-		202674D22F478A13008EAB5D /* LibraryView+DisplayModes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674D12F478A13008EAB5D /* LibraryView+DisplayModes.swift */; };
-		202674D42F489633008EAB5D /* SearchFiltersPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674D32F489633008EAB5D /* SearchFiltersPanel.swift */; };
-		202674D62F48963F008EAB5D /* SearchResultRowFromAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674D52F48963F008EAB5D /* SearchResultRowFromAPI.swift */; };
-		202674D82F48964E008EAB5D /* SearchMapComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674D72F48964E008EAB5D /* SearchMapComponents.swift */; };
-		202674DA2F489665008EAB5D /* SearchResultsDisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674D92F489665008EAB5D /* SearchResultsDisplay.swift */; };
-		202674DC2F489677008EAB5D /* SearchView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674DB2F489677008EAB5D /* SearchView+Helpers.swift */; };
-		202674DE2F489678008EAB5D /* RecentSearchesStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674DD2F489678008EAB5D /* RecentSearchesStore.swift */; };
-		202674DE2F48972A008EAB5D /* MessageCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674DD2F48972A008EAB5D /* MessageCard.swift */; };
-		202674E02F489737008EAB5D /* ChatStatusViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674DF2F489737008EAB5D /* ChatStatusViews.swift */; };
-		202674E22F48973E008EAB5D /* ChatInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674E12F48973E008EAB5D /* ChatInputView.swift */; };
-		202674E62F489757008EAB5D /* ChatMessagesList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674E52F489757008EAB5D /* ChatMessagesList.swift */; };
-		202674E82F48976C008EAB5D /* ChatView+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674E72F48976C008EAB5D /* ChatView+Extensions.swift */; };
-		202674E92F4897A4008EAB5D /* SearchResultsEmptyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202674EA2F4897A4008EAB5D /* SearchResultsEmptyState.swift */; };
-		20D8ED492F48E2B1006950A3 /* WorkflowInspector+AgentsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED482F48E2B1006950A3 /* WorkflowInspector+AgentsSection.swift */; };
-		20D8ED4B2F48E2B3006950A3 /* ActivityProgressModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED4A2F48E2B3006950A3 /* ActivityProgressModels.swift */; };
-		20D8ED4D2F48E2BE006950A3 /* WorkflowInspector+MCPTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED4C2F48E2BE006950A3 /* WorkflowInspector+MCPTools.swift */; };
-		20D8ED4F2F48E2C1006950A3 /* ActivityProgressView+LiveProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED4E2F48E2C1006950A3 /* ActivityProgressView+LiveProgress.swift */; };
-		20D8ED532F48E2CA006950A3 /* WorkflowInspector+DataLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED522F48E2CA006950A3 /* WorkflowInspector+DataLoading.swift */; };
-		20D8ED572F48E2D7006950A3 /* ActivityProgressView+HistoricalProgress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED562F48E2D7006950A3 /* ActivityProgressView+HistoricalProgress.swift */; };
-		20D8ED592F48E2DE006950A3 /* ActivityProgressView+DataLoading.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED582F48E2DE006950A3 /* ActivityProgressView+DataLoading.swift */; };
-		20D8ED5B2F48E4CA006950A3 /* TriggerDetailView+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED5A2F48E4CA006950A3 /* TriggerDetailView+Configuration.swift */; };
-		20D8ED5D2F48E4D4006950A3 /* TriggerDetailView+ExecutionHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED5C2F48E4D4006950A3 /* TriggerDetailView+ExecutionHistory.swift */; };
-		20D8ED5F2F48E4DA006950A3 /* TriggerDetailView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED5E2F48E4DA006950A3 /* TriggerDetailView+Helpers.swift */; };
-		20D8ED612F48E604006950A3 /* WorkflowSupportTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED602F48E604006950A3 /* WorkflowSupportTypes.swift */; };
-		20D8ED632F48E61C006950A3 /* SidebarItem+MoreFactories.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED622F48E61B006950A3 /* SidebarItem+MoreFactories.swift */; };
-		20D8ED652F48E61C006950A3 /* WorkflowToolTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED642F48E61C006950A3 /* WorkflowToolTypes.swift */; };
-		20D8ED672F48E626006950A3 /* DocumentStore+CRUD.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED662F48E626006950A3 /* DocumentStore+CRUD.swift */; };
-		20D8ED692F48E626006950A3 /* SidebarChatTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED682F48E626006950A3 /* SidebarChatTypes.swift */; };
-		20D8ED6B2F48E62B006950A3 /* WorkflowResponseTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED6A2F48E62B006950A3 /* WorkflowResponseTypes.swift */; };
-		20D8ED6D2F48E62F006950A3 /* DocumentStore+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED6C2F48E62F006950A3 /* DocumentStore+Helpers.swift */; };
-		20D8ED6F2F48E633006950A3 /* SidebarSearchTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED6E2F48E633006950A3 /* SidebarSearchTypes.swift */; };
-		20D8ED712F48E63B006950A3 /* DocumentStoreTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED702F48E63B006950A3 /* DocumentStoreTypes.swift */; };
-		20D8ED732F48E644006950A3 /* SidebarViewTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8ED722F48E644006950A3 /* SidebarViewTypes.swift */; };
-		20D8EDCA2F48F49C006950A3 /* BatchTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDC92F48F49C006950A3 /* BatchTypes.swift */; };
-		20D8EDCC2F48F4A8006950A3 /* LibraryWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDCB2F48F4A8006950A3 /* LibraryWindow.swift */; };
-		20D8EDD02F48F4AE006950A3 /* CheckpointTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDCF2F48F4AE006950A3 /* CheckpointTypes.swift */; };
-		20D8EDD22F48F4B4006950A3 /* IntegrationsPlaceholderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDD12F48F4B4006950A3 /* IntegrationsPlaceholderSheet.swift */; };
-		20D8EDD42F48F4BE006950A3 /* WorkflowRunResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDD32F48F4BE006950A3 /* WorkflowRunResponse.swift */; };
-		20D8EDF82F4BBC04006950A3 /* WorkflowStreamTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDF72F4BBC04006950A3 /* WorkflowStreamTypes.swift */; };
-		20D8EDFA2F4BBC12006950A3 /* ModelComparisonTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDF92F4BBC12006950A3 /* ModelComparisonTypes.swift */; };
-		20D8EDFC2F4BBC1A006950A3 /* WorkflowStreamService+Parsing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EDFB2F4BBC1A006950A3 /* WorkflowStreamService+Parsing.swift */; };
-		20D8EE202F4BBFAF006950A3 /* AppleScriptCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE1F2F4BBFAF006950A3 /* AppleScriptCommands.swift */; };
-		20D8EE222F4BBFB8006950A3 /* AutomationServiceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE212F4BBFB8006950A3 /* AutomationServiceTypes.swift */; };
-		20D8EE242F4BBFBA006950A3 /* ProviderServiceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE232F4BBFBA006950A3 /* ProviderServiceTypes.swift */; };
-		20D8EE262F4BC0E2006950A3 /* IntegrationsServiceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE252F4BC0E2006950A3 /* IntegrationsServiceTypes.swift */; };
-		20D8EE282F4BC0ED006950A3 /* IntegrationsService+AppSpecific.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE272F4BC0ED006950A3 /* IntegrationsService+AppSpecific.swift */; };
-		20D8EE2A2F4BC0F3006950A3 /* WorkflowExecutionTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE292F4BC0F3006950A3 /* WorkflowExecutionTypes.swift */; };
-		20D8EE302F4BC10F006950A3 /* WorkflowExecutionObserver+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE2F2F4BC10F006950A3 /* WorkflowExecutionObserver+Events.swift */; };
-		20D8EE382F4BD559006950A3 /* LibraryView+KeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE372F4BD559006950A3 /* LibraryView+KeyboardShortcuts.swift */; };
-		20D8EE3A2F4BD9F6006950A3 /* LibraryView+InlineEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE392F4BD9F6006950A3 /* LibraryView+InlineEditing.swift */; };
-		20D8EE3C2F4BE0D8006950A3 /* ActionsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE3B2F4BE0D8006950A3 /* ActionsService.swift */; };
-		20D8EE3E2F4BE1AB006950A3 /* ActionLibraryService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE3D2F4BE1AB006950A3 /* ActionLibraryService.swift */; };
-		20D8EE452F4BE260006950A3 /* ActionLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE442F4BE260006950A3 /* ActionLibraryView.swift */; };
-		20D8EE472F4BE285006950A3 /* ActionPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE462F4BE285006950A3 /* ActionPickerView.swift */; };
-		20D8EE492F4BED4B006950A3 /* ActionRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE482F4BED4B006950A3 /* ActionRowView.swift */; };
-		20D8EE4B2F4BED57006950A3 /* ActionDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D8EE4A2F4BED57006950A3 /* ActionDetailView.swift */; };
-		20ED240D4093078C1DD920D5 /* Spatial2DCanvasItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C09E634BBFD5CA7C83DBCC4 /* Spatial2DCanvasItems.swift */; };
-		230EB3E3E820CFEC092A3C49 /* ResearchTasksPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5287875D44BA51CD93CA12F8 /* ResearchTasksPane.swift */; };
-		235BB484E009F2DC1E3B149D /* MarkdownText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA362DBBB6387D0FEB6A7626 /* MarkdownText.swift */; };
-		24B8539890A424B7A35E21AD /* CanvasSpaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52AFBAB2B16555EF8A55BF3 /* CanvasSpaceView.swift */; };
-		24D8496D37D6F2973BD2E825 /* AnnotationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ABB27CA283069DA160FB5AA /* AnnotationStore.swift */; };
-		25B9458F0E27EB2BCD55B439 /* ClaimSummaryCard+Details.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA39991F769A1DD42BB17F01 /* ClaimSummaryCard+Details.swift */; };
-		274511309DDD1821496D42C3 /* PDFPageControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DDD973DE51567CB7FABA63C /* PDFPageControllers.swift */; };
-		283826C50E2AE354A7EB5611 /* SpatialNodeThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF5FD0D414191E6FFC18E8BC /* SpatialNodeThumbnail.swift */; };
-		28510D794CAA15808E28CB6C /* BackendHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36B2292335F30622AB8F0ABE /* BackendHost.swift */; };
-		286700373FC6B54B843E8DA5 /* NodePopover+Comparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32F310DFF84C9557A77D4FDA /* NodePopover+Comparison.swift */; };
-		2A7F1839345B56CA811A4941 /* ViewDisplayMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 956F66055D569E37A35E0377 /* ViewDisplayMode.swift */; };
-		2C2268FA2E4307AAA02C7EC4 /* APIClient+Types.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300A8405FFC476E5124372AE /* APIClient+Types.swift */; };
-		2D2BD6F65172A039357FB3D2 /* CanvasOrtho2DRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6696D9961E42071EE854350 /* CanvasOrtho2DRenderer.swift */; };
-		2D4468D68538BE7767729108 /* ResearchProjectListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE29C018865C9A1538200D8E /* ResearchProjectListView.swift */; };
-		2D54DDB20954138D91EC7359 /* DocumentInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1424D757E2C82D4E5325413F /* DocumentInspector.swift */; };
-		2E9F1141ED5087B3424E7826 /* CanvasSceneRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F287F61A7D65912EF63D362C /* CanvasSceneRenderer.swift */; };
-		2ED84CCBA91252EA2D0C5D34 /* TriggerEditorPreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BAA47F1959AD79AA6C2E3EF /* TriggerEditorPreviewPanel.swift */; };
-		2F08B4F9E864BB8619BD5138 /* NoteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFA65406167827DCB144E3E2 /* NoteStore.swift */; };
-		2FA0C9F98B2B1A0A35107B07 /* ChainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41994E6C746A0B0171534212 /* ChainStore.swift */; };
-		300ED1FDA9255CD4182A3664 /* ForceDirectedGraphView+Render.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DE62C7312D0E473288483C9 /* ForceDirectedGraphView+Render.swift */; };
-		342DA5972C51F45081E9FB80 /* EntityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B118FE1DE4F78C0EE238539 /* EntityStore.swift */; };
+		FEEDCE2D38A6FE7E36FEC8A0 /* NavigationHistoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B044A60D5A8C7BA256FF24 /* NavigationHistoryManager.swift */; };
+		FEEDDEAD0000000000000002 /* ReaderTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000001 /* ReaderTabBar.swift */; };
+		FEEDDEAD0000000000000004 /* EntityReconciliationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000003 /* EntityReconciliationSheet.swift */; };
+		FEEDDEAD0000000000000006 /* SurfaceTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000005 /* SurfaceTabBar.swift */; };
+		FEEDDEAD0000000000000008 /* WorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000007 /* WorkspaceStore.swift */; };
 		FEEDDEAD000000000000000A /* BatchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000009 /* BatchStore.swift */; };
 		FEEDDEAD000000000000000C /* BatchRunView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD000000000000000B /* BatchRunView.swift */; };
-		FEEDDEAD0000000000000008 /* WorkspaceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000007 /* WorkspaceStore.swift */; };
-		34F019EE1DA4E427EF3674EC /* OpenAffordances.swift in Sources */ = {isa = PBXBuildFile; fileRef = A68A831B2F81707B5E082D6F /* OpenAffordances.swift */; };
-		3591D3E8CE619A9731DF2242 /* CanvasDetailTier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80920949B39DD526745B0BF2 /* CanvasDetailTier.swift */; };
-		35B42F6B063872E635AD5362 /* WindowSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBE84D175FC1F5C5644EB914 /* WindowSeed.swift */; };
-		35CD189B6E6257ACC5F97863 /* SidebarItemRow+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47244E304896B65E6F12976C /* SidebarItemRow+Preview.swift */; };
-		36C67BBF07CCFEAF928943C9 /* ImageEditorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF014F0FAEFCA5233DCB114F /* ImageEditorModel.swift */; };
-		LIVE00012F27F36000EC9EE1 /* LiveEditPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = LIVE00022F27F36000EC9EE1 /* LiveEditPreview.swift */; };
-		37125B13A36AF61C3B5868C3 /* NodeComparisonSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D455270E3396946CF4F1939 /* NodeComparisonSheet.swift */; };
-		37B827A97DAB87AADDC8642A /* CanvasScene3DRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B7A8D1A3FCF024827D89665 /* CanvasScene3DRenderer.swift */; };
-		3D3445F0B90D093149C9A7D6 /* DocumentInspectorContentTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36234E44A7E494963A441CDC /* DocumentInspectorContentTab.swift */; };
-		4016BD3CF245BCA932D3D1D5 /* InviteAccountSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6337F0388FCB9CD46ACFEE95 /* InviteAccountSection.swift */; };
-		40B4487F9C8C03F6518A8988 /* PageImageGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 753C4D174F9A42A6593BECC6 /* PageImageGrid.swift */; };
-		FEEDDEAD0000000000000002 /* ReaderTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000001 /* ReaderTabBar.swift */; };
-		417694AF6ACC5AEEF6E2E4B9 /* ClaimSummaryCard+Provenance.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1CE0962968DEE7EAB60E454 /* ClaimSummaryCard+Provenance.swift */; };
-		44088B69B036974D72906372 /* ShareSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FF20EF84262D15A268246D /* ShareSettingsView.swift */; };
-		441627D26C9932352CE1FDF1 /* CanvasItemStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5921F26A97AF84B80B4DCD29 /* CanvasItemStore.swift */; };
-		4458475E8C2BF728591E504F /* AIDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C4E4291B8C33D501F176BF5 /* AIDefaults.swift */; };
-		44FA1DBF0A63CD22C7237172 /* SourceProvenancePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAC32EFF977CFA4E7D253F6A /* SourceProvenancePopover.swift */; };
-		451693E6DEA7C6AEEB8C8183 /* InspectorSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DACA616BBD1A6AA5E8518E /* InspectorSection.swift */; };
-		4521CFC5D73D8706FAE283CA /* InterpretationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = F42C41E0F485064FDA5EAEB9 /* InterpretationStore.swift */; };
-		48566E1CB89ED6382581A546 /* ObservableDomainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B628D9325A5B301E5827F0C1 /* ObservableDomainStore.swift */; };
-		48644281A751D62184D6C831 /* FicheroActionIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60A05B7F3C09F6A27BE55971 /* FicheroActionIntents.swift */; };
-		495FCF3ED790C015FBF4BE70 /* NotesBrowserView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAA77E9001736B77957513A4 /* NotesBrowserView.swift */; };
-		4A49D387AEF64378BFDC1E3E /* LiveUpdatesPausedPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53331A42DA98730B8F854E58 /* LiveUpdatesPausedPill.swift */; };
-		4AFAA394C8AB364CB2425517 /* ResearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11DB5E2213FF12794A689A7F /* ResearchService.swift */; };
-		4B6F0446E2EB820AD456A8EF /* PDFReadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75558D1F0B1D0F65CEFF577C /* PDFReadingView.swift */; };
-		4C823323E8BC468934CFD1C4 /* AppNavigationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19C6A533EA3E96E1F5AE19ED /* AppNavigationHistory.swift */; };
-		4CB7B16CFB076724595D6EE4 /* DocumentInspectorArtifactsTab+Interpretations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E852347E800839A52286849 /* DocumentInspectorArtifactsTab+Interpretations.swift */; };
-		4D873A751876E0F56C149319 /* SidebarView+UnifiedLibrarySections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 052B352354B208CBDD7F8A1F /* SidebarView+UnifiedLibrarySections.swift */; };
-		4DD61218DD8818B2488E3AC1 /* DocumentKGSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C119BA4657FD54B0F01D6C /* DocumentKGSurface.swift */; };
-		4E6331788690437E1344F2C5 /* NavigatorMiniMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BE8ADCDBC94EF23E0D0E1C4 /* NavigatorMiniMap.swift */; };
-		4EBA402FBE51F9F56366C3A5 /* FlowLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3CD4902A47A5787D61C6D72 /* FlowLayout.swift */; };
-		4F070C9F83A1E68CBABB98DA /* PairedHostEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22CF4FEC94C539A14626CD6B /* PairedHostEndpoints.swift */; };
-		4F0D8E596D331C45B6A8BC73 /* Canvas3DProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DC0777B2A518265D4ACABB8 /* Canvas3DProjection.swift */; };
-		50667A0C0A15D67B79D303AC /* ShareLibrarySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F47EED3CD156012F59D46F7B /* ShareLibrarySheet.swift */; };
-		517753E47832A6BD397EA6B3 /* EngineSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4F63C0FA3C779A6BA5B655 /* EngineSettingsView.swift */; };
-		527561D7A2B768C662B2D74E /* PaneVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B47F88D458E8ED7BD95E5B47 /* PaneVisibility.swift */; };
-		538B4B2C658DECF4B98FA0CD /* PDFRegionGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66ADB5B1F77763C5F3295611 /* PDFRegionGeometry.swift */; };
-		5435A98021D72C073130730B /* AuditHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67E28651A4F5835C8AD6A06B /* AuditHistoryView.swift */; };
-		544F0C27E64420694C462156 /* ResearchBrowserPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A2290E008AD4F8ACF613B8C /* ResearchBrowserPane.swift */; };
-		54A07EFB77CACCF2E0ADDD84 /* ImageEditingServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA2442EE35411B543D0868B /* ImageEditingServiceGenerated.swift */; };
-		54D6AB78C2AD173F9E7C3E2C /* FocusedCitation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75255EDB2E723056D7BA67B /* FocusedCitation.swift */; };
-		560311302E8DCC126BD757E2 /* LibraryToolbarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99857D7C99E753A3405778FC /* LibraryToolbarState.swift */; };
-		560712308F658F0586314B6C /* LibraryAccessDeniedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87C5267955AE57DD7BCEA674 /* LibraryAccessDeniedView.swift */; };
-		568F313267F4F71EE3FD6BEC /* iOSLibraryPickerMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015D191B1A9A578C0A4BC6BA /* iOSLibraryPickerMenu.swift */; };
-		56B06FF519C1F4B9CD4E6214 /* ActionInvokeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6175F28D959ABB4DB0C2F4CD /* ActionInvokeService.swift */; };
-		56DCD53ACD6483561CF542B3 /* KGTemporalSpatial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43EAB861267206E7A929830F /* KGTemporalSpatial.swift */; };
-		57EFBE5436C18075ECE90EFC /* ClaimStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C527476477074D83F628468 /* ClaimStore.swift */; };
-		5C81FC2A7C0C2C47F3071EB5 /* DocumentInspectorContentV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8837F3B333F0ACFB9929CF /* DocumentInspectorContentV2.swift */; };
-		5D064ECAAD353BDB778B8580 /* AnnotationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D7DC57117008EBCFE607A9 /* AnnotationService.swift */; };
-		5D621E99ED66F859FD195491 /* AnnotatableTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 032AA7721B1C054A6CD89D4C /* AnnotatableTextView.swift */; };
-		5E8 /* SidebarItemBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9 /* SidebarItemBuilder.swift */; };
-		5F01DCF2F7EC8E307F172402 /* DisplayAttributesStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E5C6B2FBD2462E90B5F43D /* DisplayAttributesStrip.swift */; };
-		5FBCA4ACC1D0F229DA5E85AC /* EntityDetailView+Metadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9506E8C3C8030EE3075E9A0 /* EntityDetailView+Metadata.swift */; };
-		600993746CBF4F9F5E6AE35B /* ReaderToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE00C2DC909B57AA030519E /* ReaderToolbar.swift */; };
-		618EC62E8F7BA72F72B5A0A1 /* NewEntitySheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 675E69DE1A8C941ABBEBB0E0 /* NewEntitySheet.swift */; };
-		63C9659B6755FB880F50C6D5 /* ForceDirectedGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 003E584BBE51001B1E3F6843 /* ForceDirectedGraphView.swift */; };
-		64000200016ACCF0AA1B529A /* UsersStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA1EB898A19FAA64EF466CD2 /* UsersStore.swift */; };
-		64574A29B56CBA1F27542556 /* BackendSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371A4629B0A6A51DE6D6D872 /* BackendSettingsView.swift */; };
-		64712D1DA458621D00C216F0 /* SpaceSceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCCA353DE8E2AFD149DADB3A /* SpaceSceneView.swift */; };
-		6577690F3500AFDA003B1E54 /* SpatialModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B320C62BB61F14256AECCF5 /* SpatialModels.swift */; };
-		669E5960825CCF224C5297A1 /* BackendWorkPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F5ED84DA059F760ECDB09B4 /* BackendWorkPill.swift */; };
-		67FA5A93E29E64305C9D74CE /* ResearchModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B98F1F8C255A9F7C3386A59 /* ResearchModels.swift */; };
-		6858AFB3D476FE28DEDE81BA /* ClaimReviewQueueSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F46B999D0208EA4C734535C /* ClaimReviewQueueSheet.swift */; };
-		6863442A96E849A029663A77 /* DocumentTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F707FEBE62834FFB3024991 /* DocumentTabView.swift */; };
-		6944EB9DA6305E692A58C4E8 /* AISettingsView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9195539F44B4ADCA2A3C9974 /* AISettingsView+Helpers.swift */; };
-		699D8A080D56300C542DEE87 /* ContradictionTriageSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53458DC3387BC4C694EE3452 /* ContradictionTriageSheet.swift */; };
-		69B6C56B15927E1F89E831D7 /* InspectorPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFC6B695132C68202062560A /* InspectorPresenter.swift */; };
-		6AFCCD468ED23422DA7132CF /* ImageViewerComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADD8AD20E191046B70950B1E /* ImageViewerComponents.swift */; };
-		6C79AC237DF842B5E8AE31E7 /* CitationsInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9C3B5A53041FFAA09E0221 /* CitationsInspectorPane.swift */; };
-		6CBF2E328348510A4B781B7C /* SidebarView+PinnedNavigationRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0DFC89B8C073DBEE0A743F /* SidebarView+PinnedNavigationRows.swift */; };
-		6EF56175D31C5732E5A0D119 /* OntologyBrowserGraphModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18ABABDD0527530DA73B5C7 /* OntologyBrowserGraphModel.swift */; };
-		6FC9AFB7D35EBFB12E9F8225 /* CitationExportButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79192DB989A34D1DBEEF3E34 /* CitationExportButton.swift */; };
-		6FE4896A20BB18BC70193BB7 /* BackupStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C062A29951726302108FD2 /* BackupStore.swift */; };
-		718AAD56294BDA27EFF854ED /* BoundingBoxOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FCDF89C1460FA69DB0A0630 /* BoundingBoxOverlay.swift */; };
-		71B9A55B210E4DE0AA4B4A2A /* ScheduleEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B5ACEA3F5BC4462B7B18AA7 /* ScheduleEditorView.swift */; };
-		7233BDB6DCB842F75D52EA15 /* ReferenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBCBCC9A6B923D6A560F7277 /* ReferenceStore.swift */; };
-		73CFDAD2CD3E5A4A2EFF5FEC /* CanvasSceneDiff.swift in Sources */ = {isa = PBXBuildFile; fileRef = F355E37D6E92E270CCE27EF6 /* CanvasSceneDiff.swift */; };
-		75FF7AE84AC04F85A9A728AA /* AuditStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8F8D42618D304271F81962 /* AuditStore.swift */; };
-		76C7BC71C747DBF9E6BD678D /* SpatialView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBBA30F68AE440FAF4DC1E4 /* SpatialView.swift */; };
-		76EEEC44E89E3A5F714F989C /* SidebarItemRow+Presentation+Body.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872F7ADB0C1953F67D681C24 /* SidebarItemRow+Presentation+Body.swift */; };
-		7800350961E1C38A10D02D54 /* ImageEditChainPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95706A3222B50B478F15D83D /* ImageEditChainPanel.swift */; };
-		78C35F469E90405F21DF19B0 /* DocumentInspectorArtifactsTab+EntitiesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F6D53AD0FD306FE58CF26D /* DocumentInspectorArtifactsTab+EntitiesTab.swift */; };
-		78F8389F0A4A57F5A2D6F260 /* BackendActivityEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E07BE5ECB91F929ADBD8595A /* BackendActivityEvent.swift */; };
-		7BC4AED0E0043218B6104F4A /* ScrollWheelZoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3080C713216B7BBD39725487 /* ScrollWheelZoom.swift */; };
-		7C874A46B0C0C85ACD9F23AA /* DocumentInspectorArtifactsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312845068CA928DA393E0468 /* DocumentInspectorArtifactsTab.swift */; };
-		FEEDDEAD0000000000000006 /* SurfaceTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000005 /* SurfaceTabBar.swift */; };
-		7D8F36CB01DB7346C305CA3C /* ContentView+ReadingLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6650E28284D750D9076B0612 /* ContentView+ReadingLayout.swift */; };
-		7DBC189DE3A7BC27C2B3BEFF /* LibraryOutlineNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453CA6ACF420E59AED37F906 /* LibraryOutlineNode.swift */; };
-		7ECBD1BC6380EBF38150DBAF /* DocumentInspectorInfoTab+RelatedClaims.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0164BBC35A375AA74214F42 /* DocumentInspectorInfoTab+RelatedClaims.swift */; };
-		7F7BE70A69F9550AE8D82690 /* AuthGateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564CF6ABBC8F558282E73502 /* AuthGateView.swift */; };
-		80C2B74EFACBD0E3CEA2B919 /* LibraryWorkspaceRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A5517E790C3AF9853989225 /* LibraryWorkspaceRoot.swift */; };
-		81C171EFA30E237D92BC79C0 /* ShellLayoutPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24BBD41061EB9112C9EB7D6F /* ShellLayoutPolicy.swift */; };
-		82E7E9935A5A324121ECB468 /* DocumentKGWebPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80DDED3870C2457BFD97D1E /* DocumentKGWebPane.swift */; };
-		832 /* Workflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 462 /* Workflow.swift */; };
-		836 /* CacheModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4119 /* CacheModel.swift */; };
-		838 /* PerformanceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4121 /* PerformanceService.swift */; };
-		840 /* ErrorService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4123 /* ErrorService.swift */; };
-		841 /* ErrorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4124 /* ErrorModel.swift */; };
-		841863C00C3C889B9C71C040 /* CanvasDropOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09D8F04A6421AEC5B5370E92 /* CanvasDropOutcome.swift */; };
-		842 /* SidebarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4125 /* SidebarState.swift */; };
-		843 /* DragDropModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4126 /* DragDropModel.swift */; };
-		850BB2FC48139F2EF4E8CA30 /* PDFLoupeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70EC13FF6B70F7EC2D9A950C /* PDFLoupeOverlay.swift */; };
-		852B1713BA5220E613865101 /* LibraryManager+Operations.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBFA9C3247C03BDCE9BE6092 /* LibraryManager+Operations.swift */; };
-		861B6FECAB63CDE10DBC5D7E /* EntityDigestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB488A4AF6BAB72C33902C4 /* EntityDigestView.swift */; };
-		8667DE091F46137A2B6AC20E /* SidebarItemRow+Presentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE6CF3DE02E1F999AE8F1A9 /* SidebarItemRow+Presentation.swift */; };
-		87738FE508498598CE9DC2F6 /* CoalescingSaveRunner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74ECCAE0282E67AA4A150871 /* CoalescingSaveRunner.swift */; };
-		898AABCC531843909C0C6AA8 /* TriggerEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75371C597B1E4689B6E1803F /* TriggerEditorView.swift */; };
-		89A148373109E3D71999629D /* FocusedDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8609BBFA7EF7B54ED73C59A1 /* FocusedDocument.swift */; };
-		8B136BE0DDA41615174E4AF4 /* SessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4FE6FA42E3E4887451FB21 /* SessionStore.swift */; };
-		7C3A91E4B2D14F0A9E5C1A70 /* KGQueryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C3A91E4B2D14F0A9E5C1A71 /* KGQueryStore.swift */; };
-		8C35E319E4B9A46AB0383C10 /* TriggerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C69898938F25CFEA64385A16 /* TriggerDetailView.swift */; };
-		8C55B492C37B1BBED91F2B9B /* NotesInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F1C6302A9E0863FB1E6775 /* NotesInspectorPane.swift */; };
-		8D462745B97D9C6E1A8EDEB0 /* ArtifactDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DA5F6DA59D0A499D28F3C75 /* ArtifactDetailView.swift */; };
-		8EC8D8B6E0595E51192F1C3C /* Representation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B71ADE00621970AC5AE6E45A /* Representation.swift */; };
-		8F7C131CEB5C672DD1E4813A /* BackendRootGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43576573521F73AE202B2E9B /* BackendRootGate.swift */; };
-		8FE44C97EB98125395148B86 /* AnnotationToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22AF6A1C596C845A9BABDAFC /* AnnotationToolbar.swift */; };
-		913F07667F8EF62FE204D1E7 /* SidebarView+ActivityRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0E93BA60F99453057135B99 /* SidebarView+ActivityRows.swift */; };
-		9155478503635D556FECE3D4 /* EngineConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C31EBD6243D124565257708 /* EngineConfig.swift */; };
-		92F3AFC896A444D7D060547E /* CanvasLayoutStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4887C223276D2F5E2C498065 /* CanvasLayoutStore.swift */; };
-		92F7E655373456AAB3EAFB8C /* ActivityMonitorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36839A1C65A10F63B92E4121 /* ActivityMonitorModel.swift */; };
-		9366577BEB84A06792568C3F /* DocumentInspectorArtifactsTab+EntityKindRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D62D87E6614928970950D52 /* DocumentInspectorArtifactsTab+EntityKindRow.swift */; };
-		93C8C41A0D48127945007810 /* SearchArrowKeyNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0888678B07B4D4F9B3111FE /* SearchArrowKeyNavigation.swift */; };
-		94E38983F9F94E779B431D3F /* AnnotationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70CC17746FA5E4A08F1F31F2 /* AnnotationDetailView.swift */; };
-		94EAA15C7E791548A7BA4E2E /* CanvasSceneState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9414DAA022DF2D96230B86A7 /* CanvasSceneState.swift */; };
-		96DDD5373DEE2458D1D94450 /* BreadcrumbBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE9F6E549990F086C442F3B /* BreadcrumbBuilder.swift */; };
-		9702C23273B6222FF84B6288 /* CanvasSceneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6D6698151FC8A29A2BE3BA /* CanvasSceneView.swift */; };
-		9905931F5511D084D56DEDD2 /* MagnifierPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14E6171BBCA610CF1B87D7F /* MagnifierPanel.swift */; };
-		9A321613F87806CF952668A1 /* PlatformAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BDC2DC273F8F91B9CA1B3C /* PlatformAliases.swift */; };
-		9A44B73B118219D1160AFFD3 /* ArtifactEntityViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5E81DFE56AC41F34CC4EAE /* ArtifactEntityViews.swift */; };
-		9A45089C636C56BF221BD7BC /* MiniToolbarComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC02D722B13BC58D4D4B37B7 /* MiniToolbarComponents.swift */; };
-		9D71A811170D438B938FC1DA /* LibraryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 377DA5DA45FB4CE09C7F76FF /* LibraryManager.swift */; };
-		9DD32C9E1B17D298CF3138F1 /* SourceSnippet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EC894548A8DBFA37D41557 /* SourceSnippet.swift */; };
-		9F50071471DB4B1EA1618E6E /* ActivityMonitorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16C939F2EE06FF349761CA2F /* ActivityMonitorView.swift */; };
-		9F8F3883E8324E76A746FAF8 /* BoundingBoxGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D870DB81D42B1614D58CE3F /* BoundingBoxGeometry.swift */; };
-		9FB2B2B858EA25B4757ECFEC /* EntitySourceGroupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8B0073490980740B06C80D7 /* EntitySourceGroupsView.swift */; };
-		A0DB690A7FF2BA11F0D05AE7 /* DocumentInspectorArtifactsTab+KGSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7EC6F2955D032D3FA13E30 /* DocumentInspectorArtifactsTab+KGSection.swift */; };
-		A13E7C1F2F27E01E00EC9EE1 /* ActivityRun.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C122F27E01E00EC9EE1 /* ActivityRun.swift */; };
-		A13E7C272F27E03300EC9EE1 /* SidebarModeIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C262F27E03300EC9EE1 /* SidebarModeIcon.swift */; };
-		A13E7C282F27E03300EC9EE1 /* SidebarModeBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C252F27E03300EC9EE1 /* SidebarModeBar.swift */; };
-		A13E7C2A2F27E04300EC9EE1 /* ActivityDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C292F27E04300EC9EE1 /* ActivityDetailView.swift */; };
-		A13E7C2E2F27E17F00EC9EE1 /* ProviderServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C2C2F27E17F00EC9EE1 /* ProviderServiceGenerated.swift */; };
-		A13E7C2F2F27E17F00EC9EE1 /* SearchServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C2D2F27E17F00EC9EE1 /* SearchServiceGenerated.swift */; };
-		A13E7C302F27E17F00EC9EE1 /* BatchServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C2B2F27E17F00EC9EE1 /* BatchServiceGenerated.swift */; };
-		A13E7C3A2F27F36000EC9EE1 /* ActivityServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */; };
-		SBX00012F27F36000EC9EE1 /* SandboxAccessServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = SBX00022F27F36000EC9EE1 /* SandboxAccessServiceGenerated.swift */; };
-		LOC00012F27F36000EC9EE1 /* LocationServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */; };
-		PDFC00012F27F36000EC9EE1 /* PDFDocumentCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = PDFC00022F27F36000EC9EE1 /* PDFDocumentCache.swift */; };
-		PRDL00012F27F36000EC9EE1 /* PreviewDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = PRDL00022F27F36000EC9EE1 /* PreviewDownloadService.swift */; };
-		A13E7C3C2F27F36000EC9EE1 /* ActivityTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C3B2F27F36000EC9EE1 /* ActivityTypes.swift */; };
-		A13E7C3D2F27F36000EC9EE1 /* ActivityStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C3E2F27F36000EC9EE1 /* ActivityStreamService.swift */; };
-		A13E7C462F280BE900EC9EE1 /* ActivityProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C432F280BE900EC9EE1 /* ActivityProgressView.swift */; };
-		A13E7C492F280BE900EC9EE1 /* ActivityConsoleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C3C2F280BE900EC9EE1 /* ActivityConsoleView.swift */; };
-		A13E7C4B2F280BE900EC9EE1 /* ActivityOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C422F280BE900EC9EE1 /* ActivityOverviewView.swift */; };
-		A13E7C4C2F280BE900EC9EE1 /* ActivityLogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C412F280BE900EC9EE1 /* ActivityLogView.swift */; };
-		A13E7C4E2F280BE900EC9EE1 /* ActivityViewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C442F280BE900EC9EE1 /* ActivityViewHelpers.swift */; };
-		A13E7C642F27F36000EC9EE1 /* ArtifactServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C632F27F36000EC9EE1 /* ArtifactServiceGenerated.swift */; };
-		A13E7C652F27F36000EC9EE1 /* StorageServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E7C662F27F36000EC9EE1 /* StorageServiceGenerated.swift */; };
-		A13E80A22F2AD75100EC9EE1 /* ModelComparisonService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E80A12F2AD75100EC9EE1 /* ModelComparisonService.swift */; };
-		A13E80A52F2AD78100EC9EE1 /* ModelComparisonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A13E80A32F2AD78100EC9EE1 /* ModelComparisonView.swift */; };
-		A14AD1B92F2E2E07001CF205 /* EmbeddedBackendService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14AD1B82F2E2E07001CF205 /* EmbeddedBackendService.swift */; };
-		A18ED3AB2F13E313007C2C6E /* FicheroAPIClient in Frameworks */ = {isa = PBXBuildFile; productRef = A18ED3AA2F13E313007C2C6E /* FicheroAPIClient */; };
-		A18ED3F22F141DFE007C2C6E /* FicheroAPIClient in Frameworks */ = {isa = PBXBuildFile; productRef = A18ED3F12F141DFE007C2C6E /* FicheroAPIClient */; };
-		A1A3A9C02F1028480021909D /* MCPToolsCatalogView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9BE2F1028480021909D /* MCPToolsCatalogView.swift */; };
-		A1A3A9C12F1028480021909D /* AddMCPServerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9BA2F1028480021909D /* AddMCPServerSheet.swift */; };
-		A1A3A9C22F1028480021909D /* MCPServerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9BB2F1028480021909D /* MCPServerDetailView.swift */; };
-		A1A3A9C32F1028480021909D /* MCPServersSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9BC2F1028480021909D /* MCPServersSheet.swift */; };
-		A1A3A9C42F1028480021909D /* MCPServersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9BD2F1028480021909D /* MCPServersView.swift */; };
-		A1A3A9F42F1028E70021909D /* MCPService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9F32F1028E70021909D /* MCPService.swift */; };
-		A1A3A9F72F110CFD0021909D /* WorkflowExecutionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9F62F110CFD0021909D /* WorkflowExecutionService.swift */; };
-		A1A3A9FA2F110D170021909D /* ContentViewModifiers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3A9F92F110D170021909D /* ContentViewModifiers.swift */; };
-		A1A3AA112F110D520021909D /* WorkflowCanvasView+DropHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA052F110D520021909D /* WorkflowCanvasView+DropHandling.swift */; };
-		A1A3AA122F110D520021909D /* WorkflowCanvasView+Gestures.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA072F110D520021909D /* WorkflowCanvasView+Gestures.swift */; };
-		A1A3AA132F110D520021909D /* NodePopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA022F110D520021909D /* NodePopover.swift */; };
-		A1A3AA142F110D520021909D /* WorkflowCanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA042F110D520021909D /* WorkflowCanvasView.swift */; };
-		A1A3AA152F110D520021909D /* WorkflowEdgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA082F110D520021909D /* WorkflowEdgeView.swift */; };
-		A1A3AA162F110D520021909D /* WorkflowEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA092F110D520021909D /* WorkflowEditor.swift */; };
-		A1A3AA172F110D520021909D /* WorkflowExecutionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA0A2F110D520021909D /* WorkflowExecutionView.swift */; };
-		A1A3AA182F110D520021909D /* WorkflowNodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA0D2F110D520021909D /* WorkflowNodeView.swift */; };
-		A1A3AA192F110D520021909D /* WorkflowLibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA0C2F110D520021909D /* WorkflowLibraryView.swift */; };
-		A1A3AA1A2F110D520021909D /* AgentNodeBlockView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA002F110D520021909D /* AgentNodeBlockView.swift */; };
-		A1A3AA1B2F110D520021909D /* SimpleWorkflowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA032F110D520021909D /* SimpleWorkflowView.swift */; };
-		A1A3AA1C2F110D520021909D /* WorkflowOutputLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA0E2F110D520021909D /* WorkflowOutputLog.swift */; };
-		A1A3AA1D2F110D520021909D /* WorkflowPortView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA0F2F110D520021909D /* WorkflowPortView.swift */; };
-		A1A3AA1E2F110D520021909D /* WorkflowInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA0B2F110D520021909D /* WorkflowInspector.swift */; };
-		A1A3AA1F2F110D520021909D /* WorkflowCanvasView+EdgeConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA062F110D520021909D /* WorkflowCanvasView+EdgeConnection.swift */; };
-		A1A3AA202F110D520021909D /* CanvasHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA012F110D520021909D /* CanvasHelpers.swift */; };
-		A1A3AA212F110D520021909D /* WorkflowToolBlocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA102F110D520021909D /* WorkflowToolBlocks.swift */; };
-		A1A3AA282F113E6F0021909D /* AutomationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA272F113E6F0021909D /* AutomationService.swift */; };
-		A1A3AA292F113E6F0021909D /* AutomationServiceMappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA2A2F113E6F0021909D /* AutomationServiceMappers.swift */; };
-		A1A3AA382F1166660021909D /* IntegrationsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AA372F1166660021909D /* IntegrationsService.swift */; };
-		A1A3AB242F11CCC70021909D /* Artifact.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AB162F11CCC70021909D /* Artifact.swift */; };
-		A1A3AB252F11CCC70021909D /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AB172F11CCC70021909D /* Event.swift */; };
-		A1A3AB262F11CCC70021909D /* Trace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AB1E2F11CCC70021909D /* Trace.swift */; };
-		A1A3AB2B2F11CCC70021909D /* MCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AB192F11CCC70021909D /* MCPServer.swift */; };
-		A1A3AB2C2F11CCC70021909D /* Run.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AB1C2F11CCC70021909D /* Run.swift */; };
-		A1A3AB2F2F11CCC70021909D /* Note.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A3AB1A2F11CCC70021909D /* Note.swift */; };
-		A1BFB2C82F042C0500EAA55A /* ViewSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2C62F042C0500EAA55A /* ViewSettings.swift */; };
-		A1BFB2C92F042C0500EAA55A /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2C52F042C0500EAA55A /* AppState.swift */; };
-		A1BFB2CF2F042C4100EAA55A /* AIModelSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2CC2F042C4100EAA55A /* AIModelSelectionView.swift */; };
-		A1BFB2D02F042C4100EAA55A /* AIProviderAddModelsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2CD2F042C4100EAA55A /* AIProviderAddModelsSheet.swift */; };
-		A1BFB2D12F042C4100EAA55A /* ProvidersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2CE2F042C4100EAA55A /* ProvidersView.swift */; };
-		A1BFB2D32F042C4100EAA55A /* AddProviderSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2CA2F042C4100EAA55A /* AddProviderSheet.swift */; };
-		A1BFB2D72F042C6D00EAA55A /* ProviderLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2D42F042C6D00EAA55A /* ProviderLogoView.swift */; };
-		A1BFB2D82F042C6D00EAA55A /* StatusBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2D52F042C6D00EAA55A /* StatusBadge.swift */; };
-		A1BFB2DC2F042E5100EAA55A /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2DA2F042E5100EAA55A /* SettingsView.swift */; };
-		A1BFB2DF2F04328300EAA55A /* ImagePreviewMenuCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2DE2F04328300EAA55A /* ImagePreviewMenuCommands.swift */; };
-		A1BFB2E02F04328300EAA55A /* FocusedCommandButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2DD2F04328300EAA55A /* FocusedCommandButtons.swift */; };
-		A1BFB2E42F0439FE00EAA55A /* ImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2E32F0439FE00EAA55A /* ImportService.swift */; };
-		A1BFB2E72F043D2300EAA55A /* StorageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2E62F043D2300EAA55A /* StorageService.swift */; };
-		A1BFB2EB2F043F4500EAA55A /* ViewContexts.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2EA2F043F4500EAA55A /* ViewContexts.swift */; };
-		A1BFB2EC2F043F4500EAA55A /* FicheroDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2E92F043F4500EAA55A /* FicheroDocument.swift */; };
-		A1BFB2F02F043FA100EAA55A /* BackendConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2EF2F043FA100EAA55A /* BackendConnectionView.swift */; };
-		A1BFB2F32F045C8A00EAA55A /* LibraryImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB2F22F045C8A00EAA55A /* LibraryImageView.swift */; };
-		SKEL00012F045C8A00EAA55A /* SkeletonPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = SKEL00022F045C8A00EAA55A /* SkeletonPlaceholder.swift */; };
-		ANIM00012F045C8A00EAA55A /* FrameAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = ANIM00022F045C8A00EAA55A /* FrameAnimation.swift */; };
-		A1BFB4032F057B9300EAA55A /* QuickLookComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB3FF2F057B9300EAA55A /* QuickLookComponents.swift */; };
-		A1BFB4052F057B9300EAA55A /* FolderAccessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB3FB2F057B9300EAA55A /* FolderAccessManager.swift */; };
-		A1BFB4092F057BAC00EAA55A /* ViewMenuCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4082F057BAC00EAA55A /* ViewMenuCommands.swift */; };
-		A1BFB4502F0AABA600EAA55A /* ItemTypeRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB44E2F0AABA600EAA55A /* ItemTypeRegistry.swift */; };
-		A1BFB4532F0AABBC00EAA55A /* AddItemMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4522F0AABBC00EAA55A /* AddItemMenu.swift */; };
-		A1BFB4572F0AAC1E00EAA55A /* MiniToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4562F0AAC1E00EAA55A /* MiniToolbar.swift */; };
-		A1BFB45C2F0AAC3700EAA55A /* WorkflowToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB45B2F0AAC3700EAA55A /* WorkflowToolbar.swift */; };
-		A1BFB45E2F0AAC3700EAA55A /* ChatViewToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4582F0AAC3700EAA55A /* ChatViewToolbar.swift */; };
-		A1BFB4612F0AADC000EAA55A /* LayoutMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4602F0AADC000EAA55A /* LayoutMode.swift */; };
-		A1BFB4F22F30000100EAA55A /* MacPlainTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1BFB4F12F30000100EAA55A /* MacPlainTextEditor.swift */; };
-		A1D8BCE82F2CD054006D91D7 /* WorkflowPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D8BCE62F2CD054006D91D7 /* WorkflowPickerSheet.swift */; };
-		A1D8BCE92F2CD054006D91D7 /* DocumentPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1D8BCE52F2CD054006D91D7 /* DocumentPickerSheet.swift */; };
-		A1FB1D7B2F0420310023093C /* AIModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D792F0420310023093C /* AIModelCatalog.swift */; };
-		A1FB1D7D2F0420930023093C /* ChatInspector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D7C2F0420930023093C /* ChatInspector.swift */; };
-		A1FB1D812F0420A90023093C /* LibraryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D7F2F0420A90023093C /* LibraryView.swift */; };
-		A1FB1D9B2F0420D50023093C /* SidebarItemContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D952F0420D50023093C /* SidebarItemContextMenu.swift */; };
-		A1FB1D9C2F0420D50023093C /* SidebarItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D962F0420D50023093C /* SidebarItemRow.swift */; };
-		A1FB1D9D2F0420D50023093C /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D992F0420D50023093C /* SidebarView.swift */; };
-		A1FB1D9F2F0420D50023093C /* SidebarStateManagers.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D982F0420D50023093C /* SidebarStateManagers.swift */; };
-		A1FB1DA02F0420D50023093C /* SidebarViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D9A2F0420D50023093C /* SidebarViewExtensions.swift */; };
-		A1FB1DA12F0420D50023093C /* SidebarSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D972F0420D50023093C /* SidebarSectionHeader.swift */; };
-		A1FB1DA22F0420D50023093C /* SidebarConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1FB1D932F0420D50023093C /* SidebarConstants.swift */; };
-		A23260012F90000100000001 /* RemoteClientPairing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23260032F90000100000001 /* RemoteClientPairing.swift */; };
-		C0FFEE0000000000000000A2 /* PairingRestoreDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFEE0000000000000000A1 /* PairingRestoreDiagnostics.swift */; };
-		C0FFEE0000000000000000A3 /* PairingRestoreDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FFEE0000000000000000A1 /* PairingRestoreDiagnostics.swift */; };
-		A23260022F90000100000001 /* MacRemoteClientPairingSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23260042F90000100000001 /* MacRemoteClientPairingSection.swift */; };
-		A23530010000000000000001 /* MobileCaptureQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23530030000000000000003 /* MobileCaptureQueue.swift */; };
-		A23530020000000000000002 /* MobileCaptureQueueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A23530040000000000000004 /* MobileCaptureQueueView.swift */; };
-		A2B7F2520C79F1636F31681A /* PageContentPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = D32974474262617AAAE4A322 /* PageContentPane.swift */; };
-		A32C13985AC2C769740EF9B7 /* OntologyBrowser+Detail.swift in Sources */ = {isa = PBXBuildFile; fileRef = B60E9A8C3AD1B87728A4E3FB /* OntologyBrowser+Detail.swift */; };
-		A35052BDBE9CC694D88D322A /* ResearchChatPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38E23447A5C31CE397D337CC /* ResearchChatPane.swift */; };
-		A3C1803DF6559D5BFCC9935E /* ComparisonDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38753C6C4C3EECE670188B92 /* ComparisonDetailView.swift */; };
-		A48C3E366EB68F5DFBD38499 /* ThinkingModePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E8C3EFBCE91C295309468AB /* ThinkingModePicker.swift */; };
-		A6400FE26A8158543B1FD124 /* SplittablePane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D0B24DE95228CEA6B853324 /* SplittablePane.swift */; };
-		A78E883CED66AEE3DC11477B /* ClaimAttributionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B16AE4AAB56FEB5190D97239 /* ClaimAttributionView.swift */; };
-		A98A6F971E62F9DA640BCA54 /* ResearchWorkspaceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74B8B6B4FF52EDA955679CF0 /* ResearchWorkspaceView.swift */; };
-		AA10000000000000000031B0 /* LocalInferenceStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000000000000000031A0 /* LocalInferenceStore.swift */; };
-		FA00000000000000003677B0 /* KnownLibraryRegistryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA00000000000000003677A0 /* KnownLibraryRegistryStore.swift */; };
-		AA10000000000000000031B1 /* AppleAvailabilityStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000000000000000031A1 /* AppleAvailabilityStore.swift */; };
-		AA10000000000000000031B2 /* LocalInferenceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA10000000000000000031A2 /* LocalInferenceSettingsView.swift */; };
-		AA112233001122AA /* LibraryView+Sorting.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA112233001122BB /* LibraryView+Sorting.swift */; };
-		AA112233001122CC /* LibraryView+ColumnConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA112233001122DD /* LibraryView+ColumnConfig.swift */; };
-		AA112233001122EE /* LibraryView+FilterAndBatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA112233001122FF /* LibraryView+FilterAndBatch.swift */; };
-		AA1DB6B1BCD300BF5D523EF2 /* SpeakerComparisonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 034677F6AF68D5DCA5CB3E8C /* SpeakerComparisonView.swift */; };
-		AA214031892F4668F16A3E75 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0104EC0811F842CAC3CC887 /* GeneralSettingsView.swift */; };
-		AC989D334C6B0156C021AA09 /* ActionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12109CF3A70EB2ACA74B24D /* ActionStore.swift */; };
-		AD284E03A3377968AE568677 /* DocumentInspectorMetadataTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7B146AE8AC4CEEC3775CB94 /* DocumentInspectorMetadataTab.swift */; };
-		ADC61F9B335300BEA77F278C /* EntityDetailView+Audit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82E8622F0305ED125BEDB904 /* EntityDetailView+Audit.swift */; };
-		ADEE74E7CF17264BA16507C7 /* FicheroWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA64CFDF3C633C03CCE24A6 /* FicheroWebView.swift */; };
-		AF3C46E684A7D133B1BAA5D2 /* TriggerEditorFormPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0264B7B8616BA5159B2CEF1 /* TriggerEditorFormPanel.swift */; };
-		AF3C8529001F34ACB80A8D50 /* EntityDetailView+Notes.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD96D53320D07109835C90BF /* EntityDetailView+Notes.swift */; };
-		AF868ABDCF249BD2499197F3 /* ContentView+NavigationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43322F30A05232A97F8B3B87 /* ContentView+NavigationHistory.swift */; };
-		AUT00022F27F36000EC9EE1 /* AutomationServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = AUT00012F27F36000EC9EE1 /* AutomationServiceGenerated.swift */; };
-		B26A164F6D09131C95152691 /* SidebarView+UnifiedRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = 688ECE0FC82045A06149A5FA /* SidebarView+UnifiedRows.swift */; };
-		B2A0020100000000BATCH2S1 /* SidebarItemRow+Label.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010100000000BATCH2S1 /* SidebarItemRow+Label.swift */; };
-		B2A0020200000000BATCH2S2 /* SidebarItemRow+DropHandlers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010200000000BATCH2S2 /* SidebarItemRow+DropHandlers.swift */; };
-		B2A0020300000000BATCH2S3 /* SidebarItemRow+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010300000000BATCH2S3 /* SidebarItemRow+Helpers.swift */; };
-		B2A0020400000000BATCH2S4 /* SidebarItemRow+Rename.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010400000000BATCH2S4 /* SidebarItemRow+Rename.swift */; };
-		B2A0020500000000BATCH2W1 /* WorkflowEditor+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010500000000BATCH2W1 /* WorkflowEditor+Actions.swift */; };
-		B2A0020600000000BATCH2W2 /* WorkflowEditor+NodeViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010600000000BATCH2W2 /* WorkflowEditor+NodeViews.swift */; };
-		B2A0020700000000BATCH2W3 /* WorkflowEditor+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010700000000BATCH2W3 /* WorkflowEditor+Preview.swift */; };
-		B2A0020800000000BATCH2C1 /* ChainListContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010800000000BATCH2C1 /* ChainListContent.swift */; };
-		B2A0020900000000BATCH2C2 /* ChainListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010900000000BATCH2C2 /* ChainListRow.swift */; };
-		B2A0020A00000000BATCH2C3 /* ChainStepRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010A00000000BATCH2C3 /* ChainStepRow.swift */; };
-		B2A0020B00000000BATCH2C4 /* ChainDetailContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010B00000000BATCH2C4 /* ChainDetailContent.swift */; };
-		B2A0020C00000000BATCH2C5 /* ChainDetailSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010C00000000BATCH2C5 /* ChainDetailSheet.swift */; };
-		B2A0020D00000000BATCH2C6 /* NewChainSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2A0010D00000000BATCH2C6 /* NewChainSheet.swift */; };
-		B30013000000000000000001 /* FirstRunWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B30013000000000000000002 /* FirstRunWindow.swift */; };
-		B34DE9B78D69C7BC29AC56E9 /* ArtifactPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7785FFCD6AB43D36199856 /* ArtifactPanel.swift */; };
-		B3742CD0628CC8C97E4788E2 /* CanvasInteractionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1E16D1FB324019CBF50B37D /* CanvasInteractionController.swift */; };
-		B384820C8A9FEDA2B98FA1B0 /* MiniToolbarOverflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F420C7687D317EE817591121 /* MiniToolbarOverflow.swift */; };
-		B3A002010000000000BATCH3 /* ProvidersView+ModelTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001010000000000BATCH3 /* ProvidersView+ModelTypes.swift */; };
-		B3A002020000000000BATCH3 /* ProvidersView+ProviderDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001020000000000BATCH3 /* ProvidersView+ProviderDetailView.swift */; };
-		B3A002030000000000BATCH3 /* ProvidersView+ProviderSettingsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001030000000000BATCH3 /* ProvidersView+ProviderSettingsRow.swift */; };
-		B3A002040000000000BATCH3 /* ChatInspector+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001040000000000BATCH3 /* ChatInspector+Actions.swift */; };
-		B3A002050000000000BATCH3 /* ChatInspector+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001050000000000BATCH3 /* ChatInspector+Header.swift */; };
-		B3A002060000000000BATCH3 /* ChatInspector+ScopedDocuments.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001060000000000BATCH3 /* ChatInspector+ScopedDocuments.swift */; };
-		B3A002070000000000BATCH3 /* ChatInspector+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001070000000000BATCH3 /* ChatInspector+Search.swift */; };
-		B3A002080000000000BATCH3 /* ActivityDataProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A001080000000000BATCH3 /* ActivityDataProcessing.swift */; };
-		B47244FDC35E7D8B8EAA65AB /* FicheroShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68C8C5672F78A996924D42D1 /* FicheroShortcuts.swift */; };
-		B4A002010000000000BATCH4 /* ModelComparisonView+Sidebar.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A001010000000000BATCH4 /* ModelComparisonView+Sidebar.swift */; };
-		B4A002020000000000BATCH4 /* ComparisonResultView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A001020000000000BATCH4 /* ComparisonResultView.swift */; };
-		B4A002030000000000BATCH4 /* ModelResultCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A001030000000000BATCH4 /* ModelResultCard.swift */; };
-		B4A002040000000000BATCH4 /* ModelPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A001040000000000BATCH4 /* ModelPickerSheet.swift */; };
-		B4A002050000000000BATCH4 /* PresetPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A001050000000000BATCH4 /* PresetPickerSheet.swift */; };
-		B4A0020B0000000000BATCH4 /* DynamicConfigView+FieldRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A0010B0000000000BATCH4 /* DynamicConfigView+FieldRendering.swift */; };
-		B4A0020C0000000000BATCH4 /* DynamicConfigView+SchemaHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A0010C0000000000BATCH4 /* DynamicConfigView+SchemaHelpers.swift */; };
-		B4A0020D0000000000BATCH4 /* DynamicConfigView+StateManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A0010D0000000000BATCH4 /* DynamicConfigView+StateManagement.swift */; };
-		B4F1A71E768A776F8AFB3E3A /* CanvasModifierTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC1CAB23253BF2D09F02A66D /* CanvasModifierTracker.swift */; };
-		B5A0020400000000BATCH5W1 /* WorkflowOutputLog+Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A0010400000000BATCH5W1 /* WorkflowOutputLog+Models.swift */; };
-		B5A0020500000000BATCH5W2 /* WorkflowOutputLog+StatusViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A0010500000000BATCH5W2 /* WorkflowOutputLog+StatusViews.swift */; };
-		B5A0020600000000BATCH5W3 /* WorkflowOutputLog+ErrorCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A0010600000000BATCH5W3 /* WorkflowOutputLog+ErrorCell.swift */; };
-		B5A0020700000000BATCH5W4 /* WorkflowOutputLog+EmptyStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A0010700000000BATCH5W4 /* WorkflowOutputLog+EmptyStates.swift */; };
-		B5A0020800000000BATCH5S1 /* ScheduleEditorView+Category.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A0010800000000BATCH5S1 /* ScheduleEditorView+Category.swift */; };
-		B5B3CB0BD14A95E9D7172810 /* OntologyBrowser+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = 376E2EE5F22D7B7127D9CB2A /* OntologyBrowser+List.swift */; };
-		B6A0020100000000BATCH6C1 /* ComparisonDetailView+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010100000000BATCH6C1 /* ComparisonDetailView+Actions.swift */; };
-		B6A0020200000000BATCH6C2 /* ComparisonDetailView+Models.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010200000000BATCH6C2 /* ComparisonDetailView+Models.swift */; };
-		B6A0020300000000BATCH6C3 /* ComparisonDetailView+Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010300000000BATCH6C3 /* ComparisonDetailView+Sections.swift */; };
-		B6A0020500000000BATCH6S2 /* SidebarView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010500000000BATCH6S2 /* SidebarView+Helpers.swift */; };
-		B6A0020600000000BATCH6S3 /* SidebarView+SelectionHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010600000000BATCH6S3 /* SidebarView+SelectionHandling.swift */; };
-		B6A0020700000000BATCH6S4 /* SidebarView+ViewComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010700000000BATCH6S4 /* SidebarView+ViewComponents.swift */; };
-		B6A0020800000000BATCH6A1 /* AddProviderSheet+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010800000000BATCH6A1 /* AddProviderSheet+Helpers.swift */; };
-		B6A0020900000000BATCH6A2 /* AddProviderSheet+Step1.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010900000000BATCH6A2 /* AddProviderSheet+Step1.swift */; };
-		B6A0020A00000000BATCH6A3 /* AddProviderSheet+Step2.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010A00000000BATCH6A3 /* AddProviderSheet+Step2.swift */; };
-		B6A0020B00000000BATCH6A4 /* AddProviderSheet+Step3.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A0010B00000000BATCH6A4 /* AddProviderSheet+Step3.swift */; };
-		B7586390552367B89CFC2E9D /* DocumentInspectorArtifactsTab+EntityKindBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A697CECBDA1A7EF050BF765 /* DocumentInspectorArtifactsTab+EntityKindBlock.swift */; };
-		B82F169352D7D0876DE0FCF9 /* EntityDetailView+Sections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C0044833E201FFB8B8A5B37 /* EntityDetailView+Sections.swift */; };
-		B8CED5AA645840B7AC1696DD /* WindowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E04EE1958EB4E23A7E1E328 /* WindowState.swift */; };
-		B9D568CD0AD338467B063C47 /* ArtifactStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC331F7BFE50CEECD3B4414 /* ArtifactStore.swift */; };
-		B9D683849EE15602A86CC385 /* AccessError.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE34A7C933EA9305CAAA50FA /* AccessError.swift */; };
-		BA24BF71010589D1597B9025 /* BackendSettingsRemoteAccessSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70599D1C032FF0B54C7C18A2 /* BackendSettingsRemoteAccessSection.swift */; };
-		BB3C5B993DECE6FA5931CEAD /* QuickLookPreviewViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAAFE05184A40A50ADFC54A9 /* QuickLookPreviewViews.swift */; };
-		BE7EB837BA99FD18B310B6A2 /* DocumentInspectorInfoTab+Bibliography.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01276A4ABA0F672CF1D8067 /* DocumentInspectorInfoTab+Bibliography.swift */; };
-		BFC56BC755C4B7C58EEAE341 /* LibraryManager+Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF91C082286A2B7BB74E438D /* LibraryManager+Persistence.swift */; };
-		C10000010000000000000001 /* SparkleUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000110000000000000001 /* SparkleUpdater.swift */; };
-		C10000010000000000000002 /* AppInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000110000000000000002 /* AppInstaller.swift */; };
-		C10000020000000000000001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; platformFilters = (macos, ); productRef = C10000310000000000000001 /* Sparkle */; };
-		C1C484907B28189E223436BE /* LibraryManager+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE5EBB51D90DE16D32A82FC /* LibraryManager+Helpers.swift */; };
-		C340001000000000PROMPT01 /* PromptPreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C340001100000000PROMPT01 /* PromptPreviewPanel.swift */; };
-		C37B1043409A6ED500E30F29 /* BackupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91100495C9D776E200E2F9C0 /* BackupsView.swift */; };
-		C38F232612EE4EEB87E62A76 /* FicheroAppEntities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FFFFE4A294ADC2F1299E2D /* FicheroAppEntities.swift */; };
-		C559CD1D045F9710AD81C44E /* CollectionWorkspaceStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C9BD4E928F0D32E6EABBA7 /* CollectionWorkspaceStub.swift */; };
-		C5B7DEB948261159D439C454 /* DocumentNotesTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = B00A8552DEACF83751D617C6 /* DocumentNotesTab.swift */; };
-		C835851846598745D40790B6 /* EntityDetailView+FilterChips.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18BA434B3CB3A8C31139293 /* EntityDetailView+FilterChips.swift */; };
-		C866DE6CD23ED6AF11B48FF0 /* DocumentStore+ChangeStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D040114E6D969FD49C8317E /* DocumentStore+ChangeStream.swift */; };
-		C8B0CB90BD1E1AFBFFF80F5A /* ContentViewHelperViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1D6A52184F57ACFC6926FBB /* ContentViewHelperViews.swift */; };
-		C8C6F3D22AFD4A309FA11A3C /* SpaceTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 626E23DB6F8B778F70AF3B35 /* SpaceTheme.swift */; };
-		C96A47B8A003AF3A6FC98CF8 /* AISettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C07B489C8F89204C43BD6E46 /* AISettingsView.swift */; };
-		CA00000000000000000000B1 /* CanvasLayoutStore+ChangeStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA00000000000000000000A1 /* CanvasLayoutStore+ChangeStream.swift */; };
-		CA00000000000000000000B2 /* CanvasItemStore+ChangeStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA00000000000000000000A2 /* CanvasItemStore+ChangeStream.swift */; };
-		CA2079FADD45BDDD971FB694 /* Canvas2DProjection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24F68955CC563FF070D02897 /* Canvas2DProjection.swift */; };
-		CBBBE21102B26A79DF02811E /* ChangeStreamTransport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F3A4A14186A5886AC932517 /* ChangeStreamTransport.swift */; };
-		CC357CD884EE29BAE8A64F4B /* PlatformPasteboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772A6A57C4986C2765A174EE /* PlatformPasteboard.swift */; };
-		CC8B35B398A7393E4D687941 /* BookmarkServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3133E93619FB262825F4F55 /* BookmarkServiceGenerated.swift */; };
-		CC92A0172BBECF22F2332F4B /* DocumentTextReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C127C3CD9D352C283597AB /* DocumentTextReader.swift */; };
-		CFC9C70DBE40510A012E46EE /* WorkflowExecutionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 669F81AC0106B415218C419D /* WorkflowExecutionStore.swift */; };
-		D0D540A3F924325236C1E440 /* DocumentInspectorArtifactsTab+Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FDDBCA3101A6E468A3105D2 /* DocumentInspectorArtifactsTab+Shared.swift */; };
-		D2A64087B8C786EE95E842A5 /* LocalModelsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4F4939BDACA726554E086D /* LocalModelsSettingsView.swift */; };
-		D584DA0264AC18C07D78233A /* KGFocusState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82A9BAC0F995F9199F94B69 /* KGFocusState.swift */; };
-		D72388A90102AB0902C995E4 /* SidebarView+LibraryHeaderHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6931274044832BD7EFE8A4D3 /* SidebarView+LibraryHeaderHelpers.swift */; };
-		D80C598CBAB2817738ECF0CB /* ChatDocumentDropPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = BCB24ED93772AA96CF319D4B /* ChatDocumentDropPayload.swift */; };
-		D9D582D305FA54570A7F6093 /* UITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 397DBEE7CB99C18C680AB85E /* UITestSupport.swift */; };
-		DA49843739ACA26F5AD0759C /* AISettingsView+Tabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4189C51250E0B39E05CD87B /* AISettingsView+Tabs.swift */; };
-		DA731A1441637DFFBE146AD4 /* EntityDetailView+Claims.swift in Sources */ = {isa = PBXBuildFile; fileRef = A99ACF7102EB736967DDAE57 /* EntityDetailView+Claims.swift */; };
-		DA736D4429C7945E0C30216E /* DocumentInspectorInfoTab+Sharing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37003B253D97CBE012D3A811 /* DocumentInspectorInfoTab+Sharing.swift */; };
-		DA7BED2393CD7FD13C5521D1 /* ImmersiveReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7E92E864B4AF4383634E221 /* ImmersiveReaderView.swift */; };
-		DAF7008910EF661F7ED718CC /* SearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE609F48196839FAA6981CFF /* SearchStore.swift */; };
-		DC1FCDEE6B31AEA018C6F0DA /* ArtifactsInspectorPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C36D41D71387394E6AEB453 /* ArtifactsInspectorPane.swift */; };
-		DCC4D9C15886A018CBA1AA2E /* FocusedNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B20829DBAC5757AEA6096835 /* FocusedNote.swift */; };
-		DCFC0B2C370966F9B57072A2 /* EntityMergeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EB5DE35F2956544D2771C85 /* EntityMergeSheet.swift */; };
-		FEEDDEAD0000000000000004 /* EntityReconciliationSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEDDEAD0000000000000003 /* EntityReconciliationSheet.swift */; };
-		DD1C07E557CD9392EF3C3BC5 /* PDFThumbnailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29C59C2205AA2F446083A9C9 /* PDFThumbnailView.swift */; };
-		5A1F3C88D4E27B0196AB3301 /* ReadingPaneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A1F3C88D4E27B0196AB3302 /* ReadingPaneView.swift */; };
-		DDE8A1E95DE61B0723A40BC9 /* DynamicConfigView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04DA25B2C1FBB75B0B1CC643 /* DynamicConfigView.swift */; };
-		E03D3AB8185C98A43134F6EF /* DocumentInspectorInfoTab+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35793BBA8A74DAA0982CCFA4 /* DocumentInspectorInfoTab+Header.swift */; };
-		E16CECCFD4B4BCE53B2FEC36 /* KGTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF77122ADD78F941D7F1968D /* KGTimelineView.swift */; };
-		E2B03B964149B8CDE9958E69 /* ImportServiceGenerated+Upload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44352F043915E2760BB0DD30 /* ImportServiceGenerated+Upload.swift */; };
-		E38C6073276421EC63C789B7 /* SidebarItemRow+Workflow.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2FF71320EAE8FE11653EB06 /* SidebarItemRow+Workflow.swift */; };
-		E6E64CE83B1FF1235DCFDF80 /* ScheduleDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BEAA9442D4996FBD92BC7F /* ScheduleDetailView.swift */; };
-		E75A45471E6698C1C2812BA6 /* DocumentInspectorInfoTab+Citations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08C74251DECC247DF8B5A816 /* DocumentInspectorInfoTab+Citations.swift */; };
-		E8DB4DEABBD7388DB33D81DA /* DocumentInspectorInfoTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD03402A88F98251F388870F /* DocumentInspectorInfoTab.swift */; };
-		E9DCE0BB3E64AD1549E6F117 /* LibraryChangeStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28B629229088E72B485569FC /* LibraryChangeStream.swift */; };
-		EA5A4BBFC0797C7403FB49B3 /* LibraryView+TableMapViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92773EAEE52587BBA8DEDC9F /* LibraryView+TableMapViews.swift */; };
-		EB1E1BBC3C6557291CA96D4B /* AdaptiveAppleShellHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5AFDD1AF51EC0A0BA0C061E /* AdaptiveAppleShellHost.swift */; };
-		EBA0B270972261795158D09B /* CaptureSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAF964748FC3450263DCB1D1 /* CaptureSettingsView.swift */; };
-		EBE6623631BD8E10280B09F8 /* DocumentInspectorArtifactsTab+KGModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = F23C597BA2DF9A27BE94F609 /* DocumentInspectorArtifactsTab+KGModels.swift */; };
-		EC4998990D9C5947B11A1E57 /* AnnotationListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39C6E9911CCE3E7F0C92E672 /* AnnotationListView.swift */; };
-		ECC8E5CB193E9BC5CE2E8294 /* SidebarItemRow+Drop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588D0F19667B99B2AA69A1A3 /* SidebarItemRow+Drop.swift */; };
-		EEE878CB5349F5D321517F55 /* ContentView+WorkflowActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 923BD592D3257176C51CAC1C /* ContentView+WorkflowActions.swift */; };
-		EF8A33F9696257468DB2325C /* ArtifactListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A63F3EB72383ED2E5BA85C0E /* ArtifactListView.swift */; };
-		EF9F8C04CD7D1BFE3514BF42 /* WorkflowSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D280D880BB4526630C8CB3 /* WorkflowSync.swift */; };
-		EFD8B28CC600C4E64EF3EA90 /* DeviceTokenRenewal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 110C8D9D75D6823D7B1EF43D /* DeviceTokenRenewal.swift */; };
-		F005FD31F4EE988533A672D9 /* Spatial2DCanvasGestures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC44420C3D37275174DF38F /* Spatial2DCanvasGestures.swift */; };
-		F023AC196079761CD2CF8E7A /* ActivityMonitorWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 811A6E6F398CBE8A81AEB7CE /* ActivityMonitorWindow.swift */; };
-		F0B74209906E1D1F5A904335 /* NodeClassPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D11FC06A71EAC1E8C4F6897 /* NodeClassPicker.swift */; };
-		F23CD14AC5C36398DB6CCC74 /* ImageEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8EFF7D9BC634BAE18E0F47 /* ImageEditorView.swift */; };
-		F248EE1CA83C5FFF604EF4CE /* SpatialModels+Links.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C0909F7C7B21871D35EB5C /* SpatialModels+Links.swift */; };
-		F272CFE1FADD5F15F71CFC23 /* ImageMarqueeOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72D05E0BE3C8D1AEA1AA3A8D /* ImageMarqueeOverlay.swift */; };
-		F2A340AB9853DC0671499E68 /* DocumentInspectorArtifactsTab+CurationHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F259EE92E81B78CBE35C9947 /* DocumentInspectorArtifactsTab+CurationHistory.swift */; };
-		F32122ACDAC4211F72C2658F /* InspectorTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = F447E424F3A26C138C9BB99D /* InspectorTab.swift */; };
-		F5924EAC2877F93A6178107C /* HeuristicReviewSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DEAE79F9381616EC474F4ED /* HeuristicReviewSheet.swift */; };
-		FB55B6D23D3573E8E04CCD50 /* UsersSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD5D9E12155EC0A6E738B878 /* UsersSettingsView.swift */; };
-		FBC6479F61CDE8E911D6BDBB /* NoteDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD4DC8D0E00D06ECFFEA224 /* NoteDetailView.swift */; };
-		FC38FF82492B7D35C486CF71 /* EditClaimSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C61D10AF212650451E8C13B /* EditClaimSheet.swift */; };
-		FC3F95AC0E1F4A7DB6B9993E /* FeatureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B27E2AF4EC43E993C19836 /* FeatureManager.swift */; };
-		FC3F95AD0E1F4A7DB6B9993F /* FeatureTiers.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B27E2BF4EC43E993C19837 /* FeatureTiers.generated.swift */; };
-		FCBC65A5D3BC1141E6FD9695 /* WorkflowRunProviderCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 506C34038F8A349C075DFBAC /* WorkflowRunProviderCache.swift */; };
-		FEEDCE2D38A6FE7E36FEC8A0 /* NavigationHistoryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63B044A60D5A8C7BA256FF24 /* NavigationHistoryManager.swift */; };
 		FFFD70EE79C8E08FE96F845D /* CitationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 878755044A42658CBFF9036E /* CitationStore.swift */; };
 		GTE2 /* GeneratedTypeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = GTE1 /* GeneratedTypeExtensions.swift */; };
 		IMP00012F27F36000EC9EE1 /* ImportServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = IMP00022F27F36000EC9EE1 /* ImportServiceGenerated.swift */; };
+		LIVE00012F27F36000EC9EE1 /* LiveEditPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = LIVE00022F27F36000EC9EE1 /* LiveEditPreview.swift */; };
+		LOC00012F27F36000EC9EE1 /* LocationServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */; };
+		MEDIA0012F69F06267FA6CCD /* MediaStreamPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = MEDIA0022F69F06267FA6CCD /* MediaStreamPreview.swift */; };
 		MOD00012F27F36000EC9EE1 /* ModelServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = MOD00022F27F36000EC9EE1 /* ModelServiceGenerated.swift */; };
+		PDFC00012F27F36000EC9EE1 /* PDFDocumentCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = PDFC00022F27F36000EC9EE1 /* PDFDocumentCache.swift */; };
+		PRDL00012F27F36000EC9EE1 /* PreviewDownloadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = PRDL00022F27F36000EC9EE1 /* PreviewDownloadService.swift */; };
+		SBX00012F27F36000EC9EE1 /* SandboxAccessServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = SBX00022F27F36000EC9EE1 /* SandboxAccessServiceGenerated.swift */; };
+		SBX00032F27F36000EC9EE1 /* SandboxAccessServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = SBX00022F27F36000EC9EE1 /* SandboxAccessServiceGenerated.swift */; };
+		SKEL00012F045C8A00EAA55A /* SkeletonPlaceholder.swift in Sources */ = {isa = PBXBuildFile; fileRef = SKEL00022F045C8A00EAA55A /* SkeletonPlaceholder.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1216,14 +1218,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		FEED00000000000000000254 = {
+		A1624FF62F2EE5710019C019 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			dstPath = "";
 			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 1;
 		};
-		A1624FF62F2EE5710019C019 /* CopyFiles */ = {
+		FEED00000000000000000254 /* CopyFiles */ = {
 			isa = PBXCopyFilesBuildPhase;
 			dstPath = "";
 			files = (
@@ -1233,7 +1235,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		FEED00000000000000000260 /* Fichero.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fichero.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		003E584BBE51001B1E3F6843 /* ForceDirectedGraphView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ForceDirectedGraphView.swift; sourceTree = "<group>"; };
 		00EC894548A8DBFA37D41557 /* SourceSnippet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SourceSnippet.swift; sourceTree = "<group>"; };
 		015D191B1A9A578C0A4BC6BA /* iOSLibraryPickerMenu.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = iOSLibraryPickerMenu.swift; sourceTree = "<group>"; };
@@ -1247,9 +1248,6 @@
 		09D8F04A6421AEC5B5370E92 /* CanvasDropOutcome.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CanvasDropOutcome.swift; sourceTree = "<group>"; };
 		0A4F63C0FA3C779A6BA5B655 /* EngineSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EngineSettingsView.swift; sourceTree = "<group>"; };
 		0B118FE1DE4F78C0EE238539 /* EntityStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityStore.swift; sourceTree = "<group>"; };
-		FEEDDEAD0000000000000009 /* BatchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BatchStore.swift; path = fichero/Models/BatchStore.swift; sourceTree = SOURCE_ROOT; };
-		FEEDDEAD000000000000000B /* BatchRunView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BatchRunView.swift; path = fichero/Views/Workflow/BatchRunView.swift; sourceTree = SOURCE_ROOT; };
-		FEEDDEAD0000000000000007 /* WorkspaceStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
 		0BE6CF3DE02E1F999AE8F1A9 /* SidebarItemRow+Presentation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SidebarItemRow+Presentation.swift"; sourceTree = "<group>"; };
 		0EBBA30F68AE440FAF4DC1E4 /* SpatialView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpatialView.swift; sourceTree = "<group>"; };
 		0F11A721FF01A4F5A66A4568 /* EntityRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityRowView.swift; sourceTree = "<group>"; };
@@ -1305,7 +1303,6 @@
 		1F4F4939BDACA726554E086D /* LocalModelsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = LocalModelsSettingsView.swift; path = fichero/Views/Settings/LocalModelsSettingsView.swift; sourceTree = SOURCE_ROOT; };
 		200BCF2B2F3D501800D7851A /* ContentView+State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+State.swift"; sourceTree = "<group>"; };
 		200BCF352F3D547F00D7851A /* ContentView+ViewBuilders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+ViewBuilders.swift"; sourceTree = "<group>"; };
-		6B2E4D99C5F38A0297BC4402 /* ContentView+Toolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+Toolbar.swift"; sourceTree = "<group>"; };
 		200BCF372F3D548000D7851A /* ContentView+Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+Persistence.swift"; sourceTree = "<group>"; };
 		200BCF392F3D548000D7851A /* ContentView+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+Navigation.swift"; sourceTree = "<group>"; };
 		200BCF3B2F3D548000D7851A /* ContentView+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+Actions.swift"; sourceTree = "<group>"; };
@@ -1401,7 +1398,6 @@
 		28B629229088E72B485569FC /* LibraryChangeStream.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LibraryChangeStream.swift; sourceTree = "<group>"; };
 		29941DE439073B7364322ECF /* FicheroApp_iOS.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FicheroApp_iOS.swift; sourceTree = "<group>"; };
 		29C59C2205AA2F446083A9C9 /* PDFThumbnailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFThumbnailView.swift; sourceTree = "<group>"; };
-		5A1F3C88D4E27B0196AB3302 /* ReadingPaneView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReadingPaneView.swift; sourceTree = "<group>"; };
 		2B320C62BB61F14256AECCF5 /* SpatialModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpatialModels.swift; sourceTree = "<group>"; };
 		2B7A8D1A3FCF024827D89665 /* CanvasScene3DRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CanvasScene3DRenderer.swift; sourceTree = "<group>"; };
 		2B9987CAE57F0DD5387F6DD2 /* OntologyBrowser+Sheets.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "OntologyBrowser+Sheets.swift"; sourceTree = "<group>"; };
@@ -1411,7 +1407,6 @@
 		300A8405FFC476E5124372AE /* APIClient+Types.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "APIClient+Types.swift"; sourceTree = "<group>"; };
 		3080C713216B7BBD39725487 /* ScrollWheelZoom.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScrollWheelZoom.swift; sourceTree = "<group>"; };
 		312845068CA928DA393E0468 /* DocumentInspectorArtifactsTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DocumentInspectorArtifactsTab.swift; path = fichero/Views/Library/DocumentInspector/DocumentInspectorArtifactsTab.swift; sourceTree = SOURCE_ROOT; };
-		FEEDDEAD0000000000000005 /* SurfaceTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SurfaceTabBar.swift; path = fichero/Views/SurfaceChrome/SurfaceTabBar.swift; sourceTree = SOURCE_ROOT; };
 		322ECCB87D28069C9539D009 /* FocusedAnnotation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FocusedAnnotation.swift; sourceTree = "<group>"; };
 		32F310DFF84C9557A77D4FDA /* NodePopover+Comparison.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "NodePopover+Comparison.swift"; sourceTree = "<group>"; };
 		35793BBA8A74DAA0982CCFA4 /* DocumentInspectorInfoTab+Header.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentInspectorInfoTab+Header.swift"; sourceTree = "<group>"; };
@@ -1470,6 +1465,7 @@
 		588D0F19667B99B2AA69A1A3 /* SidebarItemRow+Drop.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SidebarItemRow+Drop.swift"; sourceTree = "<group>"; };
 		5921F26A97AF84B80B4DCD29 /* CanvasItemStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CanvasItemStore.swift; sourceTree = "<group>"; };
 		599CF5FBD9D2B619B9353BC7 /* SpeakerComparisonView+Preview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SpeakerComparisonView+Preview.swift"; sourceTree = "<group>"; };
+		5A1F3C88D4E27B0196AB3302 /* ReadingPaneView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReadingPaneView.swift; sourceTree = "<group>"; };
 		5B0DFC89B8C073DBEE0A743F /* SidebarView+PinnedNavigationRows.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SidebarView+PinnedNavigationRows.swift"; sourceTree = "<group>"; };
 		5BAA47F1959AD79AA6C2E3EF /* TriggerEditorPreviewPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = TriggerEditorPreviewPanel.swift; path = fichero/Views/Automation/TriggerEditorView/TriggerEditorPreviewPanel.swift; sourceTree = SOURCE_ROOT; };
 		5C36D41D71387394E6AEB453 /* ArtifactsInspectorPane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArtifactsInspectorPane.swift; sourceTree = "<group>"; };
@@ -1491,6 +1487,7 @@
 		68BDC2DC273F8F91B9CA1B3C /* PlatformAliases.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlatformAliases.swift; sourceTree = "<group>"; };
 		68C8C5672F78A996924D42D1 /* FicheroShortcuts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FicheroShortcuts.swift; sourceTree = "<group>"; };
 		6931274044832BD7EFE8A4D3 /* SidebarView+LibraryHeaderHelpers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SidebarView+LibraryHeaderHelpers.swift"; sourceTree = "<group>"; };
+		6B2E4D99C5F38A0297BC4402 /* ContentView+Toolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+Toolbar.swift"; sourceTree = "<group>"; };
 		6C0044833E201FFB8B8A5B37 /* EntityDetailView+Sections.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "EntityDetailView+Sections.swift"; sourceTree = "<group>"; };
 		6D4DEA1D7E10749DA258D26F /* AnnotationHighlight.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnnotationHighlight.swift; sourceTree = "<group>"; };
 		6DA5F6DA59D0A499D28F3C75 /* ArtifactDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArtifactDetailView.swift; sourceTree = "<group>"; };
@@ -1507,19 +1504,18 @@
 		74ECCAE0282E67AA4A150871 /* CoalescingSaveRunner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CoalescingSaveRunner.swift; sourceTree = "<group>"; };
 		75371C597B1E4689B6E1803F /* TriggerEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TriggerEditorView.swift; sourceTree = "<group>"; };
 		753C4D174F9A42A6593BECC6 /* PageImageGrid.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PageImageGrid.swift; sourceTree = "<group>"; };
-		FEEDDEAD0000000000000001 /* ReaderTabBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReaderTabBar.swift; sourceTree = "<group>"; };
 		75558D1F0B1D0F65CEFF577C /* PDFReadingView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFReadingView.swift; sourceTree = "<group>"; };
 		772A6A57C4986C2765A174EE /* PlatformPasteboard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PlatformPasteboard.swift; sourceTree = "<group>"; };
 		79192DB989A34D1DBEEF3E34 /* CitationExportButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CitationExportButton.swift; sourceTree = "<group>"; };
 		7A5517E790C3AF9853989225 /* LibraryWorkspaceRoot.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LibraryWorkspaceRoot.swift; sourceTree = "<group>"; };
 		7AA64CFDF3C633C03CCE24A6 /* FicheroWebView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FicheroWebView.swift; sourceTree = "<group>"; };
 		7B5ACEA3F5BC4462B7B18AA7 /* ScheduleEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleEditorView.swift; sourceTree = "<group>"; };
+		7C3A91E4B2D14F0A9E5C1A71 /* KGQueryStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KGQueryStore.swift; sourceTree = "<group>"; };
 		7D040114E6D969FD49C8317E /* DocumentStore+ChangeStream.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentStore+ChangeStream.swift"; sourceTree = "<group>"; };
 		7F3FE2F360EADE051A3D2D51 /* EntitySplitSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntitySplitSheet.swift; sourceTree = "<group>"; };
 		7FDDBCA3101A6E468A3105D2 /* DocumentInspectorArtifactsTab+Shared.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentInspectorArtifactsTab+Shared.swift"; sourceTree = "<group>"; };
 		80920949B39DD526745B0BF2 /* CanvasDetailTier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CanvasDetailTier.swift; sourceTree = "<group>"; };
 		80E4C1042F69F06267FA6CCD /* DocumentCanvas.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DocumentCanvas.swift; sourceTree = "<group>"; };
-		MEDIA0022F69F06267FA6CCD /* MediaStreamPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MediaStreamPreview.swift; sourceTree = "<group>"; };
 		811A6E6F398CBE8A81AEB7CE /* ActivityMonitorWindow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityMonitorWindow.swift; sourceTree = "<group>"; };
 		82E8622F0305ED125BEDB904 /* EntityDetailView+Audit.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "EntityDetailView+Audit.swift"; sourceTree = "<group>"; };
 		849CA4F172401769E6140F13 /* OntologyBrowser+Toolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "OntologyBrowser+Toolbar.swift"; sourceTree = "<group>"; };
@@ -1533,7 +1529,6 @@
 		8C31EBD6243D124565257708 /* EngineConfig.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EngineConfig.swift; sourceTree = "<group>"; };
 		8C61D10AF212650451E8C13B /* EditClaimSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EditClaimSheet.swift; sourceTree = "<group>"; };
 		8EB5DE35F2956544D2771C85 /* EntityMergeSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityMergeSheet.swift; sourceTree = "<group>"; };
-		FEEDDEAD0000000000000003 /* EntityReconciliationSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityReconciliationSheet.swift; sourceTree = "<group>"; };
 		8F9C3B5A53041FFAA09E0221 /* CitationsInspectorPane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CitationsInspectorPane.swift; sourceTree = "<group>"; };
 		902DF4705DA9730D76AF2C06 /* PDFPageWithToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PDFPageWithToolbar.swift; sourceTree = "<group>"; };
 		9037096857E2AE5F3339A8DC /* DocumentInspectorInfoTab+Workflow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentInspectorInfoTab+Workflow.swift"; sourceTree = "<group>"; };
@@ -1565,10 +1560,6 @@
 		A13E7C2C2F27E17F00EC9EE1 /* ProviderServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderServiceGenerated.swift; sourceTree = "<group>"; };
 		A13E7C2D2F27E17F00EC9EE1 /* SearchServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchServiceGenerated.swift; sourceTree = "<group>"; };
 		A13E7C392F27F36000EC9EE1 /* ActivityServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityServiceGenerated.swift; sourceTree = "<group>"; };
-		SBX00022F27F36000EC9EE1 /* SandboxAccessServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxAccessServiceGenerated.swift; sourceTree = "<group>"; };
-		LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServiceGenerated.swift; sourceTree = "<group>"; };
-		PDFC00022F27F36000EC9EE1 /* PDFDocumentCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFDocumentCache.swift; sourceTree = "<group>"; };
-		PRDL00022F27F36000EC9EE1 /* PreviewDownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDownloadService.swift; sourceTree = "<group>"; };
 		A13E7C3B2F27F36000EC9EE1 /* ActivityTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTypes.swift; sourceTree = "<group>"; };
 		A13E7C3C2F280BE900EC9EE1 /* ActivityConsoleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityConsoleView.swift; sourceTree = "<group>"; };
 		A13E7C3E2F27F36000EC9EE1 /* ActivityStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStreamService.swift; sourceTree = "<group>"; };
@@ -1637,8 +1628,6 @@
 		A1BFB2EA2F043F4500EAA55A /* ViewContexts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewContexts.swift; sourceTree = "<group>"; };
 		A1BFB2EF2F043FA100EAA55A /* BackendConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendConnectionView.swift; sourceTree = "<group>"; };
 		A1BFB2F22F045C8A00EAA55A /* LibraryImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibraryImageView.swift; sourceTree = "<group>"; };
-		SKEL00022F045C8A00EAA55A /* SkeletonPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonPlaceholder.swift; sourceTree = "<group>"; };
-		ANIM00022F045C8A00EAA55A /* FrameAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameAnimation.swift; sourceTree = "<group>"; };
 		A1BFB3FB2F057B9300EAA55A /* FolderAccessManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderAccessManager.swift; sourceTree = "<group>"; };
 		A1BFB3FF2F057B9300EAA55A /* QuickLookComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLookComponents.swift; sourceTree = "<group>"; };
 		A1BFB4082F057BAC00EAA55A /* ViewMenuCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewMenuCommands.swift; sourceTree = "<group>"; };
@@ -1663,7 +1652,6 @@
 		A1FB1D992F0420D50023093C /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		A1FB1D9A2F0420D50023093C /* SidebarViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewExtensions.swift; sourceTree = "<group>"; };
 		A23260032F90000100000001 /* RemoteClientPairing.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RemoteClientPairing.swift; sourceTree = "<group>"; };
-		C0FFEE0000000000000000A1 /* PairingRestoreDiagnostics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PairingRestoreDiagnostics.swift; sourceTree = "<group>"; };
 		A23260042F90000100000001 /* MacRemoteClientPairingSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacRemoteClientPairingSection.swift; sourceTree = "<group>"; };
 		A23530030000000000000003 /* MobileCaptureQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileCaptureQueue.swift; sourceTree = "<group>"; };
 		A23530040000000000000004 /* MobileCaptureQueueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileCaptureQueueView.swift; sourceTree = "<group>"; };
@@ -1679,7 +1667,6 @@
 		A8B0073490980740B06C80D7 /* EntitySourceGroupsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntitySourceGroupsView.swift; sourceTree = "<group>"; };
 		A99ACF7102EB736967DDAE57 /* EntityDetailView+Claims.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "EntityDetailView+Claims.swift"; sourceTree = "<group>"; };
 		AA10000000000000000031A0 /* LocalInferenceStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalInferenceStore.swift; sourceTree = "<group>"; };
-		FA00000000000000003677A0 /* KnownLibraryRegistryStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KnownLibraryRegistryStore.swift; sourceTree = "<group>"; };
 		AA10000000000000000031A1 /* AppleAvailabilityStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppleAvailabilityStore.swift; sourceTree = "<group>"; };
 		AA10000000000000000031A2 /* LocalInferenceSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LocalInferenceSettingsView.swift; sourceTree = "<group>"; };
 		AA112233001122BB /* LibraryView+Sorting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibraryView+Sorting.swift"; sourceTree = "<group>"; };
@@ -1689,6 +1676,7 @@
 		AB786740043A3DAB4CDBFD6F /* DocumentInspectorAnnotationsTab.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DocumentInspectorAnnotationsTab.swift; sourceTree = "<group>"; };
 		ADD8AD20E191046B70950B1E /* ImageViewerComponents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageViewerComponents.swift; sourceTree = "<group>"; };
 		AE34A7C933EA9305CAAA50FA /* AccessError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AccessError.swift; sourceTree = "<group>"; };
+		ANIM00022F045C8A00EAA55A /* FrameAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameAnimation.swift; sourceTree = "<group>"; };
 		AUT00012F27F36000EC9EE1 /* AutomationServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationServiceGenerated.swift; sourceTree = "<group>"; };
 		B00A8552DEACF83751D617C6 /* DocumentNotesTab.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DocumentNotesTab.swift; sourceTree = "<group>"; };
 		B0E93BA60F99453057135B99 /* SidebarView+ActivityRows.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SidebarView+ActivityRows.swift"; sourceTree = "<group>"; };
@@ -1753,6 +1741,7 @@
 		BF91C082286A2B7BB74E438D /* LibraryManager+Persistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LibraryManager+Persistence.swift"; sourceTree = "<group>"; };
 		C0104EC0811F842CAC3CC887 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = GeneralSettingsView.swift; path = fichero/Views/Settings/GeneralSettingsView.swift; sourceTree = SOURCE_ROOT; };
 		C07B489C8F89204C43BD6E46 /* AISettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AISettingsView.swift; path = fichero/Views/Settings/AISettingsView.swift; sourceTree = SOURCE_ROOT; };
+		C0FFEE0000000000000000A1 /* PairingRestoreDiagnostics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PairingRestoreDiagnostics.swift; sourceTree = "<group>"; };
 		C10000110000000000000001 /* SparkleUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparkleUpdater.swift; sourceTree = "<group>"; };
 		C10000110000000000000002 /* AppInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInstaller.swift; sourceTree = "<group>"; };
 		C1424784E87E1971372F0109 /* CitationDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CitationDetailView.swift; sourceTree = "<group>"; };
@@ -1768,9 +1757,9 @@
 		CAA77E9001736B77957513A4 /* NotesBrowserView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NotesBrowserView.swift; sourceTree = "<group>"; };
 		CAAFE05184A40A50ADFC54A9 /* QuickLookPreviewViews.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickLookPreviewViews.swift; sourceTree = "<group>"; };
 		CB4FE6FA42E3E4887451FB21 /* SessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SessionStore.swift; sourceTree = "<group>"; };
-		7C3A91E4B2D14F0A9E5C1A71 /* KGQueryStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KGQueryStore.swift; sourceTree = "<group>"; };
 		CC02D722B13BC58D4D4B37B7 /* MiniToolbarComponents.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MiniToolbarComponents.swift; sourceTree = "<group>"; };
 		CD5D9E12155EC0A6E738B878 /* UsersSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UsersSettingsView.swift; sourceTree = "<group>"; };
+		CE70F7B7D331135FEFF34739 /* ArtifactEntityStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArtifactEntityStore.swift; sourceTree = "<group>"; };
 		CE7785FFCD6AB43D36199856 /* ArtifactPanel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ArtifactPanel.swift; sourceTree = "<group>"; };
 		CE9 /* SidebarItemBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarItemBuilder.swift; sourceTree = "<group>"; };
 		CFA6DF64867F557144B14A23 /* AnnotationsInspectorPane.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AnnotationsInspectorPane.swift; sourceTree = "<group>"; };
@@ -1804,7 +1793,6 @@
 		EE609F48196839FAA6981CFF /* SearchStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchStore.swift; sourceTree = "<group>"; };
 		EEFD8D2157AA0C0F66955D78 /* IdentityStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IdentityStore.swift; sourceTree = "<group>"; };
 		EF014F0FAEFCA5233DCB114F /* ImageEditorModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ImageEditorModel.swift; sourceTree = "<group>"; };
-		LIVE00022F27F36000EC9EE1 /* LiveEditPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveEditPreview.swift; sourceTree = "<group>"; };
 		EF8C2AF12DD3E6EAB64C68B4 /* WorkspaceItemPicker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceItemPicker.swift; sourceTree = "<group>"; };
 		EFA65406167827DCB144E3E2 /* NoteStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NoteStore.swift; sourceTree = "<group>"; };
 		F01276A4ABA0F672CF1D8067 /* DocumentInspectorInfoTab+Bibliography.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "DocumentInspectorInfoTab+Bibliography.swift"; sourceTree = "<group>"; };
@@ -1824,16 +1812,31 @@
 		F447E424F3A26C138C9BB99D /* InspectorTab.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InspectorTab.swift; sourceTree = "<group>"; };
 		F47EED3CD156012F59D46F7B /* ShareLibrarySheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareLibrarySheet.swift; sourceTree = "<group>"; };
 		F75255EDB2E723056D7BA67B /* FocusedCitation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FocusedCitation.swift; sourceTree = "<group>"; };
+		FA00000000000000003677A0 /* KnownLibraryRegistryStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KnownLibraryRegistryStore.swift; sourceTree = "<group>"; };
 		FAE00C2DC909B57AA030519E /* ReaderToolbar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReaderToolbar.swift; sourceTree = "<group>"; };
 		FBCBCC9A6B923D6A560F7277 /* ReferenceStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReferenceStore.swift; sourceTree = "<group>"; };
 		FBE84D175FC1F5C5644EB914 /* WindowSeed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WindowSeed.swift; sourceTree = "<group>"; };
 		FCCA353DE8E2AFD149DADB3A /* SpaceSceneView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SpaceSceneView.swift; sourceTree = "<group>"; };
 		FD8F8D42618D304271F81962 /* AuditStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuditStore.swift; sourceTree = "<group>"; };
+		FEED00000000000000000260 /* Fichero.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fichero.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		FEEDDEAD0000000000000001 /* ReaderTabBar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReaderTabBar.swift; sourceTree = "<group>"; };
+		FEEDDEAD0000000000000003 /* EntityReconciliationSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EntityReconciliationSheet.swift; sourceTree = "<group>"; };
+		FEEDDEAD0000000000000005 /* SurfaceTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SurfaceTabBar.swift; path = fichero/Views/SurfaceChrome/SurfaceTabBar.swift; sourceTree = SOURCE_ROOT; };
+		FEEDDEAD0000000000000007 /* WorkspaceStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WorkspaceStore.swift; sourceTree = "<group>"; };
+		FEEDDEAD0000000000000009 /* BatchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BatchStore.swift; path = fichero/Models/BatchStore.swift; sourceTree = SOURCE_ROOT; };
+		FEEDDEAD000000000000000B /* BatchRunView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = BatchRunView.swift; path = fichero/Views/Workflow/BatchRunView.swift; sourceTree = SOURCE_ROOT; };
 		FF58B21F339179A8162AD6C5 /* NoteService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NoteService.swift; sourceTree = "<group>"; };
 		FFC6B695132C68202062560A /* InspectorPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InspectorPresenter.swift; sourceTree = "<group>"; };
 		GTE1 /* GeneratedTypeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedTypeExtensions.swift; sourceTree = "<group>"; };
 		IMP00022F27F36000EC9EE1 /* ImportServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportServiceGenerated.swift; sourceTree = "<group>"; };
+		LIVE00022F27F36000EC9EE1 /* LiveEditPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiveEditPreview.swift; sourceTree = "<group>"; };
+		LOC00022F27F36000EC9EE1 /* LocationServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationServiceGenerated.swift; sourceTree = "<group>"; };
+		MEDIA0022F69F06267FA6CCD /* MediaStreamPreview.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MediaStreamPreview.swift; sourceTree = "<group>"; };
 		MOD00022F27F36000EC9EE1 /* ModelServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelServiceGenerated.swift; sourceTree = "<group>"; };
+		PDFC00022F27F36000EC9EE1 /* PDFDocumentCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFDocumentCache.swift; sourceTree = "<group>"; };
+		PRDL00022F27F36000EC9EE1 /* PreviewDownloadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewDownloadService.swift; sourceTree = "<group>"; };
+		SBX00022F27F36000EC9EE1 /* SandboxAccessServiceGenerated.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SandboxAccessServiceGenerated.swift; sourceTree = "<group>"; };
+		SKEL00022F045C8A00EAA55A /* SkeletonPlaceholder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SkeletonPlaceholder.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -1854,13 +1857,6 @@
 /* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		FEED00000000000000000250 = {
-			isa = PBXFrameworksBuildPhase;
-			files = (
-				FEED0000000000000000024E /* FicheroAPIClient in Frameworks */,
-				FEED0000000000000000024F /* FicheroAPIClient in Frameworks */,
-			);
-		};
 		300 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			files = (
@@ -1877,6 +1873,13 @@
 		A10521BE2EFDC94100B28C3E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			files = (
+			);
+		};
+		FEED00000000000000000250 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			files = (
+				FEED0000000000000000024E /* FicheroAPIClient in Frameworks */,
+				FEED0000000000000000024F /* FicheroAPIClient in Frameworks */,
 			);
 		};
 /* End PBXFrameworksBuildPhase section */
@@ -2345,6 +2348,7 @@
 				F1D280D880BB4526630C8CB3 /* WorkflowSync.swift */,
 				E07BE5ECB91F929ADBD8595A /* BackendActivityEvent.swift */,
 				41994E6C746A0B0171534212 /* ChainStore.swift */,
+				CE70F7B7D331135FEFF34739 /* ArtifactEntityStore.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2902,32 +2906,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		FEED00000000000000000261 /* Fichero (App Store) */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = FEED0000000000000000025F;
-			buildPhases = (
-				FEED0000000000000000024D,
-				FEED00000000000000000250,
-				FEED00000000000000000253,
-				FEED00000000000000000254,
-				FEED00000000000000000255,
-				FEED00000000000000000256,
-				SBX00042F27F36000EC9EE1,
-				SBX00052F27F36000EC9EE1,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Fichero (App Store)";
-			packageProductDependencies = (
-				A18ED3AA2F13E313007C2C6E,
-				A18ED3F12F141DFE007C2C6E,
-			);
-			productName = Fichero;
-			productReference = FEED00000000000000000260 /* Fichero.app */;
-			productType = "com.apple.product-type.application";
-		};
 		500 /* Fichero */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 600 /* Build configuration list for PBXNativeTarget "Fichero" */;
@@ -2995,6 +2973,32 @@
 			productReference = A10521C12EFDC94100B28C3E /* FicheroUITests.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
 		};
+		FEED00000000000000000261 /* Fichero (App Store) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = FEED0000000000000000025F /* Build configuration list for PBXNativeTarget "Fichero (App Store)" */;
+			buildPhases = (
+				FEED0000000000000000024D /* Sources */,
+				FEED00000000000000000250 /* Frameworks */,
+				FEED00000000000000000253 /* Resources */,
+				FEED00000000000000000254 /* CopyFiles */,
+				FEED00000000000000000255 /* SwiftLint */,
+				FEED00000000000000000256 /* Embed Fichero Engine */,
+				SBX00042F27F36000EC9EE1 /* Strip Sparkle Info.plist Keys */,
+				SBX00052F27F36000EC9EE1 /* Validate App Store Bundle */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Fichero (App Store)";
+			packageProductDependencies = (
+				A18ED3AA2F13E313007C2C6E /* FicheroAPIClient */,
+				A18ED3F12F141DFE007C2C6E /* FicheroAPIClient */,
+			);
+			productName = Fichero;
+			productReference = FEED00000000000000000260 /* Fichero.app */;
+			productType = "com.apple.product-type.application";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -3044,13 +3048,6 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
-		FEED00000000000000000253 = {
-			isa = PBXResourcesBuildPhase;
-			files = (
-				FEED00000000000000000251 /* Assets.xcassets in Resources */,
-				FEED00000000000000000252 /* Fichero.sdef in Resources */,
-			);
-		};
 		520 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			files = (
@@ -3068,410 +3065,16 @@
 			files = (
 			);
 		};
+		FEED00000000000000000253 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			files = (
+				FEED00000000000000000251 /* Assets.xcassets in Resources */,
+				FEED00000000000000000252 /* Fichero.sdef in Resources */,
+			);
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		SBX00042F27F36000EC9EE1 /* Strip Sparkle Info.plist Keys */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			files = (
-			);
-			name = "Strip Sparkle Info.plist Keys";
-			shellPath = /bin/sh;
-			shellScript = (
-				"# App Store: strip Sparkle's Info.plist keys (#3748).",
-				"#",
-				"# Sparkle is excluded from this target at the LINK level — the framework, Autoupdate",
-				"# and its XPC services are all absent from the binary. But Info.plist is SHARED with",
-				"# the Developer ID target (both set INFOPLIST_FILE = fichero/Info.plist), and it",
-				"# still advertises an update feed: SUFeedURL, SUPublicEDKey, SUEnableAutomaticChecks.",
-				"#",
-				"# An App Store app whose Info.plist declares a third-party self-update mechanism is",
-				"# exactly what guideline 2.4.5(vii) prohibits, and it is trivially greppable by a",
-				"# reviewer even though nothing can act on it. Sparkle must be ABSENT, not merely",
-				"# inert.",
-				"#",
-				"# Stripped from the BUILT bundle rather than by forking Info.plist into a second",
-				"# file, which would drift from the DMG one silently. Same shape as",
-				"# scripts/build-release-dmg.sh, which SETS SUFeedURL on the staged bundle at package",
-				"# time. This phase runs before Xcode's CodeSign phase, so the seal covers the",
-				"# stripped plist.",
-				"",
-				"PLIST=\"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"",
-				"",
-				"if [ ! -f \"$PLIST\" ]; then",
-				"  echo \"note: no Info.plist at $PLIST — nothing to strip\"",
-				"  exit 0",
-				"fi",
-				"",
-				"for KEY in SUFeedURL SUPublicEDKey SUEnableAutomaticChecks SUAllowsAutomaticUpdates SUScheduledCheckInterval; do",
-				"  if /usr/libexec/PlistBuddy -c \"Print :${KEY}\" \"$PLIST\" >/dev/null 2>&1; then",
-				"    /usr/libexec/PlistBuddy -c \"Delete :${KEY}\" \"$PLIST\"",
-				"    echo \"  removed ${KEY}\"",
-				"  fi",
-				"done",
-				"",
-				"# Fail the build rather than ship a Sparkle key to App Review.",
-				"for KEY in SUFeedURL SUPublicEDKey; do",
-				"  if /usr/libexec/PlistBuddy -c \"Print :${KEY}\" \"$PLIST\" >/dev/null 2>&1; then",
-				"    echo \"error: ${KEY} is still present in the App Store Info.plist\" >&2",
-				"    exit 1",
-				"  fi",
-				"done",
-				"",
-				"echo \"Sparkle Info.plist keys stripped from the App Store build\"",
-			);
-		};
-		SBX00052F27F36000EC9EE1 /* Validate App Store Bundle */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			files = (
-			);
-			name = "Validate App Store Bundle";
-			shellPath = /bin/sh;
-			shellScript = (
-				"# App Store: run the bundle validator against what we ACTUALLY built (#3797 follow-up).",
-				"#",
-				"# The R2 archive shipped full of .dSYMs while the build reported success, because the",
-				"# strip and its own verification both ran `find` against a SYMLINK",
-				"# (${BUILT_PRODUCTS_DIR}/Fichero.app is a symlink to DSTROOT in an archive build) and",
-				"# find does not descend into a symlinked starting point. Zero matches. Nothing",
-				"# deleted, nothing flagged, build green.",
-				"#",
-				"# The lesson is not \"fix the path\" — that is done. It is that the build must be checked",
-				"# by the SAME tool that judges the archive, instead of by bespoke assertions that can",
-				"# pass vacuously. So this phase runs scripts/validate_mas_bundle.sh, the exact script",
-				"# used on the .xcarchive, against the product we just assembled.",
-				"#",
-				"# --structure-only because Xcode's CodeSign step for the outer app runs AFTER this",
-				"# phase. Everything not dependent on that signature is checked, which is every",
-				"# rejection actually taken: .a (90284), .dSYM (90277/90278), unsandboxed nested",
-				"# executables (90296), engine placement, Sparkle.",
-				"",
-				"if [ \"${PLATFORM_NAME}\" != \"macosx\" ]; then",
-				"  exit 0",
-				"fi",
-				"",
-				"if [ \"${FICHERO_EMBED_ENGINE}\" != \"YES\" ]; then",
-				"  echo \"Skipping App Store bundle validation (no engine embedded in this configuration)\"",
-				"  exit 0",
-				"fi",
-				"",
-				"VALIDATOR=\"${SRCROOT}/../scripts/validate_mas_bundle.sh\"",
-				"if [ ! -f \"$VALIDATOR\" ]; then",
-				"  echo \"error: validator not found at $VALIDATOR\" >&2",
-				"  exit 1",
-				"fi",
-				"",
-				"APP_DST=\"${TARGET_BUILD_DIR}/${WRAPPER_NAME}\"",
-				"if [ ! -d \"$APP_DST\" ]; then",
-				"  echo \"error: no app bundle at $APP_DST\" >&2",
-				"  exit 1",
-				"fi",
-				"",
-				"echo \"Validating the App Store bundle we just built:\"",
-				"if ! /bin/bash \"$VALIDATOR\" --structure-only \"$APP_DST\"; then",
-				"  echo \"error: the App Store bundle would be REJECTED by App Store Connect — see the failures above\" >&2",
-				"  exit 1",
-				"fi",
-			);
-		};
-		FEED00000000000000000256 = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			files = (
-			);
-			name = "Embed Fichero Engine";
-			shellPath = /bin/sh;
-			shellScript = (
-				"# Embed the briefcase-built engine into the App Store app bundle — SANDBOXED.",
-				"#",
-				"# The DMG target has its own copy of this phase; the two channels diverge and",
-				"# must stay diverged. Differences here, both mandatory for App Store ingestion:",
-				"#",
-				"#   1. The engine is SIGNED IN THIS PHASE with app-sandbox + inherit. A nested",
-				"#      executable that is not sandboxed is rejected at upload (ITMS-90296).",
-				"#      Xcode's own CodeSign phase runs AFTER this one and seals the outer app,",
-				"#      so by then the helper is already correctly signed.",
-				"#   2. NEVER `codesign --deep`. --deep re-signs nested code with the PARENT's",
-				"#      entitlements, which silently replaces the engine's two-key set and breaks",
-				"#      the inherit rule (#3746 spike).",
-				"#   3. NO hardened runtime and NO com.apple.security.cs.* keys. Those are",
-				"#      NOTARIZATION requirements for the DMG; MAS is not notarized, and the",
-				"#      spike proved the engine's 2,889 native libs load without them.",
-				"",
-				"if [ \"${PLATFORM_NAME}\" != \"macosx\" ]; then",
-				"  echo \"Skipping engine embed (non-macOS platform ${PLATFORM_NAME})\"",
-				"  exit 0",
-				"fi",
-				"",
-				"if [ \"${FICHERO_EMBED_ENGINE}\" != \"YES\" ]; then",
-				"  echo \"Skipping engine embed (FICHERO_EMBED_ENGINE=${FICHERO_EMBED_ENGINE}); use external backend on :8765\"",
-				"  exit 0",
-				"fi",
-				"",
-				"# Contents/Helpers, NOT Contents/Resources (#3749). TN2206 lists the",
-				"# designated code locations for nested executables — MacOS, Frameworks,",
-				"# Helpers, PlugIns, XPCServices, Library. Resources is not one of them,",
-				"# and MAS ingestion validation is stricter than notarization: an",
-				"# executable .app under Resources is an invalid bundle structure. The",
-				"# spike (#3746) ran the engine from Contents/Helpers. The DMG target",
-				"# keeps Contents/Resources and is deliberately left alone.",
-				"",
-				"ENGINE_SRC=\"${SRCROOT}/../fichero-engine/build/engine/macos/app/Fichero Engine.app\"",
-				"ENGINE_ENTITLEMENTS=\"${SRCROOT}/fichero/FicheroEngineAppStore.entitlements\"",
-				"",
-				"# THE APP BUNDLE, AS A REAL PATH. Read this before changing it.",
-				"#",
-				"# ${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app is a SYMLINK in an archive/install build",
-				"# (ACTION=install): Xcode assembles the product under DSTROOT and leaves a symlink in",
-				"# the products dir. That is fine for `cp`, which resolves path components and writes",
-				"# THROUGH the link — which is why the engine embed always worked. It is NOT fine for",
-				"# `find`: with a symlink as its starting point and no -H/-L, find does not descend.",
-				"# It silently reports zero matches.",
-				"#",
-				"# That is what shipped the R2 archive full of .dSYMs. The strips found nothing, so",
-				"# they deleted nothing — and the \"no .dSYM remain\" assertions right below also found",
-				"# nothing, so they PASSED. A vacuous find looks exactly like a clean bundle.",
-				"#",
-				"# TARGET_BUILD_DIR/WRAPPER_NAME is the real product location in every ACTION, and",
-				"# `cd && pwd -P` resolves any remaining symlink to a physical path, so every find",
-				"# below starts at a real directory.",
-				"APP_DST=\"${TARGET_BUILD_DIR}/${WRAPPER_NAME}\"",
-				"if [ ! -d \"$APP_DST\" ]; then",
-				"  echo \"error: no app bundle at $APP_DST (TARGET_BUILD_DIR/WRAPPER_NAME)\" >&2",
-				"  exit 1",
-				"fi",
-				"APP_DST=\"$(cd \"$APP_DST\" && pwd -P)\"",
-				"ENGINE_DST=\"$APP_DST/Contents/Helpers/Fichero Engine.app\"",
-				"",
-				"# Prove the traversal works before trusting anything it says. An app bundle always",
-				"# contains files; if find sees none, it is not traversing, and every check below",
-				"# would \"pass\" without inspecting a single byte. Fail loudly instead — this is the",
-				"# assertion whose absence let the last two rejections through.",
-				"if [ \"$(find \"$APP_DST\" -type f | head -1 | wc -l | tr -d \" \")\" -eq 0 ]; then",
-				"  echo \"error: find traverses nothing under $APP_DST — the strips and their checks would vacuously pass\" >&2",
-				"  exit 1",
-				"fi",
-				"echo \"  app bundle (resolved): $APP_DST\"",
-				"",
-				"if [ ! -d \"$ENGINE_SRC\" ]; then",
-				"  echo \"error: Fichero Engine.app not found at $ENGINE_SRC — run 'briefcase build macOS --app engine' in fichero-engine/ first\" >&2",
-				"  exit 1",
-				"fi",
-				"",
-				"if [ ! -f \"$ENGINE_ENTITLEMENTS\" ]; then",
-				"  echo \"error: App Store engine entitlements not found at $ENGINE_ENTITLEMENTS\" >&2",
-				"  exit 1",
-				"fi",
-				"",
-				"echo \"Embedding engine (App Store, sandboxed): $ENGINE_SRC -> $ENGINE_DST\"",
-				"rm -rf \"$ENGINE_DST\"",
-				"mkdir -p \"$(dirname \"$ENGINE_DST\")\"",
-				"cp -R \"$ENGINE_SRC\" \"$ENGINE_DST\"",
-				"",
-				"# Remove static archives (.a). REJECTED UPLOAD, code 90284: Python.framework ships",
-				"# Tcl/Tk link-time stubs (libtclstub8.6.a, libtkstub8.6.a, libitclstub4.3.2.a,",
-				"# libtdbcstub1.1.10.a) and App Store Connect demands every nested archive be signed",
-				"# with the provisioning-profile certificate. A .a CANNOT be signed: it is an ar",
-				"# archive of object files, not a Mach-O image, and codesign has nothing to seal in",
-				"# it. So the only way to satisfy the rule is to not ship them.",
-				"#",
-				"# Safe to delete: these are LINK-time stubs. Nothing dlopens a .a; the runtime uses",
-				"# the Tcl/Tk dylibs beside them, and Fichero never touches Tk at all. Deleted rather",
-				"# than excluded at build time because the engine bundle comes from Briefcase, which",
-				"# we do not control.",
-				"archive_count=$(find \"$APP_DST\" -name \"*.a\" -type f | wc -l | tr -d \" \")",
-				"if [ \"$archive_count\" -gt 0 ]; then",
-				"  find \"$APP_DST\" -name \"*.a\" -type f -delete",
-				"  echo \"  removed $archive_count static archive(s) from the app bundle — not signable code (90284)\"",
-				"fi",
-				"",
-				"# Remove debug-symbol bundles (.dSYM). REJECTED UPLOAD, codes 90277/90278: Briefcase",
-				"# ships PyObjCTest extensions with their *.cpython-312-darwin.so.dSYM beside them, and",
-				"# a .dSYM carries the bundle identifier com.apple.xcode.dsym.* — which is Apple's own,",
-				"# not ours, and does not match the provisioning profile. Ingestion refuses it.",
-				"#",
-				"# A .dSYM is not runtime code. It is the detached DWARF for a binary; nothing loads it,",
-				"# and it exists only so a crash log can be symbolicated. Re-identifying or re-signing it",
-				"# would be dressing up a file that has no business in a shipped bundle. Delete it.",
-				"#",
-				"# Deleted BEFORE the Mach-O sweep below, deliberately: a .dSYM contains a Mach-O",
-				"# (Contents/Resources/DWARF/<name>, a \"dSYM companion\" image), so leaving them here",
-				"# would mean signing files we are about to be rejected for shipping.",
-				"dsym_count=$(find \"$APP_DST\" -name \"*.dSYM\" -type d | wc -l | tr -d \" \")",
-				"if [ \"$dsym_count\" -gt 0 ]; then",
-				"  find \"$APP_DST\" -name \"*.dSYM\" -type d -exec rm -rf {} +",
-				"  echo \"  removed $dsym_count debug-symbol bundle(s) (.dSYM) from the app bundle — not runtime code (90277/90278)\"",
-				"fi",
-				"",
-				"if [ \"${CODE_SIGNING_ALLOWED}\" != \"YES\" ] || [ -z \"${EXPANDED_CODE_SIGN_IDENTITY}\" ]; then",
-				"  echo \"note: signing not configured for ${CONFIGURATION}; engine left as copied (ad-hoc)\"",
-				"  exit 0",
-				"fi",
-				"",
-				"# Sign inside-out. Mirrors scripts/build-release-dmg.sh step 2b, minus the",
-				"# hardened runtime and secure timestamp (neither applies to MAS).",
-				"IDENTITY=\"${EXPANDED_CODE_SIGN_IDENTITY}\"",
-				"",
-				"# is_macho_executable PATH — true for a Mach-O EXECUTABLE (MH_EXECUTE), false for a",
-				"# dylib, bundle or anything else. Handles universal binaries: `file` prints one line",
-				"# per architecture, and \"executable\" appears in each.",
-				"is_macho_executable() {",
-				"  file -b \"$1\" 2>/dev/null | grep -q \"Mach-O.*executable\"",
-				"}",
-				"",
-				"# sign_mas PATH — the two-key entitlements go on every nested EXECUTABLE. Not on",
-				"# paths: on executables.",
-				"#",
-				"# REJECTED UPLOAD, code 90296: this used to key off the PATH, entitling only",
-				"# ENGINE/Contents/MacOS/*. fm-bridge — the Swift CLI the engine spawns for Apple",
-				"# Intelligence, which Briefcase packages at",
-				"# Contents/Resources/app/fichero/resources/bin/fm-bridge — therefore signed PLAIN and",
-				"# shipped with no com.apple.security.app-sandbox. Every nested executable inside a",
-				"# sandboxed app must be sandboxed; a path rule cannot know which files those are, and",
-				"# the next one Briefcase adds would have been missed the same way. Mach-O type can.",
-				"#",
-				"# Libraries take no entitlements and sign plain: a .so/.dylib is not a process, and a",
-				"# .framework is a library container. Executable BUNDLES (.app, .xpc) are processes and",
-				"# do carry them — including Python.framework's own nested Python.app.",
-				"sign_mas() {",
-				"  target=\"$1\"",
-				"  case \"$target\" in",
-				"    *.framework)",
-				"      codesign --force --sign \"$IDENTITY\" \"$target\" >/dev/null 2>&1",
-				"      return $?",
-				"      ;;",
-				"  esac",
-				"  if [ -d \"$target\" ] || is_macho_executable \"$target\"; then",
-				"    codesign --force --sign \"$IDENTITY\" --entitlements \"$ENGINE_ENTITLEMENTS\" \"$target\" >/dev/null 2>&1",
-				"  else",
-				"    codesign --force --sign \"$IDENTITY\" \"$target\" >/dev/null 2>&1",
-				"  fi",
-				"}",
-				"",
-				"# Collect every Mach-O. `file {} +` batches; drop the per-architecture lines it",
-				"# emits for universal binaries so only real paths remain.",
-				"macho_list=\"$(mktemp)\"",
-				"find \"$ENGINE_DST\" -type f -exec file {} + 2>/dev/null | awk -F': ' '/Mach-O/ && !/for architecture/ {print $1}' | sort -u > \"$macho_list\"",
-				"echo \"  signing $(wc -l < \"$macho_list\" | tr -d ' ') Mach-O binaries in the engine\"",
-				"",
-				"# Plain loop, not xargs: under xcodebuild the inherited environment can be large",
-				"# enough that xargs cannot assemble even one command (see build-release-dmg.sh).",
-				"sign_fails=0",
-				"while IFS= read -r macho; do",
-				"  if ! sign_mas \"$macho\"; then",
-				"    echo \"  error: failed to sign Mach-O: $macho\" >&2",
-				"    sign_fails=$((sign_fails + 1))",
-				"  fi",
-				"done < \"$macho_list\"",
-				"rm -f \"$macho_list\"",
-				"if [ \"$sign_fails\" -gt 0 ]; then",
-				"  echo \"error: $sign_fails Mach-O binaries failed to sign\" >&2",
-				"  exit 1",
-				"fi",
-				"",
-				"# Re-seal bundles innermost-first: longest path first guarantees a nested bundle",
-				"# is sealed before its parent, so the parent's seal hashes a correct child. The",
-				"# engine bundle itself sorts last and picks up the entitlements via sign_mas.",
-				"bundle_list=\"$(mktemp)\"",
-				"find \"$ENGINE_DST\" -type d -name '*.app' -o -type d -name '*.framework' -o -type d -name '*.xpc' > \"$bundle_list.raw\"",
-				"awk '{print length, $0}' \"$bundle_list.raw\" | sort -rn | cut -d' ' -f2- > \"$bundle_list\"",
-				"rm -f \"$bundle_list.raw\"",
-				"bundle_fails=0",
-				"while IFS= read -r bundle; do",
-				"  if ! sign_mas \"$bundle\"; then",
-				"    echo \"  error: failed to re-seal bundle: $bundle\" >&2",
-				"    bundle_fails=$((bundle_fails + 1))",
-				"  fi",
-				"done < \"$bundle_list\"",
-				"rm -f \"$bundle_list\"",
-				"if [ \"$bundle_fails\" -gt 0 ]; then",
-				"  echo \"error: $bundle_fails bundles failed to re-seal\" >&2",
-				"  exit 1",
-				"fi",
-				"",
-				"# Fail the build here rather than at ingestion if the two-key rule was broken.",
-				"if ! codesign --verify --strict \"$ENGINE_DST\" >/dev/null 2>&1; then",
-				"  echo \"error: embedded engine signature is invalid after signing\" >&2",
-				"  exit 1",
-				"fi",
-				"if ! codesign --display --entitlements - \"$ENGINE_DST\" 2>&1 | grep -q \"com.apple.security.inherit\"; then",
-				"  echo \"error: embedded engine is missing com.apple.security.inherit\" >&2",
-				"  exit 1",
-				"fi",
-				"",
-				"# The two checks that App Store Connect ran for us, run here instead. Both of these",
-				"# rejections cost a full archive + upload + wait to discover; they cost seconds here.",
-				"",
-				"# 90284 — no static archives may remain.",
-				"remaining=$(find \"$APP_DST\" -name \"*.a\" -type f | wc -l | tr -d \" \")",
-				"if [ \"$remaining\" -gt 0 ]; then",
-				"  echo \"error: $remaining static archive(s) (.a) still in the engine — ingestion rejects these (90284)\" >&2",
-				"  find \"$APP_DST\" -name \"*.a\" -type f >&2",
-				"  exit 1",
-				"fi",
-				"",
-				"# 90277/90278 — no debug-symbol bundles may remain.",
-				"remaining_dsym=$(find \"$APP_DST\" -name \"*.dSYM\" -type d | wc -l | tr -d \" \")",
-				"if [ \"$remaining_dsym\" -gt 0 ]; then",
-				"  echo \"error: $remaining_dsym .dSYM bundle(s) still in the engine — they carry com.apple.xcode.dsym identifiers and ingestion rejects them (90277/90278)\" >&2",
-				"  find \"$APP_DST\" -name \"*.dSYM\" -type d >&2",
-				"  exit 1",
-				"fi",
-				"",
-				"# 90296 — EVERY nested executable must be sandboxed, not just the engine's own.",
-				"# This is the check that would have caught fm-bridge.",
-				"exec_list=\"$(mktemp)\"",
-				"find \"$ENGINE_DST\" -type f -exec file {} + 2>/dev/null | awk -F\": \" '/Mach-O/ && /executable/ && !/for architecture/ {print $1}' | sort -u > \"$exec_list\"",
-				"unsandboxed=0",
-				"while IFS= read -r exe; do",
-				"  [ -n \"$exe\" ] || continue",
-				"  if ! codesign --display --entitlements - \"$exe\" 2>&1 | grep -q \"com.apple.security.app-sandbox\"; then",
-				"    echo \"error: nested executable is NOT sandboxed (90296): $exe\" >&2",
-				"    unsandboxed=$((unsandboxed + 1))",
-				"  fi",
-				"done < \"$exec_list\"",
-				"exec_count=$(wc -l < \"$exec_list\" | tr -d \" \")",
-				"rm -f \"$exec_list\"",
-				"if [ \"$unsandboxed\" -gt 0 ]; then",
-				"  echo \"error: $unsandboxed nested executable(s) lack com.apple.security.app-sandbox\" >&2",
-				"  exit 1",
-				"fi",
-				"",
-				"echo \"  engine signed sandboxed: $exec_count nested executable(s), all app-sandbox + inherit, no --deep, no .a\"",
-			);
-		};
-		FEED00000000000000000255 = {
-			isa = PBXShellScriptBuildPhase;
-			files = (
-			);
-			inputPaths = (
-				"$(SRCROOT)/../.swiftlint.yml",
-				"$(SRCROOT)/fichero",
-			);
-			name = SwiftLint;
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/swiftlint.done",
-			);
-			shellPath = /bin/sh;
-			shellScript = (
-				"SWIFTLINT_BIN=\"${SWIFTLINT_PATH:-/opt/homebrew/bin/swiftlint}\"",
-				"if [ ! -x \"$SWIFTLINT_BIN\" ]; then",
-				"  SWIFTLINT_BIN=\"$(command -v swiftlint || true)\"",
-				fi,
-				"",
-				"if [ -x \"$SWIFTLINT_BIN\" ]; then",
-				"  \"$SWIFTLINT_BIN\" lint --config \"$SRCROOT/../.swiftlint.yml\" \"$SRCROOT/fichero\"",
-				else,
-				"  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"",
-				fi,
-				"",
-				"mkdir -p \"$DERIVED_FILE_DIR\"",
-				"touch \"$DERIVED_FILE_DIR/swiftlint.done\"",
-				"",
-			);
-		};
 		CC0011223344556677889902 /* SwiftLint */ = {
 			isa = PBXShellScriptBuildPhase;
 			files = (
@@ -3576,604 +3179,410 @@
 				"",
 			);
 		};
+		FEED00000000000000000255 /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/../.swiftlint.yml",
+				"$(SRCROOT)/fichero",
+			);
+			name = SwiftLint;
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/swiftlint.done",
+			);
+			shellPath = /bin/sh;
+			shellScript = (
+				"SWIFTLINT_BIN=\"${SWIFTLINT_PATH:-/opt/homebrew/bin/swiftlint}\"",
+				"if [ ! -x \"$SWIFTLINT_BIN\" ]; then",
+				"  SWIFTLINT_BIN=\"$(command -v swiftlint || true)\"",
+				fi,
+				"",
+				"if [ -x \"$SWIFTLINT_BIN\" ]; then",
+				"  \"$SWIFTLINT_BIN\" lint --config \"$SRCROOT/../.swiftlint.yml\" \"$SRCROOT/fichero\"",
+				else,
+				"  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"",
+				fi,
+				"",
+				"mkdir -p \"$DERIVED_FILE_DIR\"",
+				"touch \"$DERIVED_FILE_DIR/swiftlint.done\"",
+				"",
+			);
+		};
+		FEED00000000000000000256 /* Embed Fichero Engine */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			files = (
+			);
+			name = "Embed Fichero Engine";
+			shellPath = /bin/sh;
+			shellScript = (
+				"# Embed the briefcase-built engine into the App Store app bundle — SANDBOXED.",
+				"#",
+				"# The DMG target has its own copy of this phase; the two channels diverge and",
+				"# must stay diverged. Differences here, both mandatory for App Store ingestion:",
+				"#",
+				"#   1. The engine is SIGNED IN THIS PHASE with app-sandbox + inherit. A nested",
+				"#      executable that is not sandboxed is rejected at upload (ITMS-90296).",
+				"#      Xcode's own CodeSign phase runs AFTER this one and seals the outer app,",
+				"#      so by then the helper is already correctly signed.",
+				"#   2. NEVER `codesign --deep`. --deep re-signs nested code with the PARENT's",
+				"#      entitlements, which silently replaces the engine's two-key set and breaks",
+				"#      the inherit rule (#3746 spike).",
+				"#   3. NO hardened runtime and NO com.apple.security.cs.* keys. Those are",
+				"#      NOTARIZATION requirements for the DMG; MAS is not notarized, and the",
+				"#      spike proved the engine's 2,889 native libs load without them.",
+				"",
+				"if [ \"${PLATFORM_NAME}\" != \"macosx\" ]; then",
+				"  echo \"Skipping engine embed (non-macOS platform ${PLATFORM_NAME})\"",
+				"  exit 0",
+				fi,
+				"",
+				"if [ \"${FICHERO_EMBED_ENGINE}\" != \"YES\" ]; then",
+				"  echo \"Skipping engine embed (FICHERO_EMBED_ENGINE=${FICHERO_EMBED_ENGINE}); use external backend on :8765\"",
+				"  exit 0",
+				fi,
+				"",
+				"# Contents/Helpers, NOT Contents/Resources (#3749). TN2206 lists the",
+				"# designated code locations for nested executables — MacOS, Frameworks,",
+				"# Helpers, PlugIns, XPCServices, Library. Resources is not one of them,",
+				"# and MAS ingestion validation is stricter than notarization: an",
+				"# executable .app under Resources is an invalid bundle structure. The",
+				"# spike (#3746) ran the engine from Contents/Helpers. The DMG target",
+				"# keeps Contents/Resources and is deliberately left alone.",
+				"",
+				"ENGINE_SRC=\"${SRCROOT}/../fichero-engine/build/engine/macos/app/Fichero Engine.app\"",
+				"ENGINE_ENTITLEMENTS=\"${SRCROOT}/fichero/FicheroEngineAppStore.entitlements\"",
+				"",
+				"# THE APP BUNDLE, AS A REAL PATH. Read this before changing it.",
+				"#",
+				"# ${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.app is a SYMLINK in an archive/install build",
+				"# (ACTION=install): Xcode assembles the product under DSTROOT and leaves a symlink in",
+				"# the products dir. That is fine for `cp`, which resolves path components and writes",
+				"# THROUGH the link — which is why the engine embed always worked. It is NOT fine for",
+				"# `find`: with a symlink as its starting point and no -H/-L, find does not descend.",
+				"# It silently reports zero matches.",
+				"#",
+				"# That is what shipped the R2 archive full of .dSYMs. The strips found nothing, so",
+				"# they deleted nothing — and the \"no .dSYM remain\" assertions right below also found",
+				"# nothing, so they PASSED. A vacuous find looks exactly like a clean bundle.",
+				"#",
+				"# TARGET_BUILD_DIR/WRAPPER_NAME is the real product location in every ACTION, and",
+				"# `cd && pwd -P` resolves any remaining symlink to a physical path, so every find",
+				"# below starts at a real directory.",
+				"APP_DST=\"${TARGET_BUILD_DIR}/${WRAPPER_NAME}\"",
+				"if [ ! -d \"$APP_DST\" ]; then",
+				"  echo \"error: no app bundle at $APP_DST (TARGET_BUILD_DIR/WRAPPER_NAME)\" >&2",
+				"  exit 1",
+				fi,
+				"APP_DST=\"$(cd \"$APP_DST\" && pwd -P)\"",
+				"ENGINE_DST=\"$APP_DST/Contents/Helpers/Fichero Engine.app\"",
+				"",
+				"# Prove the traversal works before trusting anything it says. An app bundle always",
+				"# contains files; if find sees none, it is not traversing, and every check below",
+				"# would \"pass\" without inspecting a single byte. Fail loudly instead — this is the",
+				"# assertion whose absence let the last two rejections through.",
+				"if [ \"$(find \"$APP_DST\" -type f | head -1 | wc -l | tr -d \" \")\" -eq 0 ]; then",
+				"  echo \"error: find traverses nothing under $APP_DST — the strips and their checks would vacuously pass\" >&2",
+				"  exit 1",
+				fi,
+				"echo \"  app bundle (resolved): $APP_DST\"",
+				"",
+				"if [ ! -d \"$ENGINE_SRC\" ]; then",
+				"  echo \"error: Fichero Engine.app not found at $ENGINE_SRC — run 'briefcase build macOS --app engine' in fichero-engine/ first\" >&2",
+				"  exit 1",
+				fi,
+				"",
+				"if [ ! -f \"$ENGINE_ENTITLEMENTS\" ]; then",
+				"  echo \"error: App Store engine entitlements not found at $ENGINE_ENTITLEMENTS\" >&2",
+				"  exit 1",
+				fi,
+				"",
+				"echo \"Embedding engine (App Store, sandboxed): $ENGINE_SRC -> $ENGINE_DST\"",
+				"rm -rf \"$ENGINE_DST\"",
+				"mkdir -p \"$(dirname \"$ENGINE_DST\")\"",
+				"cp -R \"$ENGINE_SRC\" \"$ENGINE_DST\"",
+				"",
+				"# Remove static archives (.a). REJECTED UPLOAD, code 90284: Python.framework ships",
+				"# Tcl/Tk link-time stubs (libtclstub8.6.a, libtkstub8.6.a, libitclstub4.3.2.a,",
+				"# libtdbcstub1.1.10.a) and App Store Connect demands every nested archive be signed",
+				"# with the provisioning-profile certificate. A .a CANNOT be signed: it is an ar",
+				"# archive of object files, not a Mach-O image, and codesign has nothing to seal in",
+				"# it. So the only way to satisfy the rule is to not ship them.",
+				"#",
+				"# Safe to delete: these are LINK-time stubs. Nothing dlopens a .a; the runtime uses",
+				"# the Tcl/Tk dylibs beside them, and Fichero never touches Tk at all. Deleted rather",
+				"# than excluded at build time because the engine bundle comes from Briefcase, which",
+				"# we do not control.",
+				"archive_count=$(find \"$APP_DST\" -name \"*.a\" -type f | wc -l | tr -d \" \")",
+				"if [ \"$archive_count\" -gt 0 ]; then",
+				"  find \"$APP_DST\" -name \"*.a\" -type f -delete",
+				"  echo \"  removed $archive_count static archive(s) from the app bundle — not signable code (90284)\"",
+				fi,
+				"",
+				"# Remove debug-symbol bundles (.dSYM). REJECTED UPLOAD, codes 90277/90278: Briefcase",
+				"# ships PyObjCTest extensions with their *.cpython-312-darwin.so.dSYM beside them, and",
+				"# a .dSYM carries the bundle identifier com.apple.xcode.dsym.* — which is Apple's own,",
+				"# not ours, and does not match the provisioning profile. Ingestion refuses it.",
+				"#",
+				"# A .dSYM is not runtime code. It is the detached DWARF for a binary; nothing loads it,",
+				"# and it exists only so a crash log can be symbolicated. Re-identifying or re-signing it",
+				"# would be dressing up a file that has no business in a shipped bundle. Delete it.",
+				"#",
+				"# Deleted BEFORE the Mach-O sweep below, deliberately: a .dSYM contains a Mach-O",
+				"# (Contents/Resources/DWARF/<name>, a \"dSYM companion\" image), so leaving them here",
+				"# would mean signing files we are about to be rejected for shipping.",
+				"dsym_count=$(find \"$APP_DST\" -name \"*.dSYM\" -type d | wc -l | tr -d \" \")",
+				"if [ \"$dsym_count\" -gt 0 ]; then",
+				"  find \"$APP_DST\" -name \"*.dSYM\" -type d -exec rm -rf {} +",
+				"  echo \"  removed $dsym_count debug-symbol bundle(s) (.dSYM) from the app bundle — not runtime code (90277/90278)\"",
+				fi,
+				"",
+				"if [ \"${CODE_SIGNING_ALLOWED}\" != \"YES\" ] || [ -z \"${EXPANDED_CODE_SIGN_IDENTITY}\" ]; then",
+				"  echo \"note: signing not configured for ${CONFIGURATION}; engine left as copied (ad-hoc)\"",
+				"  exit 0",
+				fi,
+				"",
+				"# Sign inside-out. Mirrors scripts/build-release-dmg.sh step 2b, minus the",
+				"# hardened runtime and secure timestamp (neither applies to MAS).",
+				"IDENTITY=\"${EXPANDED_CODE_SIGN_IDENTITY}\"",
+				"",
+				"# is_macho_executable PATH — true for a Mach-O EXECUTABLE (MH_EXECUTE), false for a",
+				"# dylib, bundle or anything else. Handles universal binaries: `file` prints one line",
+				"# per architecture, and \"executable\" appears in each.",
+				"is_macho_executable() {",
+				"  file -b \"$1\" 2>/dev/null | grep -q \"Mach-O.*executable\"",
+				"}",
+				"",
+				"# sign_mas PATH — the two-key entitlements go on every nested EXECUTABLE. Not on",
+				"# paths: on executables.",
+				"#",
+				"# REJECTED UPLOAD, code 90296: this used to key off the PATH, entitling only",
+				"# ENGINE/Contents/MacOS/*. fm-bridge — the Swift CLI the engine spawns for Apple",
+				"# Intelligence, which Briefcase packages at",
+				"# Contents/Resources/app/fichero/resources/bin/fm-bridge — therefore signed PLAIN and",
+				"# shipped with no com.apple.security.app-sandbox. Every nested executable inside a",
+				"# sandboxed app must be sandboxed; a path rule cannot know which files those are, and",
+				"# the next one Briefcase adds would have been missed the same way. Mach-O type can.",
+				"#",
+				"# Libraries take no entitlements and sign plain: a .so/.dylib is not a process, and a",
+				"# .framework is a library container. Executable BUNDLES (.app, .xpc) are processes and",
+				"# do carry them — including Python.framework's own nested Python.app.",
+				"sign_mas() {",
+				"  target=\"$1\"",
+				"  case \"$target\" in",
+				"    *.framework)",
+				"      codesign --force --sign \"$IDENTITY\" \"$target\" >/dev/null 2>&1",
+				"      return $?",
+				"      ;;",
+				"  esac",
+				"  if [ -d \"$target\" ] || is_macho_executable \"$target\"; then",
+				"    codesign --force --sign \"$IDENTITY\" --entitlements \"$ENGINE_ENTITLEMENTS\" \"$target\" >/dev/null 2>&1",
+				"  else",
+				"    codesign --force --sign \"$IDENTITY\" \"$target\" >/dev/null 2>&1",
+				"  fi",
+				"}",
+				"",
+				"# Collect every Mach-O. `file {} +` batches; drop the per-architecture lines it",
+				"# emits for universal binaries so only real paths remain.",
+				"macho_list=\"$(mktemp)\"",
+				"find \"$ENGINE_DST\" -type f -exec file {} + 2>/dev/null | awk -F': ' '/Mach-O/ && !/for architecture/ {print $1}' | sort -u > \"$macho_list\"",
+				"echo \"  signing $(wc -l < \"$macho_list\" | tr -d ' ') Mach-O binaries in the engine\"",
+				"",
+				"# Plain loop, not xargs: under xcodebuild the inherited environment can be large",
+				"# enough that xargs cannot assemble even one command (see build-release-dmg.sh).",
+				"sign_fails=0",
+				"while IFS= read -r macho; do",
+				"  if ! sign_mas \"$macho\"; then",
+				"    echo \"  error: failed to sign Mach-O: $macho\" >&2",
+				"    sign_fails=$((sign_fails + 1))",
+				"  fi",
+				"done < \"$macho_list\"",
+				"rm -f \"$macho_list\"",
+				"if [ \"$sign_fails\" -gt 0 ]; then",
+				"  echo \"error: $sign_fails Mach-O binaries failed to sign\" >&2",
+				"  exit 1",
+				fi,
+				"",
+				"# Re-seal bundles innermost-first: longest path first guarantees a nested bundle",
+				"# is sealed before its parent, so the parent's seal hashes a correct child. The",
+				"# engine bundle itself sorts last and picks up the entitlements via sign_mas.",
+				"bundle_list=\"$(mktemp)\"",
+				"find \"$ENGINE_DST\" -type d -name '*.app' -o -type d -name '*.framework' -o -type d -name '*.xpc' > \"$bundle_list.raw\"",
+				"awk '{print length, $0}' \"$bundle_list.raw\" | sort -rn | cut -d' ' -f2- > \"$bundle_list\"",
+				"rm -f \"$bundle_list.raw\"",
+				"bundle_fails=0",
+				"while IFS= read -r bundle; do",
+				"  if ! sign_mas \"$bundle\"; then",
+				"    echo \"  error: failed to re-seal bundle: $bundle\" >&2",
+				"    bundle_fails=$((bundle_fails + 1))",
+				"  fi",
+				"done < \"$bundle_list\"",
+				"rm -f \"$bundle_list\"",
+				"if [ \"$bundle_fails\" -gt 0 ]; then",
+				"  echo \"error: $bundle_fails bundles failed to re-seal\" >&2",
+				"  exit 1",
+				fi,
+				"",
+				"# Fail the build here rather than at ingestion if the two-key rule was broken.",
+				"if ! codesign --verify --strict \"$ENGINE_DST\" >/dev/null 2>&1; then",
+				"  echo \"error: embedded engine signature is invalid after signing\" >&2",
+				"  exit 1",
+				fi,
+				"if ! codesign --display --entitlements - \"$ENGINE_DST\" 2>&1 | grep -q \"com.apple.security.inherit\"; then",
+				"  echo \"error: embedded engine is missing com.apple.security.inherit\" >&2",
+				"  exit 1",
+				fi,
+				"",
+				"# The two checks that App Store Connect ran for us, run here instead. Both of these",
+				"# rejections cost a full archive + upload + wait to discover; they cost seconds here.",
+				"",
+				"# 90284 — no static archives may remain.",
+				"remaining=$(find \"$APP_DST\" -name \"*.a\" -type f | wc -l | tr -d \" \")",
+				"if [ \"$remaining\" -gt 0 ]; then",
+				"  echo \"error: $remaining static archive(s) (.a) still in the engine — ingestion rejects these (90284)\" >&2",
+				"  find \"$APP_DST\" -name \"*.a\" -type f >&2",
+				"  exit 1",
+				fi,
+				"",
+				"# 90277/90278 — no debug-symbol bundles may remain.",
+				"remaining_dsym=$(find \"$APP_DST\" -name \"*.dSYM\" -type d | wc -l | tr -d \" \")",
+				"if [ \"$remaining_dsym\" -gt 0 ]; then",
+				"  echo \"error: $remaining_dsym .dSYM bundle(s) still in the engine — they carry com.apple.xcode.dsym identifiers and ingestion rejects them (90277/90278)\" >&2",
+				"  find \"$APP_DST\" -name \"*.dSYM\" -type d >&2",
+				"  exit 1",
+				fi,
+				"",
+				"# 90296 — EVERY nested executable must be sandboxed, not just the engine's own.",
+				"# This is the check that would have caught fm-bridge.",
+				"exec_list=\"$(mktemp)\"",
+				"find \"$ENGINE_DST\" -type f -exec file {} + 2>/dev/null | awk -F\": \" '/Mach-O/ && /executable/ && !/for architecture/ {print $1}' | sort -u > \"$exec_list\"",
+				"unsandboxed=0",
+				"while IFS= read -r exe; do",
+				"  [ -n \"$exe\" ] || continue",
+				"  if ! codesign --display --entitlements - \"$exe\" 2>&1 | grep -q \"com.apple.security.app-sandbox\"; then",
+				"    echo \"error: nested executable is NOT sandboxed (90296): $exe\" >&2",
+				"    unsandboxed=$((unsandboxed + 1))",
+				"  fi",
+				"done < \"$exec_list\"",
+				"exec_count=$(wc -l < \"$exec_list\" | tr -d \" \")",
+				"rm -f \"$exec_list\"",
+				"if [ \"$unsandboxed\" -gt 0 ]; then",
+				"  echo \"error: $unsandboxed nested executable(s) lack com.apple.security.app-sandbox\" >&2",
+				"  exit 1",
+				fi,
+				"",
+				"echo \"  engine signed sandboxed: $exec_count nested executable(s), all app-sandbox + inherit, no --deep, no .a\"",
+			);
+		};
+		SBX00042F27F36000EC9EE1 /* Strip Sparkle Info.plist Keys */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			files = (
+			);
+			name = "Strip Sparkle Info.plist Keys";
+			shellPath = /bin/sh;
+			shellScript = (
+				"# App Store: strip Sparkle's Info.plist keys (#3748).",
+				"#",
+				"# Sparkle is excluded from this target at the LINK level — the framework, Autoupdate",
+				"# and its XPC services are all absent from the binary. But Info.plist is SHARED with",
+				"# the Developer ID target (both set INFOPLIST_FILE = fichero/Info.plist), and it",
+				"# still advertises an update feed: SUFeedURL, SUPublicEDKey, SUEnableAutomaticChecks.",
+				"#",
+				"# An App Store app whose Info.plist declares a third-party self-update mechanism is",
+				"# exactly what guideline 2.4.5(vii) prohibits, and it is trivially greppable by a",
+				"# reviewer even though nothing can act on it. Sparkle must be ABSENT, not merely",
+				"# inert.",
+				"#",
+				"# Stripped from the BUILT bundle rather than by forking Info.plist into a second",
+				"# file, which would drift from the DMG one silently. Same shape as",
+				"# scripts/build-release-dmg.sh, which SETS SUFeedURL on the staged bundle at package",
+				"# time. This phase runs before Xcode's CodeSign phase, so the seal covers the",
+				"# stripped plist.",
+				"",
+				"PLIST=\"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"",
+				"",
+				"if [ ! -f \"$PLIST\" ]; then",
+				"  echo \"note: no Info.plist at $PLIST — nothing to strip\"",
+				"  exit 0",
+				fi,
+				"",
+				"for KEY in SUFeedURL SUPublicEDKey SUEnableAutomaticChecks SUAllowsAutomaticUpdates SUScheduledCheckInterval; do",
+				"  if /usr/libexec/PlistBuddy -c \"Print :${KEY}\" \"$PLIST\" >/dev/null 2>&1; then",
+				"    /usr/libexec/PlistBuddy -c \"Delete :${KEY}\" \"$PLIST\"",
+				"    echo \"  removed ${KEY}\"",
+				"  fi",
+				done,
+				"",
+				"# Fail the build rather than ship a Sparkle key to App Review.",
+				"for KEY in SUFeedURL SUPublicEDKey; do",
+				"  if /usr/libexec/PlistBuddy -c \"Print :${KEY}\" \"$PLIST\" >/dev/null 2>&1; then",
+				"    echo \"error: ${KEY} is still present in the App Store Info.plist\" >&2",
+				"    exit 1",
+				"  fi",
+				done,
+				"",
+				"echo \"Sparkle Info.plist keys stripped from the App Store build\"",
+			);
+		};
+		SBX00052F27F36000EC9EE1 /* Validate App Store Bundle */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			files = (
+			);
+			name = "Validate App Store Bundle";
+			shellPath = /bin/sh;
+			shellScript = (
+				"# App Store: run the bundle validator against what we ACTUALLY built (#3797 follow-up).",
+				"#",
+				"# The R2 archive shipped full of .dSYMs while the build reported success, because the",
+				"# strip and its own verification both ran `find` against a SYMLINK",
+				"# (${BUILT_PRODUCTS_DIR}/Fichero.app is a symlink to DSTROOT in an archive build) and",
+				"# find does not descend into a symlinked starting point. Zero matches. Nothing",
+				"# deleted, nothing flagged, build green.",
+				"#",
+				"# The lesson is not \"fix the path\" — that is done. It is that the build must be checked",
+				"# by the SAME tool that judges the archive, instead of by bespoke assertions that can",
+				"# pass vacuously. So this phase runs scripts/validate_mas_bundle.sh, the exact script",
+				"# used on the .xcarchive, against the product we just assembled.",
+				"#",
+				"# --structure-only because Xcode's CodeSign step for the outer app runs AFTER this",
+				"# phase. Everything not dependent on that signature is checked, which is every",
+				"# rejection actually taken: .a (90284), .dSYM (90277/90278), unsandboxed nested",
+				"# executables (90296), engine placement, Sparkle.",
+				"",
+				"if [ \"${PLATFORM_NAME}\" != \"macosx\" ]; then",
+				"  exit 0",
+				fi,
+				"",
+				"if [ \"${FICHERO_EMBED_ENGINE}\" != \"YES\" ]; then",
+				"  echo \"Skipping App Store bundle validation (no engine embedded in this configuration)\"",
+				"  exit 0",
+				fi,
+				"",
+				"VALIDATOR=\"${SRCROOT}/../scripts/validate_mas_bundle.sh\"",
+				"if [ ! -f \"$VALIDATOR\" ]; then",
+				"  echo \"error: validator not found at $VALIDATOR\" >&2",
+				"  exit 1",
+				fi,
+				"",
+				"APP_DST=\"${TARGET_BUILD_DIR}/${WRAPPER_NAME}\"",
+				"if [ ! -d \"$APP_DST\" ]; then",
+				"  echo \"error: no app bundle at $APP_DST\" >&2",
+				"  exit 1",
+				fi,
+				"",
+				"echo \"Validating the App Store bundle we just built:\"",
+				"if ! /bin/bash \"$VALIDATOR\" --structure-only \"$APP_DST\"; then",
+				"  echo \"error: the App Store bundle would be REJECTED by App Store Connect — see the failures above\" >&2",
+				"  exit 1",
+				fi,
+			);
+		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		FEED0000000000000000024D = {
-			isa = PBXSourcesBuildPhase;
-			files = (
-				FEED00000000000000000001 /* ClaimSummaryCardView.swift in Sources */,
-				FEED00000000000000000002 /* EntityDetailView.swift in Sources */,
-				FEED00000000000000000003 /* EntityRowView.swift in Sources */,
-				FEED00000000000000000004 /* OntologyBrowser.swift in Sources */,
-				FEED00000000000000000005 /* ImagePreviewMenuCommands.swift in Sources */,
-				FEED00000000000000000006 /* ActivityProgressView+DataLoading.swift in Sources */,
-				FEED00000000000000000007 /* BackendConnectionView.swift in Sources */,
-				FEED00000000000000000008 /* MiniToolbar.swift in Sources */,
-				FEED00000000000000000009 /* QuickLookComponents.swift in Sources */,
-				FEED0000000000000000000A /* ChatMessagesList.swift in Sources */,
-				FEED0000000000000000000B /* LibraryViewComponents.swift in Sources */,
-				FEED0000000000000000000C /* AppleScriptCommands.swift in Sources */,
-				FEED0000000000000000000D /* ActivityDataProcessing.swift in Sources */,
-				FEED0000000000000000000E /* ActivityRun.swift in Sources */,
-				FEED0000000000000000000F /* DocumentStoreTypes.swift in Sources */,
-				FEED00000000000000000010 /* FolderAccessManager.swift in Sources */,
-				FEED00000000000000000011 /* ActivityProgressModels.swift in Sources */,
-				FEED00000000000000000012 /* WorkflowSupportTypes.swift in Sources */,
-				FEED00000000000000000013 /* WorkflowToolbar.swift in Sources */,
-				FEED00000000000000000014 /* ProviderServiceGenerated.swift in Sources */,
-				FEED00000000000000000015 /* SearchServiceGenerated.swift in Sources */,
-				FEED00000000000000000016 /* BatchServiceGenerated.swift in Sources */,
-				FEED00000000000000000017 /* ChatViewToolbar.swift in Sources */,
-				FEED00000000000000000018 /* SearchResultRowFromAPI.swift in Sources */,
-				FEED00000000000000000019 /* FocusedCommandButtons.swift in Sources */,
-				FEED0000000000000000001A /* FicheroApp.swift in Sources */,
-				FEED0000000000000000001B /* AppInstaller.swift in Sources */,
-				FEED0000000000000000001C /* SparkleUpdater.swift in Sources */,
-				FEED0000000000000000001D /* ContentView.swift in Sources */,
-				FEED0000000000000000001E /* Document.swift in Sources */,
-				FEED0000000000000000001F /* ContentView+Actions.swift in Sources */,
-				FEED00000000000000000020 /* IntegrationsPlaceholderSheet.swift in Sources */,
-				FEED00000000000000000021 /* MessageCard.swift in Sources */,
-				FEED00000000000000000022 /* SidebarItem.swift in Sources */,
-				FEED00000000000000000023 /* FeatureManager.swift in Sources */,
-				FEED00000000000000000024 /* FeatureTiers.generated.swift in Sources */,
-				FEED00000000000000000025 /* ActivityDetailView.swift in Sources */,
-				FEED00000000000000000026 /* SidebarItemBuilder.swift in Sources */,
-				FEED00000000000000000027 /* ContentView+ViewBuilders.swift in Sources */,
-				FEED00000000000000000028 /* ContentView+Toolbar.swift in Sources */,
-				FEED00000000000000000029 /* CacheModel.swift in Sources */,
-				FEED0000000000000000002A /* WorkflowPickerSheet.swift in Sources */,
-				FEED0000000000000000002B /* DocumentPickerSheet.swift in Sources */,
-				FEED0000000000000000002C /* PerformanceService.swift in Sources */,
-				FEED0000000000000000002D /* NodeProviderModelSelector.swift in Sources */,
-				FEED0000000000000000002E /* ErrorService.swift in Sources */,
-				FEED0000000000000000002F /* AIModelSelectionView.swift in Sources */,
-				FEED00000000000000000030 /* AIProviderAddModelsSheet.swift in Sources */,
-				FEED00000000000000000031 /* AutomationService.swift in Sources */,
-				FEED00000000000000000032 /* AutomationServiceMappers.swift in Sources */,
-				FEED00000000000000000033 /* DocumentStore+Helpers.swift in Sources */,
-				FEED00000000000000000034 /* ActionLibraryService.swift in Sources */,
-				FEED00000000000000000035 /* TranscribeNodeConfig.swift in Sources */,
-				FEED00000000000000000036 /* ThinkingModePicker.swift in Sources */,
-				FEED00000000000000000037 /* SidebarItem+MoreFactories.swift in Sources */,
-				FEED00000000000000000038 /* SearchView+Helpers.swift in Sources */,
-				FEED00000000000000000039 /* RecentSearchesStore.swift in Sources */,
-				FEED0000000000000000003A /* ProvidersView.swift in Sources */,
-				FEED0000000000000000003B /* ProvidersView+ModelTypes.swift in Sources */,
-				FEED0000000000000000003C /* ProvidersView+ProviderDetailView.swift in Sources */,
-				FEED0000000000000000003D /* ProvidersView+ProviderSettingsRow.swift in Sources */,
-				FEED0000000000000000003E /* AddProviderSheet.swift in Sources */,
-				FEED0000000000000000003F /* MCPToolsCatalogView.swift in Sources */,
-				FEED00000000000000000040 /* WorkflowMiniPreview.swift in Sources */,
-				FEED00000000000000000041 /* AddMCPServerSheet.swift in Sources */,
-				FEED00000000000000000042 /* WorkflowCanvasView+DropHandling.swift in Sources */,
-				FEED00000000000000000043 /* WorkflowCanvasView+Gestures.swift in Sources */,
-				FEED00000000000000000044 /* ActivityProgressView+HistoricalProgress.swift in Sources */,
-				FEED00000000000000000045 /* NodePopover.swift in Sources */,
-				FEED00000000000000000046 /* PromptPreviewPanel.swift in Sources */,
-				FEED00000000000000000047 /* TriggerDetailView+Helpers.swift in Sources */,
-				FEED00000000000000000048 /* LibraryView+InlineEditing.swift in Sources */,
-				FEED00000000000000000049 /* DescribeNodeConfig.swift in Sources */,
-				FEED0000000000000000004A /* WorkflowCanvasView.swift in Sources */,
-				FEED0000000000000000004B /* SidebarCreationHandlers.swift in Sources */,
-				FEED0000000000000000004C /* WorkflowEdgeView.swift in Sources */,
-				FEED0000000000000000004D /* WorkflowEditor.swift in Sources */,
-				FEED0000000000000000004E /* SidebarItemRow+Label.swift in Sources */,
-				FEED0000000000000000004F /* SidebarItemRow+DropHandlers.swift in Sources */,
-				FEED00000000000000000050 /* SidebarItemRow+Helpers.swift in Sources */,
-				FEED00000000000000000051 /* ModelComparisonTypes.swift in Sources */,
-				FEED00000000000000000052 /* SidebarItemRow+Rename.swift in Sources */,
-				FEED00000000000000000053 /* WorkflowEditor+Actions.swift in Sources */,
-				FEED00000000000000000054 /* WorkflowEditor+NodeViews.swift in Sources */,
-				FEED00000000000000000055 /* WorkflowEditor+Preview.swift in Sources */,
-				FEED00000000000000000056 /* ChainListContent.swift in Sources */,
-				FEED00000000000000000057 /* ChainListRow.swift in Sources */,
-				FEED00000000000000000058 /* ChainStepRow.swift in Sources */,
-				FEED00000000000000000059 /* ChainDetailContent.swift in Sources */,
-				FEED0000000000000000005A /* ChainDetailSheet.swift in Sources */,
-				FEED0000000000000000005B /* NewChainSheet.swift in Sources */,
-				FEED0000000000000000005C /* WorkflowExecutionView.swift in Sources */,
-				FEED0000000000000000005D /* WorkflowNodeView.swift in Sources */,
-				FEED0000000000000000005E /* WorkflowLibraryView.swift in Sources */,
-				FEED0000000000000000005F /* ActionRowView.swift in Sources */,
-				FEED00000000000000000060 /* LibraryView+KeyboardShortcuts.swift in Sources */,
-				FEED00000000000000000061 /* FilesNodeConfig.swift in Sources */,
-				FEED00000000000000000062 /* SummarizeFolderNodeConfig.swift in Sources */,
-				FEED00000000000000000063 /* WorkflowChain.swift in Sources */,
-				FEED00000000000000000064 /* CheckpointTypes.swift in Sources */,
-				FEED00000000000000000065 /* LibraryWindow.swift in Sources */,
-				FEED00000000000000000066 /* ChainService.swift in Sources */,
-				FEED00000000000000000067 /* ContentView+Persistence.swift in Sources */,
-				FEED00000000000000000068 /* ActivityServiceGenerated.swift in Sources */,
-				SBX00032F27F36000EC9EE1 /* SandboxAccessServiceGenerated.swift in Sources */,
-				FEED00000000000000000069 /* LocationServiceGenerated.swift in Sources */,
-				FEED0000000000000000006A /* PDFDocumentCache.swift in Sources */,
-				FEED0000000000000000006B /* PreviewDownloadService.swift in Sources */,
-				FEED0000000000000000006C /* ActivityStreamService.swift in Sources */,
-				FEED0000000000000000006D /* ExtractEntitiesNodeConfig.swift in Sources */,
-				FEED0000000000000000006E /* WorkflowNodeCard.swift in Sources */,
-				FEED0000000000000000006F /* AutomationServiceGenerated.swift in Sources */,
-				FEED00000000000000000070 /* WorkflowInspector+DataLoading.swift in Sources */,
-				FEED00000000000000000071 /* NodeInputMappings.swift in Sources */,
-				FEED00000000000000000072 /* WorkflowResponseTypes.swift in Sources */,
-				FEED00000000000000000073 /* ArtifactServiceGenerated.swift in Sources */,
-				FEED00000000000000000074 /* WorkflowInspector+MCPTools.swift in Sources */,
-				FEED00000000000000000075 /* IntegrationsServiceTypes.swift in Sources */,
-				FEED00000000000000000076 /* ChatStatusViews.swift in Sources */,
-				FEED00000000000000000077 /* StorageServiceGenerated.swift in Sources */,
-				FEED00000000000000000078 /* ModelServiceGenerated.swift in Sources */,
-				FEED00000000000000000079 /* ImportServiceGenerated.swift in Sources */,
-				FEED0000000000000000007A /* ActivityTypes.swift in Sources */,
-				FEED0000000000000000007B /* WorkflowChainListView.swift in Sources */,
-				FEED0000000000000000007C /* BatchTypes.swift in Sources */,
-				FEED0000000000000000007D /* ChainEditorView.swift in Sources */,
-				FEED0000000000000000007E /* ScheduleCreationSheet.swift in Sources */,
-				FEED0000000000000000007F /* TriggerCreationSheet.swift in Sources */,
-				FEED00000000000000000080 /* AgentNodeBlockView.swift in Sources */,
-				FEED00000000000000000081 /* TriggerDetailView+ExecutionHistory.swift in Sources */,
-				FEED00000000000000000082 /* SimpleWorkflowView.swift in Sources */,
-				FEED00000000000000000083 /* WorkflowDiagramPreview.swift in Sources */,
-				FEED00000000000000000084 /* WorkflowThumbnailView.swift in Sources */,
-				FEED00000000000000000085 /* WorkflowOutputLog.swift in Sources */,
-				FEED00000000000000000086 /* WorkflowPortView.swift in Sources */,
-				FEED00000000000000000087 /* WorkflowInspector.swift in Sources */,
-				FEED00000000000000000088 /* WorkflowCanvasView+EdgeConnection.swift in Sources */,
-				FEED00000000000000000089 /* CanvasHelpers.swift in Sources */,
-				FEED0000000000000000008A /* WorkflowToolBlocks.swift in Sources */,
-				FEED0000000000000000008B /* SidebarSearchTypes.swift in Sources */,
-				FEED0000000000000000008C /* EmbeddedBackendService.swift in Sources */,
-				FEED0000000000000000008D /* SearchFiltersPanel.swift in Sources */,
-				FEED0000000000000000008E /* SearchMapComponents.swift in Sources */,
-				FEED0000000000000000008F /* MCPServerDetailView.swift in Sources */,
-				FEED00000000000000000090 /* ActivityProgressView.swift in Sources */,
-				FEED00000000000000000091 /* ImageWithCursorTracking.swift in Sources */,
-				FEED00000000000000000092 /* ActivityConsoleView.swift in Sources */,
-				FEED00000000000000000093 /* ActivityOverviewView.swift in Sources */,
-				FEED00000000000000000094 /* ActivityLogView.swift in Sources */,
-				FEED00000000000000000095 /* ActivityViewHelpers.swift in Sources */,
-				FEED00000000000000000096 /* MCPServersSheet.swift in Sources */,
-				FEED00000000000000000097 /* MCPServersView.swift in Sources */,
-				FEED00000000000000000098 /* Artifact.swift in Sources */,
-				FEED00000000000000000099 /* SearchResultsDisplay.swift in Sources */,
-				FEED0000000000000000009A /* SearchResultsEmptyState.swift in Sources */,
-				FEED0000000000000000009B /* Event.swift in Sources */,
-				FEED0000000000000000009C /* Trace.swift in Sources */,
-				FEED0000000000000000009D /* MCPServer.swift in Sources */,
-				FEED0000000000000000009E /* Run.swift in Sources */,
-				FEED0000000000000000009F /* Note.swift in Sources */,
-				FEED000000000000000000A0 /* SummarizeCollectionNodeConfig.swift in Sources */,
-				FEED000000000000000000A1 /* ErrorModel.swift in Sources */,
-				FEED000000000000000000A2 /* LayoutMode.swift in Sources */,
-				FEED000000000000000000A3 /* LibraryImageView.swift in Sources */,
-				FEED000000000000000000A4 /* SkeletonPlaceholder.swift in Sources */,
-				FEED000000000000000000A5 /* FrameAnimation.swift in Sources */,
-				FEED000000000000000000A6 /* NodeConfigView.swift in Sources */,
-				FEED000000000000000000A7 /* LibraryView+DisplayModes.swift in Sources */,
-				FEED000000000000000000A8 /* LibraryView+Sorting.swift in Sources */,
-				FEED000000000000000000A9 /* LibraryView+ColumnConfig.swift in Sources */,
-				FEED000000000000000000AA /* LibraryView+FilterAndBatch.swift in Sources */,
-				FEED000000000000000000AB /* SidebarState.swift in Sources */,
-				FEED000000000000000000AC /* DragDropModel.swift in Sources */,
-				FEED000000000000000000AD /* SidebarActions.swift in Sources */,
-				FEED000000000000000000AE /* SettingsView.swift in Sources */,
-				FEED000000000000000000AF /* EditorView.swift in Sources */,
-				FEED000000000000000000B0 /* ItemTypeRegistry.swift in Sources */,
-				FEED000000000000000000B1 /* SearchView.swift in Sources */,
-				FEED000000000000000000B2 /* AIModelCatalog.swift in Sources */,
-				FEED000000000000000000B3 /* ChatView+Extensions.swift in Sources */,
-				FEED000000000000000000B4 /* ContentViewModifiers.swift in Sources */,
-				FEED000000000000000000B5 /* IntegrationsService.swift in Sources */,
-				FEED000000000000000000B6 /* NewWorkflowSheet.swift in Sources */,
-				FEED000000000000000000B7 /* LibraryView.swift in Sources */,
-				FEED000000000000000000B8 /* ProviderLogoView.swift in Sources */,
-				FEED000000000000000000B9 /* StatusBadge.swift in Sources */,
-				FEED000000000000000000BA /* MacPlainTextEditor.swift in Sources */,
-				FEED000000000000000000BB /* ViewMenuCommands.swift in Sources */,
-				FEED000000000000000000BC /* ViewSettings.swift in Sources */,
-				FEED000000000000000000BD /* AppState.swift in Sources */,
-				FEED000000000000000000BE /* WorkflowStreamService+Parsing.swift in Sources */,
-				FEED000000000000000000BF /* ChatView.swift in Sources */,
-				FEED000000000000000000C0 /* ComparisonTypes.swift in Sources */,
-				FEED000000000000000000C1 /* SearchNodeConfig.swift in Sources */,
-				FEED000000000000000000C2 /* ContentView+State.swift in Sources */,
-				FEED000000000000000000C3 /* FirstRunWindow.swift in Sources */,
-				FEED000000000000000000C4 /* DocumentStore.swift in Sources */,
-				FEED000000000000000000C5 /* WorkflowStreamTypes.swift in Sources */,
-				FEED000000000000000000C6 /* APIClient.swift in Sources */,
-				FEED000000000000000000C7 /* IntegrationsService+AppSpecific.swift in Sources */,
-				FEED000000000000000000C8 /* ModelComparisonService.swift in Sources */,
-				FEED000000000000000000C9 /* ActionLibraryView.swift in Sources */,
-				FEED000000000000000000CA /* AutomationServiceTypes.swift in Sources */,
-				FEED000000000000000000CB /* ImportService.swift in Sources */,
-				FEED000000000000000000CC /* ActionDetailView.swift in Sources */,
-				FEED000000000000000000CD /* ChatService.swift in Sources */,
-				FEED000000000000000000CE /* SavedSearchService.swift in Sources */,
-				FEED000000000000000000CF /* AddItemMenu.swift in Sources */,
-				FEED000000000000000000D0 /* WorkflowServiceGenerated.swift in Sources */,
-				FEED000000000000000000D1 /* SavedSearchServiceGenerated.swift in Sources */,
-				FEED000000000000000000D2 /* ChatInputView.swift in Sources */,
-				FEED000000000000000000D3 /* TriggerDetailView+Configuration.swift in Sources */,
-				FEED000000000000000000D4 /* ConversationServiceGenerated.swift in Sources */,
-				FEED000000000000000000D5 /* ContentView+Navigation.swift in Sources */,
-				FEED000000000000000000D6 /* WorkflowNodeRow.swift in Sources */,
-				FEED000000000000000000D7 /* ChatServiceGenerated.swift in Sources */,
-				FEED000000000000000000D8 /* WorkflowRunResponse.swift in Sources */,
-				FEED000000000000000000D9 /* DocumentServiceGenerated.swift in Sources */,
-				FEED000000000000000000DA /* ChatInspector.swift in Sources */,
-				FEED000000000000000000DB /* ChatInspector+Actions.swift in Sources */,
-				FEED000000000000000000DC /* ChatInspector+Header.swift in Sources */,
-				FEED000000000000000000DD /* ChatInspector+ScopedDocuments.swift in Sources */,
-				FEED000000000000000000DE /* ChatInspector+Search.swift in Sources */,
-				FEED000000000000000000DF /* CollectionNodeConfig.swift in Sources */,
-				FEED000000000000000000E0 /* ModelService.swift in Sources */,
-				FEED000000000000000000E1 /* ProviderServiceTypes.swift in Sources */,
-				FEED000000000000000000E2 /* SidebarItemContextMenu.swift in Sources */,
-				FEED000000000000000000E3 /* SidebarViewTypes.swift in Sources */,
-				FEED000000000000000000E4 /* ActionPickerView.swift in Sources */,
-				FEED000000000000000000E5 /* StorageService.swift in Sources */,
-				FEED000000000000000000E6 /* WorkflowLibraryRow.swift in Sources */,
-				FEED000000000000000000E7 /* ViewContexts.swift in Sources */,
-				FEED000000000000000000E8 /* TrackingImageView.swift in Sources */,
-				FEED000000000000000000E9 /* ActivityProgressView+LiveProgress.swift in Sources */,
-				FEED000000000000000000EA /* FicheroDocument.swift in Sources */,
-				FEED000000000000000000EB /* LibraryManager.swift in Sources */,
-				FEED000000000000000000EC /* LibraryManager+Operations.swift in Sources */,
-				FEED000000000000000000ED /* LibraryManager+Helpers.swift in Sources */,
-				FEED000000000000000000EE /* LibraryManager+Persistence.swift in Sources */,
-				FEED000000000000000000EF /* WindowState.swift in Sources */,
-				FEED000000000000000000F0 /* SidebarItemRow.swift in Sources */,
-				FEED000000000000000000F1 /* SidebarView.swift in Sources */,
-				FEED000000000000000000F2 /* WorkflowExecutionService.swift in Sources */,
-				FEED000000000000000000F3 /* WorkflowStreamService.swift in Sources */,
-				FEED000000000000000000F4 /* SidebarChatTypes.swift in Sources */,
-				FEED000000000000000000F5 /* WorkflowExecutionObserver.swift in Sources */,
-				FEED000000000000000000F6 /* WorkflowExecutionTypes.swift in Sources */,
-				FEED000000000000000000F7 /* SidebarModeIcon.swift in Sources */,
-				FEED000000000000000000F8 /* SidebarModeBar.swift in Sources */,
-				FEED000000000000000000F9 /* ModelComparisonView.swift in Sources */,
-				FEED000000000000000000FA /* ModelComparisonView+Sidebar.swift in Sources */,
-				FEED000000000000000000FB /* ComparisonResultView.swift in Sources */,
-				FEED000000000000000000FC /* ModelResultCard.swift in Sources */,
-				FEED000000000000000000FD /* ModelPickerSheet.swift in Sources */,
-				FEED000000000000000000FE /* PresetPickerSheet.swift in Sources */,
-				FEED000000000000000000FF /* AppleScriptSupport.swift in Sources */,
-				FEED00000000000000000100 /* SidebarStateManagers.swift in Sources */,
-				FEED00000000000000000101 /* SidebarViewExtensions.swift in Sources */,
-				FEED00000000000000000102 /* SidebarSectionHeader.swift in Sources */,
-				FEED00000000000000000103 /* SidebarConstants.swift in Sources */,
-				FEED00000000000000000104 /* Workflow.swift in Sources */,
-				FEED00000000000000000105 /* WorkflowTypes.swift in Sources */,
-				FEED00000000000000000106 /* WorkflowStore.swift in Sources */,
-				FEED00000000000000000107 /* GeneratedTypeExtensions.swift in Sources */,
-				FEED00000000000000000108 /* MCPService.swift in Sources */,
-				FEED00000000000000000109 /* WorkflowExporter.swift in Sources */,
-				FEED0000000000000000010A /* SidebarObservers.swift in Sources */,
-				FEED0000000000000000010B /* ComparisonDetailView.swift in Sources */,
-				FEED0000000000000000010C /* SummarizeFileNodeConfig.swift in Sources */,
-				FEED0000000000000000010D /* WorkflowDetailView.swift in Sources */,
-				FEED0000000000000000010E /* ScheduleDetailView.swift in Sources */,
-				FEED0000000000000000010F /* ScheduleEditorView.swift in Sources */,
-				FEED00000000000000000110 /* ActionsService.swift in Sources */,
-				FEED00000000000000000111 /* TriggerEditorView.swift in Sources */,
-				FEED00000000000000000112 /* TriggerDetailView.swift in Sources */,
-				FEED00000000000000000113 /* DynamicConfigView.swift in Sources */,
-				FEED00000000000000000114 /* DynamicConfigView+FieldRendering.swift in Sources */,
-				FEED00000000000000000115 /* WorkflowExecutionObserver+Events.swift in Sources */,
-				FEED00000000000000000116 /* DocumentStore+CRUD.swift in Sources */,
-				FEED00000000000000000117 /* DynamicConfigView+SchemaHelpers.swift in Sources */,
-				FEED00000000000000000118 /* DynamicConfigView+StateManagement.swift in Sources */,
-				FEED00000000000000000119 /* DocumentInspectorInfoTab.swift in Sources */,
-				FEED0000000000000000011A /* DocumentInspectorMetadataTab.swift in Sources */,
-				FEED0000000000000000011B /* DocumentInspectorArtifactsTab.swift in Sources */,
-				FEED0000000000000000011C /* SurfaceTabBar.swift in Sources */,
-				FEED0000000000000000011D /* DocumentInspectorContentTab.swift in Sources */,
-				FEED0000000000000000011E /* TriggerEditorFormPanel.swift in Sources */,
-				FEED0000000000000000011F /* TriggerEditorPreviewPanel.swift in Sources */,
-				FEED00000000000000000120 /* FlowLayout.swift in Sources */,
-				FEED00000000000000000121 /* AIDefaults.swift in Sources */,
-				FEED00000000000000000122 /* AISettingsView.swift in Sources */,
-				FEED00000000000000000123 /* GeneralSettingsView.swift in Sources */,
-				FEED00000000000000000124 /* WorkflowToolTypes.swift in Sources */,
-				FEED00000000000000000125 /* BackendSettingsView.swift in Sources */,
-				FEED00000000000000000126 /* LocalModelsSettingsView.swift in Sources */,
-				FEED00000000000000000127 /* WorkflowOutputLog+Models.swift in Sources */,
-				FEED00000000000000000128 /* WorkflowInspector+AgentsSection.swift in Sources */,
-				FEED00000000000000000129 /* WorkflowOutputLog+StatusViews.swift in Sources */,
-				FEED0000000000000000012A /* WorkflowOutputLog+ErrorCell.swift in Sources */,
-				FEED0000000000000000012B /* WorkflowOutputLog+EmptyStates.swift in Sources */,
-				FEED0000000000000000012C /* ScheduleEditorView+Category.swift in Sources */,
-				FEED0000000000000000012D /* ComparisonDetailView+Actions.swift in Sources */,
-				FEED0000000000000000012E /* ComparisonDetailView+Models.swift in Sources */,
-				FEED0000000000000000012F /* ComparisonDetailView+Sections.swift in Sources */,
-				FEED00000000000000000130 /* SidebarView+Helpers.swift in Sources */,
-				FEED00000000000000000131 /* SidebarView+SelectionHandling.swift in Sources */,
-				FEED00000000000000000132 /* SidebarView+ViewComponents.swift in Sources */,
-				FEED00000000000000000133 /* AddProviderSheet+Helpers.swift in Sources */,
-				FEED00000000000000000134 /* AddProviderSheet+Step1.swift in Sources */,
-				FEED00000000000000000135 /* AddProviderSheet+Step2.swift in Sources */,
-				FEED00000000000000000136 /* AddProviderSheet+Step3.swift in Sources */,
-				FEED00000000000000000137 /* EntitySourceGroupsView.swift in Sources */,
-				FEED00000000000000000138 /* SpeakerComparisonView.swift in Sources */,
-				FEED00000000000000000139 /* SpeakerComparisonView+Preview.swift in Sources */,
-				FEED0000000000000000013A /* NavigationHistoryManager.swift in Sources */,
-				FEED0000000000000000013B /* ActivityOverviewView+Cards.swift in Sources */,
-				FEED0000000000000000013C /* EntityDetailView+Biography.swift in Sources */,
-				FEED0000000000000000013D /* EntityDetailView+Audit.swift in Sources */,
-				FEED0000000000000000013E /* EntityDetailView+Claims.swift in Sources */,
-				FEED0000000000000000013F /* EntityDetailView+FilterChips.swift in Sources */,
-				FEED00000000000000000140 /* ContentView+WorkflowActions.swift in Sources */,
-				FEED00000000000000000141 /* ContentView+ReadingLayout.swift in Sources */,
-				FEED00000000000000000142 /* AISettingsView+Tabs.swift in Sources */,
-				FEED00000000000000000143 /* AISettingsView+Helpers.swift in Sources */,
-				FEED00000000000000000144 /* LibraryView+TableMapViews.swift in Sources */,
-				FEED00000000000000000145 /* ClaimSummaryCard+Details.swift in Sources */,
-				FEED00000000000000000146 /* APIClient+Types.swift in Sources */,
-				FEED00000000000000000147 /* QuickLookPreviewViews.swift in Sources */,
-				FEED00000000000000000148 /* DocumentKGWebPane.swift in Sources */,
-				FEED00000000000000000149 /* ContentView+KnowledgeSurface.swift in Sources */,
-				FEED0000000000000000014A /* UITestSupport.swift in Sources */,
-				FEED0000000000000000014B /* EditClaimSheet.swift in Sources */,
-				FEED0000000000000000014C /* EntityMergeSheet.swift in Sources */,
-				FEED0000000000000000014D /* EntityReconciliationSheet.swift in Sources */,
-				FEED0000000000000000014E /* EntitySplitSheet.swift in Sources */,
-				FEED0000000000000000014F /* KGMapView.swift in Sources */,
-				FEED00000000000000000150 /* KGTemporalSpatial.swift in Sources */,
-				FEED00000000000000000151 /* KGTimelineView.swift in Sources */,
-				FEED00000000000000000152 /* ImageEditingServiceGenerated.swift in Sources */,
-				FEED00000000000000000153 /* ImageEditorModel.swift in Sources */,
-				FEED00000000000000000154 /* LiveEditPreview.swift in Sources */,
-				FEED00000000000000000155 /* ImageEditChainPanel.swift in Sources */,
-				FEED00000000000000000156 /* ImageEditorView.swift in Sources */,
-				FEED00000000000000000157 /* ImageMarqueeOverlay.swift in Sources */,
-				FEED00000000000000000158 /* AnnotationService.swift in Sources */,
-				FEED00000000000000000159 /* DocumentInspectorAnnotationsTab.swift in Sources */,
-				FEED0000000000000000015A /* SpatialModels.swift in Sources */,
-				FEED0000000000000000015B /* SpatialView.swift in Sources */,
-				FEED0000000000000000015C /* ResearchModels.swift in Sources */,
-				FEED0000000000000000015D /* ResearchService.swift in Sources */,
-				FEED0000000000000000015E /* ResearchProjectListView.swift in Sources */,
-				FEED0000000000000000015F /* ResearchBrowserPane.swift in Sources */,
-				FEED00000000000000000160 /* ResearchTasksPane.swift in Sources */,
-				FEED00000000000000000161 /* ResearchChatPane.swift in Sources */,
-				FEED00000000000000000162 /* ResearchWorkspaceView.swift in Sources */,
-				FEED00000000000000000163 /* DocumentKGSurface.swift in Sources */,
-				FEED00000000000000000164 /* AppNavigationHistory.swift in Sources */,
-				FEED00000000000000000165 /* ContentView+NavigationHistory.swift in Sources */,
-				FEED00000000000000000166 /* KGFocusState.swift in Sources */,
-				FEED00000000000000000167 /* SpatialLibraryProjector.swift in Sources */,
-				FEED00000000000000000168 /* WorkflowRunProviderCache.swift in Sources */,
-				FEED00000000000000000169 /* ClaimReviewQueueSheet.swift in Sources */,
-				FEED0000000000000000016A /* ContradictionTriageSheet.swift in Sources */,
-				FEED0000000000000000016B /* EntityDigestView.swift in Sources */,
-				FEED0000000000000000016C /* DocumentCanvas.swift in Sources */,
-				FEED0000000000000000016D /* MediaStreamPreview.swift in Sources */,
-				FEED0000000000000000016E /* NodeComparisonSheet.swift in Sources */,
-				FEED0000000000000000016F /* NodePopover+Comparison.swift in Sources */,
-				FEED00000000000000000170 /* NoteService.swift in Sources */,
-				FEED00000000000000000171 /* DocumentNotesTab.swift in Sources */,
-				FEED00000000000000000172 /* LibraryToolbarState.swift in Sources */,
-				FEED00000000000000000173 /* EntityDetailView+Notes.swift in Sources */,
-				FEED00000000000000000174 /* NotesBrowserView.swift in Sources */,
-				FEED00000000000000000175 /* ArtifactRichTextCodec.swift in Sources */,
-				FEED00000000000000000176 /* NodeClassPicker.swift in Sources */,
-				FEED00000000000000000177 /* FicheroWebView.swift in Sources */,
-				FEED00000000000000000178 /* EngineConfig.swift in Sources */,
-				FEED00000000000000000179 /* SpatialModels+Links.swift in Sources */,
-				FEED0000000000000000017A /* OntologyBrowserGraphModel.swift in Sources */,
-				FEED0000000000000000017B /* ForceDirectedGraphView.swift in Sources */,
-				FEED0000000000000000017C /* HeuristicReviewSheet.swift in Sources */,
-				FEED0000000000000000017D /* NewEntitySheet.swift in Sources */,
-				FEED0000000000000000017E /* EntityKindChartView.swift in Sources */,
-				FEED0000000000000000017F /* OntologyBrowser+Toolbar.swift in Sources */,
-				FEED00000000000000000180 /* OntologyBrowser+List.swift in Sources */,
-				FEED00000000000000000181 /* OntologyBrowser+Detail.swift in Sources */,
-				FEED00000000000000000182 /* ForceDirectedGraphView+Render.swift in Sources */,
-				FEED00000000000000000183 /* OntologyBrowser+Sheets.swift in Sources */,
-				FEED00000000000000000184 /* DisplayAttributesStrip.swift in Sources */,
-				FEED00000000000000000185 /* DocumentInspectorArtifactsTab+Shared.swift in Sources */,
-				FEED00000000000000000186 /* DocumentInspectorArtifactsTab+EntitiesTab.swift in Sources */,
-				FEED00000000000000000187 /* DocumentInspectorArtifactsTab+KGModels.swift in Sources */,
-				FEED00000000000000000188 /* DocumentInspectorArtifactsTab+KGSection.swift in Sources */,
-				FEED00000000000000000189 /* DocumentInspectorArtifactsTab+EntityKindBlock.swift in Sources */,
-				FEED0000000000000000018A /* DocumentInspectorArtifactsTab+EntityKindRow.swift in Sources */,
-				FEED0000000000000000018B /* DocumentInspectorArtifactsTab+CurationHistory.swift in Sources */,
-				FEED0000000000000000018C /* DocumentInspectorArtifactsTab+Interpretations.swift in Sources */,
-				FEED0000000000000000018D /* DocumentInspectorArtifactsTab+Previews.swift in Sources */,
-				FEED0000000000000000018E /* SidebarView+UnifiedLibrarySections.swift in Sources */,
-				FEED0000000000000000018F /* SidebarView+UnifiedRows.swift in Sources */,
-				FEED00000000000000000190 /* SidebarView+PinnedNavigationRows.swift in Sources */,
-				FEED00000000000000000191 /* SidebarView+ActivityRows.swift in Sources */,
-				FEED00000000000000000192 /* SidebarView+LibraryHeaderHelpers.swift in Sources */,
-				FEED00000000000000000193 /* SidebarItemRow+Drop.swift in Sources */,
-				FEED00000000000000000194 /* SidebarItemRow+Presentation+Body.swift in Sources */,
-				FEED00000000000000000195 /* SidebarItemRow+Presentation.swift in Sources */,
-				FEED00000000000000000196 /* SidebarItemRow+Preview.swift in Sources */,
-				FEED00000000000000000197 /* SidebarItemRow+Workflow.swift in Sources */,
-				FEED00000000000000000198 /* DocumentInspectorInfoTab+Header.swift in Sources */,
-				FEED00000000000000000199 /* DocumentInspectorInfoTab+RelatedClaims.swift in Sources */,
-				FEED0000000000000000019A /* DocumentInspectorInfoTab+Citations.swift in Sources */,
-				FEED0000000000000000019B /* DocumentInspectorInfoTab+Bibliography.swift in Sources */,
-				FEED0000000000000000019C /* DocumentInspectorInfoTab+Workflow.swift in Sources */,
-				FEED0000000000000000019D /* DocumentInspectorInfoTab+Prototype.swift in Sources */,
-				FEED0000000000000000019E /* FileMenuCommands.swift in Sources */,
-				FEED0000000000000000019F /* EntityDetailView+Metadata.swift in Sources */,
-				FEED000000000000000001A0 /* EntityDetailView+Sections.swift in Sources */,
-				FEED000000000000000001A1 /* ClaimSummaryCard+Provenance.swift in Sources */,
-				FEED000000000000000001A2 /* EntityStore.swift in Sources */,
-				FEED000000000000000001A3 /* BatchStore.swift in Sources */,
-				FEED000000000000000001A4 /* BatchRunView.swift in Sources */,
-				FEED000000000000000001A5 /* WorkspaceStore.swift in Sources */,
-				FEED000000000000000001A6 /* LibraryChangeStream.swift in Sources */,
-				FEED000000000000000001A7 /* ClaimStore.swift in Sources */,
-				FEED000000000000000001A8 /* NoteStore.swift in Sources */,
-				FEED000000000000000001A9 /* AnnotationStore.swift in Sources */,
-				FEED000000000000000001AA /* ActionStore.swift in Sources */,
-				FEED000000000000000001AB /* ResearchStore.swift in Sources */,
-				FEED000000000000000001AC /* SearchStore.swift in Sources */,
-				FEED000000000000000001AD /* ObservableDomainStore.swift in Sources */,
-				FEED000000000000000001AE /* DocumentStore+ChangeStream.swift in Sources */,
-				FEED000000000000000001AF /* ArtifactStore.swift in Sources */,
-				FEED000000000000000001B0 /* CitationStore.swift in Sources */,
-				FEED000000000000000001B1 /* ReferenceStore.swift in Sources */,
-				FEED000000000000000001B2 /* InterpretationStore.swift in Sources */,
-				FEED000000000000000001B3 /* ActionInvokeService.swift in Sources */,
-				FEED000000000000000001B4 /* FicheroShortcuts.swift in Sources */,
-				FEED000000000000000001B5 /* FicheroActionIntents.swift in Sources */,
-				FEED000000000000000001B6 /* NoteListView.swift in Sources */,
-				FEED000000000000000001B7 /* NoteDetailView.swift in Sources */,
-				FEED000000000000000001B8 /* NotesInspectorPane.swift in Sources */,
-				FEED000000000000000001B9 /* PlatformAliases.swift in Sources */,
-				FEED000000000000000001BA /* PlatformPasteboard.swift in Sources */,
-				FEED000000000000000001BB /* CanvasLayoutStore.swift in Sources */,
-				FEED000000000000000001BC /* CanvasLayoutStore+ChangeStream.swift in Sources */,
-				FEED000000000000000001BD /* CanvasItemStore.swift in Sources */,
-				FEED000000000000000001BE /* CanvasItemStore+ChangeStream.swift in Sources */,
-				FEED000000000000000001BF /* AuditStore.swift in Sources */,
-				FEED000000000000000001C0 /* AuditHistoryView.swift in Sources */,
-				FEED000000000000000001C1 /* FicheroAppEntities.swift in Sources */,
-				FEED000000000000000001C2 /* BackupStore.swift in Sources */,
-				FEED000000000000000001C3 /* BackupsView.swift in Sources */,
-				FEED000000000000000001C4 /* SplittablePane.swift in Sources */,
-				FEED000000000000000001C5 /* WindowSeed.swift in Sources */,
-				FEED000000000000000001C6 /* LibraryOutlineNode.swift in Sources */,
-				FEED000000000000000001C7 /* FicheroApp_iOS.swift in Sources */,
-				FEED000000000000000001C8 /* MobileCaptureQueue.swift in Sources */,
-				FEED000000000000000001C9 /* MobileCaptureQueueView.swift in Sources */,
-				FEED000000000000000001CA /* MacRemoteClientPairingSection.swift in Sources */,
-				FEED000000000000000001CB /* RemoteClientPairing.swift in Sources */,
-				C0FFEE0000000000000000A3 /* PairingRestoreDiagnostics.swift in Sources */,
-				FEED000000000000000001CC /* ChatDocumentDropPayload.swift in Sources */,
-				FEED000000000000000001CD /* BackendSettingsRemoteAccessSection.swift in Sources */,
-				FEED000000000000000001CE /* EngineSettingsView.swift in Sources */,
-				FEED000000000000000001CF /* ShareSettingsView.swift in Sources */,
-				FEED000000000000000001D0 /* UsersSettingsView.swift in Sources */,
-				FEED000000000000000001D1 /* UsersStore.swift in Sources */,
-				FEED000000000000000001D2 /* LocalInferenceStore.swift in Sources */,
-				FEED000000000000000001D3 /* KnownLibraryRegistryStore.swift in Sources */,
-				FEED000000000000000001D4 /* AppleAvailabilityStore.swift in Sources */,
-				FEED000000000000000001D5 /* LocalInferenceSettingsView.swift in Sources */,
-				FEED000000000000000001D6 /* CaptureSettingsView.swift in Sources */,
-				FEED000000000000000001D7 /* iOSLibraryPickerMenu.swift in Sources */,
-				FEED000000000000000001D8 /* ImportServiceGenerated+Upload.swift in Sources */,
-				FEED000000000000000001D9 /* ActivityStore.swift in Sources */,
-				FEED000000000000000001DA /* BreadcrumbBuilder.swift in Sources */,
-				FEED000000000000000001DB /* MiniToolbarComponents.swift in Sources */,
-				FEED000000000000000001DC /* Spatial2DCanvasGestures.swift in Sources */,
-				FEED000000000000000001DD /* Spatial2DCanvasItems.swift in Sources */,
-				FEED000000000000000001DE /* SpatialNodeThumbnail.swift in Sources */,
-				FEED000000000000000001DF /* ReaderToolbar.swift in Sources */,
-				FEED000000000000000001E0 /* WorkflowExecutionStore.swift in Sources */,
-				FEED000000000000000001E1 /* ActivityMonitorModel.swift in Sources */,
-				FEED000000000000000001E2 /* ActivityMonitorView.swift in Sources */,
-				FEED000000000000000001E3 /* ActivityMonitorWindow.swift in Sources */,
-				FEED000000000000000001E4 /* DocumentInspectorInfoTab+Sharing.swift in Sources */,
-				FEED000000000000000001E5 /* Representation.swift in Sources */,
-				FEED000000000000000001E6 /* DocumentInterpretationsTab.swift in Sources */,
-				FEED000000000000000001E7 /* MarkdownText.swift in Sources */,
-				FEED000000000000000001E8 /* CoalescingSaveRunner.swift in Sources */,
-				FEED000000000000000001E9 /* AnnotationHighlight.swift in Sources */,
-				FEED000000000000000001EA /* AnnotatableTextView.swift in Sources */,
-				FEED000000000000000001EB /* BoundingBoxGeometry.swift in Sources */,
-				FEED000000000000000001EC /* PDFRegionGeometry.swift in Sources */,
-				FEED000000000000000001ED /* BookmarkServiceGenerated.swift in Sources */,
-				FEED000000000000000001EE /* BookmarksView.swift in Sources */,
-				FEED000000000000000001EF /* SessionStore.swift in Sources */,
-				FEED000000000000000001F0 /* KGQueryStore.swift in Sources */,
-				FEED000000000000000001F1 /* AuthGateView.swift in Sources */,
-				FEED000000000000000001F2 /* BackendRootGate.swift in Sources */,
-				FEED000000000000000001F3 /* BackendHost.swift in Sources */,
-				FEED000000000000000001F4 /* LibrarySharingBadge.swift in Sources */,
-				FEED000000000000000001F5 /* ViewDisplayMode.swift in Sources */,
-				FEED000000000000000001F6 /* MiniToolbarOverflow.swift in Sources */,
-				FEED000000000000000001F7 /* AboutView.swift in Sources */,
-				FEED000000000000000001F8 /* SearchArrowKeyNavigation.swift in Sources */,
-				FEED000000000000000001F9 /* SpaceSceneView.swift in Sources */,
-				FEED000000000000000001FA /* SpaceTheme.swift in Sources */,
-				FEED000000000000000001FB /* CanvasSceneState.swift in Sources */,
-				FEED000000000000000001FC /* CanvasSceneDiff.swift in Sources */,
-				FEED000000000000000001FD /* CanvasDropOutcome.swift in Sources */,
-				FEED000000000000000001FE /* CanvasDetailTier.swift in Sources */,
-				FEED000000000000000001FF /* CanvasSceneRenderer.swift in Sources */,
-				FEED00000000000000000200 /* CanvasInteractionController.swift in Sources */,
-				FEED00000000000000000201 /* Canvas2DProjection.swift in Sources */,
-				FEED00000000000000000202 /* CanvasOrtho2DRenderer.swift in Sources */,
-				FEED00000000000000000203 /* CanvasSceneView.swift in Sources */,
-				FEED00000000000000000204 /* Canvas3DProjection.swift in Sources */,
-				FEED00000000000000000205 /* CanvasScene3DRenderer.swift in Sources */,
-				FEED00000000000000000206 /* CanvasSpaceView.swift in Sources */,
-				FEED00000000000000000207 /* CanvasDropResolver.swift in Sources */,
-				FEED00000000000000000208 /* CanvasModifierTracker.swift in Sources */,
-				FEED00000000000000000209 /* EngineReadinessProbe.swift in Sources */,
-				FEED0000000000000000020A /* EngineSession.swift in Sources */,
-				FEED0000000000000000020B /* AccessError.swift in Sources */,
-				FEED0000000000000000020C /* IdentityStore.swift in Sources */,
-				FEED0000000000000000020D /* LibraryAccessDeniedView.swift in Sources */,
-				FEED0000000000000000020E /* LiveUpdatesPausedPill.swift in Sources */,
-				FEED0000000000000000020F /* DeviceTokenRenewal.swift in Sources */,
-				FEED00000000000000000210 /* ShareLibrarySheet.swift in Sources */,
-				FEED00000000000000000211 /* PairedHostEndpoints.swift in Sources */,
-				FEED00000000000000000212 /* InviteAccountSection.swift in Sources */,
-				FEED00000000000000000213 /* ChangeStreamTransport.swift in Sources */,
-				FEED00000000000000000214 /* PDFLoupeOverlay.swift in Sources */,
-				FEED00000000000000000215 /* PDFPageControllers.swift in Sources */,
-				FEED00000000000000000216 /* PDFPageView.swift in Sources */,
-				FEED00000000000000000217 /* PDFPageWithToolbar.swift in Sources */,
-				FEED00000000000000000218 /* PDFReadingView.swift in Sources */,
-				FEED00000000000000000219 /* PDFThumbnailView.swift in Sources */,
-				FEED0000000000000000021A /* ReadingPaneView.swift in Sources */,
-				FEED0000000000000000021B /* DocumentTextReader.swift in Sources */,
-				FEED0000000000000000021C /* PageContentPane.swift in Sources */,
-				FEED0000000000000000021D /* ImmersiveReaderView.swift in Sources */,
-				FEED0000000000000000021E /* AnnotationDetailView.swift in Sources */,
-				FEED0000000000000000021F /* AnnotationListView.swift in Sources */,
-				FEED00000000000000000220 /* AnnotationsInspectorPane.swift in Sources */,
-				FEED00000000000000000221 /* AnnotationToolbar.swift in Sources */,
-				FEED00000000000000000222 /* CitationDetailView.swift in Sources */,
-				FEED00000000000000000223 /* CitationListView.swift in Sources */,
-				FEED00000000000000000224 /* CitationsInspectorPane.swift in Sources */,
-				FEED00000000000000000225 /* ArtifactDetailView.swift in Sources */,
-				FEED00000000000000000226 /* ArtifactEntityViews.swift in Sources */,
-				FEED00000000000000000227 /* ArtifactListView.swift in Sources */,
-				FEED00000000000000000228 /* ArtifactPanel.swift in Sources */,
-				FEED00000000000000000229 /* ArtifactsInspectorPane.swift in Sources */,
-				FEED0000000000000000022A /* FocusedAnnotation.swift in Sources */,
-				FEED0000000000000000022B /* FocusedArtifact.swift in Sources */,
-				FEED0000000000000000022C /* FocusedCitation.swift in Sources */,
-				FEED0000000000000000022D /* FocusedDocument.swift in Sources */,
-				FEED0000000000000000022E /* FocusedNote.swift in Sources */,
-				FEED0000000000000000022F /* InspectorTab.swift in Sources */,
-				FEED00000000000000000230 /* InspectorPresenter.swift in Sources */,
-				FEED00000000000000000231 /* AdaptiveAppleShellHost.swift in Sources */,
-				FEED00000000000000000232 /* OpenAffordances.swift in Sources */,
-				FEED00000000000000000233 /* ContentViewHelperViews.swift in Sources */,
-				FEED00000000000000000234 /* DocumentTabView.swift in Sources */,
-				FEED00000000000000000235 /* ShellLayoutPolicy.swift in Sources */,
-				FEED00000000000000000236 /* DocumentInspector.swift in Sources */,
-				FEED00000000000000000237 /* DocumentInspectorContentV2.swift in Sources */,
-				FEED00000000000000000238 /* ImageViewerComponents.swift in Sources */,
-				FEED00000000000000000239 /* MagnifierPanel.swift in Sources */,
-				FEED0000000000000000023A /* ScrollWheelZoom.swift in Sources */,
-				FEED0000000000000000023B /* BoundingBoxOverlay.swift in Sources */,
-				FEED0000000000000000023C /* CheckerboardPattern.swift in Sources */,
-				FEED0000000000000000023D /* NavigatorMiniMap.swift in Sources */,
-				FEED0000000000000000023E /* LibraryWorkspaceRoot.swift in Sources */,
-				FEED0000000000000000023F /* CollectionWorkspaceStub.swift in Sources */,
-				FEED00000000000000000240 /* WorkspaceItemPicker.swift in Sources */,
-				FEED00000000000000000241 /* WorkflowSync.swift in Sources */,
-				FEED00000000000000000242 /* BackendActivityEvent.swift in Sources */,
-				FEED00000000000000000243 /* BackendWorkPill.swift in Sources */,
-				FEED00000000000000000244 /* PaneVisibility.swift in Sources */,
-				FEED00000000000000000245 /* PageImageGrid.swift in Sources */,
-				FEED00000000000000000246 /* ReaderTabBar.swift in Sources */,
-				FEED00000000000000000247 /* ChainStore.swift in Sources */,
-				FEED00000000000000000248 /* SourceSnippet.swift in Sources */,
-				FEED00000000000000000249 /* InspectorSection.swift in Sources */,
-				FEED0000000000000000024A /* SourceProvenancePopover.swift in Sources */,
-				FEED0000000000000000024B /* ClaimAttributionView.swift in Sources */,
-				FEED0000000000000000024C /* CitationExportButton.swift in Sources */,
-			);
-		};
 		510 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
@@ -4767,6 +4176,7 @@
 				44FA1DBF0A63CD22C7237172 /* SourceProvenancePopover.swift in Sources */,
 				A78E883CED66AEE3DC11477B /* ClaimAttributionView.swift in Sources */,
 				6FC9AFB7D35EBFB12E9F8225 /* CitationExportButton.swift in Sources */,
+				A6AD2F07985565F991995037 /* ArtifactEntityStore.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {
@@ -4777,6 +4187,602 @@
 		A10521BD2EFDC94100B28C3E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			files = (
+			);
+		};
+		FEED0000000000000000024D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			files = (
+				FEED00000000000000000001 /* ClaimSummaryCardView.swift in Sources */,
+				FEED00000000000000000002 /* EntityDetailView.swift in Sources */,
+				FEED00000000000000000003 /* EntityRowView.swift in Sources */,
+				FEED00000000000000000004 /* OntologyBrowser.swift in Sources */,
+				FEED00000000000000000005 /* ImagePreviewMenuCommands.swift in Sources */,
+				FEED00000000000000000006 /* ActivityProgressView+DataLoading.swift in Sources */,
+				FEED00000000000000000007 /* BackendConnectionView.swift in Sources */,
+				FEED00000000000000000008 /* MiniToolbar.swift in Sources */,
+				FEED00000000000000000009 /* QuickLookComponents.swift in Sources */,
+				FEED0000000000000000000A /* ChatMessagesList.swift in Sources */,
+				FEED0000000000000000000B /* LibraryViewComponents.swift in Sources */,
+				FEED0000000000000000000C /* AppleScriptCommands.swift in Sources */,
+				FEED0000000000000000000D /* ActivityDataProcessing.swift in Sources */,
+				FEED0000000000000000000E /* ActivityRun.swift in Sources */,
+				FEED0000000000000000000F /* DocumentStoreTypes.swift in Sources */,
+				FEED00000000000000000010 /* FolderAccessManager.swift in Sources */,
+				FEED00000000000000000011 /* ActivityProgressModels.swift in Sources */,
+				FEED00000000000000000012 /* WorkflowSupportTypes.swift in Sources */,
+				FEED00000000000000000013 /* WorkflowToolbar.swift in Sources */,
+				FEED00000000000000000014 /* ProviderServiceGenerated.swift in Sources */,
+				FEED00000000000000000015 /* SearchServiceGenerated.swift in Sources */,
+				FEED00000000000000000016 /* BatchServiceGenerated.swift in Sources */,
+				FEED00000000000000000017 /* ChatViewToolbar.swift in Sources */,
+				FEED00000000000000000018 /* SearchResultRowFromAPI.swift in Sources */,
+				FEED00000000000000000019 /* FocusedCommandButtons.swift in Sources */,
+				FEED0000000000000000001A /* FicheroApp.swift in Sources */,
+				FEED0000000000000000001B /* AppInstaller.swift in Sources */,
+				FEED0000000000000000001C /* SparkleUpdater.swift in Sources */,
+				FEED0000000000000000001D /* ContentView.swift in Sources */,
+				FEED0000000000000000001E /* Document.swift in Sources */,
+				FEED0000000000000000001F /* ContentView+Actions.swift in Sources */,
+				FEED00000000000000000020 /* IntegrationsPlaceholderSheet.swift in Sources */,
+				FEED00000000000000000021 /* MessageCard.swift in Sources */,
+				FEED00000000000000000022 /* SidebarItem.swift in Sources */,
+				FEED00000000000000000023 /* FeatureManager.swift in Sources */,
+				FEED00000000000000000024 /* FeatureTiers.generated.swift in Sources */,
+				FEED00000000000000000025 /* ActivityDetailView.swift in Sources */,
+				FEED00000000000000000026 /* SidebarItemBuilder.swift in Sources */,
+				FEED00000000000000000027 /* ContentView+ViewBuilders.swift in Sources */,
+				FEED00000000000000000028 /* ContentView+Toolbar.swift in Sources */,
+				FEED00000000000000000029 /* CacheModel.swift in Sources */,
+				FEED0000000000000000002A /* WorkflowPickerSheet.swift in Sources */,
+				FEED0000000000000000002B /* DocumentPickerSheet.swift in Sources */,
+				FEED0000000000000000002C /* PerformanceService.swift in Sources */,
+				FEED0000000000000000002D /* NodeProviderModelSelector.swift in Sources */,
+				FEED0000000000000000002E /* ErrorService.swift in Sources */,
+				FEED0000000000000000002F /* AIModelSelectionView.swift in Sources */,
+				FEED00000000000000000030 /* AIProviderAddModelsSheet.swift in Sources */,
+				FEED00000000000000000031 /* AutomationService.swift in Sources */,
+				FEED00000000000000000032 /* AutomationServiceMappers.swift in Sources */,
+				FEED00000000000000000033 /* DocumentStore+Helpers.swift in Sources */,
+				FEED00000000000000000034 /* ActionLibraryService.swift in Sources */,
+				FEED00000000000000000035 /* TranscribeNodeConfig.swift in Sources */,
+				FEED00000000000000000036 /* ThinkingModePicker.swift in Sources */,
+				FEED00000000000000000037 /* SidebarItem+MoreFactories.swift in Sources */,
+				FEED00000000000000000038 /* SearchView+Helpers.swift in Sources */,
+				FEED00000000000000000039 /* RecentSearchesStore.swift in Sources */,
+				FEED0000000000000000003A /* ProvidersView.swift in Sources */,
+				FEED0000000000000000003B /* ProvidersView+ModelTypes.swift in Sources */,
+				FEED0000000000000000003C /* ProvidersView+ProviderDetailView.swift in Sources */,
+				FEED0000000000000000003D /* ProvidersView+ProviderSettingsRow.swift in Sources */,
+				FEED0000000000000000003E /* AddProviderSheet.swift in Sources */,
+				FEED0000000000000000003F /* MCPToolsCatalogView.swift in Sources */,
+				FEED00000000000000000040 /* WorkflowMiniPreview.swift in Sources */,
+				FEED00000000000000000041 /* AddMCPServerSheet.swift in Sources */,
+				FEED00000000000000000042 /* WorkflowCanvasView+DropHandling.swift in Sources */,
+				FEED00000000000000000043 /* WorkflowCanvasView+Gestures.swift in Sources */,
+				FEED00000000000000000044 /* ActivityProgressView+HistoricalProgress.swift in Sources */,
+				FEED00000000000000000045 /* NodePopover.swift in Sources */,
+				FEED00000000000000000046 /* PromptPreviewPanel.swift in Sources */,
+				FEED00000000000000000047 /* TriggerDetailView+Helpers.swift in Sources */,
+				FEED00000000000000000048 /* LibraryView+InlineEditing.swift in Sources */,
+				FEED00000000000000000049 /* DescribeNodeConfig.swift in Sources */,
+				FEED0000000000000000004A /* WorkflowCanvasView.swift in Sources */,
+				FEED0000000000000000004B /* SidebarCreationHandlers.swift in Sources */,
+				FEED0000000000000000004C /* WorkflowEdgeView.swift in Sources */,
+				FEED0000000000000000004D /* WorkflowEditor.swift in Sources */,
+				FEED0000000000000000004E /* SidebarItemRow+Label.swift in Sources */,
+				FEED0000000000000000004F /* SidebarItemRow+DropHandlers.swift in Sources */,
+				FEED00000000000000000050 /* SidebarItemRow+Helpers.swift in Sources */,
+				FEED00000000000000000051 /* ModelComparisonTypes.swift in Sources */,
+				FEED00000000000000000052 /* SidebarItemRow+Rename.swift in Sources */,
+				FEED00000000000000000053 /* WorkflowEditor+Actions.swift in Sources */,
+				FEED00000000000000000054 /* WorkflowEditor+NodeViews.swift in Sources */,
+				FEED00000000000000000055 /* WorkflowEditor+Preview.swift in Sources */,
+				FEED00000000000000000056 /* ChainListContent.swift in Sources */,
+				FEED00000000000000000057 /* ChainListRow.swift in Sources */,
+				FEED00000000000000000058 /* ChainStepRow.swift in Sources */,
+				FEED00000000000000000059 /* ChainDetailContent.swift in Sources */,
+				FEED0000000000000000005A /* ChainDetailSheet.swift in Sources */,
+				FEED0000000000000000005B /* NewChainSheet.swift in Sources */,
+				FEED0000000000000000005C /* WorkflowExecutionView.swift in Sources */,
+				FEED0000000000000000005D /* WorkflowNodeView.swift in Sources */,
+				FEED0000000000000000005E /* WorkflowLibraryView.swift in Sources */,
+				FEED0000000000000000005F /* ActionRowView.swift in Sources */,
+				FEED00000000000000000060 /* LibraryView+KeyboardShortcuts.swift in Sources */,
+				FEED00000000000000000061 /* FilesNodeConfig.swift in Sources */,
+				FEED00000000000000000062 /* SummarizeFolderNodeConfig.swift in Sources */,
+				FEED00000000000000000063 /* WorkflowChain.swift in Sources */,
+				FEED00000000000000000064 /* CheckpointTypes.swift in Sources */,
+				FEED00000000000000000065 /* LibraryWindow.swift in Sources */,
+				FEED00000000000000000066 /* ChainService.swift in Sources */,
+				FEED00000000000000000067 /* ContentView+Persistence.swift in Sources */,
+				FEED00000000000000000068 /* ActivityServiceGenerated.swift in Sources */,
+				SBX00032F27F36000EC9EE1 /* SandboxAccessServiceGenerated.swift in Sources */,
+				FEED00000000000000000069 /* LocationServiceGenerated.swift in Sources */,
+				FEED0000000000000000006A /* PDFDocumentCache.swift in Sources */,
+				FEED0000000000000000006B /* PreviewDownloadService.swift in Sources */,
+				FEED0000000000000000006C /* ActivityStreamService.swift in Sources */,
+				FEED0000000000000000006D /* ExtractEntitiesNodeConfig.swift in Sources */,
+				FEED0000000000000000006E /* WorkflowNodeCard.swift in Sources */,
+				FEED0000000000000000006F /* AutomationServiceGenerated.swift in Sources */,
+				FEED00000000000000000070 /* WorkflowInspector+DataLoading.swift in Sources */,
+				FEED00000000000000000071 /* NodeInputMappings.swift in Sources */,
+				FEED00000000000000000072 /* WorkflowResponseTypes.swift in Sources */,
+				FEED00000000000000000073 /* ArtifactServiceGenerated.swift in Sources */,
+				FEED00000000000000000074 /* WorkflowInspector+MCPTools.swift in Sources */,
+				FEED00000000000000000075 /* IntegrationsServiceTypes.swift in Sources */,
+				FEED00000000000000000076 /* ChatStatusViews.swift in Sources */,
+				FEED00000000000000000077 /* StorageServiceGenerated.swift in Sources */,
+				FEED00000000000000000078 /* ModelServiceGenerated.swift in Sources */,
+				FEED00000000000000000079 /* ImportServiceGenerated.swift in Sources */,
+				FEED0000000000000000007A /* ActivityTypes.swift in Sources */,
+				FEED0000000000000000007B /* WorkflowChainListView.swift in Sources */,
+				FEED0000000000000000007C /* BatchTypes.swift in Sources */,
+				FEED0000000000000000007D /* ChainEditorView.swift in Sources */,
+				FEED0000000000000000007E /* ScheduleCreationSheet.swift in Sources */,
+				FEED0000000000000000007F /* TriggerCreationSheet.swift in Sources */,
+				FEED00000000000000000080 /* AgentNodeBlockView.swift in Sources */,
+				FEED00000000000000000081 /* TriggerDetailView+ExecutionHistory.swift in Sources */,
+				FEED00000000000000000082 /* SimpleWorkflowView.swift in Sources */,
+				FEED00000000000000000083 /* WorkflowDiagramPreview.swift in Sources */,
+				FEED00000000000000000084 /* WorkflowThumbnailView.swift in Sources */,
+				FEED00000000000000000085 /* WorkflowOutputLog.swift in Sources */,
+				FEED00000000000000000086 /* WorkflowPortView.swift in Sources */,
+				FEED00000000000000000087 /* WorkflowInspector.swift in Sources */,
+				FEED00000000000000000088 /* WorkflowCanvasView+EdgeConnection.swift in Sources */,
+				FEED00000000000000000089 /* CanvasHelpers.swift in Sources */,
+				FEED0000000000000000008A /* WorkflowToolBlocks.swift in Sources */,
+				FEED0000000000000000008B /* SidebarSearchTypes.swift in Sources */,
+				FEED0000000000000000008C /* EmbeddedBackendService.swift in Sources */,
+				FEED0000000000000000008D /* SearchFiltersPanel.swift in Sources */,
+				FEED0000000000000000008E /* SearchMapComponents.swift in Sources */,
+				FEED0000000000000000008F /* MCPServerDetailView.swift in Sources */,
+				FEED00000000000000000090 /* ActivityProgressView.swift in Sources */,
+				FEED00000000000000000091 /* ImageWithCursorTracking.swift in Sources */,
+				FEED00000000000000000092 /* ActivityConsoleView.swift in Sources */,
+				FEED00000000000000000093 /* ActivityOverviewView.swift in Sources */,
+				FEED00000000000000000094 /* ActivityLogView.swift in Sources */,
+				FEED00000000000000000095 /* ActivityViewHelpers.swift in Sources */,
+				FEED00000000000000000096 /* MCPServersSheet.swift in Sources */,
+				FEED00000000000000000097 /* MCPServersView.swift in Sources */,
+				FEED00000000000000000098 /* Artifact.swift in Sources */,
+				FEED00000000000000000099 /* SearchResultsDisplay.swift in Sources */,
+				FEED0000000000000000009A /* SearchResultsEmptyState.swift in Sources */,
+				FEED0000000000000000009B /* Event.swift in Sources */,
+				FEED0000000000000000009C /* Trace.swift in Sources */,
+				FEED0000000000000000009D /* MCPServer.swift in Sources */,
+				FEED0000000000000000009E /* Run.swift in Sources */,
+				FEED0000000000000000009F /* Note.swift in Sources */,
+				FEED000000000000000000A0 /* SummarizeCollectionNodeConfig.swift in Sources */,
+				FEED000000000000000000A1 /* ErrorModel.swift in Sources */,
+				FEED000000000000000000A2 /* LayoutMode.swift in Sources */,
+				FEED000000000000000000A3 /* LibraryImageView.swift in Sources */,
+				FEED000000000000000000A4 /* SkeletonPlaceholder.swift in Sources */,
+				FEED000000000000000000A5 /* FrameAnimation.swift in Sources */,
+				FEED000000000000000000A6 /* NodeConfigView.swift in Sources */,
+				FEED000000000000000000A7 /* LibraryView+DisplayModes.swift in Sources */,
+				FEED000000000000000000A8 /* LibraryView+Sorting.swift in Sources */,
+				FEED000000000000000000A9 /* LibraryView+ColumnConfig.swift in Sources */,
+				FEED000000000000000000AA /* LibraryView+FilterAndBatch.swift in Sources */,
+				FEED000000000000000000AB /* SidebarState.swift in Sources */,
+				FEED000000000000000000AC /* DragDropModel.swift in Sources */,
+				FEED000000000000000000AD /* SidebarActions.swift in Sources */,
+				FEED000000000000000000AE /* SettingsView.swift in Sources */,
+				FEED000000000000000000AF /* EditorView.swift in Sources */,
+				FEED000000000000000000B0 /* ItemTypeRegistry.swift in Sources */,
+				FEED000000000000000000B1 /* SearchView.swift in Sources */,
+				FEED000000000000000000B2 /* AIModelCatalog.swift in Sources */,
+				FEED000000000000000000B3 /* ChatView+Extensions.swift in Sources */,
+				FEED000000000000000000B4 /* ContentViewModifiers.swift in Sources */,
+				FEED000000000000000000B5 /* IntegrationsService.swift in Sources */,
+				FEED000000000000000000B6 /* NewWorkflowSheet.swift in Sources */,
+				FEED000000000000000000B7 /* LibraryView.swift in Sources */,
+				FEED000000000000000000B8 /* ProviderLogoView.swift in Sources */,
+				FEED000000000000000000B9 /* StatusBadge.swift in Sources */,
+				FEED000000000000000000BA /* MacPlainTextEditor.swift in Sources */,
+				FEED000000000000000000BB /* ViewMenuCommands.swift in Sources */,
+				FEED000000000000000000BC /* ViewSettings.swift in Sources */,
+				FEED000000000000000000BD /* AppState.swift in Sources */,
+				FEED000000000000000000BE /* WorkflowStreamService+Parsing.swift in Sources */,
+				FEED000000000000000000BF /* ChatView.swift in Sources */,
+				FEED000000000000000000C0 /* ComparisonTypes.swift in Sources */,
+				FEED000000000000000000C1 /* SearchNodeConfig.swift in Sources */,
+				FEED000000000000000000C2 /* ContentView+State.swift in Sources */,
+				FEED000000000000000000C3 /* FirstRunWindow.swift in Sources */,
+				FEED000000000000000000C4 /* DocumentStore.swift in Sources */,
+				FEED000000000000000000C5 /* WorkflowStreamTypes.swift in Sources */,
+				FEED000000000000000000C6 /* APIClient.swift in Sources */,
+				FEED000000000000000000C7 /* IntegrationsService+AppSpecific.swift in Sources */,
+				FEED000000000000000000C8 /* ModelComparisonService.swift in Sources */,
+				FEED000000000000000000C9 /* ActionLibraryView.swift in Sources */,
+				FEED000000000000000000CA /* AutomationServiceTypes.swift in Sources */,
+				FEED000000000000000000CB /* ImportService.swift in Sources */,
+				FEED000000000000000000CC /* ActionDetailView.swift in Sources */,
+				FEED000000000000000000CD /* ChatService.swift in Sources */,
+				FEED000000000000000000CE /* SavedSearchService.swift in Sources */,
+				FEED000000000000000000CF /* AddItemMenu.swift in Sources */,
+				FEED000000000000000000D0 /* WorkflowServiceGenerated.swift in Sources */,
+				FEED000000000000000000D1 /* SavedSearchServiceGenerated.swift in Sources */,
+				FEED000000000000000000D2 /* ChatInputView.swift in Sources */,
+				FEED000000000000000000D3 /* TriggerDetailView+Configuration.swift in Sources */,
+				FEED000000000000000000D4 /* ConversationServiceGenerated.swift in Sources */,
+				FEED000000000000000000D5 /* ContentView+Navigation.swift in Sources */,
+				FEED000000000000000000D6 /* WorkflowNodeRow.swift in Sources */,
+				FEED000000000000000000D7 /* ChatServiceGenerated.swift in Sources */,
+				FEED000000000000000000D8 /* WorkflowRunResponse.swift in Sources */,
+				FEED000000000000000000D9 /* DocumentServiceGenerated.swift in Sources */,
+				FEED000000000000000000DA /* ChatInspector.swift in Sources */,
+				FEED000000000000000000DB /* ChatInspector+Actions.swift in Sources */,
+				FEED000000000000000000DC /* ChatInspector+Header.swift in Sources */,
+				FEED000000000000000000DD /* ChatInspector+ScopedDocuments.swift in Sources */,
+				FEED000000000000000000DE /* ChatInspector+Search.swift in Sources */,
+				FEED000000000000000000DF /* CollectionNodeConfig.swift in Sources */,
+				FEED000000000000000000E0 /* ModelService.swift in Sources */,
+				FEED000000000000000000E1 /* ProviderServiceTypes.swift in Sources */,
+				FEED000000000000000000E2 /* SidebarItemContextMenu.swift in Sources */,
+				FEED000000000000000000E3 /* SidebarViewTypes.swift in Sources */,
+				FEED000000000000000000E4 /* ActionPickerView.swift in Sources */,
+				FEED000000000000000000E5 /* StorageService.swift in Sources */,
+				FEED000000000000000000E6 /* WorkflowLibraryRow.swift in Sources */,
+				FEED000000000000000000E7 /* ViewContexts.swift in Sources */,
+				FEED000000000000000000E8 /* TrackingImageView.swift in Sources */,
+				FEED000000000000000000E9 /* ActivityProgressView+LiveProgress.swift in Sources */,
+				FEED000000000000000000EA /* FicheroDocument.swift in Sources */,
+				FEED000000000000000000EB /* LibraryManager.swift in Sources */,
+				FEED000000000000000000EC /* LibraryManager+Operations.swift in Sources */,
+				FEED000000000000000000ED /* LibraryManager+Helpers.swift in Sources */,
+				FEED000000000000000000EE /* LibraryManager+Persistence.swift in Sources */,
+				FEED000000000000000000EF /* WindowState.swift in Sources */,
+				FEED000000000000000000F0 /* SidebarItemRow.swift in Sources */,
+				FEED000000000000000000F1 /* SidebarView.swift in Sources */,
+				FEED000000000000000000F2 /* WorkflowExecutionService.swift in Sources */,
+				FEED000000000000000000F3 /* WorkflowStreamService.swift in Sources */,
+				FEED000000000000000000F4 /* SidebarChatTypes.swift in Sources */,
+				FEED000000000000000000F5 /* WorkflowExecutionObserver.swift in Sources */,
+				FEED000000000000000000F6 /* WorkflowExecutionTypes.swift in Sources */,
+				FEED000000000000000000F7 /* SidebarModeIcon.swift in Sources */,
+				FEED000000000000000000F8 /* SidebarModeBar.swift in Sources */,
+				FEED000000000000000000F9 /* ModelComparisonView.swift in Sources */,
+				FEED000000000000000000FA /* ModelComparisonView+Sidebar.swift in Sources */,
+				FEED000000000000000000FB /* ComparisonResultView.swift in Sources */,
+				FEED000000000000000000FC /* ModelResultCard.swift in Sources */,
+				FEED000000000000000000FD /* ModelPickerSheet.swift in Sources */,
+				FEED000000000000000000FE /* PresetPickerSheet.swift in Sources */,
+				FEED000000000000000000FF /* AppleScriptSupport.swift in Sources */,
+				FEED00000000000000000100 /* SidebarStateManagers.swift in Sources */,
+				FEED00000000000000000101 /* SidebarViewExtensions.swift in Sources */,
+				FEED00000000000000000102 /* SidebarSectionHeader.swift in Sources */,
+				FEED00000000000000000103 /* SidebarConstants.swift in Sources */,
+				FEED00000000000000000104 /* Workflow.swift in Sources */,
+				FEED00000000000000000105 /* WorkflowTypes.swift in Sources */,
+				FEED00000000000000000106 /* WorkflowStore.swift in Sources */,
+				FEED00000000000000000107 /* GeneratedTypeExtensions.swift in Sources */,
+				FEED00000000000000000108 /* MCPService.swift in Sources */,
+				FEED00000000000000000109 /* WorkflowExporter.swift in Sources */,
+				FEED0000000000000000010A /* SidebarObservers.swift in Sources */,
+				FEED0000000000000000010B /* ComparisonDetailView.swift in Sources */,
+				FEED0000000000000000010C /* SummarizeFileNodeConfig.swift in Sources */,
+				FEED0000000000000000010D /* WorkflowDetailView.swift in Sources */,
+				FEED0000000000000000010E /* ScheduleDetailView.swift in Sources */,
+				FEED0000000000000000010F /* ScheduleEditorView.swift in Sources */,
+				FEED00000000000000000110 /* ActionsService.swift in Sources */,
+				FEED00000000000000000111 /* TriggerEditorView.swift in Sources */,
+				FEED00000000000000000112 /* TriggerDetailView.swift in Sources */,
+				FEED00000000000000000113 /* DynamicConfigView.swift in Sources */,
+				FEED00000000000000000114 /* DynamicConfigView+FieldRendering.swift in Sources */,
+				FEED00000000000000000115 /* WorkflowExecutionObserver+Events.swift in Sources */,
+				FEED00000000000000000116 /* DocumentStore+CRUD.swift in Sources */,
+				FEED00000000000000000117 /* DynamicConfigView+SchemaHelpers.swift in Sources */,
+				FEED00000000000000000118 /* DynamicConfigView+StateManagement.swift in Sources */,
+				FEED00000000000000000119 /* DocumentInspectorInfoTab.swift in Sources */,
+				FEED0000000000000000011A /* DocumentInspectorMetadataTab.swift in Sources */,
+				FEED0000000000000000011B /* DocumentInspectorArtifactsTab.swift in Sources */,
+				FEED0000000000000000011C /* SurfaceTabBar.swift in Sources */,
+				FEED0000000000000000011D /* DocumentInspectorContentTab.swift in Sources */,
+				FEED0000000000000000011E /* TriggerEditorFormPanel.swift in Sources */,
+				FEED0000000000000000011F /* TriggerEditorPreviewPanel.swift in Sources */,
+				FEED00000000000000000120 /* FlowLayout.swift in Sources */,
+				FEED00000000000000000121 /* AIDefaults.swift in Sources */,
+				FEED00000000000000000122 /* AISettingsView.swift in Sources */,
+				FEED00000000000000000123 /* GeneralSettingsView.swift in Sources */,
+				FEED00000000000000000124 /* WorkflowToolTypes.swift in Sources */,
+				FEED00000000000000000125 /* BackendSettingsView.swift in Sources */,
+				FEED00000000000000000126 /* LocalModelsSettingsView.swift in Sources */,
+				FEED00000000000000000127 /* WorkflowOutputLog+Models.swift in Sources */,
+				FEED00000000000000000128 /* WorkflowInspector+AgentsSection.swift in Sources */,
+				FEED00000000000000000129 /* WorkflowOutputLog+StatusViews.swift in Sources */,
+				FEED0000000000000000012A /* WorkflowOutputLog+ErrorCell.swift in Sources */,
+				FEED0000000000000000012B /* WorkflowOutputLog+EmptyStates.swift in Sources */,
+				FEED0000000000000000012C /* ScheduleEditorView+Category.swift in Sources */,
+				FEED0000000000000000012D /* ComparisonDetailView+Actions.swift in Sources */,
+				FEED0000000000000000012E /* ComparisonDetailView+Models.swift in Sources */,
+				FEED0000000000000000012F /* ComparisonDetailView+Sections.swift in Sources */,
+				FEED00000000000000000130 /* SidebarView+Helpers.swift in Sources */,
+				FEED00000000000000000131 /* SidebarView+SelectionHandling.swift in Sources */,
+				FEED00000000000000000132 /* SidebarView+ViewComponents.swift in Sources */,
+				FEED00000000000000000133 /* AddProviderSheet+Helpers.swift in Sources */,
+				FEED00000000000000000134 /* AddProviderSheet+Step1.swift in Sources */,
+				FEED00000000000000000135 /* AddProviderSheet+Step2.swift in Sources */,
+				FEED00000000000000000136 /* AddProviderSheet+Step3.swift in Sources */,
+				FEED00000000000000000137 /* EntitySourceGroupsView.swift in Sources */,
+				FEED00000000000000000138 /* SpeakerComparisonView.swift in Sources */,
+				FEED00000000000000000139 /* SpeakerComparisonView+Preview.swift in Sources */,
+				FEED0000000000000000013A /* NavigationHistoryManager.swift in Sources */,
+				FEED0000000000000000013B /* ActivityOverviewView+Cards.swift in Sources */,
+				FEED0000000000000000013C /* EntityDetailView+Biography.swift in Sources */,
+				FEED0000000000000000013D /* EntityDetailView+Audit.swift in Sources */,
+				FEED0000000000000000013E /* EntityDetailView+Claims.swift in Sources */,
+				FEED0000000000000000013F /* EntityDetailView+FilterChips.swift in Sources */,
+				FEED00000000000000000140 /* ContentView+WorkflowActions.swift in Sources */,
+				FEED00000000000000000141 /* ContentView+ReadingLayout.swift in Sources */,
+				FEED00000000000000000142 /* AISettingsView+Tabs.swift in Sources */,
+				FEED00000000000000000143 /* AISettingsView+Helpers.swift in Sources */,
+				FEED00000000000000000144 /* LibraryView+TableMapViews.swift in Sources */,
+				FEED00000000000000000145 /* ClaimSummaryCard+Details.swift in Sources */,
+				FEED00000000000000000146 /* APIClient+Types.swift in Sources */,
+				FEED00000000000000000147 /* QuickLookPreviewViews.swift in Sources */,
+				FEED00000000000000000148 /* DocumentKGWebPane.swift in Sources */,
+				FEED00000000000000000149 /* ContentView+KnowledgeSurface.swift in Sources */,
+				FEED0000000000000000014A /* UITestSupport.swift in Sources */,
+				FEED0000000000000000014B /* EditClaimSheet.swift in Sources */,
+				FEED0000000000000000014C /* EntityMergeSheet.swift in Sources */,
+				FEED0000000000000000014D /* EntityReconciliationSheet.swift in Sources */,
+				FEED0000000000000000014E /* EntitySplitSheet.swift in Sources */,
+				FEED0000000000000000014F /* KGMapView.swift in Sources */,
+				FEED00000000000000000150 /* KGTemporalSpatial.swift in Sources */,
+				FEED00000000000000000151 /* KGTimelineView.swift in Sources */,
+				FEED00000000000000000152 /* ImageEditingServiceGenerated.swift in Sources */,
+				FEED00000000000000000153 /* ImageEditorModel.swift in Sources */,
+				FEED00000000000000000154 /* LiveEditPreview.swift in Sources */,
+				FEED00000000000000000155 /* ImageEditChainPanel.swift in Sources */,
+				FEED00000000000000000156 /* ImageEditorView.swift in Sources */,
+				FEED00000000000000000157 /* ImageMarqueeOverlay.swift in Sources */,
+				FEED00000000000000000158 /* AnnotationService.swift in Sources */,
+				FEED00000000000000000159 /* DocumentInspectorAnnotationsTab.swift in Sources */,
+				FEED0000000000000000015A /* SpatialModels.swift in Sources */,
+				FEED0000000000000000015B /* SpatialView.swift in Sources */,
+				FEED0000000000000000015C /* ResearchModels.swift in Sources */,
+				FEED0000000000000000015D /* ResearchService.swift in Sources */,
+				FEED0000000000000000015E /* ResearchProjectListView.swift in Sources */,
+				FEED0000000000000000015F /* ResearchBrowserPane.swift in Sources */,
+				FEED00000000000000000160 /* ResearchTasksPane.swift in Sources */,
+				FEED00000000000000000161 /* ResearchChatPane.swift in Sources */,
+				FEED00000000000000000162 /* ResearchWorkspaceView.swift in Sources */,
+				FEED00000000000000000163 /* DocumentKGSurface.swift in Sources */,
+				FEED00000000000000000164 /* AppNavigationHistory.swift in Sources */,
+				FEED00000000000000000165 /* ContentView+NavigationHistory.swift in Sources */,
+				FEED00000000000000000166 /* KGFocusState.swift in Sources */,
+				FEED00000000000000000167 /* SpatialLibraryProjector.swift in Sources */,
+				FEED00000000000000000168 /* WorkflowRunProviderCache.swift in Sources */,
+				FEED00000000000000000169 /* ClaimReviewQueueSheet.swift in Sources */,
+				FEED0000000000000000016A /* ContradictionTriageSheet.swift in Sources */,
+				FEED0000000000000000016B /* EntityDigestView.swift in Sources */,
+				FEED0000000000000000016C /* DocumentCanvas.swift in Sources */,
+				FEED0000000000000000016D /* MediaStreamPreview.swift in Sources */,
+				FEED0000000000000000016E /* NodeComparisonSheet.swift in Sources */,
+				FEED0000000000000000016F /* NodePopover+Comparison.swift in Sources */,
+				FEED00000000000000000170 /* NoteService.swift in Sources */,
+				FEED00000000000000000171 /* DocumentNotesTab.swift in Sources */,
+				FEED00000000000000000172 /* LibraryToolbarState.swift in Sources */,
+				FEED00000000000000000173 /* EntityDetailView+Notes.swift in Sources */,
+				FEED00000000000000000174 /* NotesBrowserView.swift in Sources */,
+				FEED00000000000000000175 /* ArtifactRichTextCodec.swift in Sources */,
+				FEED00000000000000000176 /* NodeClassPicker.swift in Sources */,
+				FEED00000000000000000177 /* FicheroWebView.swift in Sources */,
+				FEED00000000000000000178 /* EngineConfig.swift in Sources */,
+				FEED00000000000000000179 /* SpatialModels+Links.swift in Sources */,
+				FEED0000000000000000017A /* OntologyBrowserGraphModel.swift in Sources */,
+				FEED0000000000000000017B /* ForceDirectedGraphView.swift in Sources */,
+				FEED0000000000000000017C /* HeuristicReviewSheet.swift in Sources */,
+				FEED0000000000000000017D /* NewEntitySheet.swift in Sources */,
+				FEED0000000000000000017E /* EntityKindChartView.swift in Sources */,
+				FEED0000000000000000017F /* OntologyBrowser+Toolbar.swift in Sources */,
+				FEED00000000000000000180 /* OntologyBrowser+List.swift in Sources */,
+				FEED00000000000000000181 /* OntologyBrowser+Detail.swift in Sources */,
+				FEED00000000000000000182 /* ForceDirectedGraphView+Render.swift in Sources */,
+				FEED00000000000000000183 /* OntologyBrowser+Sheets.swift in Sources */,
+				FEED00000000000000000184 /* DisplayAttributesStrip.swift in Sources */,
+				FEED00000000000000000185 /* DocumentInspectorArtifactsTab+Shared.swift in Sources */,
+				FEED00000000000000000186 /* DocumentInspectorArtifactsTab+EntitiesTab.swift in Sources */,
+				FEED00000000000000000187 /* DocumentInspectorArtifactsTab+KGModels.swift in Sources */,
+				FEED00000000000000000188 /* DocumentInspectorArtifactsTab+KGSection.swift in Sources */,
+				FEED00000000000000000189 /* DocumentInspectorArtifactsTab+EntityKindBlock.swift in Sources */,
+				FEED0000000000000000018A /* DocumentInspectorArtifactsTab+EntityKindRow.swift in Sources */,
+				FEED0000000000000000018B /* DocumentInspectorArtifactsTab+CurationHistory.swift in Sources */,
+				FEED0000000000000000018C /* DocumentInspectorArtifactsTab+Interpretations.swift in Sources */,
+				FEED0000000000000000018D /* DocumentInspectorArtifactsTab+Previews.swift in Sources */,
+				FEED0000000000000000018E /* SidebarView+UnifiedLibrarySections.swift in Sources */,
+				FEED0000000000000000018F /* SidebarView+UnifiedRows.swift in Sources */,
+				FEED00000000000000000190 /* SidebarView+PinnedNavigationRows.swift in Sources */,
+				FEED00000000000000000191 /* SidebarView+ActivityRows.swift in Sources */,
+				FEED00000000000000000192 /* SidebarView+LibraryHeaderHelpers.swift in Sources */,
+				FEED00000000000000000193 /* SidebarItemRow+Drop.swift in Sources */,
+				FEED00000000000000000194 /* SidebarItemRow+Presentation+Body.swift in Sources */,
+				FEED00000000000000000195 /* SidebarItemRow+Presentation.swift in Sources */,
+				FEED00000000000000000196 /* SidebarItemRow+Preview.swift in Sources */,
+				FEED00000000000000000197 /* SidebarItemRow+Workflow.swift in Sources */,
+				FEED00000000000000000198 /* DocumentInspectorInfoTab+Header.swift in Sources */,
+				FEED00000000000000000199 /* DocumentInspectorInfoTab+RelatedClaims.swift in Sources */,
+				FEED0000000000000000019A /* DocumentInspectorInfoTab+Citations.swift in Sources */,
+				FEED0000000000000000019B /* DocumentInspectorInfoTab+Bibliography.swift in Sources */,
+				FEED0000000000000000019C /* DocumentInspectorInfoTab+Workflow.swift in Sources */,
+				FEED0000000000000000019D /* DocumentInspectorInfoTab+Prototype.swift in Sources */,
+				FEED0000000000000000019E /* FileMenuCommands.swift in Sources */,
+				FEED0000000000000000019F /* EntityDetailView+Metadata.swift in Sources */,
+				FEED000000000000000001A0 /* EntityDetailView+Sections.swift in Sources */,
+				FEED000000000000000001A1 /* ClaimSummaryCard+Provenance.swift in Sources */,
+				FEED000000000000000001A2 /* EntityStore.swift in Sources */,
+				FEED000000000000000001A3 /* BatchStore.swift in Sources */,
+				FEED000000000000000001A4 /* BatchRunView.swift in Sources */,
+				FEED000000000000000001A5 /* WorkspaceStore.swift in Sources */,
+				FEED000000000000000001A6 /* LibraryChangeStream.swift in Sources */,
+				FEED000000000000000001A7 /* ClaimStore.swift in Sources */,
+				FEED000000000000000001A8 /* NoteStore.swift in Sources */,
+				FEED000000000000000001A9 /* AnnotationStore.swift in Sources */,
+				FEED000000000000000001AA /* ActionStore.swift in Sources */,
+				FEED000000000000000001AB /* ResearchStore.swift in Sources */,
+				FEED000000000000000001AC /* SearchStore.swift in Sources */,
+				FEED000000000000000001AD /* ObservableDomainStore.swift in Sources */,
+				FEED000000000000000001AE /* DocumentStore+ChangeStream.swift in Sources */,
+				FEED000000000000000001AF /* ArtifactStore.swift in Sources */,
+				FEED000000000000000001B0 /* CitationStore.swift in Sources */,
+				FEED000000000000000001B1 /* ReferenceStore.swift in Sources */,
+				FEED000000000000000001B2 /* InterpretationStore.swift in Sources */,
+				FEED000000000000000001B3 /* ActionInvokeService.swift in Sources */,
+				FEED000000000000000001B4 /* FicheroShortcuts.swift in Sources */,
+				FEED000000000000000001B5 /* FicheroActionIntents.swift in Sources */,
+				FEED000000000000000001B6 /* NoteListView.swift in Sources */,
+				FEED000000000000000001B7 /* NoteDetailView.swift in Sources */,
+				FEED000000000000000001B8 /* NotesInspectorPane.swift in Sources */,
+				FEED000000000000000001B9 /* PlatformAliases.swift in Sources */,
+				FEED000000000000000001BA /* PlatformPasteboard.swift in Sources */,
+				FEED000000000000000001BB /* CanvasLayoutStore.swift in Sources */,
+				FEED000000000000000001BC /* CanvasLayoutStore+ChangeStream.swift in Sources */,
+				FEED000000000000000001BD /* CanvasItemStore.swift in Sources */,
+				FEED000000000000000001BE /* CanvasItemStore+ChangeStream.swift in Sources */,
+				FEED000000000000000001BF /* AuditStore.swift in Sources */,
+				FEED000000000000000001C0 /* AuditHistoryView.swift in Sources */,
+				FEED000000000000000001C1 /* FicheroAppEntities.swift in Sources */,
+				FEED000000000000000001C2 /* BackupStore.swift in Sources */,
+				FEED000000000000000001C3 /* BackupsView.swift in Sources */,
+				FEED000000000000000001C4 /* SplittablePane.swift in Sources */,
+				FEED000000000000000001C5 /* WindowSeed.swift in Sources */,
+				FEED000000000000000001C6 /* LibraryOutlineNode.swift in Sources */,
+				FEED000000000000000001C7 /* FicheroApp_iOS.swift in Sources */,
+				FEED000000000000000001C8 /* MobileCaptureQueue.swift in Sources */,
+				FEED000000000000000001C9 /* MobileCaptureQueueView.swift in Sources */,
+				FEED000000000000000001CA /* MacRemoteClientPairingSection.swift in Sources */,
+				FEED000000000000000001CB /* RemoteClientPairing.swift in Sources */,
+				C0FFEE0000000000000000A3 /* PairingRestoreDiagnostics.swift in Sources */,
+				FEED000000000000000001CC /* ChatDocumentDropPayload.swift in Sources */,
+				FEED000000000000000001CD /* BackendSettingsRemoteAccessSection.swift in Sources */,
+				FEED000000000000000001CE /* EngineSettingsView.swift in Sources */,
+				FEED000000000000000001CF /* ShareSettingsView.swift in Sources */,
+				FEED000000000000000001D0 /* UsersSettingsView.swift in Sources */,
+				FEED000000000000000001D1 /* UsersStore.swift in Sources */,
+				FEED000000000000000001D2 /* LocalInferenceStore.swift in Sources */,
+				FEED000000000000000001D3 /* KnownLibraryRegistryStore.swift in Sources */,
+				FEED000000000000000001D4 /* AppleAvailabilityStore.swift in Sources */,
+				FEED000000000000000001D5 /* LocalInferenceSettingsView.swift in Sources */,
+				FEED000000000000000001D6 /* CaptureSettingsView.swift in Sources */,
+				FEED000000000000000001D7 /* iOSLibraryPickerMenu.swift in Sources */,
+				FEED000000000000000001D8 /* ImportServiceGenerated+Upload.swift in Sources */,
+				FEED000000000000000001D9 /* ActivityStore.swift in Sources */,
+				FEED000000000000000001DA /* BreadcrumbBuilder.swift in Sources */,
+				FEED000000000000000001DB /* MiniToolbarComponents.swift in Sources */,
+				FEED000000000000000001DC /* Spatial2DCanvasGestures.swift in Sources */,
+				FEED000000000000000001DD /* Spatial2DCanvasItems.swift in Sources */,
+				FEED000000000000000001DE /* SpatialNodeThumbnail.swift in Sources */,
+				FEED000000000000000001DF /* ReaderToolbar.swift in Sources */,
+				FEED000000000000000001E0 /* WorkflowExecutionStore.swift in Sources */,
+				FEED000000000000000001E1 /* ActivityMonitorModel.swift in Sources */,
+				FEED000000000000000001E2 /* ActivityMonitorView.swift in Sources */,
+				FEED000000000000000001E3 /* ActivityMonitorWindow.swift in Sources */,
+				FEED000000000000000001E4 /* DocumentInspectorInfoTab+Sharing.swift in Sources */,
+				FEED000000000000000001E5 /* Representation.swift in Sources */,
+				FEED000000000000000001E6 /* DocumentInterpretationsTab.swift in Sources */,
+				FEED000000000000000001E7 /* MarkdownText.swift in Sources */,
+				FEED000000000000000001E8 /* CoalescingSaveRunner.swift in Sources */,
+				FEED000000000000000001E9 /* AnnotationHighlight.swift in Sources */,
+				FEED000000000000000001EA /* AnnotatableTextView.swift in Sources */,
+				FEED000000000000000001EB /* BoundingBoxGeometry.swift in Sources */,
+				FEED000000000000000001EC /* PDFRegionGeometry.swift in Sources */,
+				FEED000000000000000001ED /* BookmarkServiceGenerated.swift in Sources */,
+				FEED000000000000000001EE /* BookmarksView.swift in Sources */,
+				FEED000000000000000001EF /* SessionStore.swift in Sources */,
+				FEED000000000000000001F0 /* KGQueryStore.swift in Sources */,
+				FEED000000000000000001F1 /* AuthGateView.swift in Sources */,
+				FEED000000000000000001F2 /* BackendRootGate.swift in Sources */,
+				FEED000000000000000001F3 /* BackendHost.swift in Sources */,
+				FEED000000000000000001F4 /* LibrarySharingBadge.swift in Sources */,
+				FEED000000000000000001F5 /* ViewDisplayMode.swift in Sources */,
+				FEED000000000000000001F6 /* MiniToolbarOverflow.swift in Sources */,
+				FEED000000000000000001F7 /* AboutView.swift in Sources */,
+				FEED000000000000000001F8 /* SearchArrowKeyNavigation.swift in Sources */,
+				FEED000000000000000001F9 /* SpaceSceneView.swift in Sources */,
+				FEED000000000000000001FA /* SpaceTheme.swift in Sources */,
+				FEED000000000000000001FB /* CanvasSceneState.swift in Sources */,
+				FEED000000000000000001FC /* CanvasSceneDiff.swift in Sources */,
+				FEED000000000000000001FD /* CanvasDropOutcome.swift in Sources */,
+				FEED000000000000000001FE /* CanvasDetailTier.swift in Sources */,
+				FEED000000000000000001FF /* CanvasSceneRenderer.swift in Sources */,
+				FEED00000000000000000200 /* CanvasInteractionController.swift in Sources */,
+				FEED00000000000000000201 /* Canvas2DProjection.swift in Sources */,
+				FEED00000000000000000202 /* CanvasOrtho2DRenderer.swift in Sources */,
+				FEED00000000000000000203 /* CanvasSceneView.swift in Sources */,
+				FEED00000000000000000204 /* Canvas3DProjection.swift in Sources */,
+				FEED00000000000000000205 /* CanvasScene3DRenderer.swift in Sources */,
+				FEED00000000000000000206 /* CanvasSpaceView.swift in Sources */,
+				FEED00000000000000000207 /* CanvasDropResolver.swift in Sources */,
+				FEED00000000000000000208 /* CanvasModifierTracker.swift in Sources */,
+				FEED00000000000000000209 /* EngineReadinessProbe.swift in Sources */,
+				FEED0000000000000000020A /* EngineSession.swift in Sources */,
+				FEED0000000000000000020B /* AccessError.swift in Sources */,
+				FEED0000000000000000020C /* IdentityStore.swift in Sources */,
+				FEED0000000000000000020D /* LibraryAccessDeniedView.swift in Sources */,
+				FEED0000000000000000020E /* LiveUpdatesPausedPill.swift in Sources */,
+				FEED0000000000000000020F /* DeviceTokenRenewal.swift in Sources */,
+				FEED00000000000000000210 /* ShareLibrarySheet.swift in Sources */,
+				FEED00000000000000000211 /* PairedHostEndpoints.swift in Sources */,
+				FEED00000000000000000212 /* InviteAccountSection.swift in Sources */,
+				FEED00000000000000000213 /* ChangeStreamTransport.swift in Sources */,
+				FEED00000000000000000214 /* PDFLoupeOverlay.swift in Sources */,
+				FEED00000000000000000215 /* PDFPageControllers.swift in Sources */,
+				FEED00000000000000000216 /* PDFPageView.swift in Sources */,
+				FEED00000000000000000217 /* PDFPageWithToolbar.swift in Sources */,
+				FEED00000000000000000218 /* PDFReadingView.swift in Sources */,
+				FEED00000000000000000219 /* PDFThumbnailView.swift in Sources */,
+				FEED0000000000000000021A /* ReadingPaneView.swift in Sources */,
+				FEED0000000000000000021B /* DocumentTextReader.swift in Sources */,
+				FEED0000000000000000021C /* PageContentPane.swift in Sources */,
+				FEED0000000000000000021D /* ImmersiveReaderView.swift in Sources */,
+				FEED0000000000000000021E /* AnnotationDetailView.swift in Sources */,
+				FEED0000000000000000021F /* AnnotationListView.swift in Sources */,
+				FEED00000000000000000220 /* AnnotationsInspectorPane.swift in Sources */,
+				FEED00000000000000000221 /* AnnotationToolbar.swift in Sources */,
+				FEED00000000000000000222 /* CitationDetailView.swift in Sources */,
+				FEED00000000000000000223 /* CitationListView.swift in Sources */,
+				FEED00000000000000000224 /* CitationsInspectorPane.swift in Sources */,
+				FEED00000000000000000225 /* ArtifactDetailView.swift in Sources */,
+				FEED00000000000000000226 /* ArtifactEntityViews.swift in Sources */,
+				FEED00000000000000000227 /* ArtifactListView.swift in Sources */,
+				FEED00000000000000000228 /* ArtifactPanel.swift in Sources */,
+				FEED00000000000000000229 /* ArtifactsInspectorPane.swift in Sources */,
+				FEED0000000000000000022A /* FocusedAnnotation.swift in Sources */,
+				FEED0000000000000000022B /* FocusedArtifact.swift in Sources */,
+				FEED0000000000000000022C /* FocusedCitation.swift in Sources */,
+				FEED0000000000000000022D /* FocusedDocument.swift in Sources */,
+				FEED0000000000000000022E /* FocusedNote.swift in Sources */,
+				FEED0000000000000000022F /* InspectorTab.swift in Sources */,
+				FEED00000000000000000230 /* InspectorPresenter.swift in Sources */,
+				FEED00000000000000000231 /* AdaptiveAppleShellHost.swift in Sources */,
+				FEED00000000000000000232 /* OpenAffordances.swift in Sources */,
+				FEED00000000000000000233 /* ContentViewHelperViews.swift in Sources */,
+				FEED00000000000000000234 /* DocumentTabView.swift in Sources */,
+				FEED00000000000000000235 /* ShellLayoutPolicy.swift in Sources */,
+				FEED00000000000000000236 /* DocumentInspector.swift in Sources */,
+				FEED00000000000000000237 /* DocumentInspectorContentV2.swift in Sources */,
+				FEED00000000000000000238 /* ImageViewerComponents.swift in Sources */,
+				FEED00000000000000000239 /* MagnifierPanel.swift in Sources */,
+				FEED0000000000000000023A /* ScrollWheelZoom.swift in Sources */,
+				FEED0000000000000000023B /* BoundingBoxOverlay.swift in Sources */,
+				FEED0000000000000000023C /* CheckerboardPattern.swift in Sources */,
+				FEED0000000000000000023D /* NavigatorMiniMap.swift in Sources */,
+				FEED0000000000000000023E /* LibraryWorkspaceRoot.swift in Sources */,
+				FEED0000000000000000023F /* CollectionWorkspaceStub.swift in Sources */,
+				FEED00000000000000000240 /* WorkspaceItemPicker.swift in Sources */,
+				FEED00000000000000000241 /* WorkflowSync.swift in Sources */,
+				FEED00000000000000000242 /* BackendActivityEvent.swift in Sources */,
+				FEED00000000000000000243 /* BackendWorkPill.swift in Sources */,
+				FEED00000000000000000244 /* PaneVisibility.swift in Sources */,
+				FEED00000000000000000245 /* PageImageGrid.swift in Sources */,
+				FEED00000000000000000246 /* ReaderTabBar.swift in Sources */,
+				FEED00000000000000000247 /* ChainStore.swift in Sources */,
+				FEED00000000000000000248 /* SourceSnippet.swift in Sources */,
+				FEED00000000000000000249 /* InspectorSection.swift in Sources */,
+				FEED0000000000000000024A /* SourceProvenancePopover.swift in Sources */,
+				FEED0000000000000000024B /* ClaimAttributionView.swift in Sources */,
+				FEED0000000000000000024C /* CitationExportButton.swift in Sources */,
+				23BB0DDC9E8089CB1452632D /* ArtifactEntityStore.swift in Sources */,
 			);
 		};
 /* End PBXSourcesBuildPhase section */
@@ -4795,616 +4801,6 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		FEED00000000000000000257 = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				AUTOMATION_APPLE_EVENTS = YES;
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
-				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2026071401;
-				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_ASSET_PATHS = "";
-				ENABLE_APP_SANDBOX = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
-				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
-				ENABLE_PREVIEWS = YES;
-				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
-				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
-				ENABLE_USER_SELECTED_FILES = readwrite;
-				FICHERO_EMBED_ENGINE = NO;
-				FICHERO_FEATURE_TIER = dev;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = fichero/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
-				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
-					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
-					"$(SRCROOT)/fichero/Views/Components",
-					"$(SRCROOT)/fichero/Views/Settings",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2026.07.14;
-				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
-				PRODUCT_NAME = Fichero;
-				REGISTER_APP_GROUPS = YES;
-				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
-				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Debug;
-		};
-		FEED00000000000000000258 = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				AUTOMATION_APPLE_EVENTS = YES;
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
-				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2026071401;
-				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = QAPB6CWYR6;
-				ENABLE_APP_SANDBOX = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
-				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
-				ENABLE_PREVIEWS = YES;
-				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
-				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
-				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
-				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
-				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
-				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
-				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
-				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
-				ENABLE_RESOURCE_ACCESS_USB = NO;
-				ENABLE_USER_SELECTED_FILES = readwrite;
-				FICHERO_EMBED_ENGINE = NO;
-				FICHERO_FEATURE_TIER = alpha;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = fichero/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
-				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
-					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
-					"$(SRCROOT)/fichero/Views/Components",
-					"$(SRCROOT)/fichero/Views/Settings",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2026.07.14;
-				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
-				PRODUCT_NAME = Fichero;
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				REGISTER_APP_GROUPS = YES;
-				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
-				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
-				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
-				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
-				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
-				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
-				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
-				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Alpha;
-		};
-		FEED00000000000000000259 = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				AUTOMATION_APPLE_EVENTS = YES;
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
-				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2026071401;
-				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = QAPB6CWYR6;
-				ENABLE_APP_SANDBOX = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
-				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
-				ENABLE_PREVIEWS = YES;
-				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
-				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
-				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
-				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
-				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
-				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
-				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
-				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
-				ENABLE_RESOURCE_ACCESS_USB = NO;
-				ENABLE_USER_SELECTED_FILES = readwrite;
-				FICHERO_EMBED_ENGINE = NO;
-				FICHERO_FEATURE_TIER = beta;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = fichero/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
-				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
-					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
-					"$(SRCROOT)/fichero/Views/Components",
-					"$(SRCROOT)/fichero/Views/Settings",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2026.07.14;
-				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
-				PRODUCT_NAME = Fichero;
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				REGISTER_APP_GROUPS = YES;
-				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
-				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
-				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
-				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
-				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
-				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
-				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
-				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Beta;
-		};
-		FEED0000000000000000025A = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				AUTOMATION_APPLE_EVENTS = YES;
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
-				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2026071401;
-				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = QAPB6CWYR6;
-				ENABLE_APP_SANDBOX = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
-				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
-				ENABLE_PREVIEWS = YES;
-				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
-				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
-				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
-				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
-				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
-				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
-				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
-				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
-				ENABLE_RESOURCE_ACCESS_USB = NO;
-				ENABLE_USER_SELECTED_FILES = readwrite;
-				FICHERO_EMBED_ENGINE = YES;
-				FICHERO_FEATURE_TIER = release;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = fichero/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
-				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
-					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
-					"$(SRCROOT)/fichero/Views/Components",
-					"$(SRCROOT)/fichero/Views/Settings",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2026.07.14;
-				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
-				PRODUCT_NAME = Fichero;
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				REGISTER_APP_GROUPS = YES;
-				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
-				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
-				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
-				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
-				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
-				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
-				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
-				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = Release;
-		};
-		FEED0000000000000000025B = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				AUTOMATION_APPLE_EVENTS = YES;
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
-				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2026071401;
-				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_ASSET_PATHS = "";
-				ENABLE_APP_SANDBOX = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
-				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
-				ENABLE_PREVIEWS = YES;
-				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
-				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
-				ENABLE_USER_SELECTED_FILES = readwrite;
-				FICHERO_EMBED_ENGINE = YES;
-				FICHERO_FEATURE_TIER = dev;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = fichero/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
-				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
-					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
-					"$(SRCROOT)/fichero/Views/Components",
-					"$(SRCROOT)/fichero/Views/Settings",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2026.07.14;
-				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
-				PRODUCT_NAME = Fichero;
-				REGISTER_APP_GROUPS = YES;
-				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
-				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Dev Embedded";
-		};
-		FEED0000000000000000025C = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				AUTOMATION_APPLE_EVENTS = YES;
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
-				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2026071401;
-				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = QAPB6CWYR6;
-				ENABLE_APP_SANDBOX = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
-				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
-				ENABLE_PREVIEWS = YES;
-				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
-				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
-				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
-				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
-				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
-				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
-				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
-				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
-				ENABLE_RESOURCE_ACCESS_USB = NO;
-				ENABLE_USER_SELECTED_FILES = readwrite;
-				FICHERO_EMBED_ENGINE = YES;
-				FICHERO_FEATURE_TIER = alpha;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = fichero/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
-				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
-					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
-					"$(SRCROOT)/fichero/Views/Components",
-					"$(SRCROOT)/fichero/Views/Settings",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2026.07.14;
-				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
-				PRODUCT_NAME = Fichero;
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				REGISTER_APP_GROUPS = YES;
-				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
-				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
-				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
-				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
-				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
-				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
-				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
-				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Alpha Embedded";
-		};
-		FEED0000000000000000025D = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				AUTOMATION_APPLE_EVENTS = YES;
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
-				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2026071401;
-				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = QAPB6CWYR6;
-				ENABLE_APP_SANDBOX = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
-				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
-				ENABLE_PREVIEWS = YES;
-				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
-				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
-				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
-				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
-				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
-				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
-				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
-				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
-				ENABLE_RESOURCE_ACCESS_USB = NO;
-				ENABLE_USER_SELECTED_FILES = readwrite;
-				FICHERO_EMBED_ENGINE = YES;
-				FICHERO_FEATURE_TIER = beta;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = fichero/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
-				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
-					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
-					"$(SRCROOT)/fichero/Views/Components",
-					"$(SRCROOT)/fichero/Views/Settings",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2026.07.14;
-				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
-				PRODUCT_NAME = Fichero;
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				REGISTER_APP_GROUPS = YES;
-				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
-				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
-				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
-				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
-				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
-				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
-				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
-				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Beta Embedded";
-		};
-		FEED0000000000000000025E = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
-				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
-				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				AUTOMATION_APPLE_EVENTS = YES;
-				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
-				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
-				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 2026071401;
-				DEAD_CODE_STRIPPING = YES;
-				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = QAPB6CWYR6;
-				ENABLE_APP_SANDBOX = YES;
-				ENABLE_HARDENED_RUNTIME = YES;
-				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
-				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
-				ENABLE_PREVIEWS = YES;
-				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
-				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
-				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
-				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
-				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
-				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
-				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
-				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
-				ENABLE_RESOURCE_ACCESS_USB = NO;
-				ENABLE_USER_SELECTED_FILES = readwrite;
-				FICHERO_EMBED_ENGINE = NO;
-				FICHERO_FEATURE_TIER = release;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_FILE = fichero/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
-				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "";
-				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
-				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/../Frameworks",
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
-					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
-					"$(SRCROOT)/fichero/Views/Components",
-					"$(SRCROOT)/fichero/Views/Settings",
-				);
-				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = 2026.07.14;
-				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
-				PRODUCT_NAME = Fichero;
-				PROVISIONING_PROFILE_SPECIFIER = "";
-				REGISTER_APP_GROUPS = YES;
-				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
-				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
-				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
-				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
-				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
-				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
-				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
-				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
-				SUPPORTS_MACCATALYST = NO;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 6.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = "Release Local";
-		};
 		20969FA93000614800D06A60 /* Alpha */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -6649,23 +6045,619 @@
 			};
 			name = "Release Local";
 		};
+		FEED00000000000000000257 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				AUTOMATION_APPLE_EVENTS = YES;
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 2026071401;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
+				ENABLE_USER_SELECTED_FILES = readwrite;
+				FICHERO_EMBED_ENGINE = NO;
+				FICHERO_FEATURE_TIER = dev;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = fichero/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
+					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
+					"$(SRCROOT)/fichero/Views/Components",
+					"$(SRCROOT)/fichero/Views/Settings",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 2026.07.14;
+				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
+				PRODUCT_NAME = Fichero;
+				REGISTER_APP_GROUPS = YES;
+				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
+				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		FEED00000000000000000258 /* Alpha */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				AUTOMATION_APPLE_EVENTS = YES;
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 2026071401;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = QAPB6CWYR6;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
+				ENABLE_USER_SELECTED_FILES = readwrite;
+				FICHERO_EMBED_ENGINE = NO;
+				FICHERO_FEATURE_TIER = alpha;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = fichero/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
+					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
+					"$(SRCROOT)/fichero/Views/Components",
+					"$(SRCROOT)/fichero/Views/Settings",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 2026.07.14;
+				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
+				PRODUCT_NAME = Fichero;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
+				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
+				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
+				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Alpha;
+		};
+		FEED00000000000000000259 /* Beta */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				AUTOMATION_APPLE_EVENTS = YES;
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 2026071401;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = QAPB6CWYR6;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
+				ENABLE_USER_SELECTED_FILES = readwrite;
+				FICHERO_EMBED_ENGINE = NO;
+				FICHERO_FEATURE_TIER = beta;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = fichero/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
+					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
+					"$(SRCROOT)/fichero/Views/Components",
+					"$(SRCROOT)/fichero/Views/Settings",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 2026.07.14;
+				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
+				PRODUCT_NAME = Fichero;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
+				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
+				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
+				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Beta;
+		};
+		FEED0000000000000000025A /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				AUTOMATION_APPLE_EVENTS = YES;
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 2026071401;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = QAPB6CWYR6;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
+				ENABLE_USER_SELECTED_FILES = readwrite;
+				FICHERO_EMBED_ENGINE = YES;
+				FICHERO_FEATURE_TIER = release;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = fichero/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
+					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
+					"$(SRCROOT)/fichero/Views/Components",
+					"$(SRCROOT)/fichero/Views/Settings",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 2026.07.14;
+				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
+				PRODUCT_NAME = Fichero;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
+				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
+				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
+				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		FEED0000000000000000025B /* Dev Embedded */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				AUTOMATION_APPLE_EVENTS = YES;
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 2026071401;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_ASSET_PATHS = "";
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
+				ENABLE_USER_SELECTED_FILES = readwrite;
+				FICHERO_EMBED_ENGINE = YES;
+				FICHERO_FEATURE_TIER = dev;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = fichero/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
+					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
+					"$(SRCROOT)/fichero/Views/Components",
+					"$(SRCROOT)/fichero/Views/Settings",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 2026.07.14;
+				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
+				PRODUCT_NAME = Fichero;
+				REGISTER_APP_GROUPS = YES;
+				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
+				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Dev Embedded";
+		};
+		FEED0000000000000000025C /* Alpha Embedded */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				AUTOMATION_APPLE_EVENTS = YES;
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 2026071401;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = QAPB6CWYR6;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
+				ENABLE_USER_SELECTED_FILES = readwrite;
+				FICHERO_EMBED_ENGINE = YES;
+				FICHERO_FEATURE_TIER = alpha;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = fichero/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
+					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
+					"$(SRCROOT)/fichero/Views/Components",
+					"$(SRCROOT)/fichero/Views/Settings",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 2026.07.14;
+				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
+				PRODUCT_NAME = Fichero;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
+				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
+				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
+				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Alpha Embedded";
+		};
+		FEED0000000000000000025D /* Beta Embedded */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				AUTOMATION_APPLE_EVENTS = YES;
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 2026071401;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = QAPB6CWYR6;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
+				ENABLE_USER_SELECTED_FILES = readwrite;
+				FICHERO_EMBED_ENGINE = YES;
+				FICHERO_FEATURE_TIER = beta;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = fichero/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
+					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
+					"$(SRCROOT)/fichero/Views/Components",
+					"$(SRCROOT)/fichero/Views/Settings",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 2026.07.14;
+				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
+				PRODUCT_NAME = Fichero;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
+				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
+				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
+				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Beta Embedded";
+		};
+		FEED0000000000000000025E /* Release Local */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphoneos*]" = "AppIcon-iOS";
+				"ASSETCATALOG_COMPILER_APPICON_NAME[sdk=iphonesimulator*]" = "AppIcon-iOS";
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				AUTOMATION_APPLE_EVENTS = YES;
+				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
+				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
+				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 2026071401;
+				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_ASSET_PATHS = "";
+				DEVELOPMENT_TEAM = QAPB6CWYR6;
+				ENABLE_APP_SANDBOX = YES;
+				ENABLE_HARDENED_RUNTIME = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = YES;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_PREVIEWS = YES;
+				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = NO;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
+				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PHOTO_LIBRARY = YES;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
+				ENABLE_USER_SELECTED_FILES = readwrite;
+				FICHERO_EMBED_ENGINE = NO;
+				FICHERO_FEATURE_TIER = release;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = fichero/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Fichero;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
+				INFOPLIST_KEY_LSSupportsOpeningDocumentsInPlace = YES;
+				INFOPLIST_KEY_NSCameraUsageDescription = "Fichero uses the camera to scan pairing QR codes and capture new photos into your queue.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSLocalNetworkUsageDescription = "Fichero uses local network discovery to find a nearby Mac host for QR pairing.";
+				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "Fichero uses your photo library when you choose existing images to add to the capture queue.";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UTExportedTypeDeclarations = "{\n    UTTypeConformsTo =     (\n        \"public.data\"\n    );\n    UTTypeDescription = \"Fichero Item\";\n    UTTypeIdentifier = \"com.tubb.fichero.item\";\n}";
+				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(SRCROOT)/fichero/Views/Library/DocumentInspector",
+					"$(SRCROOT)/fichero/Views/Automation/TriggerEditorView",
+					"$(SRCROOT)/fichero/Views/Components",
+					"$(SRCROOT)/fichero/Views/Settings",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 26.0;
+				MARKETING_VERSION = 2026.07.14;
+				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero;
+				PRODUCT_NAME = Fichero;
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				REGISTER_APP_GROUPS = YES;
+				RUNTIME_EXCEPTION_ALLOW_DYLD_ENVIRONMENT_VARIABLES = NO;
+				RUNTIME_EXCEPTION_ALLOW_JIT = NO;
+				RUNTIME_EXCEPTION_ALLOW_UNSIGNED_EXECUTABLE_MEMORY = NO;
+				RUNTIME_EXCEPTION_DEBUGGING_TOOL = NO;
+				RUNTIME_EXCEPTION_DISABLE_EXECUTABLE_PAGE_PROTECTION = NO;
+				RUNTIME_EXCEPTION_DISABLE_LIBRARY_VALIDATION = NO;
+				SPARKLE_FEED_URL = "https://raw.githubusercontent.com/dtubb/fichero/main/fichero/appcast.xml";
+				SPARKLE_PUBLIC_ED_KEY = "z3UPbmGi74NGSqTQL25E2WFD1yulIzYRvtDitbIZvNY=";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator macosx";
+				SUPPORTS_MACCATALYST = NO;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "FICHERO_APP_STORE $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 6.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = "Release Local";
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		FEED0000000000000000025F = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				FEED00000000000000000257,
-				FEED00000000000000000258,
-				FEED00000000000000000259,
-				FEED0000000000000000025A,
-				FEED0000000000000000025B,
-				FEED0000000000000000025C,
-				FEED0000000000000000025D,
-				FEED0000000000000000025E,
-			);
-			defaultConfigurationName = Release;
-		};
 		600 /* Build configuration list for PBXNativeTarget "Fichero" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -6719,6 +6711,20 @@
 				20969FB23000614800D06A60 /* Alpha Embedded */,
 				20969FB33000614800D06A60 /* Beta Embedded */,
 				20969FB43000614800D06A60 /* Release Local */,
+			);
+			defaultConfigurationName = Release;
+		};
+		FEED0000000000000000025F /* Build configuration list for PBXNativeTarget "Fichero (App Store)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FEED00000000000000000257 /* Debug */,
+				FEED00000000000000000258 /* Alpha */,
+				FEED00000000000000000259 /* Beta */,
+				FEED0000000000000000025A /* Release */,
+				FEED0000000000000000025B /* Dev Embedded */,
+				FEED0000000000000000025C /* Alpha Embedded */,
+				FEED0000000000000000025D /* Beta Embedded */,
+				FEED0000000000000000025E /* Release Local */,
 			);
 			defaultConfigurationName = Release;
 		};

--- a/fichero/fichero/Views/ContentViewModifiers.swift
+++ b/fichero/fichero/Views/ContentViewModifiers.swift
@@ -7,7 +7,7 @@ private let logger = Logger(subsystem: "app.fichero.fichero", category: "Content
 
 /// Data loading modifiers (initial task + cache rebuilding)
 struct DataLoadingModifiers: ViewModifier {
-    @Environment(FeatureManager.self) private var featureManager
+    @EnvironmentObject private var featureManager: FeatureManager
     let documentStore: DocumentStore
     let workflowStore: WorkflowStore
     let conversationService: ConversationServiceGenerated

--- a/fichero/fichero/Views/Library/LibraryView+DisplayModes.swift
+++ b/fichero/fichero/Views/Library/LibraryView+DisplayModes.swift
@@ -479,7 +479,9 @@ struct LibrarySelectableRow<Identity: Equatable, Content: View>: View, Equatable
     let tint: Color
     @ViewBuilder let content: Content
 
-    static func == (lhs: Self, rhs: Self) -> Bool {
+    // nonisolated: this View is implicitly @MainActor, but Equatable's `==` must be
+    // nonisolated (Swift 6). Safe — all compared properties are immutable value types.
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.identity == rhs.identity
             && lhs.isSelected == rhs.isSelected
             && lhs.tint == rhs.tint

--- a/fichero/fichero/Views/Library/Workspace/LibraryWorkspaceRoot.swift
+++ b/fichero/fichero/Views/Library/Workspace/LibraryWorkspaceRoot.swift
@@ -36,7 +36,7 @@ enum LibraryWorkspaceSelection {
 /// iPad, and visionOS embed the same workspace directly.
 struct LibraryWorkspaceRoot: View {
     @Environment(AppState.self) private var appState
-    @Environment(FeatureManager.self) private var featureManager
+    @EnvironmentObject private var featureManager: FeatureManager
     @Environment(LibraryManager.self) private var libraryManager
     #if canImport(UIKit) && !os(macOS)
     @Environment(MobileCaptureQueueStore.self) private var captureQueue


### PR DESCRIPTION
main did not compile (the commit-only-workers-don't-build gap catching up from the perf pass). Three blockers, all fixed:

- **B1** `LibraryView+DisplayModes.swift` — `LibrarySelectableRow.==` marked `nonisolated` (Swift-6: a View is implicit @MainActor, Equatable needs nonisolated `==`; compared props are immutable value types). From #3868.
- **B2** `ContentViewModifiers.swift` + `LibraryWorkspaceRoot.swift` — `@Environment(FeatureManager.self)` → `@EnvironmentObject` (FeatureManager is ObservableObject, injected via .environmentObject; 10 other usages already correct). From #3881.
- **B3** `ArtifactEntityStore.swift` registered in both app targets via `scripts/add-swift-file.rb` (the file + its types existed but had no pbxproj membership). From #3861.

swiftlint-clean on the edits; version-date guard OK; pbxproj plist lints OK, objectVersion + unquoted MARKETING_VERSION preserved (the large line delta is the gem's canonicalization). No other error files in the App Store build log. Verification = f_manager's App Store rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)