### PR TITLE
fix: synchronize embedded engine versions

### DIFF
--- a/fichero-engine/tests/unit/test_release_scripts.py
+++ b/fichero-engine/tests/unit/test_release_scripts.py
@@ -14,6 +14,7 @@ These are pure filesystem + subprocess tests — no Python imports required.
 from __future__ import annotations
 
 import subprocess
+import plistlib
 from pathlib import Path
 
 import pytest
@@ -30,6 +31,7 @@ NIGHTLY_RELEASE = SCRIPTS_DIR / "nightly-release.sh"
 START_BACKEND = REPO_ROOT / "fichero-engine" / "scripts" / "start_backend.sh"
 BUILD_BACKEND_BUNDLE = REPO_ROOT / "fichero-engine" / "scripts" / "build_backend_bundle.sh"
 BUNDLE_PYTHON_BACKEND = REPO_ROOT / "fichero-engine" / "scripts" / "bundle_python_backend.sh"
+CLEAN_EMBEDDED_ENGINE = SCRIPTS_DIR / "clean-embedded-engine.sh"
 
 ALL_SCRIPTS = [BUILD_RELEASE, BUILD_AND_VALIDATE, NOTARIZE, CREATE_RELEASE, NIGHTLY_RELEASE]
 
@@ -115,6 +117,40 @@ def test_build_release_has_dry_run_flag() -> None:
     text = _script_text(BUILD_RELEASE)
     assert "--dry-run" in text
     assert "run_or_dry" in text
+    assert "preflight-embedded-engine.sh" in text
+
+
+def test_embedded_engine_version_guard_rejects_stale_bundle(tmp_path: Path) -> None:
+    expected = next(
+        line.split('"')[1]
+        for line in (REPO_ROOT / "fichero-engine" / "pyproject.toml").read_text().splitlines()
+        if line.startswith('version = "')
+    )
+    app = tmp_path / "Fichero Engine.app"
+    contents = app / "Contents"
+    metadata = contents / "Resources" / "app" / f"engine-{expected}.dist-info" / "METADATA"
+    metadata.parent.mkdir(parents=True)
+    metadata.write_text(f"Name: engine\nVersion: {expected}\n")
+    plist = contents / "Info.plist"
+    with plist.open("wb") as handle:
+        plistlib.dump({"CFBundleShortVersionString": expected}, handle)
+
+    current = subprocess.run(
+        [str(CLEAN_EMBEDDED_ENGINE), "--check-version", str(app)],
+        capture_output=True,
+        text=True,
+    )
+    assert current.returncode == 0, current.stderr
+
+    with plist.open("wb") as handle:
+        plistlib.dump({"CFBundleShortVersionString": "2026.7.17.2"}, handle)
+    stale = subprocess.run(
+        [str(CLEAN_EMBEDDED_ENGINE), "--check-version", str(app)],
+        capture_output=True,
+        text=True,
+    )
+    assert stale.returncode == 1
+    assert f"expected={expected} bundle=2026.7.17.2 package={expected}" in stale.stderr
 
 
 def test_build_and_validate_uses_current_paths() -> None:

--- a/scripts/build-release.sh
+++ b/scripts/build-release.sh
@@ -70,30 +70,7 @@ if [ "$SKIP_BACKEND" = true ]; then
   fi
 else
   echo "[1/4] Building engine with Briefcase"
-
-  if [ "$DRY_RUN" = false ]; then
-    cd "$ENGINE_ROOT"
-
-    # Look for briefcase in dedicated venv, then PATH
-    if [ -x "$ENGINE_ROOT/.briefcase-venv/bin/briefcase" ]; then
-      export PATH="$ENGINE_ROOT/.briefcase-venv/bin:$PATH"
-    elif ! command -v briefcase >/dev/null 2>&1; then
-      echo "error: briefcase not found. Set up with:" >&2
-      echo "  python3.13 -m venv fichero-engine/.briefcase-venv" >&2
-      echo "  fichero-engine/.briefcase-venv/bin/pip install briefcase" >&2
-      exit 1
-    fi
-  fi
-
-  # briefcase build produces an adhoc-signed .app — we re-sign with
-  # Developer ID later in scripts/notarize.sh. Using `build` (not `package`)
-  # avoids briefcase's installer-cert path which can't be satisfied with
-  # only Apple Development.
-  #
-  # `briefcase update` first: `briefcase build` alone re-signs the bundle but
-  # does NOT re-copy source files, so .py edits ship stale otherwise.
-  run_or_dry briefcase update macOS --app engine
-  run_or_dry briefcase build macOS --app engine
+  run_or_dry "$ROOT_DIR/scripts/preflight-embedded-engine.sh" --rebuild
 
   if [ "$DRY_RUN" = false ]; then
     if [ ! -d "$ENGINE_APP" ]; then
@@ -105,7 +82,7 @@ else
   fi
 fi
 
-if [ -d "$ENGINE_APP" ]; then
+if [ "$SKIP_BACKEND" = true ] && [ -d "$ENGINE_APP" ]; then
   echo "  Cleaning embedded engine bundle for release distribution"
   run_or_dry "$ROOT_DIR/scripts/clean-embedded-engine.sh" "$ENGINE_APP"
 fi

--- a/scripts/clean-embedded-engine.sh
+++ b/scripts/clean-embedded-engine.sh
@@ -2,6 +2,11 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CHECK_VERSION=false
+if [ "${1:-}" = "--check-version" ]; then
+  CHECK_VERSION=true
+  shift
+fi
 ENGINE_APP="${1:-$ROOT_DIR/fichero-engine/build/engine/macos/app/Fichero Engine.app}"
 SIGN_IDENTITY="${FICHERO_CODESIGN_IDENTITY:-}"
 REQUIRED_AUTHORITY="${FICHERO_REQUIRED_CODESIGN_AUTHORITY:-}"
@@ -13,6 +18,17 @@ if [ ! -d "$ENGINE_APP" ]; then
   echo "error: embedded engine bundle not found at $ENGINE_APP" >&2
   exit 1
 fi
+
+EXPECTED_VERSION="$(grep -m1 '^version = "' "$ROOT_DIR/fichero-engine/pyproject.toml" | sed -E 's/^version = "([^"]+)".*/\1/')"
+BUNDLE_VERSION="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$ENGINE_APP/Contents/Info.plist" 2>/dev/null || true)"
+METADATA_PATH="$(find "$ENGINE_APP/Contents/Resources/app" -maxdepth 2 -path '*/engine-*.dist-info/METADATA' -print -quit 2>/dev/null || true)"
+PACKAGE_VERSION="$(awk -F': ' '$1 == "Version" { print $2; exit }' "$METADATA_PATH" 2>/dev/null || true)"
+if [ -z "$EXPECTED_VERSION" ] || [ "$BUNDLE_VERSION" != "$EXPECTED_VERSION" ] || [ "$PACKAGE_VERSION" != "$EXPECTED_VERSION" ]; then
+  echo "error: embedded engine version mismatch (expected=$EXPECTED_VERSION bundle=$BUNDLE_VERSION package=$PACKAGE_VERSION)" >&2
+  exit 1
+fi
+echo "  Embedded engine version: $EXPECTED_VERSION"
+[ "$CHECK_VERSION" = false ] || exit 0
 
 remove_tree_if_present() {
   local path="$1"

--- a/scripts/preflight-embedded-engine.sh
+++ b/scripts/preflight-embedded-engine.sh
@@ -11,14 +11,7 @@ ENGINE_APP="$ENGINE_DIR/build/engine/macos/app/Fichero Engine.app"
 case "${1:-}" in
   "") ;;
   --rebuild) rebuild=true ;;
-  --check)
-    if [ -d "$ENGINE_APP" ]; then
-      echo "Embedded engine ready: $ENGINE_APP"
-      exit 0
-    fi
-    echo "error: embedded engine missing: $ENGINE_APP" >&2
-    exit 1
-    ;;
+  --check) check_only=true ;;
   *)
     echo "usage: $0 [--check|--rebuild]" >&2
     exit 2
@@ -39,6 +32,10 @@ engine_is_current() {
   [ -d "$ENGINE_APP" ] || return 1
   local staged="$ENGINE_APP/Contents/Resources/app/fichero/api/main.py"
   [ -f "$staged" ] || return 1
+  if ! "$ROOT_DIR/scripts/clean-embedded-engine.sh" --check-version "$ENGINE_APP"; then
+    echo "Embedded engine has STALE version metadata — rebuilding"
+    return 1
+  fi
   # Content, not mtime: git checkouts/merges bump mtimes without changing bytes,
   if ! diff -rq --exclude=__pycache__ "$ENGINE_DIR/src/fichero" "$ENGINE_APP/Contents/Resources/app/fichero" >/dev/null 2>&1; then
     echo "Embedded engine is STALE (engine sources are newer than the staged copy) — rebuilding"
@@ -51,6 +48,15 @@ engine_is_current() {
   fi
   return 0
 }
+
+if [ "${check_only:-false}" = true ]; then
+  if engine_is_current; then
+    echo "Embedded engine ready: $ENGINE_APP"
+    exit 0
+  fi
+  echo "error: embedded engine is missing or stale: $ENGINE_APP" >&2
+  exit 1
+fi
 
 if [ "${rebuild:-false}" = false ] && engine_is_current; then
   echo "Embedded engine ready: $ENGINE_APP"
@@ -69,6 +75,14 @@ else
 fi
 
 echo "Building embedded engine with Briefcase"
+
+# Briefcase update refreshes code and dependencies, but not the generated app
+# template (including Info.plist). Recreate only when the stamped version has
+# changed; otherwise keep the much faster update/build path.
+if [ -d "$ENGINE_APP" ] && ! "$ROOT_DIR/scripts/clean-embedded-engine.sh" --check-version "$ENGINE_APP" >/dev/null 2>&1; then
+  echo "Recreating Briefcase app template for the stamped engine version"
+  rm -rf "$ENGINE_DIR/build/engine/macos/app"
+fi
 (
   cd "$ENGINE_DIR"
   if [ ! -d "$ENGINE_DIR/build/engine/macos/app" ]; then

--- a/scripts/release-all.sh
+++ b/scripts/release-all.sh
@@ -180,6 +180,11 @@ if [ "$RUN_MAC_TESTFLIGHT" = true ] || [ "$RUN_IOS_TESTFLIGHT" = true ]; then
   echo "  security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k <login-pw> ~/Library/Keychains/login.keychain-db"
 fi
 
+if [ "$RUN_MAC_TESTFLIGHT" = true ] && [ "$SKIP_DMG" = true ] && [ "$SKIP_BACKEND" = false ]; then
+  echo "  Building current embedded engine for Mac TestFlight"
+  "$ROOT_DIR/scripts/preflight-embedded-engine.sh" --rebuild
+fi
+
 AUTH_ARGS=()
 if [ -f "$APP_STORE_CONNECT_KEY_PATH" ]; then
   echo "  Using App Store Connect API key: $APP_STORE_CONNECT_KEY_ID"


### PR DESCRIPTION
Closes #4019

## Summary
- recreate the Briefcase app template only when stamped engine metadata changes
- route release builds through the shared embedded-engine preflight
- reject any bundle whose pyproject, Info.plist, and dist-info versions differ
- cover the stale outer Info.plist regression

## Verification
- real fresh Briefcase stage: Info.plist = 2026.7.19; package metadata = 2026.7.19
- scripts/verify_all.sh --fast
- 40 release-script tests passed
- ruff and bash syntax checks passed