### PR TITLE
fix: unblock FicheroTests target build (Swift 6 nonisolated test constant)

### DIFF
--- a/fichero/fichero-tests/CompactShellPolicyTests.swift
+++ b/fichero/fichero-tests/CompactShellPolicyTests.swift
@@ -6,7 +6,10 @@ import XCTest
 final class CompactShellPolicyTests: XCTestCase {
     /// Every `AppViewMode` case, so this list fails to compile if the enum
     /// gains a case without the test being updated alongside the policy switch.
-    private static let allModes: [AppViewMode] = [
+    /// nonisolated(unsafe): AppViewMode's associated model types aren't all
+    /// Sendable, but this is an immutable test constant never mutated across
+    /// domains — safe by construction (Swift 6).
+    private nonisolated(unsafe) static let allModes: [AppViewMode] = [
         .library(nil), .search(nil), .chat(nil), .comparison(nil),
         .workflow(nil), .chain(nil), .batches, .batch(nil),
         .automation, .schedule(nil), .trigger(nil), .activity(nil)


### PR DESCRIPTION
The App Store build passes, but the **test target** wouldn't compile — pre-existing Swift-6 error `CompactShellPolicyTests.swift:9: static 'allModes' is not concurrency-safe because non-Sendable [AppViewMode]`. It's an immutable test constant never mutated across domains, so `nonisolated(unsafe)` is the safe minimal fix (making AppViewMode itself Sendable would require verifying all 10 associated model types are Sendable, unbuildable to confirm here). Unblocks RuntimeLibraryGrantOrderingTests + the suite. Test-only; verification = f_manager's test-target rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)