### PR TITLE
test: align ingest tests with security boundary

### DIFF
--- a/fichero-engine/tests/unit/test_api.py
+++ b/fichero-engine/tests/unit/test_api.py
@@ -10,7 +10,9 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from starlette.requests import Request
 
+from fichero.actions.registry import ActionResult
 from fichero.models import ActionAudit
 from fichero.models import Document, DocType, FileType, Status, Artifact
 
@@ -416,23 +418,27 @@ class TestIngestRoutes:
         from fichero.api.routes import ingest as ingest_routes
 
         request = ingest_routes.IngestFileRequest(path="/tmp/input.jpg")
+        http_request = Request({"type": "http", "headers": []})
+        http_request.state.user = MagicMock()
         db = MagicMock()
         doc = Document(id="new123", name="ingested.jpg", doc_type=DocType.file)
-        to_thread = AsyncMock(return_value=doc)
+        to_thread = AsyncMock(return_value=ActionResult(True, doc, "", []))
 
         with patch.object(ingest_routes.asyncio, "to_thread", to_thread):
             result = await ingest_routes.ingest_file(
                 request,
+                http_request=http_request,
                 db=db,
                 x_fichero_library_path="/tmp/library.fichero",
             )
 
         to_thread.assert_awaited_once()
         assert to_thread.await_args.args == (
-            ingest_routes.import_file_impl,
+            ingest_routes.registry.invoke,
             db,
-            request,
-            Path("/tmp/library.fichero"),
+            "import.file",
+            request.model_dump(mode="json"),
+            ingest_routes._ingest_action_context(http_request, "/tmp/library.fichero"),
         )
         assert result is doc
 
@@ -460,9 +466,16 @@ class TestIngestRoutes:
     def test_ingest_file_not_found(self, client):
         """Ingest nonexistent file returns 400."""
         response = client.post("/api/ingest/file", json={
-            "path": "/nonexistent/file.jpg",
+            "path": str(Path(tempfile.gettempdir()) / "does-not-exist.jpg"),
         })
         assert response.status_code == 400
+
+    def test_ingest_file_disallowed_path_forbidden(self, client):
+        """Ingest paths outside the allowlist return 403."""
+        response = client.post("/api/ingest/file", json={
+            "path": "/nonexistent/file.jpg",
+        })
+        assert response.status_code == 403
 
     def test_ingest_folder_starts_task(self, client):
         """Ingest folder returns task ID."""

--- a/fichero-engine/tests/unit/test_api.py
+++ b/fichero-engine/tests/unit/test_api.py
@@ -42,6 +42,13 @@ def sample_collection():
     )
 
 
+@pytest.fixture
+def record_background_task():
+    """Prevent TestClient from running scheduled background ingestion."""
+    with patch("starlette.background.BackgroundTasks.add_task") as add_task:
+        yield add_task
+
+
 class TestHealthEndpoint:
     """Tests for /api/health endpoint."""
 
@@ -477,7 +484,7 @@ class TestIngestRoutes:
         })
         assert response.status_code == 403
 
-    def test_ingest_folder_starts_task(self, client):
+    def test_ingest_folder_starts_task(self, client, record_background_task):
         """Ingest folder returns task ID."""
         with tempfile.TemporaryDirectory() as tmpdir:
             # Create a test file
@@ -494,11 +501,12 @@ class TestIngestRoutes:
                 data = response.json()
                 assert "task_id" in data
                 assert data["status"] == "pending"
+                record_background_task.assert_called_once()
 
     def test_ingest_folder_not_found(self, client):
         """Ingest nonexistent folder returns 400."""
         response = client.post("/api/ingest/folder", json={
-            "path": "/nonexistent/folder",
+            "path": str(Path(tempfile.gettempdir()) / "does-not-exist-folder"),
         })
         assert response.status_code == 400
 
@@ -568,7 +576,7 @@ class TestIngestRoutes:
         })
         assert response.status_code == 422
 
-    def test_ingest_folder_with_parameters(self, client):
+    def test_ingest_folder_with_parameters(self, client, record_background_task):
         """Ingest folder with all parameters."""
         with tempfile.TemporaryDirectory() as tmpdir:
             # Create test files
@@ -609,7 +617,7 @@ class TestIngestRoutes:
         finally:
             Path(temp_path).unlink(missing_ok=True)
 
-    def test_ingest_folder_empty_directory(self, client):
+    def test_ingest_folder_empty_directory(self, client, record_background_task):
         """Ingest empty folder returns task ID."""
         with tempfile.TemporaryDirectory() as tmpdir:
             # Empty directory
@@ -631,7 +639,7 @@ class TestIngestRoutes:
         })
         assert response.status_code == 422
 
-    def test_get_ingest_status_valid_task(self, client):
+    def test_get_ingest_status_valid_task(self, client, record_background_task):
         """Get status of valid task returns task info."""
         # First, start a task
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -744,7 +752,7 @@ class TestIngestRoutes:
         finally:
             Path(temp_path).unlink(missing_ok=True)
 
-    def test_ingest_folder_recursive_parameter(self, client):
+    def test_ingest_folder_recursive_parameter(self, client, record_background_task):
         """Test recursive parameter in folder ingest."""
         with tempfile.TemporaryDirectory() as tmpdir:
             # Create nested structure
@@ -770,7 +778,7 @@ class TestIngestRoutes:
                 })
                 assert response.status_code == 200
 
-    def test_ingest_status_progress_tracking(self, client):
+    def test_ingest_status_progress_tracking(self, client, record_background_task):
         """Test progress tracking in task status."""
         # This would require more complex setup with actual background tasks
         # For now, just verify the structure

--- a/fichero-engine/tests/unit/test_import_actions.py
+++ b/fichero-engine/tests/unit/test_import_actions.py
@@ -167,11 +167,16 @@ class TestImportFileAction:
     def test_file_is_undoable(self, db):
         assert registry.get("import.file").undoable is True
 
-    def test_file_missing_path_400(self, db, fake_ingest):
+    def test_file_missing_path_400(self, db, tmp_path, fake_ingest):
         # (d) a naive impl would hand a non-existent path to the loader
         with pytest.raises(HTTPException) as exc:
-            registry.invoke(db, "import.file", {"path": "/no/such/file.pdf"}, _ctx(db))
+            registry.invoke(db, "import.file", {"path": str(tmp_path / "missing.pdf")}, _ctx(db))
         assert exc.value.status_code == 400
+
+    def test_file_disallowed_path_403(self, db, fake_ingest):
+        with pytest.raises(HTTPException) as exc:
+            registry.invoke(db, "import.file", {"path": "/no/such/file.pdf"}, _ctx(db))
+        assert exc.value.status_code == 403
 
     def test_file_directory_as_file_400(self, db, tmp_path, fake_ingest):
         # (d) a directory is not a file
@@ -229,10 +234,15 @@ class TestImportFolderAction:
         # the audit still records the (empty) request for forensics
         assert _audit(db, result.audit_id).action_name == "import.folder"
 
-    def test_folder_missing_path_400(self, db, fake_ingest):
+    def test_folder_missing_path_400(self, db, tmp_path, fake_ingest):
+        with pytest.raises(HTTPException) as exc:
+            registry.invoke(db, "import.folder", {"path": str(tmp_path / "missing")}, _ctx(db))
+        assert exc.value.status_code == 400
+
+    def test_folder_disallowed_path_403(self, db, fake_ingest):
         with pytest.raises(HTTPException) as exc:
             registry.invoke(db, "import.folder", {"path": "/no/such/dir"}, _ctx(db))
-        assert exc.value.status_code == 400
+        assert exc.value.status_code == 403
 
     def test_folder_file_as_folder_400(self, db, tmp_path, fake_ingest):
         # (d) a file path is not a directory


### PR DESCRIPTION
## Summary
- pass required HTTP request context to direct ingest route tests
- preserve missing-file/folder 400 assertions inside the allowed boundary
- assert disallowed ingest files and folders return 403
- prevent TestClient from executing real folder-ingest background work in six scheduling tests

## Verification
- TestIngestRoutes: 21 passed
- test_import_actions.py: 27 passed
- Ruff clean on both changed test files
- full engine unit suite: running in integration lane

Closes #3268
Closes #3995