### PR TITLE
fix: wait for embedded engine before restoring libraries

### DIFF
--- a/fichero/fichero-tests/LibraryRestoreReadinessTests.swift
+++ b/fichero/fichero-tests/LibraryRestoreReadinessTests.swift
@@ -1,0 +1,59 @@
+@testable import Fichero
+import XCTest
+
+@MainActor
+final class LibraryRestoreReadinessTests: XCTestCase {
+    private let libraryManager = LibraryManager.shared
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        libraryManager.openLibraries = []
+        libraryManager.backendIsReady = false
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("LibraryRestoreReadinessTests")
+            .appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        libraryManager.openLibraries = []
+        libraryManager.backendIsReady = false
+        try? FileManager.default.removeItem(at: tempDirectory)
+        try super.tearDownWithError()
+    }
+
+    func testSavedLibrariesWaitForBackendReadiness() throws {
+        let defaults = UserDefaults.standard
+        let originalPaths = defaults.stringArray(forKey: LibraryManager.openLibraryPathsKey)
+        let originalNames = defaults.dictionary(forKey: LibraryManager.libraryDisplayNamesByPathKey)
+        defer {
+            if let originalPaths {
+                defaults.set(originalPaths, forKey: LibraryManager.openLibraryPathsKey)
+            } else {
+                defaults.removeObject(forKey: LibraryManager.openLibraryPathsKey)
+            }
+            if let originalNames {
+                defaults.set(originalNames, forKey: LibraryManager.libraryDisplayNamesByPathKey)
+            } else {
+                defaults.removeObject(forKey: LibraryManager.libraryDisplayNamesByPathKey)
+            }
+        }
+
+        let savedLibrary = tempDirectory.appendingPathComponent("Restored.fichero", isDirectory: true)
+        try FileManager.default.createDirectory(at: savedLibrary, withIntermediateDirectories: true)
+        defaults.set([savedLibrary.path], forKey: LibraryManager.openLibraryPathsKey)
+
+        libraryManager.restoreSavedLibraries()
+
+        XCTAssertTrue(
+            libraryManager.openLibraries.isEmpty,
+            "Saved-library restoration must not issue registry work before the backend is ready"
+        )
+
+        libraryManager.backendIsReady = true
+        libraryManager.restoreSavedLibraries()
+
+        XCTAssertEqual(libraryManager.openLibraries.map(\.url), [savedLibrary])
+    }
+}

--- a/fichero/fichero-ui-tests/LibrarySmokeUITests.swift
+++ b/fichero/fichero-ui-tests/LibrarySmokeUITests.swift
@@ -69,6 +69,38 @@ final class LibrarySmokeUITests: XCTestCase {
         XCTAssertEqual(app.state, .runningForeground, "App left the foreground after launch.")
     }
 
+    /// Runs only in an embedded macOS scheme. It exercises the real startup
+    /// ordering with one saved library, while keeping all data under the test
+    /// support directory.
+    @MainActor
+    func testEmbeddedEngineLaunchRestoresLibraryAfterReadiness() throws {
+        let embeddedApp = XCUIApplication()
+        embeddedApp.launchArguments = ["--uitesting", "--uitesting-embedded"]
+        embeddedApp.launchEnvironment = [
+            "FICHERO_UITEST_HOME": tempHome.path,
+            "FICHERO_UITEST_RESTORE_LIBRARY": "1",
+            "FICHERO_ALL_FEATURES": "1"
+        ]
+
+        embeddedApp.launch()
+
+        XCTAssertTrue(
+            embeddedApp.wait(for: .runningForeground, timeout: 45),
+            "Embedded engine launch did not reach the foreground."
+        )
+        XCTAssertTrue(
+            embeddedApp.windows.firstMatch.waitForExistence(timeout: 15),
+            "No window appeared after embedded engine launch."
+        )
+        Thread.sleep(forTimeInterval: 2)
+        XCTAssertEqual(
+            embeddedApp.state,
+            .runningForeground,
+            "App left the foreground while restoring a saved library after engine readiness."
+        )
+        embeddedApp.terminate()
+    }
+
     // Flow 5 — the in-content view-mode icon rail was removed (#2032):
     // presentation lives in the View menu (LibraryLayoutSection, ⌘1–4), not in
     // a floating in-content icon bar, so the former

--- a/fichero/fichero.xcodeproj/xcshareddata/xcschemes/Fichero (App Store).xcscheme
+++ b/fichero/fichero.xcodeproj/xcshareddata/xcschemes/Fichero (App Store).xcscheme
@@ -6,6 +6,24 @@
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"
       buildArchitectures = "Automatic">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Preflight embedded engine"
+               scriptText = "&quot;${SRCROOT}/../scripts/preflight-embedded-engine.sh&quot;">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "FEED00000000000000000261"
+                     BuildableName = "Fichero.app"
+                     BlueprintName = "Fichero (App Store)"
+                     ReferencedContainer = "container:fichero.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"

--- a/fichero/fichero/FicheroApp.swift
+++ b/fichero/fichero/FicheroApp.swift
@@ -112,10 +112,8 @@ struct FicheroApp: App {
         logger.info("⏱ AppInstaller check: \(installerMs, format: .fixed(precision: 1))ms")
         #endif
 
-        let restoreStart = Date()
-        LibraryManager.shared.restoreSavedLibraries()
-        let restoreMs = Date().timeIntervalSince(restoreStart) * 1000
-        logger.info("⏱ restoreSavedLibraries: \(restoreMs, format: .fixed(precision: 1))ms")
+        // Saved libraries are restored only after the embedded engine completes
+        // its authenticated health probe. Restoring here races its :8765 bind.
     }
 
     // MARK: - File Opening
@@ -227,6 +225,9 @@ struct FicheroApp: App {
                 return
             }
 
+            let readyMs = Date().timeIntervalSince(backendStart) * 1000
+            logger.info("⏱ engine authenticated and ready: \(readyMs, format: .fixed(precision: 1))ms")
+
             backendService.status = .running
             backendService.errorMessage = nil
             // The heartbeat is the single ongoing poller once ready (#3108); its
@@ -240,7 +241,10 @@ struct FicheroApp: App {
             await DeviceTokenRenewal.renewIfNeeded(host: EngineConfig.host)
             // The one shared post-ready side-effect block (#3113); adopt is a
             // no-op on an embedded/local host, so no `usesExternal` branch here.
+            let restorationStart = Date()
             await libraryManager.refreshAfterBackendBecameReady()
+            let restorationMs = Date().timeIntervalSince(restorationStart) * 1000
+            logger.info("⏱ post-ready library restoration: \(restorationMs, format: .fixed(precision: 1))ms")
         } catch BackendError.portConflict(let pid) {
             // A process we didn't spawn holds :8765 → surface the in-window
             // decision (#3111): Stop it / Use it / Quit. Never a pre-window

--- a/fichero/fichero/FicheroApp.swift
+++ b/fichero/fichero/FicheroApp.swift
@@ -95,7 +95,7 @@ struct FicheroApp: App {
         // the developer's real libraries). The isolated global library — rooted
         // under FICHERO_UITEST_HOME — still loads lazily via LibraryManager so
         // the window has something to show.
-        if isUITesting() {
+        if isUITesting() && !isEmbeddedEngineUITesting() {
             openUITestLibraryOverrideIfNeeded()
             return
         }
@@ -107,9 +107,11 @@ struct FicheroApp: App {
         // sweep enumerates and SIGTERMs processes we do not own, which the App
         // Sandbox forbids. Compiled out rather than no-op'd at runtime so the
         // MAS binary carries no /usr/bin/pgrep or /usr/sbin/lsof at all.
-        AppInstaller.promptToMoveToApplicationsIfNeeded()
-        let installerMs = Date().timeIntervalSince(startupClock) * 1000
-        logger.info("⏱ AppInstaller check: \(installerMs, format: .fixed(precision: 1))ms")
+        if !isEmbeddedEngineUITesting() {
+            AppInstaller.promptToMoveToApplicationsIfNeeded()
+            let installerMs = Date().timeIntervalSince(startupClock) * 1000
+            logger.info("⏱ AppInstaller check: \(installerMs, format: .fixed(precision: 1))ms")
+        }
         #endif
 
         // Saved libraries are restored only after the embedded engine completes

--- a/fichero/fichero/Models/LibraryManager+Helpers.swift
+++ b/fichero/fichero/Models/LibraryManager+Helpers.swift
@@ -43,6 +43,10 @@ extension LibraryManager {
     /// The heartbeat (AppState) and iOS capture-queue resume layer on in the
     /// callers, since those aren't library concerns.
     func refreshAfterBackendBecameReady() async {
+        // Flip readiness before any library work so restore's registry writes
+        // cannot race the engine's socket bind.
+        backendIsReady = true
+        restoreSavedLibraries()
         await KnownLibraryRegistryStore.shared.refresh()
         adoptPairedRemoteLibrary()
         reconcileOpenLibrariesFromRegistry()

--- a/fichero/fichero/Models/LibraryManager+Persistence.swift
+++ b/fichero/fichero/Models/LibraryManager+Persistence.swift
@@ -88,6 +88,11 @@ extension LibraryManager {
 
     /// Restore libraries from saved paths
     func restoreSavedLibraries() {
+        guard backendIsReady else {
+            libraryManagerLogger.info("Deferring saved-library restoration until backend ready")
+            return
+        }
+
         // Canonicalize any legacy NFD-keyed defaults before reading them (#3076);
         // idempotent, so running on every launch is harmless.
         Self.migrateStoredPathsToNFC()

--- a/fichero/fichero/Models/LibraryManager+Persistence.swift
+++ b/fichero/fichero/Models/LibraryManager+Persistence.swift
@@ -83,6 +83,9 @@ extension LibraryManager {
 
     /// Get previously open library paths
     func getSavedLibraryPaths() -> [String] {
+        if let testLibrary = uiTestRestoredLibraryURL() {
+            return [testLibrary.path]
+        }
         return UserDefaults.standard.stringArray(forKey: Self.openLibraryPathsKey) ?? []
     }
 

--- a/fichero/fichero/Services/EngineConfig.swift
+++ b/fichero/fichero/Services/EngineConfig.swift
@@ -325,7 +325,7 @@ enum EngineConfig {
         return EngineProvisioningInputs(
             isMacOS: allowsEmbeddedLocalDefault,
             isDebugBuild: isDebugBuild,
-            isInertHost: isPreview || isRunningXCTests() || isUITesting(),
+            isInertHost: isPreview || isRunningXCTests() || (isUITesting() && !isEmbeddedEngineUITesting()),
             hostRequiresRemoteConnection: requiresExternalBackendConnection,
             hasExplicitConfiguredHost: hasConfiguredHost
         )

--- a/fichero/fichero/Services/UITestSupport.swift
+++ b/fichero/fichero/Services/UITestSupport.swift
@@ -14,6 +14,26 @@ func isUITesting() -> Bool {
     ProcessInfo.processInfo.arguments.contains("--uitesting")
 }
 
+/// Opt-in UI-test mode that exercises the real embedded macOS engine. Normal
+/// UI smoke tests remain inert so they can run without a Briefcase bundle.
+func isEmbeddedEngineUITesting() -> Bool {
+    isUITesting() && ProcessInfo.processInfo.arguments.contains("--uitesting-embedded")
+}
+
+/// A disposable restored-library fixture for the embedded-engine launch smoke.
+/// It lives under the app's existing UI-test support directory, never in the
+/// developer's defaults or library tree.
+func uiTestRestoredLibraryURL() -> URL? {
+    guard isEmbeddedEngineUITesting(),
+          ProcessInfo.processInfo.environment["FICHERO_UITEST_RESTORE_LIBRARY"] == "1",
+          let root = uiTestSupportDirectory() else {
+        return nil
+    }
+    let library = root.appendingPathComponent("Restored.fichero", isDirectory: true)
+    try? FileManager.default.createDirectory(at: library, withIntermediateDirectories: true)
+    return library
+}
+
 /// During UI testing the harness points the app at a disposable Application
 /// Support directory (passed via `FICHERO_UITEST_HOME`) so the smoke tests
 /// never read or write the developer's real `global.fichero`. Returns nil

--- a/scripts/preflight-embedded-engine.sh
+++ b/scripts/preflight-embedded-engine.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure a manual Xcode embedded-macOS build has its Briefcase engine input.
+# Normal use is a fast no-op; pass --rebuild after changing engine sources.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENGINE_DIR="$ROOT_DIR/fichero-engine"
+ENGINE_APP="$ENGINE_DIR/build/engine/macos/app/Fichero Engine.app"
+
+case "${1:-}" in
+  "") ;;
+  --rebuild) rebuild=true ;;
+  --check)
+    if [ -d "$ENGINE_APP" ]; then
+      echo "Embedded engine ready: $ENGINE_APP"
+      exit 0
+    fi
+    echo "error: embedded engine missing: $ENGINE_APP" >&2
+    exit 1
+    ;;
+  *)
+    echo "usage: $0 [--check|--rebuild]" >&2
+    exit 2
+    ;;
+esac
+
+if [ -d "$ENGINE_APP" ] && [ "${rebuild:-false}" = false ]; then
+  echo "Embedded engine ready: $ENGINE_APP"
+  exit 0
+fi
+
+if [ -x "$ENGINE_DIR/.briefcase-venv/bin/briefcase" ]; then
+  BRIEFCASE="$ENGINE_DIR/.briefcase-venv/bin/briefcase"
+elif [ -x "$ROOT_DIR/.venv/bin/briefcase" ]; then
+  BRIEFCASE="$ROOT_DIR/.venv/bin/briefcase"
+elif BRIEFCASE="$(command -v briefcase 2>/dev/null)"; then
+  :
+else
+  echo "error: briefcase is not installed; activate the project virtualenv first" >&2
+  exit 1
+fi
+
+echo "Building embedded engine with Briefcase"
+(
+  cd "$ENGINE_DIR"
+  if [ ! -d "$ENGINE_DIR/build/engine/macos/app" ]; then
+    "$BRIEFCASE" create macOS --app engine
+  fi
+  "$BRIEFCASE" update macOS --app engine
+  "$BRIEFCASE" build macOS --app engine
+)
+
+if [ ! -x "$ENGINE_APP/Contents/MacOS/Fichero Engine" ]; then
+  echo "error: Briefcase did not produce an executable engine at $ENGINE_APP" >&2
+  exit 1
+fi
+
+echo "Embedded engine ready: $ENGINE_APP"


### PR DESCRIPTION
Closes #3911

Saved-library restoration previously ran synchronously from `FicheroApp.init`, before the embedded engine bound TLS on `127.0.0.1:8765`. The app now restores only after the authenticated health probe, with a defensive readiness guard and startup timing logs.

Validation:
- `swiftlint lint` on changed files: no serious violations (one pre-existing advisory in `connectBackend`)
- `git diff --check`
- Added `LibraryRestoreReadinessTests` regression coverage.

Requires an App Store embedded launch check; full FicheroTests is currently blocked by tracked unrelated test-target Swift 6 compile cleanup.