### PR TITLE
fix: always rebuild engine for releases

### DIFF
--- a/fichero-engine/tests/unit/test_release_scripts.py
+++ b/fichero-engine/tests/unit/test_release_scripts.py
@@ -28,6 +28,7 @@ BUILD_AND_VALIDATE = SCRIPTS_DIR / "build-and-validate.sh"
 NOTARIZE = SCRIPTS_DIR / "notarize.sh"
 CREATE_RELEASE = SCRIPTS_DIR / "create-github-release.sh"
 NIGHTLY_RELEASE = SCRIPTS_DIR / "nightly-release.sh"
+RELEASE_ALL = SCRIPTS_DIR / "release-all.sh"
 START_BACKEND = REPO_ROOT / "fichero-engine" / "scripts" / "start_backend.sh"
 BUILD_BACKEND_BUNDLE = REPO_ROOT / "fichero-engine" / "scripts" / "build_backend_bundle.sh"
 BUNDLE_PYTHON_BACKEND = REPO_ROOT / "fichero-engine" / "scripts" / "bundle_python_backend.sh"
@@ -151,6 +152,15 @@ def test_embedded_engine_version_guard_rejects_stale_bundle(tmp_path: Path) -> N
     )
     assert stale.returncode == 1
     assert f"expected={expected} bundle=2026.7.17.2 package={expected}" in stale.stderr
+
+
+def test_release_all_always_rebuilds_engine_before_packaging() -> None:
+    text = _script_text(RELEASE_ALL)
+    rebuild = text.index('preflight-embedded-engine.sh" --rebuild')
+    packaging = text.index('if [ "$SKIP_DMG" = false ]')
+
+    assert rebuild < packaging
+    assert '--skip-backend) SKIP_BACKEND=true' not in text
 
 
 def test_build_and_validate_uses_current_paths() -> None:

--- a/scripts/release-all.sh
+++ b/scripts/release-all.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 #   3. Optional universal iPhone/iPad TestFlight upload via App Store Connect.
 #
 # Usage:
-#   scripts/release-all.sh [--skip-backend] [--skip-dmg] [--skip-notarize]
+#   scripts/release-all.sh [--skip-dmg] [--skip-notarize]
 #                          [--skip-testflight | --skip-mac-testflight | --skip-ios-testflight]
 #                          [--mac-only | --ios-only] [--github] [--draft]
 #
@@ -99,7 +99,6 @@ install_ios_app_store_profile() {
   install_provisioning_profile "$IOS_APP_STORE_PROFILE_PATH" "$IOS_APP_STORE_PROFILE_NAME" IOS_APP_STORE_PROFILE_UUID
 }
 
-SKIP_BACKEND=false
 SKIP_DMG=false
 SKIP_NOTARIZE=false
 RUN_MAC_TESTFLIGHT=true
@@ -109,7 +108,6 @@ GITHUB_ARGS=()
 
 for arg in "$@"; do
   case "$arg" in
-    --skip-backend) SKIP_BACKEND=true ;;
     --skip-dmg) SKIP_DMG=true ;;
     --skip-notarize) SKIP_NOTARIZE=true ;;
     --skip-testflight)
@@ -159,12 +157,14 @@ else
   export FICHERO_RELEASE_VERSION="$(project_setting MARKETING_VERSION)"
 fi
 
+echo
+echo "── Engine: rebuild current Briefcase stage ──"
+"$ROOT_DIR/scripts/preflight-embedded-engine.sh" --rebuild
+
 if [ "$SKIP_DMG" = false ]; then
   echo
   echo "── DMG: build + Developer ID sign ──"
-  BUILD_ARGS=()
-  [ "$SKIP_BACKEND" = true ] && BUILD_ARGS+=("--skip-backend")
-  "$ROOT_DIR/scripts/build-release-dmg.sh" "${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"}"
+  "$ROOT_DIR/scripts/build-release-dmg.sh" --skip-backend
 fi
 
 if [ "$SKIP_NOTARIZE" = false ]; then
@@ -178,11 +178,6 @@ if [ "$RUN_MAC_TESTFLIGHT" = true ] || [ "$RUN_IOS_TESTFLIGHT" = true ]; then
   echo "── TestFlight note ──"
   echo "  If codesign prompts hang in a headless session, run once in Terminal:"
   echo "  security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k <login-pw> ~/Library/Keychains/login.keychain-db"
-fi
-
-if [ "$RUN_MAC_TESTFLIGHT" = true ] && [ "$SKIP_DMG" = true ] && [ "$SKIP_BACKEND" = false ]; then
-  echo "  Building current embedded engine for Mac TestFlight"
-  "$ROOT_DIR/scripts/preflight-embedded-engine.sh" --rebuild
 fi
 
 AUTH_ARGS=()


### PR DESCRIPTION
Refs #4019

The release wrapper now always runs `./scripts/preflight-embedded-engine.sh --rebuild` immediately after version stamping. DMG packaging reuses that verified stage, and the public `--skip-backend` release bypass is removed.

Verification: 41 release-script tests passed; ruff and bash syntax checks passed.