### PR TITLE
fix: precompile Xcode embedded engines and enable FicheroTests

### DIFF
--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -3176,6 +3176,7 @@
 				"mkdir -p \"$(dirname \"$ENGINE_DST\")\"",
 				"",
 				"cp -R \"$ENGINE_SRC\" \"$ENGINE_DST\"",
+				"\"${SRCROOT}/../scripts/clean-embedded-engine.sh\" \"$ENGINE_DST\"",
 				"",
 			);
 		};
@@ -3302,6 +3303,7 @@
 				"rm -rf \"$ENGINE_DST\"",
 				"mkdir -p \"$(dirname \"$ENGINE_DST\")\"",
 				"cp -R \"$ENGINE_SRC\" \"$ENGINE_DST\"",
+				"\"${SRCROOT}/../scripts/clean-embedded-engine.sh\" \"$ENGINE_DST\"",
 				"",
 				"# Remove static archives (.a). REJECTED UPLOAD, code 90284: Python.framework ships",
 				"# Tcl/Tk link-time stubs (libtclstub8.6.a, libtkstub8.6.a, libitclstub4.3.2.a,",
@@ -4804,42 +4806,54 @@
 		20969FA93000614800D06A60 /* Alpha */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_NAME = FicheroTests;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Alpha;
 		};
 		20969FAA3000614800D06A60 /* Beta */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_NAME = FicheroTests;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Beta;
 		};
 		20969FAB3000614800D06A60 /* Dev Embedded */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_NAME = FicheroTests;
+				SWIFT_VERSION = 5.0;
 			};
 			name = "Dev Embedded";
 		};
 		20969FAC3000614800D06A60 /* Alpha Embedded */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_NAME = FicheroTests;
+				SWIFT_VERSION = 5.0;
 			};
 			name = "Alpha Embedded";
 		};
 		20969FAD3000614800D06A60 /* Beta Embedded */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_NAME = FicheroTests;
+				SWIFT_VERSION = 5.0;
 			};
 			name = "Beta Embedded";
 		};
 		20969FAE3000614800D06A60 /* Release Local */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GENERATE_INFOPLIST_FILE = YES;
 				PRODUCT_NAME = FicheroTests;
+				SWIFT_VERSION = 5.0;
 			};
 			name = "Release Local";
 		};
@@ -5462,7 +5476,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Fichero.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Fichero";
 			};
 			name = Debug;
@@ -5485,7 +5499,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = app.fichero.fichero.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 6.0;
+				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Fichero.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Fichero";
 			};
 			name = Release;

--- a/scripts/check_mac_app_store_target.py
+++ b/scripts/check_mac_app_store_target.py
@@ -89,6 +89,23 @@ def main() -> int:
 
     mas, dmg = found[MAS_TARGET], found[DMG_TARGET]
 
+    # Both macOS channels copy the Briefcase bundle during their Xcode build.
+    # Precompile only after that copy: running Briefcase update afterwards replaces
+    # the bundle and silently discards its .pyc files.
+    for target in (mas, dmg):
+        embed_phase = phase_named(objects, target, "Embed Fichero Engine")
+        if embed_phase is None:
+            fail(f"{target['name']} has no 'Embed Fichero Engine' phase")
+            continue
+        embed_script = shell_of(embed_phase)
+        copy_at = embed_script.find('cp -R "$ENGINE_SRC" "$ENGINE_DST"')
+        cleanup_at = embed_script.find("clean-embedded-engine.sh")
+        if copy_at < 0 or cleanup_at < copy_at:
+            fail(
+                f"{target['name']} must precompile the copied engine after `cp -R` and before signing. "
+                "Briefcase updates replace earlier .pyc files."
+            )
+
     # 1. Sparkle: absent from MAS at the LINK level, present in the DMG.
     # A #if does not help — a linked framework still ships, and the reviewer sees it.
     if any(p == "Sparkle" for p in spm_products(objects, mas)):

--- a/scripts/verify_all.sh
+++ b/scripts/verify_all.sh
@@ -393,9 +393,9 @@ run_platform_checks() {
       -scheme "${XCODE_SCHEME}" \
       -destination 'platform=macOS'
 
-    run_xcode_test "xcodebuild macOS test (Swift suite + CrossLanguageGate -> Python gate)" \
+    run_xcode_test "xcodebuild macOS test (FicheroTests test plan)" \
       -project "${XCODE_PROJECT}" \
-      -scheme "${XCODE_SCHEME}" \
+      -scheme "FicheroTests" \
       -destination 'platform=macOS' \
       -resultBundlePath "$(mktemp -d)/verify.xcresult"
 


### PR DESCRIPTION
Preserves the recovered worktree changes: precompile copied engine bundles in both macOS Xcode embed phases, guard the required ordering, and add the missing FicheroTests build settings. Static MAS guard and shell syntax pass; Xcode build gate remains required before merge.