### PR TITLE
fix: unblock 3 more FicheroTests compile errors (@MainActor, imports, test helper)

### DIFF
--- a/fichero/fichero-tests/ChatViewBoundaryTests.swift
+++ b/fichero/fichero-tests/ChatViewBoundaryTests.swift
@@ -1,3 +1,5 @@
+@testable import Fichero
+import SwiftUI
 import XCTest
 
 final class ChatViewBoundaryTests: XCTestCase {

--- a/fichero/fichero-tests/ClaimSummaryCardTests.swift
+++ b/fichero/fichero-tests/ClaimSummaryCardTests.swift
@@ -352,6 +352,23 @@ final class ClaimSummaryCardTests: XCTestCase {
         XCTAssertTrue(EntityDetailView.parseDuplicateCandidates(Data(), excluding: "x").isEmpty)
     }
 
+    private func makeKnowledgeEntity(
+        id: String,
+        name: String,
+        type: Components.Schemas.EntityTypeOutput
+    ) -> Components.Schemas.KnowledgeEntity {
+        Components.Schemas.KnowledgeEntity(
+            id: id,
+            canonicalName: name,
+            entityType: type,
+            aliases: nil,
+            description: nil,
+            language: nil,
+            metadata: nil,
+            mergedIntoId: nil
+        )
+    }
+
     func testLocationEntitiesHideGenericClaimsSection() {
         let location = makeKnowledgeEntity(id: "entity-1", name: "Andagoya", type: .location)
         let person = makeKnowledgeEntity(id: "entity-2", name: "Crawfurd", type: .person)

--- a/fichero/fichero-tests/WorkflowExecutionStatusMappingTests.swift
+++ b/fichero/fichero-tests/WorkflowExecutionStatusMappingTests.swift
@@ -5,6 +5,7 @@ import XCTest
 /// checks the canonical raws (completed/error/failed/cancelled/stopped/deleted);
 /// this pins the untested branches: `paused`, the synonym groups, the nil/unknown
 /// → .running default, and case-insensitivity. Pure static mapping, no engine.
+@MainActor  // mapStatus is main-actor-isolated (Swift 6); sync helpers need the case isolated.
 final class WorkflowExecutionStatusMappingTests: XCTestCase {
 
     private func map(_ raw: String?) -> ExecutionStatus {


### PR DESCRIPTION
Continuing the test-target compile cleanup (commit-only workers never built FicheroTests). App Store build stays green; this only unblocks running the suite.

- **WorkflowExecutionStatusMappingTests** → `@MainActor` case (map() calls @MainActor mapStatus sync).
- **ChatViewBoundaryTests** → add `@testable import Fichero` + `import SwiftUI` (it only imported XCTest; the types all exist).
- **ClaimSummaryCardTests** → local `makeKnowledgeEntity` helper (the sibling's is private).

swiftlint-clean; verification = f_manager's FicheroTests rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)