### PR TITLE
chore: ignore local profiling workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ BLOCK.md
 
 # release-notes generator cursor (local state)
 .release-notes-cursor
+profile/
 
 # internal agent orchestration (not for public repo)
 PLAN-GOVERNANCE.md


### PR DESCRIPTION
Ignore the local `profile/` directory used for profiling artifacts.