### PR TITLE
fix: defer restored libraries until embedded engine is ready

### DIFF
--- a/fichero/fichero-ui-tests/LibrarySmokeUITests.swift
+++ b/fichero/fichero-ui-tests/LibrarySmokeUITests.swift
@@ -87,6 +87,10 @@ final class LibrarySmokeUITests: XCTestCase {
             embeddedApp.wait(for: .runningForeground, timeout: 45),
             "Embedded engine launch did not reach the foreground."
         )
+        XCTAssertTrue(
+            embeddedApp.windows.firstMatch.waitForExistence(timeout: 15),
+            "No window appeared after embedded engine launch."
+        )
         // Give the bundled engine time to bind and the deferred saved-library
         // restore time to run. The unit test covers the ordering predicate;
         // this exercises the real app process and engine bundle together.


### PR DESCRIPTION
Brings the remaining embedded-engine launch ordering work into a reviewable PR.

- defers local library restoration until authenticated engine readiness
- adds embedded-engine UI smoke coverage and a Briefcase preflight helper
- preserves inert UI tests for non-embedded schemes

Closes #3911