### PR TITLE
fix: resolve verify Python in worktrees (#4022)

### DIFF
--- a/fichero-engine/tests/unit/scripts/test_find_project_python.py
+++ b/fichero-engine/tests/unit/scripts/test_find_project_python.py
@@ -1,0 +1,82 @@
+"""Project-Python resolution for the verification gate (#4022)."""
+
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).resolve().parents[4]
+RESOLVER = ROOT / "scripts" / "find_project_python.sh"
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, check=False, capture_output=True, text=True)
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir()
+    _run("git", "-C", str(path), "init")
+    (path / "tracked").write_text("fixture\n", encoding="utf-8")
+    _run("git", "-C", str(path), "add", "tracked")
+    _run(
+        "git",
+        "-C",
+        str(path),
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "commit",
+        "-m",
+        "fixture",
+    )
+
+
+def _add_fake_python(repo: Path) -> Path:
+    python = repo / ".venv" / "bin" / "python"
+    python.parent.mkdir(parents=True)
+    python.write_text("#!/bin/sh\n", encoding="utf-8")
+    python.chmod(python.stat().st_mode | 0o111)
+    return python
+
+
+def test_resolves_main_checkout_venv(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    python = _add_fake_python(repo)
+
+    result = _run(str(RESOLVER), str(repo))
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == str(python)
+
+
+def test_resolves_main_venv_from_linked_worktree(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    worktree = tmp_path / "worktree"
+    _init_repo(repo)
+    python = _add_fake_python(repo)
+    result = _run("git", "-C", str(repo), "worktree", "add", "-b", "worker", str(worktree))
+    assert result.returncode == 0, result.stderr
+
+    result = _run(str(RESOLVER), str(worktree))
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == str(python)
+
+
+def test_fails_closed_without_project_venv(tmp_path: Path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+
+    result = _run(str(RESOLVER), str(repo))
+
+    assert result.returncode == 2
+    assert "project Python not found" in result.stderr
+
+
+def test_verify_all_preserves_explicit_override() -> None:
+    verify_all = (ROOT / "scripts" / "verify_all.sh").read_text(encoding="utf-8")
+
+    assert 'if [[ -n "${PYTHON_BIN:-}" ]]' in verify_all
+    assert 'PYTHON_BIN="$(scripts/find_project_python.sh .)"' in verify_all
+    assert 'PYTHON_BIN="python3"' not in verify_all

--- a/scripts/find_project_python.sh
+++ b/scripts/find_project_python.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${1:-.}"
+repo_root="$(cd "$repo_root" && pwd -P)"
+
+local_python="$repo_root/.venv/bin/python"
+if [[ -x "$local_python" ]]; then
+  printf '%s\n' "$local_python"
+  exit 0
+fi
+
+common_git_dir="$(git -C "$repo_root" rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" || {
+  echo "error: cannot locate the project venv outside a git checkout" >&2
+  exit 2
+}
+shared_python="$(dirname "$common_git_dir")/.venv/bin/python"
+if [[ -x "$shared_python" ]]; then
+  printf '%s\n' "$shared_python"
+  exit 0
+fi
+
+echo "error: project Python not found; create .venv in the main checkout" >&2
+exit 2

--- a/scripts/verify_all.sh
+++ b/scripts/verify_all.sh
@@ -126,10 +126,8 @@ fi
 
 if [[ -n "${PYTHON_BIN:-}" ]]; then
   PYTHON_BIN="$PYTHON_BIN"
-elif [[ -x ".venv/bin/python" ]]; then
-  PYTHON_BIN=".venv/bin/python"
 else
-  PYTHON_BIN="python3"
+  PYTHON_BIN="$(scripts/find_project_python.sh .)" || exit 2
 fi
 
 PYTEST_CMD=("${PYTHON_BIN}" -m pytest)


### PR DESCRIPTION
## Summary
- resolve the project venv from either the current checkout or Git common directory
- fail closed instead of falling back to Xcode/system Python
- exercise main checkout, linked worktree, override, and missing-venv cases

## Verification
- 5 focused pytest tests passed
- ruff clean
- bash -n clean
- comment hygiene clean

Closes #4022