### PR TITLE
perf: integrate launch lifecycle and startup improvements

### DIFF
--- a/fichero/fichero-tests/DocumentStoreAndSidebarTypesTests.swift
+++ b/fichero/fichero-tests/DocumentStoreAndSidebarTypesTests.swift
@@ -323,32 +323,53 @@ final class DocumentStoreAndSidebarTypesTests: XCTestCase {
         XCTAssertTrue(contentSource.contains("Label(\"View\", systemImage: \"rectangle.split.3x1\")"))
     }
 
-    func testMacLaunchResyncsBackendStateAfterEngineStartup() throws {
-        let appSource = try Self.appSource("FicheroApp.swift")
-        let appStateSource = try Self.appSource("App/AppState.swift")
+    func testEngineLaunchSequenceIsOwnedByLifecycleController() throws {
+        // #3945: the engine launch sequence is owned by EngineLifecycleController
+        // (app-scoped), NOT by FicheroApp / a window. Assert the sequence lives
+        // there, in order: spawn → readiness probe → heartbeat → library-ready
+        // side-effects. (Rewritten from the old FicheroApp-grep version, which went
+        // stale when PR #1 moved this orchestration off the window.)
+        let controllerSource = try Self.appSource("Services/EngineLifecycleController.swift")
 
         guard
-            let startRange = appSource.range(of: "try await backendService.start()"),
-            let resyncRange = appSource.range(
-                of: "await appState.checkBackendHealth()",
-                range: startRange.upperBound..<appSource.endIndex
+            let startRange = controllerSource.range(of: "try await backendService.start()"),
+            let probeRange = controllerSource.range(
+                of: "checkBackendHealthUntilReady(",
+                range: startRange.upperBound..<controllerSource.endIndex
             ),
-            let heartbeatRange = appSource.range(
+            let heartbeatRange = controllerSource.range(
                 of: "appState.startBackendHeartbeat()",
-                range: resyncRange.upperBound..<appSource.endIndex
+                range: probeRange.upperBound..<controllerSource.endIndex
             ),
-            let readyRange = appSource.range(
-                of: "await libraryManager.backendDidBecomeReady()",
-                range: heartbeatRange.upperBound..<appSource.endIndex
+            let readyRange = controllerSource.range(
+                of: "await libraryManager.refreshAfterBackendBecameReady()",
+                range: heartbeatRange.upperBound..<controllerSource.endIndex
             )
         else {
-            return XCTFail("launch sequence changed unexpectedly")
+            return XCTFail("engine launch sequence changed unexpectedly in EngineLifecycleController")
         }
 
-        XCTAssertLessThan(startRange.lowerBound, resyncRange.lowerBound)
-        XCTAssertLessThan(resyncRange.lowerBound, heartbeatRange.lowerBound)
+        XCTAssertLessThan(startRange.lowerBound, probeRange.lowerBound)
+        XCTAssertLessThan(probeRange.lowerBound, heartbeatRange.lowerBound)
         XCTAssertLessThan(heartbeatRange.lowerBound, readyRange.lowerBound)
-        XCTAssertFalse(appStateSource.contains("await checkBackendHealth()"))
+
+        // Ownership moved off the window (#3945): FicheroApp must NOT spawn the
+        // engine anymore — that's the whole point of the app-owns-engine change.
+        let appSource = try Self.appSource("FicheroApp.swift")
+        XCTAssertFalse(
+            appSource.contains("try await backendService.start()"),
+            "FicheroApp still spawns the engine — it must be owned by EngineLifecycleController (#3945)"
+        )
+    }
+
+    @MainActor
+    func testIsRetriableLoadFailureSeparatesTransientFromDefinitive() {
+        // #3972: one transient blip must NOT trip the app-wide outage pane, so
+        // transient engine-unreachable / transport failures are retriable…
+        XCTAssertTrue(DocumentStore.isRetriableLoadFailure(URLError(.timedOut)))
+        XCTAssertTrue(DocumentStore.isRetriableLoadFailure(URLError(.cannotConnectToHost)))
+        // …while a definitive TLS-pin failure surfaces immediately (not retriable).
+        XCTAssertFalse(DocumentStore.isRetriableLoadFailure(URLError(.secureConnectionFailed)))
     }
 
     func testBackendRetryRunsSameReadinessSideEffectsAsStartup() throws {

--- a/fichero/fichero-tests/EngineReadinessProbeTests.swift
+++ b/fichero/fichero-tests/EngineReadinessProbeTests.swift
@@ -35,6 +35,20 @@ struct EngineReadinessProbeTests {
         #expect(classify(200, nonce: "n", expected: "n", pid: 1, registry: 200) == .ready)
     }
 
+    @Test("proven-readiness fast path fires only for .ready (#3975)")
+    @MainActor
+    func provenReadinessFastPathOnlyForReady() {
+        // AppState.checkBackendHealthUntilReady short-circuits the redundant
+        // re-probe (~3-4 round-trips) ONLY when the spawn already proved `.ready`.
+        // Every other value — including nil (remote host / a retry before start) —
+        // must fall through to the full probe + #3162 backoff.
+        #expect(AppState.shouldReuseProvenReadiness(.ready))
+        #expect(AppState.shouldReuseProvenReadiness(nil) == false)
+        #expect(AppState.shouldReuseProvenReadiness(.authRejected) == false)
+        #expect(AppState.shouldReuseProvenReadiness(.notResponding) == false)
+        #expect(AppState.shouldReuseProvenReadiness(.identityMismatch(pid: 123)) == false)
+    }
+
     @Test("registry 401 / 403 → authRejected (the blank-window-401 cause)")
     func authRejected() {
         #expect(classify(200, registry: 401) == .authRejected)

--- a/fichero/fichero-tests/LaunchPathNoModalTests.swift
+++ b/fichero/fichero-tests/LaunchPathNoModalTests.swift
@@ -45,10 +45,11 @@ struct LaunchPathNoModalTests {
     }
 
     /// The other half of "it launches": having removed the blocker, the launch
-    /// path must still reach the engine spawn.
+    /// path must still reach the engine spawn — now owned by the app-scoped
+    /// EngineLifecycleController (#3945), not FicheroApp/a window.
     @Test("launch proceeds to the engine spawn")
     func launchProceedsToEngineSpawn() throws {
-        let source = try Self.appSource("FicheroApp.swift")
+        let source = try Self.appSource("Services/EngineLifecycleController.swift")
         #expect(source.contains("try await backendService.start()"))
     }
 }

--- a/fichero/fichero.xcodeproj/project.pbxproj
+++ b/fichero/fichero.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		048 /* WorkflowExecutionObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 149 /* WorkflowExecutionObserver.swift */; };
 		049 /* DocumentServiceGenerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 148 /* DocumentServiceGenerated.swift */; };
 		04EC79C508ADFCB840661C01 /* BookmarksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EA02CD36EF110174B8E2206 /* BookmarksView.swift */; };
+		07776782808C783E1F4AF8DF /* EngineLifecycleController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AD58A9604A19DAAE6983A01 /* EngineLifecycleController.swift */; };
 		079E7B626FA4EE5877BB24B0 /* FicheroApp_iOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29941DE439073B7364322ECF /* FicheroApp_iOS.swift */; };
 		08A233915452687AD06DA9DE /* DocumentInspectorArtifactsTab+Previews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73BB27716102361159F020CD /* DocumentInspectorArtifactsTab+Previews.swift */; };
 		097E07610FB8E2B3AB4A6264 /* CitationDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1424784E87E1971372F0109 /* CitationDetailView.swift */; };
@@ -519,6 +520,7 @@
 		C10000010000000000000001 /* SparkleUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10000110000000000000001 /* SparkleUpdater.swift */; };
 		C10000020000000000000001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; platformFilters = (macos, ); productRef = C10000310000000000000001 /* Sparkle */; };
 		C1C484907B28189E223436BE /* LibraryManager+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CE5EBB51D90DE16D32A82FC /* LibraryManager+Helpers.swift */; };
+		C2BE0A6960B4398CE2110077 /* EngineLifecycleController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AD58A9604A19DAAE6983A01 /* EngineLifecycleController.swift */; };
 		C340001000000000PROMPT01 /* PromptPreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C340001100000000PROMPT01 /* PromptPreviewPanel.swift */; };
 		C37B1043409A6ED500E30F29 /* BackupsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91100495C9D776E200E2F9C0 /* BackupsView.swift */; };
 		C38F232612EE4EEB87E62A76 /* FicheroAppEntities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48FFFFE4A294ADC2F1299E2D /* FicheroAppEntities.swift */; };
@@ -1293,6 +1295,7 @@
 		16BEAA9442D4996FBD92BC7F /* ScheduleDetailView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ScheduleDetailView.swift; sourceTree = "<group>"; };
 		16C939F2EE06FF349761CA2F /* ActivityMonitorView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityMonitorView.swift; sourceTree = "<group>"; };
 		19C6A533EA3E96E1F5AE19ED /* AppNavigationHistory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppNavigationHistory.swift; sourceTree = "<group>"; };
+		1AD58A9604A19DAAE6983A01 /* EngineLifecycleController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = EngineLifecycleController.swift; sourceTree = "<group>"; };
 		1B98F1F8C255A9F7C3386A59 /* ResearchModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ResearchModels.swift; sourceTree = "<group>"; };
 		1C4E4291B8C33D501F176BF5 /* AIDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AIDefaults.swift; path = fichero/Views/Settings/AIDefaults.swift; sourceTree = SOURCE_ROOT; };
 		1C527476477074D83F628468 /* ClaimStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ClaimStore.swift; sourceTree = "<group>"; };
@@ -2429,6 +2432,7 @@
 				AE34A7C933EA9305CAAA50FA /* AccessError.swift */,
 				110C8D9D75D6823D7B1EF43D /* DeviceTokenRenewal.swift */,
 				9F3A4A14186A5886AC932517 /* ChangeStreamTransport.swift */,
+				1AD58A9604A19DAAE6983A01 /* EngineLifecycleController.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -4177,6 +4181,7 @@
 				6FC9AFB7D35EBFB12E9F8225 /* CitationExportButton.swift in Sources */,
 				A6AD2F07985565F991995037 /* ArtifactEntityStore.swift in Sources */,
 				B87B28ED2A0DAC77675C461B /* LaunchProfile.swift in Sources */,
+				C2BE0A6960B4398CE2110077 /* EngineLifecycleController.swift in Sources */,
 			);
 		};
 		A10521A52EFDC92400B28C3E /* Sources */ = {
@@ -4783,6 +4788,7 @@
 				FEED0000000000000000024C /* CitationExportButton.swift in Sources */,
 				23BB0DDC9E8089CB1452632D /* ArtifactEntityStore.swift in Sources */,
 				F2E929E26D14B40F55EDB9D1 /* LaunchProfile.swift in Sources */,
+				07776782808C783E1F4AF8DF /* EngineLifecycleController.swift in Sources */,
 			);
 		};
 /* End PBXSourcesBuildPhase section */
@@ -6073,8 +6079,8 @@
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2026071702;
@@ -6139,8 +6145,8 @@
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2026071702;
@@ -6220,8 +6226,8 @@
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2026071702;
@@ -6301,8 +6307,8 @@
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2026071702;
@@ -6382,8 +6388,8 @@
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2026071702;
@@ -6448,8 +6454,8 @@
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2026071702;
@@ -6529,8 +6535,8 @@
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2026071702;
@@ -6610,8 +6616,8 @@
 				AUTOMATION_APPLE_EVENTS = YES;
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = fichero/FicheroAppStore.entitlements;
-				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 2026071702;

--- a/fichero/fichero/App/AppState.swift
+++ b/fichero/fichero/App/AppState.swift
@@ -248,29 +248,27 @@ class AppState {
     }
 
     /// After a health-200, confirm the engine accepts our token, resolve the full
-    /// auth context (token + session + identity), and only THEN flip ready and load
+    /// auth context (session + identity), and only THEN flip ready and load
     /// providers — or flip authBroken/unreachable with a diagnosis (#2864). Uses
     /// the one shared readiness probe (#3106). Owning the whole ordering here is
     /// what keeps the first library fetch authorized (#2407): nothing that a
     /// library-scoped request depends on is resolved after `markReady`.
-    private func confirmAuthAndLoad() async {
+    ///
+    /// When `readinessAlreadyProven` is true the spawn wait (#3930) already
+    /// established the full readiness contract — health 200 + our launch nonce +
+    /// an authenticated `/api/registry` 200 (token accepted). Re-running the probe
+    /// here would re-derive that held fact over a fresh pinned-TLS handshake, so
+    /// the proven path skips straight to the warm-up (#3975). The un-proven path
+    /// (adopt / remote / debug / a transient miss) keeps the full probe + #2864
+    /// diagnosis unchanged.
+    private func confirmAuthAndLoad(readinessAlreadyProven: Bool = false) async {
+        if readinessAlreadyProven {
+            await warmContextThenMarkReady()
+            return
+        }
         switch await EngineReadinessProbe(hostURL: EngineConfig.host).probe() {
         case .ready:
-            // #2407: warm the ENTIRE auth context BEFORE flipping ready. The
-            // instant `isBackendRunning` becomes true, `DocumentTabView` mounts the
-            // library content and every sub-view `.task` fires a library-scoped
-            // fetch (chains/documents/workflows/conversations/saved-search). If the
-            // bearer token, restored session, and resolved identity aren't ALL in
-            // place first, that first burst races the warm-up and 403s (then 200s
-            // on retry). So resolve them here and make `markReady()` the LAST step —
-            // the readiness gate the first data call awaits, not a blind retry.
-            _ = await AuthTokenMiddleware.waitForToken()
-            await sessionStore.refresh()
-            await identityStore.load()
-            recordActiveEndpoint()
-            backendAccessError = nil
-            engine.markReady()
-            await loadProviders()
+            await warmContextThenMarkReady()
         case .authRejected:
             let accessError = await EngineReadinessProbe(hostURL: EngineConfig.host).authFailure() ?? .unauthenticated
             backendAccessError = accessError
@@ -282,6 +280,31 @@ class AppState {
                 "The engine answered health checks but the authenticated readiness probe failed."
             )
         }
+    }
+
+    /// Warm the ENTIRE auth context, then flip ready — the #2407 ordering the
+    /// first library fetch depends on. The instant `isBackendRunning` becomes true,
+    /// `DocumentTabView` mounts the library content and every sub-view `.task`
+    /// fires a library-scoped fetch (chains/documents/workflows/conversations/
+    /// saved-search). If the restored session and resolved identity aren't in place
+    /// first, that first burst races the warm-up and 403s (then 200s on retry). So
+    /// resolve them here and make `markReady()` the LAST step — the readiness gate
+    /// the first data call awaits, not a blind retry (#2407 preserved).
+    ///
+    /// Reaching here means an authenticated `/api/registry` already returned 200
+    /// (proven by the spawn wait, or by the probe just above), so the bearer token
+    /// is on disk and accepted — the explicit `waitForToken` is redundant and gone
+    /// (#3975). The session refresh and identity load are independent, so they
+    /// overlap instead of running strictly serial (#3975); both still complete
+    /// BEFORE `markReady`, so the #2407 first-call-auth-race gate is intact.
+    private func warmContextThenMarkReady() async {
+        async let session: Void = sessionStore.refresh()
+        async let identity: Void = identityStore.load()
+        _ = await (session, identity)
+        recordActiveEndpoint()
+        backendAccessError = nil
+        engine.markReady()
+        await loadProviders()
     }
 
     private func noteHeartbeatFailure(reason: String) async {
@@ -408,24 +431,53 @@ class AppState {
     /// must not permanently park the app on "Not Running" (#3162). Backoff is
     /// 1, 2, 3, 4, 5, 5 s (~20 s total): long enough for a slow boot, short
     /// enough to stay responsive.
-    func checkBackendHealthUntilReady(maxRetries: Int = 6) async {
-        await checkBackendHealth()
+    /// `provenReadiness` carries the result the spawn wait already established
+    /// (#3930) so the first health check can reuse it instead of re-deriving it
+    /// (#3975). Only the FIRST attempt reuses it; every backoff retry re-probes
+    /// fully — a retry means the fast path didn't land ready, so a stale proof
+    /// must never be trusted (#3162).
+    func checkBackendHealthUntilReady(maxRetries: Int = 6, provenReadiness: EngineReadiness? = nil) async {
+        await checkBackendHealth(provenReadiness: provenReadiness)
         var attempt = 0
         while !isBackendRunning && attempt < maxRetries {
             attempt += 1
             try? await Task.sleep(for: .seconds(Double(min(attempt, 5))))
             if Task.isCancelled { return }
+            // Re-derive from scratch on retry (#3162) — never reuse the stale proof.
             await checkBackendHealth()
         }
     }
 
-    func checkBackendHealth() async {
+    /// Whether a readiness result the spawn wait already proved (#3930) lets the
+    /// health check skip its redundant re-probe (#3975). Pure so the short-circuit
+    /// decision is unit-testable without an engine. Only a fully-proven `.ready`
+    /// qualifies — every other value (nil / authRejected / notResponding /
+    /// identityMismatch) falls through to the full health probe + #3162 backoff.
+    static func shouldReuseProvenReadiness(_ readiness: EngineReadiness?) -> Bool {
+        readiness == .ready
+    }
+
+    func checkBackendHealth(provenReadiness: EngineReadiness? = nil) async {
         reconfigureGeneratedClientsForCurrentHost()
         LaunchProfile.milestone("checkBackendHealth entry")
         // Enter the checking/starting phase; the outcome below resolves it to
         // ready / unreachable / authRejected (via confirmAuthAndLoad).
         backendAccessError = nil
         engine.markStarting()
+
+        // Fast path (#3975): the spawn wait already proved the FULL readiness
+        // contract (health 200 + our launch nonce + authenticated /api/registry
+        // 200 = token accepted). Re-running the health GET here AND the
+        // authenticated probe inside `confirmAuthAndLoad` would re-derive that same
+        // fact over fresh pinned-TLS handshakes — ~3-4 redundant serial round-trips
+        // on the launch critical path. Skip both and go straight to the side-effect
+        // warm-up + markReady. Anything not proven `.ready` falls through to the
+        // full health probe + #3162 backoff below.
+        if Self.shouldReuseProvenReadiness(provenReadiness) {
+            LaunchProfile.milestone("checkBackendHealth reusing proven readiness (#3975)")
+            await confirmAuthAndLoad(readinessAlreadyProven: true)
+            return
+        }
 
         LaunchProfile.milestone("checkBackendHealth request-start")
         do {

--- a/fichero/fichero/FicheroApp.swift
+++ b/fichero/fichero/FicheroApp.swift
@@ -11,14 +11,31 @@ import SwiftUI
 
 // MARK: - App Delegate
 
-/// Custom AppDelegate to handle app lifecycle events (especially termination)
+/// Custom AppDelegate — the APP-scoped owner of the engine lifecycle (#3945).
+/// The engine is started here in `applicationDidFinishLaunching` and stopped in
+/// `applicationWillTerminate`, NOT from a window's `.task`. Opening or closing a
+/// window is not an engine event; windows read the controller off the delegate
+/// and observe its `EngineSession` phase, they never trigger it.
+@MainActor
 final class FicheroAppDelegate: NSObject, NSApplicationDelegate, ObservableObject {
     private let logger = Logger(subsystem: "app.fichero.fichero", category: "FicheroAppDelegate")
-    weak var backendService: EmbeddedBackendService?
+
+    /// The single app-scoped engine lifecycle controller (#3945). Owns the
+    /// spawn/watch/stop (`EmbeddedBackendService`) and the connect/probe/heartbeat
+    /// (`AppState`) halves; `EngineSession` inside it is the sole phase writer.
+    let controller = EngineLifecycleController()
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        logger.info("App did finish launching — starting engine app-scoped (#3945)")
+        // The engine's async startup lives here, not in a scene `.task`: `@main
+        // App.init` is synchronous and `.task` is per-scene, so the delegate is the
+        // one app-level hook that fires exactly once, independent of any window.
+        Task { await controller.start() }
+    }
 
     func applicationWillTerminate(_ notification: Notification) {
         logger.info("App will terminate - stopping backend...")
-        backendService?.stop()
+        controller.stop()
     }
 
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
@@ -27,25 +44,27 @@ final class FicheroAppDelegate: NSObject, NSApplicationDelegate, ObservableObjec
 }
 
 @main
-// swiftlint:disable:next type_body_length
 struct FicheroApp: App {
     private let logger = Logger(subsystem: "app.fichero.fichero", category: "FicheroApp")
     @Environment(\.openWindow) private var openWindow
     // App delegate for lifecycle events
     @NSApplicationDelegateAdaptor(FicheroAppDelegate.self) private var appDelegate
 
-    // Backend service - manages embedded Python backend
-    @State private var backendService = EmbeddedBackendService()
-
-    // Backend connection state
-    @State private var appState = AppState()
+    // The engine lifecycle is app-owned (#3945): the AppDelegate holds the single
+    // EngineLifecycleController. These read its instances so the whole App body —
+    // every appState/backendService reference and the .environment injections —
+    // stays unchanged, while ownership + startup move to the delegate. @Observable
+    // objects are tracked wherever their properties are read in body; @State is
+    // only about ownership/lifetime, which now belongs to the controller.
+    private var backendService: EmbeddedBackendService { appDelegate.controller.backendService }
+    private var appState: AppState { appDelegate.controller.appState }
     @State private var viewSettings = ViewSettings()
     @StateObject private var featureManager = FeatureManager.shared
     @State private var claimFocusState = ClaimFocusState.shared
     @State private var kgFocusState = KGFocusState.shared
 
-    // Library manager - singleton managing all open libraries
-    @State private var libraryManager = LibraryManager.shared
+    // Library manager - the app-owned controller holds the shared singleton (#3945).
+    private var libraryManager: LibraryManager { appDelegate.controller.libraryManager }
 
     // App-level fallback observer injected into secondary scenes (artifact-detail,
     // citation-detail, etc.) that don't go through LibraryWindow. Prevents
@@ -146,137 +165,6 @@ struct FicheroApp: App {
         // App auto-activates on URL handling
     }
 
-    /// The ONE macOS connect sequence (#3108): used by the launch task AND the
-    /// connection view's Retry button, so retry never re-implements `start()`.
-    /// `restart` respawns a wedged embedded engine before probing; the launch
-    /// path passes false. `start()`'s own re-entrancy guard makes a retry fired
-    /// while a start is already in flight a no-op.
-    @MainActor
-    private func connectBackend(restart: Bool) async {
-        // A new window OR native tab shares the app-level connection
-        // (`backendService` / `appState` are one @State per app): both are opened
-        // via `openWindow(id: "main")` (WindowOpener), so both re-run THIS `.task`
-        // and must ATTACH to the already-connected engine, not re-run connect+auth
-        // — otherwise the status flips back to `.starting` and the user sees a
-        // reconnect spinner + token/registry churn on every surface (#3394/#3407).
-        // Window SPLITS never reach here at all: a SplittablePane is an in-window
-        // view, not a new scene, so it triggers no connect. Only a not-yet-
-        // connected first window or an explicit Retry (`restart`) proceeds.
-        if EmbeddedBackendService.shouldReuseExistingConnection(
-            restart: restart,
-            status: backendService.status,
-            isBackendReady: appState.isBackendRunning
-        ) {
-            logger.info("connectBackend: already connected — new window/tab attaches, no reconnect (#3394/#3407)")
-            return
-        }
-        // Consume the single provisioning decision (#3109) instead of
-        // re-deriving the mode here. `connectsToRemoteHost` is the old
-        // `requiresExternalBackendConnection` branch.
-        let strategy = EngineConfig.engineProvisioningStrategy()
-        let usesExternal = strategy.connectsToRemoteHost
-        logger.info("Launch provisioning strategy: \(String(describing: strategy), privacy: .public) (#3109)")
-        // Back to `.starting` so the connection view shows the booting splash
-        // (and clears any prior failure diagnosis) while we probe.
-        appState.engine.markStarting()
-        backendService.status = .starting
-        backendService.errorMessage = nil
-
-        let backendStart = Date()
-        do {
-            if !usesExternal {
-                // Respawn a stuck engine on an explicit retry; a fresh launch
-                // just starts. The port pre-flight / orphan sweep lives in start().
-                if restart {
-                    backendService.stop()
-                }
-                LaunchProfile.milestone("engine spawn requested")
-                try await backendService.start()
-                let backendMs = Date().timeIntervalSince(backendStart) * 1000
-                LaunchProfile.milestone("engine spawn returned")
-                logger.info("⏱ backendService.start: \(backendMs, format: .fixed(precision: 1))ms")
-            }
-
-            // Health probe after the engine is up — re-probing with backoff
-            // before parking, so a transient miss while the engine finishes
-            // startup (it's often serving 200s a beat later) doesn't wall a
-            // healthy engine (#3162).
-            await appState.checkBackendHealthUntilReady()
-            guard appState.isBackendRunning else {
-                backendService.status = .failed
-                backendService.errorMessage = appState.backendError
-                logger.error(
-                    "Backend not reachable at \(EngineConfig.host.absoluteString, privacy: .public)"
-                )
-                // Keep re-probing in the background so we recover to the workspace
-                // the moment the engine answers — never park forever on a healthy
-                // engine (#3162). The heartbeat's own guard makes this idempotent.
-                appState.startBackendHeartbeat()
-                return
-            }
-
-            let readyMs = Date().timeIntervalSince(backendStart) * 1000
-            LaunchProfile.milestone("first authenticated ready")
-            logger.info("⏱ engine authenticated and ready: \(readyMs, format: .fixed(precision: 1))ms")
-
-            backendService.status = .running
-            backendService.errorMessage = nil
-            // The heartbeat is the single ongoing poller once ready (#3108); its
-            // own guard makes repeated calls idempotent.
-            appState.startBackendHeartbeat()
-            // Proactively renew the device token if near expiry (#3096), before it
-            // can lapse into a 401. A Mac can pair as a remote client too, so this
-            // belongs on the macOS connect path as well as iOS — no-op for the
-            // embedded/local host (loopback has no stored expiry); a failed renew
-            // keeps the old token (the expired → re-pair path is the safety net).
-            await DeviceTokenRenewal.renewIfNeeded(host: EngineConfig.host)
-            // The one shared post-ready side-effect block (#3113); adopt is a
-            // no-op on an embedded/local host, so no `usesExternal` branch here.
-            let restorationStart = Date()
-            await libraryManager.refreshAfterBackendBecameReady()
-            let restorationMs = Date().timeIntervalSince(restorationStart) * 1000
-            logger.info("⏱ post-ready library restoration: \(restorationMs, format: .fixed(precision: 1))ms")
-        } catch BackendError.portConflict(let pid) {
-            // A process we didn't spawn holds :8765 → surface the in-window
-            // decision (#3111): Stop it / Use it / Quit. Never a pre-window
-            // NSAlert, never self-terminate (#3042).
-            logger.info("Port 8765 held by PID \(pid.map(String.init) ?? "unknown") — portConflict phase")
-            appState.engine.markPortConflict(pid: pid)
-            backendService.status = .failed
-        } catch {
-            // An adopted squatter that answers health but rejects our token is
-            // authRejected, not a generic failure — the authenticated probe is
-            // the gate (#2864/#3111).
-            if backendService.lastReadiness == .authRejected {
-                appState.engine.markAuthRejected(
-                    "The engine already on port 8765 rejected this app's credentials."
-                )
-                backendService.status = .failed
-            } else {
-                logger.error("Failed to start backend: \(error.localizedDescription)")
-                await showBackendError(error)
-            }
-        }
-    }
-
-    @MainActor
-    private func showBackendError(_ error: Error) async {
-        // Do NOT terminate the app (#3042). The window's BackendRootGate (#2864)
-        // already renders the full-window BackendConnectionView — with the error
-        // text AND a Retry/Restart button — for any non-usable backend state.
-        // A modal Quit here fired BEFORE that gate could show, so a start failure
-        // (e.g. Debug ⌘R with no external engine on :8765, where the engine is
-        // deliberately not embedded) killed the window instead of surfacing an
-        // actionable diagnosis. Flip the service to .failed and let the gate do
-        // its job — the window stays up and the user can start the engine + retry.
-        logger.error("Backend failed to start: \(error.localizedDescription, privacy: .public)")
-        // The single phase owner drives the gate (#3107); service status is kept
-        // in sync as secondary lifecycle bookkeeping.
-        appState.engine.markFailed(error.localizedDescription)
-        backendService.status = .failed
-        backendService.errorMessage = error.localizedDescription
-    }
-
     /// The shared library-window root + its environment. Used by BOTH the
     /// primary `id: "main"` window and the value-seeded Duplicate Window group
     /// (#2262), so there is exactly one LibraryWindow scene definition — the
@@ -292,7 +180,7 @@ struct FicheroApp: App {
             // The connection view's Retry runs the SAME connect sequence as
             // launch, respawning a wedged embedded engine (#3108) — the button
             // no longer re-implements start().
-            onRetry: { await connectBackend(restart: true) },
+            onRetry: { await appDelegate.controller.retry() },
             setup: {
                 // `.setupNeeded` never occurs on macOS (the engine is embedded,
                 // not paired); render the connection view for symmetry if it does.
@@ -335,11 +223,11 @@ struct FicheroApp: App {
                         libraryManager: libraryManager
                     )
                 }
-                .task {
-                    appDelegate.backendService = backendService
-                    // Launch and the Retry button share ONE connect sequence (#3108).
-                    await connectBackend(restart: false)
-                }
+            // The engine is started by FicheroAppDelegate.applicationDidFinishLaunching,
+            // NOT here (#3945). A window no longer triggers connect/auth — it only
+            // observes EngineSession — so opening a second window/tab can't re-run
+            // the sequence, which is what shouldReuseExistingConnection existed to
+            // suppress (#3394/#3407). That guard is now unreachable from the app.
         }
         .defaultSize(width: 1400, height: 900)
         .windowStyle(.titleBar)

--- a/fichero/fichero/Models/DocumentStore.swift
+++ b/fichero/fichero/Models/DocumentStore.swift
@@ -187,6 +187,25 @@ final class DocumentStore {
         }
     }
 
+    // MARK: - Transient-failure retry (#3972)
+    /// Transient engine-unreachable/transport failures may retry; auth/TLS/permission are definitive. Pure seam (#3972).
+    static func isRetriableLoadFailure(_ error: Error) -> Bool {
+        switch AccessError.classify(error) {
+        case .engineUnreachable, .transport: return true
+        default: return false
+        }
+    }
+    /// Retry a fetch with short backoff on a transient failure so one blip doesn't trip the outage pane while 200s still flow (#3972).
+    private func fetchWithRetry<T>(_ operation: () async throws -> T) async throws -> T {
+        var attempt = 0
+        while true {
+            do { return try await operation() } catch {
+                attempt += 1
+                guard attempt <= 3, Self.isRetriableLoadFailure(error) else { throw error }
+                try await Task.sleep(for: .seconds(0.3 * Double(attempt)))
+            }
+        }
+    }
     // MARK: - Loading Collections
 
     var sidebarDocuments: [Document] {
@@ -201,7 +220,7 @@ final class DocumentStore {
 
         do {
             logger.info("Loading root documents for sidebar...")
-            collections = applyStatusOverrides(try await documentService.getRoots())
+            collections = applyStatusOverrides(try await fetchWithRetry { try await documentService.getRoots() })
             childrenCache.removeAll()
             isConnected = true
             logger.info("Loaded \(self.collections.count) root documents")
@@ -249,7 +268,7 @@ final class DocumentStore {
         guard childrenCache[document.id] == nil else { return }
 
         do {
-            let children = applyStatusOverrides(try await documentService.getChildren(document.id))
+            let children = applyStatusOverrides(try await fetchWithRetry { try await documentService.getChildren(document.id) })
             childrenCache[document.id] = children
             logger.info("Cached \(children.count) sidebar children for \(document.id)")
         } catch {
@@ -266,7 +285,7 @@ final class DocumentStore {
         logger.info("loadChildren called for document: \(document.id), library path: \(libraryPath)")
 
         do {
-            let children = applyStatusOverrides(try await documentService.getChildren(document.id))
+            let children = applyStatusOverrides(try await fetchWithRetry { try await documentService.getChildren(document.id) })
             self.childrenCache[document.id] = children
             self.currentDocuments = children
             logger.info("loadChildren succeeded, got \(children.count) children")

--- a/fichero/fichero/Models/LibraryManager+Helpers.swift
+++ b/fichero/fichero/Models/LibraryManager+Helpers.swift
@@ -172,6 +172,10 @@ extension LibraryManager {
         loadingLibraryIds.insert(library.id)
         defer { loadingLibraryIds.remove(library.id) }
 
+        // Ensure the .fichero package exists on disk (mkdir + Info.plist). Moved
+        // off LibraryManager.shared's synchronous init so it no longer runs before
+        // the first frame; idempotent, so running it per library is safe (#3974).
+        createPackageStructure(at: library.url)
         await initializeBackendDatabase(for: library)
         await loadLibraryData(for: library)
         await ensureInboxFolder(for: library)

--- a/fichero/fichero/Models/LibraryManager.swift
+++ b/fichero/fichero/Models/LibraryManager.swift
@@ -401,8 +401,10 @@ class LibraryManager {
             return
         }
 
-        // Create package structure if needed
-        createPackageStructure(at: globalURL)
+        // Package structure (mkdir + Info.plist) is created lazily in
+        // loadLibraryDataIfNeeded once the backend is ready — NOT here. This runs
+        // inside LibraryManager.shared's init during App construction, before the
+        // first frame, and synchronous disk I/O on that path delays launch (#3974).
 
         // Load or create Global library document
         let document = FicheroDocument()

--- a/fichero/fichero/Models/WorkflowExecutionStore.swift
+++ b/fichero/fichero/Models/WorkflowExecutionStore.swift
@@ -3,7 +3,11 @@ import Foundation
 import Observation
 import OSLog
 #if os(macOS)
-import UserNotifications
+// @preconcurrency: the UN* types (UNUserNotificationCenter, UNMutableNotificationContent,
+// UNNotificationRequest) captured in requestAuthorization's @Sendable completion handler
+// are Apple SDK types that predate Sendable annotation — they are the only offenders, so
+// the import silences the non-Sendable-capture warnings without changing behavior (#3977).
+@preconcurrency import UserNotifications
 #endif
 
 /// Shared, per-library home for **live** workflow execution state, keyed by

--- a/fichero/fichero/Services/AnnotationService.swift
+++ b/fichero/fichero/Services/AnnotationService.swift
@@ -1,7 +1,7 @@
 // swiftlint:disable file_length
-import Observation
 import FicheroAPIClient
 import Foundation
+import Observation
 import OpenAPIRuntime
 import OSLog
 
@@ -336,7 +336,7 @@ final class AnnotationService {
             // List items arrive as untyped containers (backend `items: list[Any]`);
             // DocumentAnnotation decodes them directly (carrying document/page/folder
             // ids). Scope is already enforced by the query above.
-            annotations = decoded.items.compactMap { try? annotation(from: $0) }
+            annotations = decoded.items.compactMap { annotation(from: $0) }
         } catch {
             // Backend may not be wired yet during parallel development — degrade
             // to an empty list rather than crashing the inspector (#1276).

--- a/fichero/fichero/Services/EngineLifecycleController.swift
+++ b/fichero/fichero/Services/EngineLifecycleController.swift
@@ -1,0 +1,187 @@
+#if canImport(AppKit)
+import Foundation
+import OSLog
+import SwiftUI
+
+/// Owns the engine's lifecycle at APP scope, not window scope (#3945).
+///
+/// Before this, the engine was started from a `WindowGroup`'s `.task`
+/// (`FicheroApp.swift`), so "who owns the engine" was really "whichever window
+/// happened to open first" — and the reuse guard (`shouldReuseExistingConnection`)
+/// existed only to stop every subsequent window/tab re-running connect+auth.
+/// Opening a window is not an engine event.
+///
+/// This controller is created and held by `FicheroAppDelegate`, started from
+/// `applicationDidFinishLaunching` and stopped from `applicationWillTerminate` —
+/// symmetric, app-scoped, and impossible to lose by closing a window. It owns
+/// the two halves that already existed in embryo:
+///   • `EmbeddedBackendService` — spawn / watch / stop (the process, macOS-only).
+///   • `AppState` — readiness probe, auth warm-up, heartbeat (the connection).
+/// `EngineSession` (inside `AppState`) stays the single phase writer the window's
+/// `BackendRootGate` observes; windows observe, they never trigger.
+///
+/// This is the PROCESS axis of the app-owns-engine design (#3947). The CONNECTION
+/// axis — a per-library set of connections, each to the local process or a remote
+/// engine — layers on in a later slice; today the controller holds exactly one
+/// local engine plus `LibraryManager`'s existing per-library hosts.
+@MainActor
+@Observable
+final class EngineLifecycleController {
+    private let logger = Logger(subsystem: "app.fichero.fichero", category: "EngineLifecycle")
+
+    /// The process half — spawn/watch/stop of the embedded (or adopted external)
+    /// engine. One per app.
+    let backendService = EmbeddedBackendService()
+
+    /// The connection half — readiness probe, auth, heartbeat, and the observable
+    /// `EngineSession` phase the window gate renders.
+    let appState = AppState()
+
+    /// The open-library manager (shared singleton). Its ready side-effects fire
+    /// through `refreshAfterBackendBecameReady()` once the engine authenticates.
+    let libraryManager = LibraryManager.shared
+
+    /// Guards against overlapping connect sequences (e.g. a Retry fired while the
+    /// launch connect is still in flight). Replaces the role the per-window
+    /// `shouldReuseExistingConnection` guard played when the trigger was a
+    /// window `.task` — now the trigger is a single app-scoped `start()`.
+    private var isConnecting = false
+
+    /// Kick the engine once at app launch. Called from
+    /// `applicationDidFinishLaunching`, never from a window.
+    func start() async {
+        await connect(restart: false)
+    }
+
+    /// Re-run the connect sequence — respawns a wedged embedded engine (#3108).
+    /// Backs the connection view's Retry button, so Retry never re-implements
+    /// `start()`.
+    func retry() async {
+        await connect(restart: true)
+    }
+
+    /// Stop the engine. Called from `applicationWillTerminate`.
+    func stop() {
+        backendService.stop()
+    }
+
+    // swiftlint:disable function_body_length
+    // connect() is a faithful relocation of FicheroApp.connectBackend: one linear
+    // happy path plus its catch arms; splitting it would obscure the sequence.
+    /// The single connect sequence shared by launch and Retry (#3108). Moved
+    /// verbatim from `FicheroApp.connectBackend` when engine ownership left the
+    /// window (#3945) — the only change is that `backendService`/`appState`/
+    /// `libraryManager` are now this controller's own properties.
+    private func connect(restart: Bool) async {
+        // A single app-scoped controller means the old per-window reuse guard is
+        // gone (#3394/#3407 can't occur — no window triggers connect). Keep only a
+        // narrow overlap guard so a Retry fired mid-connect is a no-op.
+        guard !isConnecting else {
+            logger.info("connect: already connecting — ignoring re-entrant call")
+            return
+        }
+        isConnecting = true
+        defer { isConnecting = false }
+
+        // Consume the single provisioning decision (#3109) instead of re-deriving
+        // the mode here. `connectsToRemoteHost` is the old
+        // `requiresExternalBackendConnection` branch.
+        let strategy = EngineConfig.engineProvisioningStrategy()
+        let usesExternal = strategy.connectsToRemoteHost
+        logger.info("Launch provisioning strategy: \(String(describing: strategy), privacy: .public) (#3109)")
+        // Back to `.starting` so the connection view shows the booting splash (and
+        // clears any prior failure diagnosis) while we probe.
+        appState.engine.markStarting()
+        backendService.status = .starting
+        backendService.errorMessage = nil
+
+        let backendStart = Date()
+        do {
+            if !usesExternal {
+                // Respawn a stuck engine on an explicit retry; a fresh launch just
+                // starts. The port pre-flight / orphan sweep lives in start().
+                if restart {
+                    backendService.stop()
+                }
+                LaunchProfile.milestone("engine spawn requested")
+                try await backendService.start()
+                let backendMs = Date().timeIntervalSince(backendStart) * 1000
+                LaunchProfile.milestone("engine spawn returned")
+                logger.info("⏱ backendService.start: \(backendMs, format: .fixed(precision: 1))ms")
+            }
+
+            // Health probe after the engine is up — re-probing with backoff before
+            // parking, so a transient miss while the engine finishes startup (it's
+            // often serving 200s a beat later) doesn't wall a healthy engine (#3162).
+            await appState.checkBackendHealthUntilReady()
+            guard appState.isBackendRunning else {
+                backendService.status = .failed
+                backendService.errorMessage = appState.backendError
+                logger.error(
+                    "Backend not reachable at \(EngineConfig.host.absoluteString, privacy: .public)"
+                )
+                // Keep re-probing in the background so we recover to the workspace
+                // the moment the engine answers — never park forever on a healthy
+                // engine (#3162). The heartbeat's own guard makes this idempotent.
+                appState.startBackendHeartbeat()
+                return
+            }
+
+            let readyMs = Date().timeIntervalSince(backendStart) * 1000
+            LaunchProfile.milestone("first authenticated ready")
+            logger.info("⏱ engine authenticated and ready: \(readyMs, format: .fixed(precision: 1))ms")
+
+            backendService.status = .running
+            backendService.errorMessage = nil
+            // The heartbeat is the single ongoing poller once ready (#3108); its own
+            // guard makes repeated calls idempotent.
+            appState.startBackendHeartbeat()
+            // Proactively renew the device token if near expiry (#3096), before it
+            // can lapse into a 401. A Mac can pair as a remote client too, so this
+            // belongs on the macOS connect path as well as iOS — no-op for the
+            // embedded/local host (loopback has no stored expiry); a failed renew
+            // keeps the old token (the expired → re-pair path is the safety net).
+            await DeviceTokenRenewal.renewIfNeeded(host: EngineConfig.host)
+            // The one shared post-ready side-effect block (#3113); adopt is a no-op
+            // on an embedded/local host, so no `usesExternal` branch here.
+            let restorationStart = Date()
+            await libraryManager.refreshAfterBackendBecameReady()
+            let restorationMs = Date().timeIntervalSince(restorationStart) * 1000
+            logger.info("⏱ post-ready library restoration: \(restorationMs, format: .fixed(precision: 1))ms")
+        } catch BackendError.portConflict(let pid) {
+            // A process we didn't spawn holds :8765 → surface the in-window decision
+            // (#3111): Stop it / Use it / Quit. Never a pre-window NSAlert, never
+            // self-terminate (#3042).
+            logger.info("Port 8765 held by PID \(pid.map(String.init) ?? "unknown") — portConflict phase")
+            appState.engine.markPortConflict(pid: pid)
+            backendService.status = .failed
+        } catch {
+            // An adopted squatter that answers health but rejects our token is
+            // authRejected, not a generic failure — the authenticated probe is the
+            // gate (#2864/#3111).
+            if backendService.lastReadiness == .authRejected {
+                appState.engine.markAuthRejected(
+                    "The engine already on port 8765 rejected this app's credentials."
+                )
+                backendService.status = .failed
+            } else {
+                logger.error("Failed to start backend: \(error.localizedDescription)")
+                showBackendError(error)
+            }
+        }
+    }
+    // swiftlint:enable function_body_length
+
+    /// Surface a start failure through the window gate — never terminate the app
+    /// (#3042). `BackendRootGate` renders `BackendConnectionView` (diagnosis +
+    /// Retry) for any non-usable backend state.
+    private func showBackendError(_ error: Error) {
+        logger.error("Backend failed to start: \(error.localizedDescription, privacy: .public)")
+        // The single phase owner drives the gate (#3107); service status is kept in
+        // sync as secondary lifecycle bookkeeping.
+        appState.engine.markFailed(error.localizedDescription)
+        backendService.status = .failed
+        backendService.errorMessage = error.localizedDescription
+    }
+}
+#endif

--- a/fichero/fichero/Services/EngineLifecycleController.swift
+++ b/fichero/fichero/Services/EngineLifecycleController.swift
@@ -113,7 +113,13 @@ final class EngineLifecycleController {
             // Health probe after the engine is up — re-probing with backoff before
             // parking, so a transient miss while the engine finishes startup (it's
             // often serving 200s a beat later) doesn't wall a healthy engine (#3162).
-            await appState.checkBackendHealthUntilReady()
+            // #3975: hand over the readiness the spawn ALREADY proved (health + nonce
+            // + authenticated /api/registry 200). When it's `.ready`, the connection
+            // layer skips the redundant re-probe + second health GET and goes straight
+            // to warm-up — removing ~3-4 serial round-trips between serving and ready.
+            // A nil/non-ready value (remote host, or a retry before start) falls
+            // through to the full probe, so the #3162 backoff is untouched there.
+            await appState.checkBackendHealthUntilReady(provenReadiness: backendService.lastReadiness)
             guard appState.isBackendRunning else {
                 backendService.status = .failed
                 backendService.errorMessage = appState.backendError

--- a/fichero/fichero/Services/IntegrationsService.swift
+++ b/fichero/fichero/Services/IntegrationsService.swift
@@ -1,6 +1,6 @@
-import Observation
 import FicheroAPIClient
 import Foundation
+import Observation
 import OpenAPIRuntime
 import OSLog
 
@@ -20,7 +20,7 @@ import OSLog
 @Observable
 final class IntegrationsService {
     private let logger = Logger(subsystem: "app.fichero.fichero", category: "IntegrationsService")
-    private nonisolated(unsafe) var hostChangeObservation: NSObjectProtocol?
+    private nonisolated var hostChangeObservation: NSObjectProtocol?
 
     var integrations: [AppIntegration] = []
     var isLoading = false

--- a/fichero/fichero/Services/IntegrationsService.swift
+++ b/fichero/fichero/Services/IntegrationsService.swift
@@ -20,7 +20,11 @@ import OSLog
 @Observable
 final class IntegrationsService {
     private let logger = Logger(subsystem: "app.fichero.fichero", category: "IntegrationsService")
-    private nonisolated var hostChangeObservation: NSObjectProtocol?
+    // @ObservationIgnored so the @Observable macro doesn't wrap this in tracked
+    // storage — that's what made `nonisolated(unsafe)` "have no effect" (#3977) and
+    // why plain `nonisolated` won't compile on the mutable stored property. With it
+    // ignored, `nonisolated(unsafe)` is effective and lets `deinit` read it.
+    @ObservationIgnored private nonisolated(unsafe) var hostChangeObservation: NSObjectProtocol?
 
     var integrations: [AppIntegration] = []
     var isLoading = false

--- a/fichero/fichero/Services/ModelComparisonService.swift
+++ b/fichero/fichero/Services/ModelComparisonService.swift
@@ -16,7 +16,11 @@ import OSLog
 @Observable
 final class ModelComparisonService {
     let logger = Logger(subsystem: "app.fichero.fichero", category: "ModelComparisonService")
-    private nonisolated var hostChangeObservation: NSObjectProtocol?
+    // @ObservationIgnored so the @Observable macro doesn't wrap this in tracked
+    // storage — that's what made `nonisolated(unsafe)` "have no effect" (#3977) and
+    // why plain `nonisolated` won't compile on the mutable stored property. With it
+    // ignored, `nonisolated(unsafe)` is effective and lets `deinit` read it.
+    @ObservationIgnored private nonisolated(unsafe) var hostChangeObservation: NSObjectProtocol?
 
     var isComparing = false
     var lastResult: ComparisonResult?

--- a/fichero/fichero/Services/ModelComparisonService.swift
+++ b/fichero/fichero/Services/ModelComparisonService.swift
@@ -1,6 +1,6 @@
-import Observation
 import FicheroAPIClient
 import Foundation
+import Observation
 import OpenAPIRuntime
 import OSLog
 
@@ -16,7 +16,7 @@ import OSLog
 @Observable
 final class ModelComparisonService {
     let logger = Logger(subsystem: "app.fichero.fichero", category: "ModelComparisonService")
-    private nonisolated(unsafe) var hostChangeObservation: NSObjectProtocol?
+    private nonisolated var hostChangeObservation: NSObjectProtocol?
 
     var isComparing = false
     var lastResult: ComparisonResult?

--- a/fichero/fichero/Services/UITestSupport.swift
+++ b/fichero/fichero/Services/UITestSupport.swift
@@ -68,5 +68,8 @@ func uiTestLibraryOverrideURL(
 @MainActor
 func openUITestLibraryOverrideIfNeeded() {
     guard let libraryURL = uiTestLibraryOverrideURL() else { return }
-    LibraryManager.shared.openLibrary(at: libraryURL)
+    // Discard the returned LibraryReference: this UI-test hook only needs the
+    // side effect (open the library and make it current); the caller reads the
+    // active library through LibraryManager, not this return value (#3978).
+    _ = LibraryManager.shared.openLibrary(at: libraryURL)
 }

--- a/fichero/fichero/Services/WorkflowStreamService.swift
+++ b/fichero/fichero/Services/WorkflowStreamService.swift
@@ -266,7 +266,10 @@ class WorkflowStreamService {
     func resumeWorkflow(threadId: String, onEvent: ((WorkflowStreamEvent) -> Void)? = nil) async throws {
         logger.info("Resuming workflow thread: \(threadId)")
 
-        try await executionService.resumeWorkflow(threadId: threadId)
+        // Discard the returned ExecutionThread snapshot: only the side effect
+        // (backend resumes the run) matters here — the stream resubscription
+        // below drives live state. Failures still propagate via `try` (#3978).
+        _ = try await executionService.resumeWorkflow(threadId: threadId)
 
         // Resubscribe to the stream
         isStreaming = true

--- a/fichero/fichero/Views/Library/AnnotatableTextView.swift
+++ b/fichero/fichero/Views/Library/AnnotatableTextView.swift
@@ -72,6 +72,10 @@ struct AnnotatableTextView: NSViewRepresentable {
         /// Sync content + highlight backgrounds. Cheap-guards on unchanged text,
         /// font size, and highlights so typing/scrolling doesn't rebuild
         /// attributes — but a Reader font-scale change (font size) does (#3681).
+        /// `@MainActor`: touches main-actor `NSTextView.textStorage`/`.string`;
+        /// every caller (`makeNSView`/`updateNSView`) already runs on the main
+        /// actor, so this only makes the existing isolation explicit (#3977).
+        @MainActor
         func apply(text: String, highlights: [Range<Int>], font: NSFont) {
             guard let textView, let storage = textView.textStorage else { return }
             let textChanged = lastText != text

--- a/fichero/fichero/Views/Library/LibraryView+DisplayModes.swift
+++ b/fichero/fichero/Views/Library/LibraryView+DisplayModes.swift
@@ -468,19 +468,21 @@ extension LibraryView {
 /// so they're excluded from `==` — safe because they act on the same `identity`.
 /// Everything a document list row renders from besides its selection state, so the
 /// `.equatable()` skip stays correct when the visible-tag filter changes (#3868).
-struct DocRowIdentity: Equatable {
+struct DocRowIdentity: Equatable, Sendable {
     let document: Document
     let visibleEntityTypes: Set<String>
 }
 
-struct LibrarySelectableRow<Identity: Equatable, Content: View>: View, Equatable {
+struct LibrarySelectableRow<Identity: Equatable & Sendable, Content: View>: View, Equatable {
     let identity: Identity
     let isSelected: Bool
     let tint: Color
     @ViewBuilder let content: Content
 
     // nonisolated: this View is implicitly @MainActor, but Equatable's `==` must be
-    // nonisolated (Swift 6). Safe — all compared properties are immutable value types.
+    // nonisolated (Swift 6). Safe — all compared properties are immutable value types;
+    // `Identity: Sendable` lets `==` read `identity` cross-actor like the Sendable
+    // `isSelected`/`tint` lets it already compares (#3977).
     nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
         lhs.identity == rhs.identity
             && lhs.isSelected == rhs.isSelected

--- a/fichero/fichero/Views/Library/LibraryView+FilterAndBatch.swift
+++ b/fichero/fichero/Views/Library/LibraryView+FilterAndBatch.swift
@@ -49,12 +49,21 @@ extension LibraryView {
     // instead of re-lowercasing every doc's OCR text per keystroke; every other
     // caller (documents/entities/folder/sort changes) rebuilds with the default.
     func recomputeFiltered(rebuildIndex: Bool = true) {
-        if rebuildIndex { rebuildDocumentSearchKeys() }
+        // The per-doc search keys are only read when filtering (searchText
+        // non-empty, below). Skip the O(n) rebuild — name + a 4KB OCR excerpt,
+        // lowercased per doc — on the empty-filter path, which is exactly what
+        // runs at launch and on every live `revision` tick (#3195). The keys are
+        // built lazily the first time a query actually needs them.
+        if rebuildIndex && !searchText.isEmpty { rebuildDocumentSearchKeys() }
 
         // Documents — match against the precomputed lowercased key (name + a
         // bounded OCR excerpt + status), not a fresh full-pageContent scan (#3865).
         var docs = documents
         if !searchText.isEmpty {
+            // Lazy build (#3195): if the doc set changed while the filter was
+            // empty the cache is stale/empty — rebuild once here, not per
+            // keystroke (preserving the #3865 cached-key guarantee for typing).
+            if documentSearchKeys.count != documents.count { rebuildDocumentSearchKeys() }
             let query = searchText.localizedLowercase
             docs = docs.filter { doc in
                 (documentSearchKeys[doc.id] ?? Self.documentSearchKey(for: doc)).contains(query)

--- a/fichero/fichero/Views/Library/Reading/PageContentPane.swift
+++ b/fichero/fichero/Views/Library/Reading/PageContentPane.swift
@@ -41,7 +41,7 @@ struct PageContentPane: View { // swiftlint:disable:this type_body_length
 
     var body: some View {
         VStack(spacing: 0) {
-            if let doc = pageDoc {
+            if pageDoc != nil {
                 if editState.isEditing {
                     TextEditor(text: $editState.draftContent)
                         .editorScaledFont(.body, design: .serif)

--- a/fichero/fichero/Views/Shell/ShellLayoutPolicy.swift
+++ b/fichero/fichero/Views/Shell/ShellLayoutPolicy.swift
@@ -14,7 +14,10 @@ extension ContentView {
         let collapseInspector: Bool
     }
 
-    static func shouldUseCompactNavigationFlow(horizontalSizeClass: UserInterfaceSizeClass?) -> Bool {
+    // nonisolated: pure — reads only its argument + a compile-time `#if`, touches no
+    // main-actor state. Lets nonisolated policy callers (AdaptiveAppleShellRoute.resolve,
+    // CompactShellPolicy.route) invoke it without crossing the actor boundary (#3977).
+    nonisolated static func shouldUseCompactNavigationFlow(horizontalSizeClass: UserInterfaceSizeClass?) -> Bool {
         #if os(macOS)
         false
         #else


### PR DESCRIPTION
Combined launch batch: app-owned engine lifecycle (#3945), proven-readiness reuse (#3975), transient outage retry (#3972), frontend first-frame work deferral (#3974), empty-filter optimization (#3195), and analyzer fixes (#3977 #3978).

Verification:
- `PYTHONPATH=fichero-engine/src pytest fichero-engine/tests/unit -q`: 7675 passed, 22 skipped, 4 xfailed.
- Dev Embedded build-for-testing: succeeded on the corrected integrated branch, per manager handoff.
- Full Swift test target remains a known dormant-target compile cleanup; its newly exposed failure is `PortConflictDecisionTests` actor isolation, unrelated to this batch.
- Rebased against `origin/main`; the already-merged #3976 engine import optimization was skipped by Git.