### PR TITLE
fix: accept signed bridge in engine freshness check (#4034)

### DIFF
--- a/fichero-engine/tests/unit/test_release_scripts.py
+++ b/fichero-engine/tests/unit/test_release_scripts.py
@@ -163,6 +163,14 @@ def test_release_all_always_rebuilds_engine_before_packaging() -> None:
     assert '--skip-backend) SKIP_BACKEND=true' not in text
 
 
+def test_preflight_accepts_distribution_signed_fm_bridge() -> None:
+    text = _script_text(REPO_ROOT / "scripts" / "preflight-embedded-engine.sh")
+
+    assert "--exclude=.DS_Store" in text
+    assert "--exclude=fm-bridge" in text
+    assert text.count("dwarfdump --uuid") == 2
+
+
 def test_build_and_validate_uses_current_paths() -> None:
     text = _script_text(BUILD_AND_VALIDATE)
     assert "fichero/fichero.xcodeproj" in text

--- a/scripts/preflight-embedded-engine.sh
+++ b/scripts/preflight-embedded-engine.sh
@@ -36,8 +36,16 @@ engine_is_current() {
     echo "Embedded engine has STALE version metadata — rebuilding"
     return 1
   fi
-  # Content, not mtime: git checkouts/merges bump mtimes without changing bytes,
-  if ! diff -rq --exclude=__pycache__ "$ENGINE_DIR/src/fichero" "$ENGINE_APP/Contents/Resources/app/fichero" >/dev/null 2>&1; then
+  # Content, not mtime: git checkouts/merges bump mtimes without changing bytes.
+  # The App Store signer changes fm-bridge's signature bytes, so compare its
+  # stable Mach-O UUID separately instead of forcing a rebuild after signing.
+  local source_bridge="$ENGINE_DIR/src/fichero/resources/bin/fm-bridge"
+  local staged_bridge="$ENGINE_APP/Contents/Resources/app/fichero/resources/bin/fm-bridge"
+  if ! diff -rq --exclude=__pycache__ --exclude=.DS_Store --exclude=fm-bridge \
+      "$ENGINE_DIR/src/fichero" "$ENGINE_APP/Contents/Resources/app/fichero" >/dev/null 2>&1 \
+      || [ ! -f "$source_bridge" ] || [ ! -f "$staged_bridge" ] \
+      || [ "$(dwarfdump --uuid "$source_bridge" | awk 'NR == 1 { print $2 }')" \
+           != "$(dwarfdump --uuid "$staged_bridge" | awk 'NR == 1 { print $2 }')" ]; then
     echo "Embedded engine is STALE (engine sources are newer than the staged copy) — rebuilding"
     return 1
   fi


### PR DESCRIPTION
## Summary
- ignore Finder metadata during embedded-engine freshness checks
- compare the re-signed fm-bridge by stable Mach-O UUID
- add a release-script regression guard

## Verification
- `bash -n scripts/preflight-embedded-engine.sh`
- `PYTHONPATH=fichero-engine/src .venv/bin/pytest fichero-engine/tests/unit/test_release_scripts.py -q` (42 passed)
- `scripts/preflight-embedded-engine.sh --check`

Closes #4034