### PR TITLE
feat: notify on workflow completion and failure

### DIFF
--- a/fichero/fichero-tests/WorkflowCompletionNotifierTests.swift
+++ b/fichero/fichero-tests/WorkflowCompletionNotifierTests.swift
@@ -1,0 +1,47 @@
+@testable import Fichero
+import XCTest
+
+/// The enabled-gate for workflow completion notifications (#1869).
+///
+/// The single on/off preference must default ON — an unset key reads as enabled —
+/// and honour an explicit off. This is the non-UI logic worth pinning: the
+/// notifier posts nothing (and never prompts for authorization) when it is off,
+/// so a wrong default here would either spam or silence every run.
+final class WorkflowCompletionNotifierTests: XCTestCase {
+
+    private let key = WorkflowCompletionNotifier.enabledDefaultsKey
+
+    /// Save + restore the real defaults value so the test never leaks state.
+    private func withCleanDefault(_ body: () -> Void) {
+        let defaults = UserDefaults.standard
+        let saved = defaults.object(forKey: key)
+        defer {
+            if let saved { defaults.set(saved, forKey: key) } else { defaults.removeObject(forKey: key) }
+        }
+        defaults.removeObject(forKey: key)
+        body()
+    }
+
+    func testDefaultsToEnabledWhenUnset() {
+        withCleanDefault {
+            XCTAssertTrue(
+                WorkflowCompletionNotifier.isEnabled,
+                "an unset preference must default ON, not off"
+            )
+        }
+    }
+
+    func testDisabledWhenExplicitlyOff() {
+        withCleanDefault {
+            UserDefaults.standard.set(false, forKey: key)
+            XCTAssertFalse(WorkflowCompletionNotifier.isEnabled)
+        }
+    }
+
+    func testEnabledWhenExplicitlyOn() {
+        withCleanDefault {
+            UserDefaults.standard.set(true, forKey: key)
+            XCTAssertTrue(WorkflowCompletionNotifier.isEnabled)
+        }
+    }
+}

--- a/fichero/fichero/Models/WorkflowExecutionStore.swift
+++ b/fichero/fichero/Models/WorkflowExecutionStore.swift
@@ -2,6 +2,9 @@ import FicheroAPIClient
 import Foundation
 import Observation
 import OSLog
+#if os(macOS)
+import UserNotifications
+#endif
 
 /// Shared, per-library home for **live** workflow execution state, keyed by
 /// `threadId` (#2546).
@@ -133,11 +136,81 @@ final class WorkflowExecutionStore {
         executions[threadId] = execution
 
         switch event {
-        case .complete, .cancelled, .error, .systemicError:
+        case .complete:
+            unsubscribe(threadId: threadId)
+            WorkflowCompletionNotifier.notify(name: execution.name, outcome: .completed)
+        case .error(_, let error), .systemicError(_, let error, _, _):
+            unsubscribe(threadId: threadId)
+            WorkflowCompletionNotifier.notify(name: execution.name, outcome: .failed(error))
+        case .cancelled:
+            // User-initiated stop — no notification (the brief is completed/failed only).
             unsubscribe(threadId: threadId)
         default:
             break
         }
+    }
+}
+
+// MARK: - Completion notifications (#1869)
+
+/// Posts a local system notification when a workflow run the app ALREADY observes
+/// reaches a terminal state (#1869). Front-end only: it reacts to the same
+/// completed/failed events `WorkflowExecutionStore` reduces — it does no backend
+/// work and adds no new event plumbing.
+///
+/// Dead-simple: a single on/off preference (default ON), and authorization is
+/// requested lazily the first time a notification is actually posted (the system
+/// shows its prompt only once). When the preference is off it posts nothing and
+/// never prompts.
+enum WorkflowCompletionNotifier {
+    /// What finished, carrying the failure message only when it failed.
+    enum Outcome {
+        case completed
+        case failed(String)
+    }
+
+    /// The single on/off preference, shared with the Settings toggle. Default ON:
+    /// an UNSET key reads as enabled (UserDefaults.bool returns false for unset,
+    /// so the presence check is required to make the default ON, not off).
+    static let enabledDefaultsKey = "notificationsEnabled"
+
+    static var isEnabled: Bool {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: enabledDefaultsKey) != nil else { return true }
+        return defaults.bool(forKey: enabledDefaultsKey)
+    }
+
+    /// Post a completed/failed notification for a finished run. No-op (and no
+    /// authorization prompt) when the preference is off.
+    @MainActor
+    static func notify(name: String, outcome: Outcome) {
+        guard isEnabled else { return }
+        #if os(macOS)
+        let body: String
+        switch outcome {
+        case .completed:
+            body = "Completed"
+        case .failed(let error):
+            body = error.isEmpty ? "Failed" : "Failed — \(error)"
+        }
+
+        let content = UNMutableNotificationContent()
+        content.title = name.isEmpty ? "Workflow" : name
+        content.body = body
+        content.sound = .default
+
+        let center = UNUserNotificationCenter.current()
+        // Lazy, once: requestAuthorization only shows the system prompt the first
+        // time; later calls just return the existing decision without a prompt.
+        center.requestAuthorization(options: [.alert, .sound]) { granted, _ in
+            guard granted else { return }
+            center.add(UNNotificationRequest(
+                identifier: UUID().uuidString,
+                content: content,
+                trigger: nil  // deliver immediately
+            ))
+        }
+        #endif
     }
 }
 

--- a/fichero/fichero/Views/Settings/GeneralSettingsView.swift
+++ b/fichero/fichero/Views/Settings/GeneralSettingsView.swift
@@ -8,6 +8,8 @@ struct GeneralSettingsView: View {
     @AppStorage("defaultImportMode") private var defaultImportMode: String = IngestMode.link.rawValue
     @AppStorage("autoExtractText") private var autoExtractText: Bool = true
     @AppStorage("autoCreateEmbeddings") private var autoCreateEmbeddings: Bool = true
+    // #1869 — single on/off; key shared with WorkflowCompletionNotifier. Default ON.
+    @AppStorage(WorkflowCompletionNotifier.enabledDefaultsKey) private var notificationsEnabled: Bool = true
 
     // Typography settings
     @AppStorage("editor.fontName") private var fontName: String = "System"
@@ -74,6 +76,13 @@ struct GeneralSettingsView: View {
             Section("Ingestion") {
                 Toggle("Auto-extract text from documents", isOn: $autoExtractText)
                 Toggle("Auto-create search embeddings", isOn: $autoCreateEmbeddings)
+            }
+
+            Section("Notifications") {
+                Toggle("Notify when a workflow finishes", isOn: $notificationsEnabled)
+                Text("Shows a system notification when a workflow run completes or fails.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
 
             Section {


### PR DESCRIPTION
Adds local notification preferences and emits completion/failure notifications from the workflow execution store.

Closes #1869